### PR TITLE
Add DateTime to_rfc3339p(z) methods, tests

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -287,7 +287,7 @@ impl<Tz: TimeZone> DateTime<Tz> where Tz::Offset: fmt::Display {
         use format::Fixed::*;
         use format::Fixed::Nanosecond;
 
-        static PREFIX: &[Item<'static>] = &[
+        const PREFIX: &'static [Item<'static>] = &[
             Numeric(Year, Zero),
             Literal("-"),
             Numeric(Month, Zero),

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -309,10 +309,13 @@ impl<Tz: TimeZone> DateTime<Tz> where Tz::Offset: fmt::Display {
             }
         };
 
-        let tzitem = Item::Fixed(match use_z {
-            true  => Fixed::TimezoneOffsetColonZ,
-            false => Fixed::TimezoneOffsetColon
-        });
+        let tzitem = Item::Fixed(
+            if use_z {
+                Fixed::TimezoneOffsetColonZ
+            } else {
+                Fixed::TimezoneOffsetColon
+            }
+        );
 
         match ssitem {
             None =>

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -281,38 +281,37 @@ impl<Tz: TimeZone> DateTime<Tz> where Tz::Offset: fmt::Display {
 
     fn rfc3339_via_items(&self, subform: Option<Fixed>, use_z: bool) -> String
     {
-        use format::Item::*;
         use format::Numeric::*;
         use format::Pad::Zero;
-        use format::Fixed::*;
-        use format::Fixed::Nanosecond;
 
         const PREFIX: &'static [Item<'static>] = &[
-            Numeric(Year, Zero),
-            Literal("-"),
-            Numeric(Month, Zero),
-            Literal("-"),
-            Numeric(Day, Zero),
-            Literal("T"),
-            Numeric(Hour, Zero),
-            Literal(":"),
-            Numeric(Minute, Zero),
-            Literal(":"),
-            Numeric(Second, Zero),
+            Item::Numeric(Year, Zero),
+            Item::Literal("-"),
+            Item::Numeric(Month, Zero),
+            Item::Literal("-"),
+            Item::Numeric(Day, Zero),
+            Item::Literal("T"),
+            Item::Numeric(Hour, Zero),
+            Item::Literal(":"),
+            Item::Numeric(Minute, Zero),
+            Item::Literal(":"),
+            Item::Numeric(Second, Zero),
         ];
 
         let ssitem = match subform {
             None => None,
             Some(sf) => match sf {
-                Nanosecond |
-                Nanosecond3 | Nanosecond6 | Nanosecond9 => Some(Fixed(sf)),
+                Fixed::Nanosecond |
+                Fixed::Nanosecond3 |
+                Fixed::Nanosecond6 |
+                Fixed::Nanosecond9 => Some(Item::Fixed(sf)),
                 _ => panic!("Unsupported rfc_3339p subsecond format {:?}", sf)
             }
         };
 
-        let tzitem = Fixed(match use_z {
-            true  => TimezoneOffsetColonZ,
-            false => TimezoneOffsetColon
+        let tzitem = Item::Fixed(match use_z {
+            true  => Fixed::TimezoneOffsetColonZ,
+            false => Fixed::TimezoneOffsetColon
         });
 
         match ssitem {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,7 +406,7 @@ pub use oldtime::Duration;
 #[doc(no_inline)] pub use offset::{TimeZone, Offset, LocalResult, Utc, FixedOffset, Local};
 #[doc(no_inline)] pub use naive::{NaiveDate, IsoWeek, NaiveTime, NaiveDateTime};
 pub use date::{Date, MIN_DATE, MAX_DATE};
-pub use datetime::DateTime;
+pub use datetime::{DateTime, SecondsFormat};
 #[cfg(feature = "rustc-serialize")] pub use datetime::rustc_serialize::TsSeconds;
 pub use format::{ParseError, ParseResult};
 
@@ -417,7 +417,7 @@ pub mod prelude {
     #[doc(no_inline)] pub use {Utc, FixedOffset, Local};
     #[doc(no_inline)] pub use {NaiveDate, NaiveTime, NaiveDateTime};
     #[doc(no_inline)] pub use Date;
-    #[doc(no_inline)] pub use DateTime;
+    #[doc(no_inline)] pub use {DateTime, SecondsFormat};
 }
 
 // useful throughout the codebase


### PR DESCRIPTION
These additions allow convenient control of RFC 3339 formatted output:

 * Number of subsecond digits to display

 * Whether to use the 'Z' variant, instead of "+00:00" for TZ offset
   0, UTC.

...while remaining faithful to the RFC 3339. The implementation uses the existing formatting Item mechanism.

The 'Z' variant was originally requested in #157 where it was suggested a PR was welcome.   Control of subsecond digits was requested in #178 and @quodlibetor gave me a starting point for using the formatting Item mechanism.

Tests and rustdoc are included. Please consider merging this or let me know if it has any deficits, thanks! 