### PR TITLE
Fix rfc 2822 format when day is less than 10

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1367,8 +1367,12 @@ mod tests {
                    "2015-02-18T23:16:09+00:00");
         assert_eq!(EDT.ymd(2015, 2, 18).and_hms_milli(23, 16, 9, 150).to_rfc2822(),
                    "Wed, 18 Feb 2015 23:16:09 +0500");
+        assert_eq!(EDT.ymd(2015, 2, 3).and_hms_milli(23, 16, 9, 150).to_rfc2822(),
+                   "Tue, 3 Feb 2015 23:16:09 +0500");
         assert_eq!(EDT.ymd(2015, 2, 18).and_hms_milli(23, 16, 9, 150).to_rfc3339(),
                    "2015-02-18T23:16:09.150+05:00");
+        assert_eq!(EDT.ymd(2015, 2, 3).and_hms_milli(23, 16, 9, 150).to_rfc3339(),
+                   "2015-02-03T23:16:09.150+05:00");
         assert_eq!(EDT.ymd(2015, 2, 18).and_hms_micro(23, 59, 59, 1_234_567).to_rfc2822(),
                    "Wed, 18 Feb 2015 23:59:60 +0500");
         assert_eq!(EDT.ymd(2015, 2, 18).and_hms_micro(23, 59, 59, 1_234_567).to_rfc3339(),

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -495,9 +495,9 @@ pub fn format<'a, I>(w: &mut fmt::Formatter, date: Option<&NaiveDate>, time: Opt
                         if let (Some(d), Some(t), Some(&(_, off))) = (date, time, off) {
                             let sec = t.second() + t.nanosecond() / 1_000_000_000;
                             try!(write!(w, "{}, {} {} {:04} {:02}:{:02}:{:02} ",
-                                    SHORT_WEEKDAYS[d.weekday().num_days_from_monday() as usize],
-                                    d.day(), SHORT_MONTHS[d.month0() as usize], d.year(),
-                                    t.hour(), t.minute(), sec));
+                                        SHORT_WEEKDAYS[d.weekday().num_days_from_monday() as usize],
+                                        d.day(), SHORT_MONTHS[d.month0() as usize], d.year(),
+                                        t.hour(), t.minute(), sec));
                             Some(write_local_minus_utc(w, off, false, false))
                         } else {
                             None

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -494,17 +494,10 @@ pub fn format<'a, I>(w: &mut fmt::Formatter, date: Option<&NaiveDate>, time: Opt
                     RFC2822 => // same to `%a, %e %b %Y %H:%M:%S %z`
                         if let (Some(d), Some(t), Some(&(_, off))) = (date, time, off) {
                             let sec = t.second() + t.nanosecond() / 1_000_000_000;
-                            if d.day() < 10 {
-                                try!(write!(w, "{}, {:1} {} {:04} {:02}:{:02}:{:02} ",
-                                        SHORT_WEEKDAYS[d.weekday().num_days_from_monday() as usize],
-                                        d.day(), SHORT_MONTHS[d.month0() as usize], d.year(),
-                                        t.hour(), t.minute(), sec));
-                            } else {
-                                try!(write!(w, "{}, {:2} {} {:04} {:02}:{:02}:{:02} ",
-                                        SHORT_WEEKDAYS[d.weekday().num_days_from_monday() as usize],
-                                        d.day(), SHORT_MONTHS[d.month0() as usize], d.year(),
-                                        t.hour(), t.minute(), sec));
-                            }
+                            try!(write!(w, "{}, {} {} {:04} {:02}:{:02}:{:02} ",
+                                    SHORT_WEEKDAYS[d.weekday().num_days_from_monday() as usize],
+                                    d.day(), SHORT_MONTHS[d.month0() as usize], d.year(),
+                                    t.hour(), t.minute(), sec));
                             Some(write_local_minus_utc(w, off, false, false))
                         } else {
                             None

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -52,7 +52,7 @@ pub enum Pad {
 /// If the number is too long or (in some cases) negative, it is printed as is.
 ///
 /// The **parsing width** is the maximal width to be scanned.
-/// The parser only tries to consume from one to given number of digits (greedily). 
+/// The parser only tries to consume from one to given number of digits (greedily).
 /// It also trims the preceding whitespaces if any.
 /// It cannot parse the negative number, so some date and time cannot be formatted then
 /// parsed with the same formatting items.
@@ -494,10 +494,17 @@ pub fn format<'a, I>(w: &mut fmt::Formatter, date: Option<&NaiveDate>, time: Opt
                     RFC2822 => // same to `%a, %e %b %Y %H:%M:%S %z`
                         if let (Some(d), Some(t), Some(&(_, off))) = (date, time, off) {
                             let sec = t.second() + t.nanosecond() / 1_000_000_000;
-                            try!(write!(w, "{}, {:2} {} {:04} {:02}:{:02}:{:02} ",
+                            if d.day() < 10 {
+                                try!(write!(w, "{}, {:1} {} {:04} {:02}:{:02}:{:02} ",
                                         SHORT_WEEKDAYS[d.weekday().num_days_from_monday() as usize],
                                         d.day(), SHORT_MONTHS[d.month0() as usize], d.year(),
                                         t.hour(), t.minute(), sec));
+                            } else {
+                                try!(write!(w, "{}, {:2} {} {:04} {:02}:{:02}:{:02} ",
+                                        SHORT_WEEKDAYS[d.weekday().num_days_from_monday() as usize],
+                                        d.day(), SHORT_MONTHS[d.month0() as usize], d.year(),
+                                        t.hour(), t.minute(), sec));
+                            }
                             Some(write_local_minus_utc(w, off, false, false))
                         } else {
                             None


### PR DESCRIPTION
Test : `EDT.ymd(2015, 2, 3).and_hms_milli(23, 16, 9, 150)` generates `Tue,<space><space>3 Feb 2015 23:16:09 +0500` i.e. 2 spaces before day's value `3`.

It should be  `Tue,<space>3 Feb 2015 23:16:09 +0500`

Fixed it.