### PR TITLE
Upgrade to serde 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ name = "chrono"
 time = "^0.1.36"
 num = { version = "0.1", default-features = false }
 rustc-serialize = { version = "0.3", optional = true }
-serde = { version = "0.9", optional = true }
+serde = { version = "1", optional = true }
 
 [dev-dependencies]
-serde_json = { version = ">=0.9.0" }
-bincode = { version = "1.0.0-alpha6", features = ["serde"], default-features = false }
+serde_json = { version = "1" }
+bincode = { version = "0.7.0", features = ["serde"], default-features = false, git = "https://github.com/TyOverby/bincode.git" }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -418,9 +418,9 @@ fn test_encodable_json<FUTC, FFixed, E>(to_string_utc: FUTC, to_string_fixed: FF
 fn test_decodable_json<FUTC, FFixed, FLocal, E>(utc_from_str: FUTC,
                                                      fixed_from_str: FFixed,
                                                      local_from_str: FLocal)
-    where FUTC: for<'de> Fn(&'de str) -> Result<DateTime<UTC>, E>,
-          FFixed: for<'de> Fn(&'de str) -> Result<DateTime<FixedOffset>, E>,
-          FLocal: for<'de> Fn(&'de str) -> Result<DateTime<Local>, E>,
+    where FUTC: Fn(&str) -> Result<DateTime<UTC>, E>,
+          FFixed: Fn(&str) -> Result<DateTime<FixedOffset>, E>,
+          FLocal: Fn(&str) -> Result<DateTime<Local>, E>,
           E: ::std::fmt::Debug
 {
     // should check against the offset as well (the normal DateTime comparison will ignore them)

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -520,8 +520,18 @@ mod serde {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where S: ser::Serializer
         {
+            struct FormatWrapped<'a, D: 'a> {
+                inner: &'a D
+            }
+
+            impl<'a, D: fmt::Debug> fmt::Display for FormatWrapped<'a, D> {
+                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    self.inner.fmt(f)
+                }
+            }
+
             // Debug formatting is correct RFC3339, and it allows Zulu.
-            serializer.serialize_str(&format!("{:?}", self))
+            serializer.collect_str(&FormatWrapped { inner: &self })
         }
     }
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1570,7 +1570,17 @@ mod serde {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where S: ser::Serializer
         {
-            serializer.serialize_str(&format!("{:?}", self))
+            struct FormatWrapped<'a, D: 'a> {
+                inner: &'a D
+            }
+
+            impl<'a, D: fmt::Debug> fmt::Display for FormatWrapped<'a, D> {
+                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    self.inner.fmt(f)
+                }
+            }
+
+            serializer.collect_str(&FormatWrapped { inner: &self })
         }
     }
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1495,7 +1495,7 @@ fn test_encodable_json<F, E>(to_string: F)
 
 #[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
 fn test_decodable_json<F, E>(from_str: F)
