### PR TITLE
Fix Allow parsing of timestamps with additional subsecond precision

### DIFF
--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -550,7 +550,6 @@ impl Parsed {
             try!(parsed.set_ordinal(datetime.ordinal() as i64)); // more efficient than ymd
             try!(parsed.set_hour   (datetime.hour()    as i64));
             try!(parsed.set_minute (datetime.minute()  as i64));
-            try!(parsed.set_nanosecond(0)); // no nanosecond precision in timestamp
 
             // validate other fields (e.g. week) and return
             let date = try!(parsed.to_naive_date());
@@ -933,7 +932,7 @@ mod tests {
                    ymdhmsn(2012,2,3, 5,6,7,890_123_456));
         assert_eq!(parse!(timestamp: 0), ymdhms(1970,1,1, 0,0,0));
         assert_eq!(parse!(timestamp: 1, nanosecond: 0), ymdhms(1970,1,1, 0,0,1));
-        assert_eq!(parse!(timestamp: 1, nanosecond: 1), Err(IMPOSSIBLE));
+        assert_eq!(parse!(timestamp: 1, nanosecond: 1), ymdhmsn(1970,1,1, 0,0,1, 1));
         assert_eq!(parse!(timestamp: 1_420_000_000), ymdhms(2014,12,31, 4,26,40));
         assert_eq!(parse!(timestamp: -0x1_0000_0000), ymdhms(1833,11,24, 17,31,44));
 

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -1914,6 +1914,8 @@ mod tests {
     #[test]
     fn test_datetime_parse_from_str() {
         let ymdhms = |y,m,d,h,n,s| NaiveDate::from_ymd(y,m,d).and_hms(h,n,s);
+        let ymdhmsn =
+            |y,m,d,h,n,s,nano| NaiveDate::from_ymd(y, m, d).and_hms_nano(h, n, s, nano);
         assert_eq!(NaiveDateTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
                    Ok(ymdhms(2014, 5, 7, 12, 34, 56))); // ignore offset
         assert_eq!(NaiveDateTime::parse_from_str("2015-W06-1 000000", "%G-W%V-%u%H%M%S"),
@@ -1925,6 +1927,16 @@ mod tests {
                                               "%a, %d %b %Y %H:%M:%S GMT").is_err());
         assert!(NaiveDateTime::parse_from_str("2014-5-7 12:3456", "%Y-%m-%d %H:%M:%S").is_err());
         assert!(NaiveDateTime::parse_from_str("12:34:56", "%H:%M:%S").is_err()); // insufficient
+        assert_eq!(NaiveDateTime::parse_from_str("1441497364", "%s"),
+                   Ok(ymdhms(2015, 9, 5, 23, 56, 4)));
+        assert_eq!(NaiveDateTime::parse_from_str("1283929614.1234", "%s.%f"),
+                   Ok(ymdhmsn(2010, 9, 8, 7, 6, 54, 1234)));
+        assert_eq!(NaiveDateTime::parse_from_str("1441497364.649", "%s%.3f"),
+                   Ok(ymdhmsn(2015, 9, 5, 23, 56, 4, 649000000)));
+        assert_eq!(NaiveDateTime::parse_from_str("1497854303.087654", "%s%.6f"),
+                   Ok(ymdhmsn(2017, 6, 19, 6, 38, 23, 87654000)));
+        assert_eq!(NaiveDateTime::parse_from_str("1437742189.918273645", "%s%.9f"),
+                   Ok(ymdhmsn(2015, 7, 24, 12, 49, 49, 918273645)));
     }
 
     #[test]


### PR DESCRIPTION
Fixes https://github.com/chronotope/chrono/issues/175