### PR TITLE
support Add/Sub assignment operators for Naive types.

### DIFF
--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -48,7 +48,7 @@
 //! This is currently the internal format of Chrono's date types.
 
 use std::{str, fmt, hash};
-use std::ops::{Add, Sub};
+use std::ops::{Add, Sub, AddAssign, SubAssign};
 use num::traits::ToPrimitive;
 
 use {Weekday, Datelike};
@@ -1318,6 +1318,12 @@ impl Add<Duration> for NaiveDate {
     }
 }
 
+impl AddAssign<Duration> for NaiveDate {
+    fn add_assign(&mut self, rhs: Duration) {
+        *self = self.add(rhs);
+    }
+}
+
 /// A subtraction of `NaiveDate` from `NaiveDate` yields a `Duration` of integral numbers.
 ///
 /// This does not overflow or underflow at all,
@@ -1381,6 +1387,12 @@ impl Sub<Duration> for NaiveDate {
     #[inline]
     fn sub(self, rhs: Duration) -> NaiveDate {
         self.checked_sub(rhs).expect("`NaiveDate - Duration` overflowed")
+    }
+}
+
+impl SubAssign<Duration> for NaiveDate {
+    fn sub_assign(&mut self, rhs: Duration) {
+        *self = self.sub(rhs);
     }
 }
 
@@ -1976,6 +1988,26 @@ mod tests {
 
         check((MAX_YEAR, 12, 31), (0, 1, 1), Duration::days(MAX_DAYS_FROM_YEAR_0 as i64));
         check((MIN_YEAR, 1, 1), (0, 1, 1), Duration::days(MIN_DAYS_FROM_YEAR_0 as i64));
+    }
+
+    #[test]
+    fn test_date_addassignment() {
+        let ymd = NaiveDate::from_ymd;
+        let mut date = ymd(2016, 10, 1);
+        date += Duration::days(10);
+        assert_eq!(date,  ymd(2016, 10, 11));
+        date += Duration::days(30);
+        assert_eq!(date, ymd(2016, 11, 10));
+    }
+
+    #[test]
+    fn test_date_subassignment() {
+        let ymd = NaiveDate::from_ymd;
+        let mut date = ymd(2016, 10, 11);
+        date -= Duration::days(10);
+        assert_eq!(date,  ymd(2016, 10, 1));
+        date -= Duration::days(2);
+        assert_eq!(date, ymd(2016, 9, 29));
     }
 
     #[test]

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -5,7 +5,7 @@
 //! ISO 8601 date and time without timezone.
 
 use std::{str, fmt, hash};
-use std::ops::{Add, Sub};
+use std::ops::{Add, Sub, AddAssign, SubAssign};
 use num::traits::ToPrimitive;
 
 use {Weekday, Timelike, Datelike};
@@ -1101,6 +1101,12 @@ impl Add<Duration> for NaiveDateTime {
     }
 }
 
+impl AddAssign<Duration> for NaiveDateTime {
+    fn add_assign(&mut self, rhs: Duration) {
+        *self = self.add(rhs);
+    }
+}
+
 /// A subtraction of `NaiveDateTime` from `NaiveDateTime` yields a `Duration`.
 /// This does not overflow or underflow at all.
 ///
@@ -1201,6 +1207,12 @@ impl Sub<Duration> for NaiveDateTime {
     #[inline]
     fn sub(self, rhs: Duration) -> NaiveDateTime {
         self.checked_sub(rhs).expect("`NaiveDateTime - Duration` overflowed")
+    }
+}
+
+impl SubAssign<Duration> for NaiveDateTime {
+    fn sub_assign(&mut self, rhs: Duration) {
+        *self = self.sub(rhs);
     }
 }
 
@@ -1613,6 +1625,26 @@ mod tests {
                    Duration::seconds(86399));
         assert_eq!(ymdhms(2001, 9, 9, 1, 46, 39) - ymdhms(1970, 1, 1, 0, 0, 0),
                    Duration::seconds(999_999_999));
+    }
+
+    #[test]
+    fn test_datetime_addassignment() {
+        let ymdhms = |y,m,d,h,n,s| NaiveDate::from_ymd(y,m,d).and_hms(h,n,s);
+        let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
+        date += Duration::minutes(10_000_000);
+        assert_eq!(date,  ymdhms(2035, 10, 6, 20, 50, 10));
+        date += Duration::days(10);
+        assert_eq!(date,  ymdhms(2035, 10, 16, 20, 50, 10));
+    }
+
+    #[test]
+    fn test_datetime_subassignment() {
+        let ymdhms = |y,m,d,h,n,s| NaiveDate::from_ymd(y,m,d).and_hms(h,n,s);
+        let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
+        date -= Duration::minutes(10_000_000);
+        assert_eq!(date,  ymdhms(1997, 9, 26, 23, 30, 10));
+        date -= Duration::days(10);
+        assert_eq!(date,  ymdhms(1997, 9, 16, 23, 30, 10));
     }
 
     #[test]

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -158,7 +158,7 @@
 //! **there is absolutely no guarantee that the leap second read has actually happened**.
 
 use std::{str, fmt, hash};
-use std::ops::{Add, Sub};
+use std::ops::{Add, Sub, AddAssign, SubAssign};
 
 use Timelike;
 use div::div_mod_floor;
@@ -972,6 +972,12 @@ impl Add<Duration> for NaiveTime {
     }
 }
 
+impl AddAssign<Duration> for NaiveTime {
+    fn add_assign(&mut self, rhs: Duration) {
+        *self = self.add(rhs);
+    }
+}
+
 /// A subtraction of `NaiveTime` from `NaiveTime` yields a `Duration` within +/- 1 day.
 /// This does not overflow or underflow at all.
 ///
@@ -1092,6 +1098,12 @@ impl Sub<Duration> for NaiveTime {
     #[inline]
     fn sub(self, rhs: Duration) -> NaiveTime {
         self.overflowing_sub(rhs).0
+    }
+}
+
+impl SubAssign<Duration> for NaiveTime {
+    fn sub_assign(&mut self, rhs: Duration) {
+        *self = self.sub(rhs);
     }
 }
 
@@ -1535,6 +1547,26 @@ mod tests {
                    (hmsm(3, 4, 5, 678), 86400));
         assert_eq!(hmsm(3, 4, 5, 1_678).overflowing_add(Duration::days(-1)),
                    (hmsm(3, 4, 6, 678), -86400));
+    }
+
+    #[test]
+    fn test_time_addassignment() {
+        let hms = NaiveTime::from_hms;
+        let mut time = hms(12, 12, 12);
+        time += Duration::hours(10);
+        assert_eq!(time, hms(22, 12, 12));
+        time += Duration::hours(10);
+        assert_eq!(time, hms(8, 12, 12));
+    }
+
+    #[test]
+    fn test_time_subassignment() {
+        let hms = NaiveTime::from_hms;
+        let mut time = hms(12, 12, 12);
+        time -= Duration::hours(10);
+        assert_eq!(time, hms(2, 12, 12));
+        time -= Duration::hours(10);
+        assert_eq!(time, hms(16, 12, 12));
     }
 
     #[test]


### PR DESCRIPTION
Requires Rust 1.8 or higher.