-    where F: for<'de> Fn(&'de str) -> Result<NaiveDate, E>, E: ::std::fmt::Debug
+    where F: Fn(&str) -> Result<NaiveDate, E>, E: ::std::fmt::Debug
 {
     use std::{i32, i64};
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1495,7 +1495,7 @@ fn test_encodable_json<F, E>(to_string: F)
 
 #[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
 fn test_decodable_json<F, E>(from_str: F)
-    where F: Fn(&str) -> Result<NaiveDate, E>, E: ::std::fmt::Debug
+    where F: for<'de> Fn(&'de str) -> Result<NaiveDate, E>, E: ::std::fmt::Debug
 {
     use std::{i32, i64};
 
@@ -1576,7 +1576,7 @@ mod serde {
 
     struct NaiveDateVisitor;
 
-    impl de::Visitor for NaiveDateVisitor {
+    impl<'de> de::Visitor<'de> for NaiveDateVisitor {
         type Value = NaiveDate;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result 
@@ -1591,9 +1591,9 @@ mod serde {
         }
     }
 
-    impl de::Deserialize for NaiveDate {
+    impl<'de> de::Deserialize<'de> for NaiveDate {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-            where D: de::Deserializer
+            where D: de::Deserializer<'de>
         {
             deserializer.deserialize_str(NaiveDateVisitor)
         }
@@ -1609,7 +1609,7 @@ mod serde {
 
     #[test]
     fn test_serde_deserialize() {
-        super::test_decodable_json(self::serde_json::from_str);
+        super::test_decodable_json(|input| self::serde_json::from_str(&input));
     }
 
     #[test]

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -1371,7 +1371,7 @@ fn test_encodable_json<F, E>(to_string: F)
 
 #[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
 fn test_decodable_json<F, E>(from_str: F)
-    where F: Fn(&str) -> Result<NaiveDateTime, E>, E: ::std::fmt::Debug
+    where F: for<'de> Fn(&'de str) -> Result<NaiveDateTime, E>, E: ::std::fmt::Debug
 {
     use naive::date;
 
@@ -1474,7 +1474,7 @@ mod serde {
 
     struct NaiveDateTimeVisitor;
 
-    impl de::Visitor for NaiveDateTimeVisitor {
+    impl<'de> de::Visitor<'de> for NaiveDateTimeVisitor {
         type Value = NaiveDateTime;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result 
@@ -1489,9 +1489,9 @@ mod serde {
         }
     }
 
-    impl de::Deserialize for NaiveDateTime {
+    impl<'de> de::Deserialize<'de> for NaiveDateTime {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-            where D: de::Deserializer
+            where D: de::Deserializer<'de>
         {
             deserializer.deserialize_str(NaiveDateTimeVisitor)
         }
@@ -1507,7 +1507,7 @@ mod serde {
 
     #[test]
     fn test_serde_deserialize() {
-        super::test_decodable_json(self::serde_json::from_str);
+        super::test_decodable_json(|input| self::serde_json::from_str(&input));
     }
 
     #[test]

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -1468,7 +1468,17 @@ mod serde {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where S: ser::Serializer
         {
-            serializer.serialize_str(&format!("{:?}", self))
+            struct FormatWrapped<'a, D: 'a> {
+                inner: &'a D
+            }
+
+            impl<'a, D: fmt::Debug> fmt::Display for FormatWrapped<'a, D> {
+                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    self.inner.fmt(f)
+                }
+            }
+
+            serializer.collect_str(&FormatWrapped { inner: &self })
         }
     }
 

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -1371,7 +1371,7 @@ fn test_encodable_json<F, E>(to_string: F)
 
 #[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
 fn test_decodable_json<F, E>(from_str: F)
-    where F: for<'de> Fn(&'de str) -> Result<NaiveDateTime, E>, E: ::std::fmt::Debug
+    where F: Fn(&str) -> Result<NaiveDateTime, E>, E: ::std::fmt::Debug
 {
     use naive::date;
 

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -1261,7 +1261,7 @@ fn test_encodable_json<F, E>(to_string: F)
 
 #[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
 fn test_decodable_json<F, E>(from_str: F)
-    where F: for<'de> Fn(&'de str) -> Result<NaiveTime, E>, E: ::std::fmt::Debug
+    where F: Fn(&str) -> Result<NaiveTime, E>, E: ::std::fmt::Debug
 {
     assert_eq!(from_str(r#""00:00:00""#).ok(),
                Some(NaiveTime::from_hms(0, 0, 0)));

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -1261,7 +1261,7 @@ fn test_encodable_json<F, E>(to_string: F)
 
 #[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
 fn test_decodable_json<F, E>(from_str: F)
-    where F: Fn(&str) -> Result<NaiveTime, E>, E: ::std::fmt::Debug
+    where F: for<'de> Fn(&'de str) -> Result<NaiveTime, E>, E: ::std::fmt::Debug
 {
     assert_eq!(from_str(r#""00:00:00""#).ok(),
                Some(NaiveTime::from_hms(0, 0, 0)));
@@ -1352,7 +1352,7 @@ mod serde {
 
     struct NaiveTimeVisitor;
 
-    impl de::Visitor for NaiveTimeVisitor {
+    impl<'de> de::Visitor<'de> for NaiveTimeVisitor {
         type Value = NaiveTime;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result 
@@ -1367,9 +1367,9 @@ mod serde {
         }
     }
 
-    impl de::Deserialize for NaiveTime {
+    impl<'de> de::Deserialize<'de> for NaiveTime {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-            where D: de::Deserializer
+            where D: de::Deserializer<'de>
         {
             deserializer.deserialize_str(NaiveTimeVisitor)
         }
@@ -1385,7 +1385,7 @@ mod serde {
 
     #[test]
     fn test_serde_deserialize() {
-        super::test_decodable_json(self::serde_json::from_str);
+        super::test_decodable_json(|input| self::serde_json::from_str(&input));
     }
 
     #[test]

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -1346,7 +1346,7 @@ mod serde {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where S: ser::Serializer
         {
-            serializer.serialize_str(&format!("{:?}", self))
+            serializer.collect_str(&self)
         }
     }
 


### PR DESCRIPTION
Closes #141

- Peppered around a few lifetimes for the changes to `Deserialize`
- Use [`collect_str`](https://docs.serde.rs/serde/trait.Serializer.html#method.collect_str) in `Serialize` to possibly avoid a `String` allocation when serialising dates

cc: @lifthrasiir 