### PR TITLE
Revert "Allow a false-positive clippy lint" as it has been fixed in clippy

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -269,8 +269,6 @@ macro_rules! fix  { ($x:ident) => (Item::Fixed(Fixed::$x)) }
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct ParseError(ParseErrorKind);
 
-// clippy false positive https://github.com/rust-lang-nursery/rust-clippy/issues/2475
-#[cfg_attr(feature = "cargo-clippy", allow(empty_line_after_outer_attr))]
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 enum ParseErrorKind {
     /// Given field is out of permitted range.


### PR DESCRIPTION
The issue has been fixed with the latest clippy release (in https://github.com/rust-lang-nursery/rust-clippy/pull/2577) and we don't have to `allow` anymore.

This reverts commit 7f990144ccb81c93354c8112f566d4c065c6b49e.