### PR TITLE
Deprecated warnings in cargo output for rustc-serialize feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Chrono obeys the principle of [Semantic Versioning](http://semver.org/).
 There were/are numerous minor versions before 1.0 due to the language changes.
 Versions with only mechnical changes will be omitted from the following list.
 
+## 0.4.next
+
+* More strongly deprecate RustcSerialize: remove it from documentation unless
+  the feature is enabled, issue a deprecation warning if the rustc-serialize
+  feature is enabled (@quodlibetor)
+
 ## 0.4.1
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -46,20 +46,13 @@ Put this in your `Cargo.toml`:
 chrono = "0.4"
 ```
 
-Or, if you want [Serde](https://github.com/serde-rs/serde) or
-[rustc-serialize](https://github.com/rust-lang-nursery/rustc-serialize) support,
-include the features like this:
+Or, if you want [Serde](https://github.com/serde-rs/serde) include the feature
+like this:
 
 ```toml
 [dependencies]
-chrono = { version = "0.4", features = ["serde", "rustc-serialize"] }
+chrono = { version = "0.4", features = ["serde"] }
 ```
-
-> Note that Chrono's support for rustc-serialize is now considered deprecated.
-Starting from 0.4.0 there is no further guarantee that
-the features available in Serde will be also available to rustc-serialize,
-and the support can be removed in any future major version.
-**Rustc-serialize users are strongly recommended to migrate to Serde.**
 
 Then put this in your crate root:
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -695,7 +695,9 @@ pub mod rustc_serialize {
         }
     }
 
+    #[allow(deprecated)]
     impl Decodable for TsSeconds<FixedOffset> {
+        #[allow(deprecated)]
         fn decode<D: Decoder>(d: &mut D) -> Result<TsSeconds<FixedOffset>, D::Error> {
             from(FixedOffset::east(0).timestamp_opt(d.read_i64()?, 0), d)
                 .map(TsSeconds)
@@ -717,13 +719,16 @@ pub mod rustc_serialize {
     #[derive(Debug)]
     pub struct TsSeconds<Tz: TimeZone>(DateTime<Tz>);
 
+    #[allow(deprecated)]
     impl<Tz: TimeZone> From<TsSeconds<Tz>> for DateTime<Tz> {
         /// Pull the inner DateTime<Tz> out
+        #[allow(deprecated)]
         fn from(obj: TsSeconds<Tz>) -> DateTime<Tz> {
             obj.0
         }
     }
 
+    #[allow(deprecated)]
     impl<Tz: TimeZone> Deref for TsSeconds<Tz> {
         type Target = DateTime<Tz>;
 
@@ -732,6 +737,7 @@ pub mod rustc_serialize {
         }
     }
 
+    #[allow(deprecated)]
     impl Decodable for TsSeconds<Utc> {
         fn decode<D: Decoder>(d: &mut D) -> Result<TsSeconds<Utc>, D::Error> {
             from(Utc.timestamp_opt(d.read_i64()?, 0), d)
@@ -748,7 +754,9 @@ pub mod rustc_serialize {
         }
     }
 
+    #[allow(deprecated)]
     impl Decodable for TsSeconds<Local> {
+        #[allow(deprecated)]
         fn decode<D: Decoder>(d: &mut D) -> Result<TsSeconds<Local>, D::Error> {
             from(Utc.timestamp_opt(d.read_i64()?, 0), d)
                 .map(|dt| TsSeconds(dt.with_timezone(&Local)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,7 +411,8 @@ pub use oldtime::Duration;
 #[doc(no_inline)] pub use naive::{NaiveDate, IsoWeek, NaiveTime, NaiveDateTime};
 pub use date::{Date, MIN_DATE, MAX_DATE};
 pub use datetime::{DateTime, SecondsFormat};
-#[cfg(feature = "rustc-serialize")] pub use datetime::rustc_serialize::TsSeconds;
+#[cfg(feature = "rustc-serialize")]
+pub use datetime::rustc_serialize::TsSeconds;
 pub use format::{ParseError, ParseResult};
 pub use round::SubsecRound;
 
@@ -451,6 +452,7 @@ pub mod naive {
     pub use self::time::NaiveTime;
     pub use self::datetime::NaiveDateTime;
     #[cfg(feature = "rustc-serialize")]
+    #[allow(deprecated)]
     pub use self::datetime::rustc_serialize::TsSeconds;
 
 

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -1503,24 +1503,32 @@ pub mod rustc_serialize {
 
     /// A `DateTime` that can be deserialized from a seconds-based timestamp
     #[derive(Debug)]
+    #[deprecated(since = "1.4.2",
+                 note = "RustcSerialize will be removed before chrono 1.0, use Serde instead")]
     pub struct TsSeconds(NaiveDateTime);
 
+    #[allow(deprecated)]
     impl From<TsSeconds> for NaiveDateTime {
         /// Pull the internal NaiveDateTime out
+        #[allow(deprecated)]
         fn from(obj: TsSeconds) -> NaiveDateTime {
             obj.0
         }
     }
 
+    #[allow(deprecated)]
     impl Deref for TsSeconds {
         type Target = NaiveDateTime;
 
+        #[allow(deprecated)]
         fn deref(&self) -> &Self::Target {
             &self.0
         }
     }
 
+    #[allow(deprecated)]
     impl Decodable for TsSeconds {
+        #[allow(deprecated)]
         fn decode<D: Decoder>(d: &mut D) -> Result<TsSeconds, D::Error> {
             Ok(TsSeconds(
                 NaiveDateTime::from_timestamp_opt(d.read_i64()?, 0)


### PR DESCRIPTION
Unfortunately due to rust-lang/rust#39935 placing the annotation on the `impl`s
of `Encodable`/`Decodable` for the various items have no effect whatsoever, so
we need to place it on some type that chrono actually uses internally. The only
*type* that I can find that only exists for rustc-serialize only is the
 `TsSeconds` struct.

So, marking TsSeconds deprecated causes Chrono's internal uses of `TsSeconds`
to emit deprecation warnings, both in our builds and for packages that specify
Chrono as a dependency with the `rustc-serialize` feature active. This means
that the current commit will cause a `warning: use of deprecated item:
RustcSerialize will be removed before chrono 1.0, use Serde instead` to appear
in `cargo build` output.

Unfortunately I don't think that it's possible for downstream crates to disable
the warning the warning in any way other than actually switching to Serde or
using an older chrono. That's the reason for all the `#[allow(deprecated)]`
through the code, it means that the warning appears almost exactly once,
instead of dozens of times.