### PR TITLE
Serde 0.8 support timestamps when deserializing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ rustc-serialize = { version = "0.3", optional = true }
 serde = { version = "<0.9", optional = true }
 
 [dev-dependencies]
-serde_json = { version = ">=0.7.0" }
-bincode = { version = "0.6", features = ["serde"], default-features = false }
+serde_json = { version = ">=0.7.0,<0.9" }
+bincode = { version = ">=0.6,<0.7", features = ["serde"], default-features = false }

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -1439,6 +1439,20 @@ mod serde {
         {
             value.parse().map_err(|err| E::custom(format!("{}", err)))
         }
+
+        fn visit_i64<E>(&mut self, value: i64) -> Result<NaiveDateTime, E>
+            where E: de::Error
+        {
+            NaiveDateTime::from_timestamp_opt(value, 0)
+                .ok_or_else(|| E::custom(format!("value is not a legal timestamp: {}", value)))
+        }
+
+        fn visit_u64<E>(&mut self, value: u64) -> Result<NaiveDateTime, E>
+            where E: de::Error
+        {
+            NaiveDateTime::from_timestamp_opt(value as i64, 0)
+                .ok_or_else(|| E::custom(format!("value is not a legal timestamp: {}", value)))
+        }
     }
 
     impl de::Deserialize for NaiveDateTime {
@@ -1511,6 +1525,17 @@ mod serde {
         assert_eq!(
             from_str(r#""+262143-12-31T23:59:60.9999999999997""#).ok(), // excess digits are ignored
             Some(date::MAX.and_hms_nano(23, 59, 59, 1_999_999_999)));
+        assert_eq!(
+            from_str("0").unwrap(),
+            NaiveDate::from_ymd(1970, 1, 1).and_hms(0, 0, 0),
+            "should parse integers as timestamps"
+        );
+        assert_eq!(
+            from_str("-1").unwrap(),
+            NaiveDate::from_ymd(1969, 12, 31).and_hms(23, 59, 59),
+            "should parse integers as timestamps"
+        );
+
 
         // bad formats
         assert!(from_str(r#""""#).is_err());
@@ -1527,7 +1552,6 @@ mod serde {
         assert!(from_str(r#""2016-07-08 09:10:48.090""#).is_err());
         assert!(from_str(r#""2016-007-08T09:10:48.090""#).is_err());
         assert!(from_str(r#""yyyy-mm-ddThh:mm:ss.fffffffff""#).is_err());
-        assert!(from_str(r#"0"#).is_err());
         assert!(from_str(r#"20160708000000"#).is_err());
         assert!(from_str(r#"{}"#).is_err());
         assert!(from_str(r#"{"date":{"ymdf":20},"time":{"secs":0,"frac":0}}"#).is_err()); // :(


### PR DESCRIPTION
This is useful when using `derive(Deserialize)` on something that contains some sort of `DateTime` but the API you're interacting with returns integers instead of strings.

I've got another PR incoming that implements this for serde 0.9. I'm not sure if there are any plans to continue supporting 0.8, but I need it until the ecosystems finishes catching up to the 0.9 changes.