### PR TITLE
Support deserializing from timestamps

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# This is the script that's executed by travis, you can run it yourself to run
+# the exact same suite
+
+set -e
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+channel() {
+    if [ -n "${TRAVIS}" ]; then
+        if [ "${TRAVIS_RUST_VERSION}" = "${CHANNEL}" ]; then
+            pwd
+            (set -x; cargo "$@")
+        fi
+    elif [ -n "${APPVEYOR}" ]; then
+        if [ "${APPVEYOR_RUST_CHANNEL}" = "${CHANNEL}" ]; then
+            pwd
+            (set -x; cargo "$@")
+        fi
+    else
+        pwd
+        (set -x; cargo "+${CHANNEL}" "$@")
+    fi
+}
+
+build_and_test() {
+  # interleave building and testing in hope that it saves time
+  # also vary the local time zone to (hopefully) catch tz-dependent bugs
+  # also avoid doc-testing multiple times---it takes a lot and rarely helps
+  cargo clean
+  channel build -v
+  TZ=ACST-9:30 channel test -v --lib
+  channel build -v --features rustc-serialize
+  TZ=EST4 channel test -v --features rustc-serialize --lib
+  channel build -v --features 'serde bincode'
+  TZ=UTC0 channel test -v --features 'serde bincode'
+}
+
+build_only() {
+  # Rust 1.13 doesn't support custom derive, so, to avoid doctests which
+  # validate that, we just build there.
+  cargo clean
+  channel build -v
+  channel build -v --features rustc-serialize
+  channel build -v --features 'serde bincode'
+}
+
+rustc --version
+cargo --version
+
+CHANNEL=nightly
+build_and_test
+
+CHANNEL=beta
+build_and_test
+
+CHANNEL=stable
+build_and_test
+
+CHANNEL=1.13.0
+build_only

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 sudo: false
 rust:
-  # 1.13.0 is the earliest version that Serde 0.9 tests, so we follow suit
+  # 1.13.0 is the earliest version that Serde 1.0 tests, so we follow suit
   - 1.13.0
   - stable
   - beta
@@ -15,16 +15,7 @@ matrix:
 env:
   global:
     - LD_LIBRARY_PATH: /usr/local/lib
-script:
-  # interleave building and testing in hope that it saves time
-  # also vary the local time zone to (hopefully) catch tz-dependent bugs
-  # also avoid doc-testing multiple times---it takes a lot and rarely helps
-  - cargo build -v
-  - TZ=ACST-9:30 cargo test -v
-  - cargo build -v --features rustc-serialize
-  - TZ=EST4 cargo test -v --features rustc-serialize --lib
-  - cargo build -v --features 'serde bincode'
-  - TZ=UTC0 cargo test -v --features 'serde bincode' --lib
+script: ./.travis.sh
 notifications:
   email: false
   irc:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,5 @@ serde = { version = "1", optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1" }
+serde_derive = { version = "1" }
 bincode = { version = "0.8.0", features = ["serde"], default-features = false }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ install:
   - ps: $env:PATH="$env:PATH;C:\rust\bin"
   - rustc -vV
   - cargo -vV
-build_script:
-  # do not test all combinations, Travis will handle that
-  - cargo build -v --features "serde rustc-serialize"
+
+build: false
+
 test_script:
-  - cargo test -v --features "serde rustc-serialize"
+  - sh -c 'PATH=`rustc --print sysroot`/bin:$PATH ./.travis.sh'

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -1443,6 +1443,23 @@ fn test_decodable_json<F, E>(from_str: F)
     assert!(from_str(r#"null"#).is_err());
 }
 
+
+#[cfg(all(test, feature = "rustc-serialize"))]
+fn test_decodable_json_timestamp<F, E>(from_str: F)
+    where F: Fn(&str) -> Result<TsSeconds, E>, E: ::std::fmt::Debug
+{
+    assert_eq!(
+        *from_str("0").unwrap(),
+        NaiveDate::from_ymd(1970, 1, 1).and_hms(0, 0, 0),
+        "should parse integers as timestamps"
+    );
+    assert_eq!(
+        *from_str("-1").unwrap(),
+        NaiveDate::from_ymd(1969, 12, 31).and_hms(23, 59, 59),
+        "should parse integers as timestamps"
+    );
+}
+
 #[cfg(feature = "rustc-serialize")]
 mod rustc_serialize {
     use super::{NaiveDateTime, TsSeconds};
@@ -1478,6 +1495,12 @@ mod rustc_serialize {
     #[test]
     fn test_decodable() {
         super::test_decodable_json(json::decode);
+    }
+
+    #[test]
+    fn test_decodable_timestamps() {
+        super::test_decodable_json_timestamp(json::decode);
+
     }
 
 }


### PR DESCRIPTION
This is almost identical to #124, but for serde 0.9. This is built on top of #122.

This is useful when using `derive(Deserialize)` on a struct that contains some sort of `DateTime`, but the foreign API returns timestamps instead of strs.