### PR TITLE
Use no_std-compatible num dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ name = "chrono"
 
 [dependencies]
 time = "^0.1.36"
-num = { version = "0.1", default-features = false }
+num-integer = { version = "0.1.36", default-features = false }
+num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3", optional = true }
 serde = { version = "1", optional = true }
 
@@ -29,6 +30,7 @@ serde = { version = "1", optional = true }
 serde_json = { version = "1" }
 serde_derive = { version = "1" }
 bincode = { version = "0.8.0" }
+num-iter = { version = "0.1.35", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/div.rs
+++ b/src/div.rs
@@ -7,7 +7,7 @@
 // Algorithm from [Daan Leijen. _Division and Modulus for Computer Scientists_,
 // December 2001](http://research.microsoft.com/pubs/151917/divmodnote-letter.pdf)
 
-pub use num::integer::{div_rem, div_floor, mod_floor, div_mod_floor};
+pub use num_integer::{div_rem, div_floor, mod_floor, div_mod_floor};
 
 #[cfg(test)]
 mod tests {

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -4,7 +4,7 @@
 //! A collection of parsed date and time items.
 //! They can be constructed incrementally while being checked for consistency.
 
-use num::traits::ToPrimitive;
+use num_traits::ToPrimitive;
 use oldtime::Duration as OldDuration;
 
 use {Datelike, Timelike};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -394,7 +394,8 @@
 #![cfg_attr(feature = "cargo-clippy", allow(const_static_lifetime))]
 
 extern crate time as oldtime;
-extern crate num;
+extern crate num_integer;
+extern crate num_traits;
 #[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
 #[cfg(feature = "serde")]
@@ -615,7 +616,7 @@ impl Weekday {
 /// Any weekday can be represented as an integer from 0 to 6, which equals to
 /// [`Weekday::num_days_from_monday`](#method.num_days_from_monday) in this implementation.
 /// Do not heavily depend on this though; use explicit methods whenever possible.
-impl num::traits::FromPrimitive for Weekday {
+impl num_traits::FromPrimitive for Weekday {
     #[inline]
     fn from_i64(n: i64) -> Option<Weekday> {
         match n {
@@ -930,9 +931,11 @@ pub trait Timelike: Sized {
     }
 }
 
+#[cfg(test)] extern crate num_iter;
+
 #[test]
 fn test_readme_doomsday() {
-    use num::iter::range_inclusive;
+    use num_iter::range_inclusive;
 
     for y in range_inclusive(naive::MIN_DATE.year(), naive::MAX_DATE.year()) {
         // even months

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -5,7 +5,7 @@
 
 use std::{str, fmt};
 use std::ops::{Add, Sub, AddAssign, SubAssign};
-use num::traits::ToPrimitive;
+use num_traits::ToPrimitive;
 use oldtime::Duration as OldDuration;
 
 use {Weekday, Datelike};

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -5,7 +5,7 @@
 
 use std::{str, fmt, hash};
 use std::ops::{Add, Sub, AddAssign, SubAssign};
-use num::traits::ToPrimitive;
+use num_traits::ToPrimitive;
 use oldtime::Duration as OldDuration;
 
 use {Weekday, Timelike, Datelike};

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -16,7 +16,7 @@
 #![allow(dead_code)] // some internal methods have been left for consistency
 
 use std::{i32, fmt};
-use num::traits::FromPrimitive;
+use num_traits::FromPrimitive;
 use Weekday;
 use div::{div_rem, mod_floor};
 
@@ -469,12 +469,13 @@ impl fmt::Debug for Mdf {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(test)] extern crate num_iter;
     #[cfg(bench)] extern crate test;
 
     use Weekday;
     use super::{Of, Mdf};
     use super::{YearFlags, A, B, C, D, E, F, G, AG, BA, CB, DC, ED, FE, GF};
-    use num::iter::range_inclusive;
+    use num_iter::range_inclusive;
     use std::u32;
 
     const NONLEAP_FLAGS: [YearFlags; 7] = [A, B, C, D, E, F, G];


### PR DESCRIPTION
Rather than the `num` meta-crate, use `num-integer` and `num-traits`
without default features to make them `#[no_std]`.  `num-iter` is
just a dev-dependency now for a few test cases.

The only public change is the `impl FromPrimitive for Weekday`, but this
is still the same exact trait that `num` re-exports, so this is not a
breaking change.