### PR TITLE
Extra serde modules

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -998,24 +998,117 @@ pub mod serde {
         }
     }
 
-    /// TODO
+    /// Ser/de to/from timestamps in milliseconds
+    ///
+    /// Intended for use with `serde`s `with` attribute.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # // We mark this ignored so that we can test on 1.13 (which does not
+    /// # // support custom derive), and run tests with --ignored on beta and
+    /// # // nightly to actually trigger these.
+    /// #
+    /// # #[macro_use] extern crate serde_derive;
+    /// # #[macro_use] extern crate serde_json;
+    /// # extern crate chrono;
+    /// # use chrono::{TimeZone, DateTime, Utc};
+    /// use chrono::serde::ts_milliseconds;
+    /// #[derive(Deserialize, Serialize)]
+    /// struct S {
+    ///     #[serde(with = "ts_milliseconds")]
+    ///     time: DateTime<Utc>
+    /// }
+    ///
+    /// # fn example() -> Result<S, serde_json::Error> {
+    /// let time = Utc.ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918);
+    /// let my_s = S {
+    ///     time: time.clone(),
+    /// };
+    ///
+    /// let as_string = serde_json::to_string(&my_s)?;
+    /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
+    /// let my_s: S = serde_json::from_str(&as_string)?;
+    /// assert_eq!(my_s.time, time);
+    /// # Ok(my_s)
+    /// # }
+    /// # fn main() { example().unwrap(); }
+    /// ```
     pub mod ts_milliseconds {
         use std::fmt;
         use serdelib::{ser, de};
 
-        use {DateTime, Utc, FixedOffset};
+        use {DateTime, Utc};
         use offset::TimeZone;
 
         use super::serde_from;
 
-        /// TODO
+        /// Serialize a UTC datetime into an integer number of milliseconds since the epoch
+        ///
+        /// Intended for use with `serde`s `serialize_with` attribute.
+        ///
+        /// # Example:
+        ///
+        /// ```rust
+        /// # // We mark this ignored so that we can test on 1.13 (which does not
+        /// # // support custom derive), and run tests with --ignored on beta and
+        /// # // nightly to actually trigger these.
+        /// #
+        /// # #[macro_use] extern crate serde_derive;
+        /// # #[macro_use] extern crate serde_json;
+        /// # extern crate chrono;
+        /// # use chrono::{TimeZone, DateTime, Utc};
+        /// use chrono::serde::ts_milliseconds::serialize as to_milli_ts;
+        /// #[derive(Serialize)]
+        /// struct S {
+        ///     #[serde(serialize_with = "to_milli_ts")]
+        ///     time: DateTime<Utc>
+        /// }
+        ///
+        /// # fn example() -> Result<String, serde_json::Error> {
+        /// let my_s = S {
+        ///     time: Utc.ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918),
+        /// };
+        /// let as_string = serde_json::to_string(&my_s)?;
+        /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
+        /// # Ok(as_string)
+        /// # }
+        /// # fn main() { example().unwrap(); }
+        /// ```
         pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
             where S: ser::Serializer
         {
             serializer.serialize_i64(dt.timestamp_millis())
         }
 
-        /// TODO
+        /// Deserialize a `DateTime` from a millisecond timestamp
+        ///
+        /// Intended for use with `serde`s `deserialize_with` attribute.
+        ///
+        /// # Example:
+        ///
+        /// ```rust
+        /// # // We mark this ignored so that we can test on 1.13 (which does not
+        /// # // support custom derive), and run tests with --ignored on beta and
+        /// # // nightly to actually trigger these.
+        /// #
+        /// # #[macro_use] extern crate serde_derive;
+        /// # #[macro_use] extern crate serde_json;
+        /// # extern crate chrono;
+        /// # use chrono::{DateTime, Utc};
+        /// use chrono::serde::ts_milliseconds::deserialize as from_milli_ts;
+        /// #[derive(Deserialize)]
+        /// struct S {
+        ///     #[serde(deserialize_with = "from_milli_ts")]
+        ///     time: DateTime<Utc>
+        /// }
+        ///
+        /// # fn example() -> Result<S, serde_json::Error> {
+        /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
+        /// # Ok(my_s)
+        /// # }
+        /// # fn main() { example().unwrap(); }
+        /// ```
         pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
             where D: de::Deserializer<'de>
         {
@@ -1092,7 +1185,7 @@ pub mod serde {
         use std::fmt;
         use serdelib::{ser, de};
 
-        use {DateTime, Utc, FixedOffset};
+        use {DateTime, Utc};
         use offset::TimeZone;
 
         use super::serde_from;

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -832,163 +832,22 @@ pub mod serde {
     use super::DateTime;
     #[cfg(feature="clock")]
     use offset::Local;
-    use offset::{TimeZone, Utc, FixedOffset};
+    use offset::{LocalResult, TimeZone, Utc, FixedOffset};
     use serdelib::{ser, de};
 
-    /// Ser/de to/from timestamps in seconds
-    ///
-    /// Intended for use with `serde`'s `with` attribute.
-    ///
-    /// # Example:
-    ///
-    /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
-    /// # use chrono::{TimeZone, DateTime, Utc};
-    /// use chrono::serde::ts_seconds;
-    /// #[derive(Deserialize, Serialize)]
-    /// struct S {
-    ///     #[serde(with = "ts_seconds")]
-    ///     time: DateTime<Utc>
-    /// }
-    ///
-    /// # fn example() -> Result<S, serde_json::Error> {
-    /// let time = Utc.ymd(2015, 5, 15).and_hms(10, 0, 0);
-    /// let my_s = S {
-    ///     time: time.clone(),
-    /// };
-    ///
-    /// let as_string = serde_json::to_string(&my_s)?;
-    /// assert_eq!(as_string, r#"{"time":1431684000}"#);
-    /// let my_s: S = serde_json::from_str(&as_string)?;
-    /// assert_eq!(my_s.time, time);
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
-    /// ```
-    pub mod ts_seconds {
-        use std::fmt;
-        use serdelib::{ser, de};
-
-        use {DateTime, Utc, FixedOffset};
-        use offset::{LocalResult, TimeZone};
-
-        /// Deserialize a `DateTime` from a seconds timestamp
-        ///
-        /// Intended for use with `serde`s `deserialize_with` attribute.
-        ///
-        /// # Example:
-        ///
-        /// ```rust
-        /// # // We mark this ignored so that we can test on 1.13 (which does not
-        /// # // support custom derive), and run tests with --ignored on beta and
-        /// # // nightly to actually trigger these.
-        /// #
-        /// # #[macro_use] extern crate serde_derive;
-        /// # #[macro_use] extern crate serde_json;
-        /// # extern crate chrono;
-        /// # use chrono::{DateTime, Utc};
-        /// use chrono::serde::ts_seconds::deserialize as from_ts;
-        /// #[derive(Deserialize)]
-        /// struct S {
-        ///     #[serde(deserialize_with = "from_ts")]
-        ///     time: DateTime<Utc>
-        /// }
-        ///
-        /// # fn example() -> Result<S, serde_json::Error> {
-        /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
-        /// # Ok(my_s)
-        /// # }
-        /// # fn main() { example().unwrap(); }
-        /// ```
-        pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
-            where D: de::Deserializer<'de>
-        {
-            Ok(try!(d.deserialize_i64(SecondsTimestampVisitor).map(|dt| dt.with_timezone(&Utc))))
-        }
-
-        /// Serialize a UTC datetime into an integer number of seconds since the epoch
-        ///
-        /// Intended for use with `serde`s `serialize_with` attribute.
-        ///
-        /// # Example:
-        ///
-        /// ```rust
-        /// # // We mark this ignored so that we can test on 1.13 (which does not
-        /// # // support custom derive), and run tests with --ignored on beta and
-        /// # // nightly to actually trigger these.
-        /// #
-        /// # #[macro_use] extern crate serde_derive;
-        /// # #[macro_use] extern crate serde_json;
-        /// # extern crate chrono;
-        /// # use chrono::{TimeZone, DateTime, Utc};
-        /// use chrono::serde::ts_seconds::serialize as to_ts;
-        /// #[derive(Serialize)]
-        /// struct S {
-        ///     #[serde(serialize_with = "to_ts")]
-        ///     time: DateTime<Utc>
-        /// }
-        ///
-        /// # fn example() -> Result<String, serde_json::Error> {
-        /// let my_s = S {
-        ///     time: Utc.ymd(2015, 5, 15).and_hms(10, 0, 0),
-        /// };
-        /// let as_string = serde_json::to_string(&my_s)?;
-        /// assert_eq!(as_string, r#"{"time":1431684000}"#);
-        /// # Ok(as_string)
-        /// # }
-        /// # fn main() { example().unwrap(); }
-        /// ```
-        pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
-            where S: ser::Serializer
-        {
-            serializer.serialize_i64(dt.timestamp())
-        }
-
-        struct SecondsTimestampVisitor;
-
-        impl<'de> de::Visitor<'de> for SecondsTimestampVisitor {
-            type Value = DateTime<FixedOffset>;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result
-            {
-                write!(formatter, "a unix timestamp in seconds")
-            }
-
-            /// Deserialize a timestamp in seconds since the epoch
-            fn visit_i64<E>(self, value: i64) -> Result<DateTime<FixedOffset>, E>
-                where E: de::Error
-            {
-                from(FixedOffset::east(0).timestamp_opt(value, 0), &value)
-            }
-
-            /// Deserialize a timestamp in seconds since the epoch
-            fn visit_u64<E>(self, value: u64) -> Result<DateTime<FixedOffset>, E>
-                where E: de::Error
-            {
-                from(FixedOffset::east(0).timestamp_opt(value as i64, 0), &value)
-            }
-        }
-
-        // try!-like function to convert a LocalResult into a serde-ish Result
-        fn from<T, E, V>(me: LocalResult<T>, ts: &V) -> Result<T, E>
-            where E: de::Error,
-                  V: fmt::Display,
-                  T: fmt::Display,
-        {
-            match me {
-                LocalResult::None => Err(E::custom(
-                    format!("value is not a legal timestamp: {}", ts))),
-                LocalResult::Ambiguous(min, max) => Err(E::custom(
-                    format!("value is an ambiguous timestamp: {}, could be either of {}, {}",
-                            ts, min, max))),
-                LocalResult::Single(val) => Ok(val)
-            }
+    // try!-like function to convert a LocalResult into a serde-ish Result
+    fn serde_from<T, E, V>(me: LocalResult<T>, ts: &V) -> Result<T, E>
+        where E: de::Error,
+                V: fmt::Display,
+                T: fmt::Display,
+    {
+        match me {
+            LocalResult::None => Err(E::custom(
+                format!("value is not a legal timestamp: {}", ts))),
+            LocalResult::Ambiguous(min, max) => Err(E::custom(
+                format!("value is an ambiguous timestamp: {}, could be either of {}, {}",
+                        ts, min, max))),
+            LocalResult::Single(val) => Ok(val)
         }
     }
 
@@ -1033,41 +892,9 @@ pub mod serde {
         use serdelib::{ser, de};
 
         use {DateTime, Utc};
-        use offset::{LocalResult, TimeZone};
+        use offset::TimeZone;
 
-        /// Deserialize a `DateTime` from a nanosecond timestamp
-        ///
-        /// Intended for use with `serde`s `deserialize_with` attribute.
-        ///
-        /// # Example:
-        ///
-        /// ```rust
-        /// # // We mark this ignored so that we can test on 1.13 (which does not
-        /// # // support custom derive), and run tests with --ignored on beta and
-        /// # // nightly to actually trigger these.
-        /// #
-        /// # #[macro_use] extern crate serde_derive;
-        /// # #[macro_use] extern crate serde_json;
-        /// # extern crate chrono;
-        /// # use chrono::{DateTime, Utc};
-        /// use chrono::serde::ts_nanoseconds::deserialize as from_nano_ts;
-        /// #[derive(Deserialize)]
-        /// struct S {
-        ///     #[serde(deserialize_with = "from_nano_ts")]
-        ///     time: DateTime<Utc>
-        /// }
-        ///
-        /// # fn example() -> Result<S, serde_json::Error> {
-        /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
-        /// # Ok(my_s)
-        /// # }
-        /// # fn main() { example().unwrap(); }
-        /// ```
-        pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
-            where D: de::Deserializer<'de>
-        {
-            Ok(try!(d.deserialize_i64(NanoSecondsTimestampVisitor)))
-        }
+        use super::serde_from;
 
         /// Serialize a UTC datetime into an integer number of nanoseconds since the epoch
         ///
@@ -1107,6 +934,40 @@ pub mod serde {
             serializer.serialize_i64(dt.timestamp_nanos())
         }
 
+        /// Deserialize a `DateTime` from a nanosecond timestamp
+        ///
+        /// Intended for use with `serde`s `deserialize_with` attribute.
+        ///
+        /// # Example:
+        ///
+        /// ```rust
+        /// # // We mark this ignored so that we can test on 1.13 (which does not
+        /// # // support custom derive), and run tests with --ignored on beta and
+        /// # // nightly to actually trigger these.
+        /// #
+        /// # #[macro_use] extern crate serde_derive;
+        /// # #[macro_use] extern crate serde_json;
+        /// # extern crate chrono;
+        /// # use chrono::{DateTime, Utc};
+        /// use chrono::serde::ts_nanoseconds::deserialize as from_nano_ts;
+        /// #[derive(Deserialize)]
+        /// struct S {
+        ///     #[serde(deserialize_with = "from_nano_ts")]
+        ///     time: DateTime<Utc>
+        /// }
+        ///
+        /// # fn example() -> Result<S, serde_json::Error> {
+        /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
+        /// # Ok(my_s)
+        /// # }
+        /// # fn main() { example().unwrap(); }
+        /// ```
+        pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
+            where D: de::Deserializer<'de>
+        {
+            Ok(try!(d.deserialize_i64(NanoSecondsTimestampVisitor)))
+        }
+
         struct NanoSecondsTimestampVisitor;
 
         impl<'de> de::Visitor<'de> for NanoSecondsTimestampVisitor {
@@ -1121,8 +982,8 @@ pub mod serde {
             fn visit_i64<E>(self, value: i64) -> Result<DateTime<Utc>, E>
                 where E: de::Error
             {
-                from(Utc.timestamp_opt(value / 1_000_000_000,
-                                       (value % 1_000_000_000) as u32),
+                serde_from(Utc.timestamp_opt(value / 1_000_000_000,
+                                            (value % 1_000_000_000) as u32),
                      &value)
             }
 
@@ -1130,25 +991,206 @@ pub mod serde {
             fn visit_u64<E>(self, value: u64) -> Result<DateTime<Utc>, E>
                 where E: de::Error
             {
-                from(Utc.timestamp_opt(value as i64 / 1_000_000_000,
-                                       (value as i64 % 1_000_000_000) as u32),
+                serde_from(Utc.timestamp_opt((value / 1_000_000_000) as i64,
+                                             (value % 1_000_000_000) as u32),
                      &value)
             }
         }
+    }
 
-        // try!-like function to convert a LocalResult into a serde-ish Result
-        fn from<T, E, V>(me: LocalResult<T>, ts: &V) -> Result<T, E>
-            where E: de::Error,
-                  V: fmt::Display,
-                  T: fmt::Display,
+    /// TODO
+    pub mod ts_milliseconds {
+        use std::fmt;
+        use serdelib::{ser, de};
+
+        use {DateTime, Utc, FixedOffset};
+        use offset::TimeZone;
+
+        use super::serde_from;
+
+        /// TODO
+        pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+            where S: ser::Serializer
         {
-            match me {
-                LocalResult::None => Err(E::custom(
-                    format!("value is not a legal timestamp: {}", ts))),
-                LocalResult::Ambiguous(min, max) => Err(E::custom(
-                    format!("value is an ambiguous timestamp: {}, could be either of {}, {}",
-                            ts, min, max))),
-                LocalResult::Single(val) => Ok(val)
+            serializer.serialize_i64(dt.timestamp_millis())
+        }
+
+        /// TODO
+        pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
+            where D: de::Deserializer<'de>
+        {
+            Ok(try!(d.deserialize_i64(MilliSecondsTimestampVisitor).map(|dt| dt.with_timezone(&Utc))))
+        }
+
+        struct MilliSecondsTimestampVisitor;
+
+        impl<'de> de::Visitor<'de> for MilliSecondsTimestampVisitor {
+            type Value = DateTime<Utc>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result
+            {
+                formatter.write_str("a unix timestamp in milliseconds")
+            }
+
+            /// Deserialize a timestamp in milliseconds since the epoch
+            fn visit_i64<E>(self, value: i64) -> Result<DateTime<Utc>, E>
+                where E: de::Error
+            {
+                serde_from(Utc.timestamp_opt(value / 1000,
+                                           ((value % 1000) * 1_000_000) as u32),
+                    &value)
+            }
+
+            /// Deserialize a timestamp in milliseconds since the epoch
+            fn visit_u64<E>(self, value: u64) -> Result<DateTime<Utc>, E>
+                where E: de::Error
+            {
+                serde_from(Utc.timestamp_opt((value / 1000) as i64,
+                                            ((value % 1000) * 1_000_000) as u32),
+                    &value)
+            }
+        }
+    }
+
+    /// Ser/de to/from timestamps in seconds
+    ///
+    /// Intended for use with `serde`'s `with` attribute.
+    ///
+    /// # Example:
+    ///
+    /// ```rust
+    /// # // We mark this ignored so that we can test on 1.13 (which does not
+    /// # // support custom derive), and run tests with --ignored on beta and
+    /// # // nightly to actually trigger these.
+    /// #
+    /// # #[macro_use] extern crate serde_derive;
+    /// # #[macro_use] extern crate serde_json;
+    /// # extern crate chrono;
+    /// # use chrono::{TimeZone, DateTime, Utc};
+    /// use chrono::serde::ts_seconds;
+    /// #[derive(Deserialize, Serialize)]
+    /// struct S {
+    ///     #[serde(with = "ts_seconds")]
+    ///     time: DateTime<Utc>
+    /// }
+    ///
+    /// # fn example() -> Result<S, serde_json::Error> {
+    /// let time = Utc.ymd(2015, 5, 15).and_hms(10, 0, 0);
+    /// let my_s = S {
+    ///     time: time.clone(),
+    /// };
+    ///
+    /// let as_string = serde_json::to_string(&my_s)?;
+    /// assert_eq!(as_string, r#"{"time":1431684000}"#);
+    /// let my_s: S = serde_json::from_str(&as_string)?;
+    /// assert_eq!(my_s.time, time);
+    /// # Ok(my_s)
+    /// # }
+    /// # fn main() { example().unwrap(); }
+    /// ```
+    pub mod ts_seconds {
+        use std::fmt;
+        use serdelib::{ser, de};
+
+        use {DateTime, Utc, FixedOffset};
+        use offset::TimeZone;
+
+        use super::serde_from;
+
+        /// Serialize a UTC datetime into an integer number of seconds since the epoch
+        ///
+        /// Intended for use with `serde`s `serialize_with` attribute.
+        ///
+        /// # Example:
+        ///
+        /// ```rust
+        /// # // We mark this ignored so that we can test on 1.13 (which does not
+        /// # // support custom derive), and run tests with --ignored on beta and
+        /// # // nightly to actually trigger these.
+        /// #
+        /// # #[macro_use] extern crate serde_derive;
+        /// # #[macro_use] extern crate serde_json;
+        /// # extern crate chrono;
+        /// # use chrono::{TimeZone, DateTime, Utc};
+        /// use chrono::serde::ts_seconds::serialize as to_ts;
+        /// #[derive(Serialize)]
+        /// struct S {
+        ///     #[serde(serialize_with = "to_ts")]
+        ///     time: DateTime<Utc>
+        /// }
+        ///
+        /// # fn example() -> Result<String, serde_json::Error> {
+        /// let my_s = S {
+        ///     time: Utc.ymd(2015, 5, 15).and_hms(10, 0, 0),
+        /// };
+        /// let as_string = serde_json::to_string(&my_s)?;
+        /// assert_eq!(as_string, r#"{"time":1431684000}"#);
+        /// # Ok(as_string)
+        /// # }
+        /// # fn main() { example().unwrap(); }
+        /// ```
+        pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+            where S: ser::Serializer
+        {
+            serializer.serialize_i64(dt.timestamp())
+        }
+
+        /// Deserialize a `DateTime` from a seconds timestamp
+        ///
+        /// Intended for use with `serde`s `deserialize_with` attribute.
+        ///
+        /// # Example:
+        ///
+        /// ```rust
+        /// # // We mark this ignored so that we can test on 1.13 (which does not
+        /// # // support custom derive), and run tests with --ignored on beta and
+        /// # // nightly to actually trigger these.
+        /// #
+        /// # #[macro_use] extern crate serde_derive;
+        /// # #[macro_use] extern crate serde_json;
+        /// # extern crate chrono;
+        /// # use chrono::{DateTime, Utc};
+        /// use chrono::serde::ts_seconds::deserialize as from_ts;
+        /// #[derive(Deserialize)]
+        /// struct S {
+        ///     #[serde(deserialize_with = "from_ts")]
+        ///     time: DateTime<Utc>
+        /// }
+        ///
+        /// # fn example() -> Result<S, serde_json::Error> {
+        /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
+        /// # Ok(my_s)
+        /// # }
+        /// # fn main() { example().unwrap(); }
+        /// ```
+        pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
+            where D: de::Deserializer<'de>
+        {
+            Ok(try!(d.deserialize_i64(SecondsTimestampVisitor)))
+        }
+
+        struct SecondsTimestampVisitor;
+
+        impl<'de> de::Visitor<'de> for SecondsTimestampVisitor {
+            type Value = DateTime<Utc>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result
+            {
+                formatter.write_str("a unix timestamp in seconds")
+            }
+
+            /// Deserialize a timestamp in seconds since the epoch
+            fn visit_i64<E>(self, value: i64) -> Result<DateTime<Utc>, E>
+                where E: de::Error
+            {
+                serde_from(Utc.timestamp_opt(value, 0), &value)
+            }
+
+            /// Deserialize a timestamp in seconds since the epoch
+            fn visit_u64<E>(self, value: u64) -> Result<DateTime<Utc>, E>
+                where E: de::Error
+            {
+                serde_from(Utc.timestamp_opt(value as i64, 0), &value)
             }
         }
     }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -978,7 +978,7 @@ pub mod serde {
                 write!(formatter, "a unix timestamp in seconds")
             }
 
-            /// Deserialize a timestamp in seconds since the epoch
+            /// Deserialize a timestamp in nanoseconds since the epoch
             fn visit_i64<E>(self, value: i64) -> Result<DateTime<Utc>, E>
                 where E: de::Error
             {
@@ -987,7 +987,7 @@ pub mod serde {
                      &value)
             }
 
-            /// Deserialize a timestamp in seconds since the epoch
+            /// Deserialize a timestamp in nanoseconds since the epoch
             fn visit_u64<E>(self, value: u64) -> Result<DateTime<Utc>, E>
                 where E: de::Error
             {

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -1692,21 +1692,117 @@ pub mod serde {
         }
     }
 
-    /// TODO
+    /// Used to serialize/deserialize from nanosecond-precision timestamps
+    ///
+    /// # Example:
+    ///
+    /// ```rust
+    /// # // We mark this ignored so that we can test on 1.13 (which does not
+    /// # // support custom derive), and run tests with --ignored on beta and
+    /// # // nightly to actually trigger these.
+    /// #
+    /// # #[macro_use] extern crate serde_derive;
+    /// # extern crate serde_json;
+    /// # extern crate serde;
+    /// # extern crate chrono;
+    /// # use chrono::{TimeZone, NaiveDate, NaiveDateTime, Utc};
+    /// use chrono::naive::serde::ts_nanoseconds;
+    /// #[derive(Deserialize, Serialize)]
+    /// struct S {
+    ///     #[serde(with = "ts_nanoseconds")]
+    ///     time: NaiveDateTime
+    /// }
+    ///
+    /// # fn example() -> Result<S, serde_json::Error> {
+    /// let time = NaiveDate::from_ymd(2018, 5, 17).and_hms_nano(02, 04, 59, 918355733);
+    /// let my_s = S {
+    ///     time: time.clone(),
+    /// };
+    ///
+    /// let as_string = serde_json::to_string(&my_s)?;
+    /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
+    /// let my_s: S = serde_json::from_str(&as_string)?;
+    /// assert_eq!(my_s.time, time);
+    /// # Ok(my_s)
+    /// # }
+    /// # fn main() { example().unwrap(); }
+    /// ```
     pub mod ts_nanoseconds {
         use std::fmt;
         use serdelib::{ser, de};
 
         use NaiveDateTime;
 
-        /// TODO
+        /// Serialize a UTC datetime into an integer number of nanoseconds since the epoch
+        ///
+        /// Intended for use with `serde`s `serialize_with` attribute.
+        ///
+        /// # Example:
+        ///
+        /// ```rust
+        /// # // We mark this ignored so that we can test on 1.13 (which does not
+        /// # // support custom derive), and run tests with --ignored on beta and
+        /// # // nightly to actually trigger these.
+        /// #
+        /// # #[macro_use] extern crate serde_derive;
+        /// # #[macro_use] extern crate serde_json;
+        /// # #[macro_use] extern crate serde;
+        /// # extern crate chrono;
+        /// # use chrono::{TimeZone, NaiveDate, NaiveDateTime, Utc};
+        /// # use serde::Serialize;
+        /// use chrono::naive::serde::ts_nanoseconds::serialize as to_nano_ts;
+        /// #[derive(Serialize)]
+        /// struct S {
+        ///     #[serde(serialize_with = "to_nano_ts")]
+        ///     time: NaiveDateTime
+        /// }
+        ///
+        /// # fn example() -> Result<String, serde_json::Error> {
+        /// let my_s = S {
+        ///     time: NaiveDate::from_ymd(2018, 5, 17).and_hms_nano(02, 04, 59, 918355733),
+        /// };
+        /// let as_string = serde_json::to_string(&my_s)?;
+        /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
+        /// # Ok(as_string)
+        /// # }
+        /// # fn main() { example().unwrap(); }
+        /// ```
         pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
             where S: ser::Serializer
         {
-            serializer.serialize_i64(dt.timestamp())
+            serializer.serialize_i64(dt.timestamp_nanos())
         }
 
-        /// TODO
+        /// Deserialize a `DateTime` from a nanoseconds timestamp
+        ///
+        /// Intended for use with `serde`s `deserialize_with` attribute.
+        ///
+        /// # Example:
+        ///
+        /// ```rust
+        /// # // We mark this ignored so that we can test on 1.13 (which does not
+        /// # // support custom derive), and run tests with --ignored on beta and
+        /// # // nightly to actually trigger these.
+        /// #
+        /// # #[macro_use] extern crate serde_derive;
+        /// # #[macro_use] extern crate serde_json;
+        /// # extern crate serde;
+        /// # extern crate chrono;
+        /// # use chrono::{NaiveDateTime, Utc};
+        /// # use serde::Deserialize;
+        /// use chrono::naive::serde::ts_nanoseconds::deserialize as from_nano_ts;
+        /// #[derive(Deserialize)]
+        /// struct S {
+        ///     #[serde(deserialize_with = "from_nano_ts")]
+        ///     time: NaiveDateTime
+        /// }
+        ///
+        /// # fn example() -> Result<S, serde_json::Error> {
+        /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
+        /// # Ok(my_s)
+        /// # }
+        /// # fn main() { example().unwrap(); }
+        /// ```
         pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
             where D: de::Deserializer<'de>
         {
@@ -1741,21 +1837,117 @@ pub mod serde {
         }
     }
 
-    /// TODO
+    /// Used to serialize/deserialize from millisecond-precision timestamps
+    ///
+    /// # Example:
+    ///
+    /// ```rust
+    /// # // We mark this ignored so that we can test on 1.13 (which does not
+    /// # // support custom derive), and run tests with --ignored on beta and
+    /// # // nightly to actually trigger these.
+    /// #
+    /// # #[macro_use] extern crate serde_derive;
+    /// # extern crate serde_json;
+    /// # extern crate serde;
+    /// # extern crate chrono;
+    /// # use chrono::{TimeZone, NaiveDate, NaiveDateTime, Utc};
+    /// use chrono::naive::serde::ts_milliseconds;
+    /// #[derive(Deserialize, Serialize)]
+    /// struct S {
+    ///     #[serde(with = "ts_milliseconds")]
+    ///     time: NaiveDateTime
+    /// }
+    ///
+    /// # fn example() -> Result<S, serde_json::Error> {
+    /// let time = NaiveDate::from_ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918);
+    /// let my_s = S {
+    ///     time: time.clone(),
+    /// };
+    ///
+    /// let as_string = serde_json::to_string(&my_s)?;
+    /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
+    /// let my_s: S = serde_json::from_str(&as_string)?;
+    /// assert_eq!(my_s.time, time);
+    /// # Ok(my_s)
+    /// # }
+    /// # fn main() { example().unwrap(); }
+    /// ```
     pub mod ts_milliseconds {
         use std::fmt;
         use serdelib::{ser, de};
 
         use NaiveDateTime;
 
-        /// TODO
+        /// Serialize a UTC datetime into an integer number of milliseconds since the epoch
+        ///
+        /// Intended for use with `serde`s `serialize_with` attribute.
+        ///
+        /// # Example:
+        ///
+        /// ```rust
+        /// # // We mark this ignored so that we can test on 1.13 (which does not
+        /// # // support custom derive), and run tests with --ignored on beta and
+        /// # // nightly to actually trigger these.
+        /// #
+        /// # #[macro_use] extern crate serde_derive;
+        /// # #[macro_use] extern crate serde_json;
+        /// # #[macro_use] extern crate serde;
+        /// # extern crate chrono;
+        /// # use chrono::{TimeZone, NaiveDate, NaiveDateTime, Utc};
+        /// # use serde::Serialize;
+        /// use chrono::naive::serde::ts_milliseconds::serialize as to_milli_ts;
+        /// #[derive(Serialize)]
+        /// struct S {
+        ///     #[serde(serialize_with = "to_milli_ts")]
+        ///     time: NaiveDateTime
+        /// }
+        ///
+        /// # fn example() -> Result<String, serde_json::Error> {
+        /// let my_s = S {
+        ///     time: NaiveDate::from_ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918),
+        /// };
+        /// let as_string = serde_json::to_string(&my_s)?;
+        /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
+        /// # Ok(as_string)
+        /// # }
+        /// # fn main() { example().unwrap(); }
+        /// ```
         pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
             where S: ser::Serializer
         {
-            serializer.serialize_i64(dt.timestamp())
+            serializer.serialize_i64(dt.timestamp_millis())
         }
 
-        /// TODO
+        /// Deserialize a `DateTime` from a milliseconds timestamp
+        ///
+        /// Intended for use with `serde`s `deserialize_with` attribute.
+        ///
+        /// # Example:
+        ///
+        /// ```rust
+        /// # // We mark this ignored so that we can test on 1.13 (which does not
+        /// # // support custom derive), and run tests with --ignored on beta and
+        /// # // nightly to actually trigger these.
+        /// #
+        /// # #[macro_use] extern crate serde_derive;
+        /// # #[macro_use] extern crate serde_json;
+        /// # extern crate serde;
+        /// # extern crate chrono;
+        /// # use chrono::{NaiveDateTime, Utc};
+        /// # use serde::Deserialize;
+        /// use chrono::naive::serde::ts_milliseconds::deserialize as from_milli_ts;
+        /// #[derive(Deserialize)]
+        /// struct S {
+        ///     #[serde(deserialize_with = "from_milli_ts")]
+        ///     time: NaiveDateTime
+        /// }
+        ///
+        /// # fn example() -> Result<S, serde_json::Error> {
+        /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
+        /// # Ok(my_s)
+        /// # }
+        /// # fn main() { example().unwrap(); }
+        /// ```
         pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
             where D: de::Deserializer<'de>
         {
@@ -1775,16 +1967,16 @@ pub mod serde {
             fn visit_i64<E>(self, value: i64) -> Result<NaiveDateTime, E>
                 where E: de::Error
             {
-                NaiveDateTime::from_timestamp_opt(value / 1_000_000_000,
-                                                 (value % 1_000_000_000) as u32)
+                NaiveDateTime::from_timestamp_opt(value / 1000,
+                                                ((value % 1000) * 1_000_000) as u32)
                     .ok_or_else(|| E::custom(format!("value is not a legal timestamp: {}", value)))
             }
 
             fn visit_u64<E>(self, value: u64) -> Result<NaiveDateTime, E>
                 where E: de::Error
             {
-                NaiveDateTime::from_timestamp_opt(value as i64 / 1_000_000_000,
-                                                 (value as i64 % 1_000_000_000) as u32)
+                NaiveDateTime::from_timestamp_opt((value / 1000) as i64,
+                                                 ((value % 1000) * 1_000_000) as u32)
                     .ok_or_else(|| E::custom(format!("value is not a legal timestamp: {}", value)))
             }
         }

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -1692,6 +1692,104 @@ pub mod serde {
         }
     }
 
+    /// TODO
+    pub mod ts_nanoseconds {
+        use std::fmt;
+        use serdelib::{ser, de};
+
+        use NaiveDateTime;
+
+        /// TODO
+        pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
+            where S: ser::Serializer
+        {
+            serializer.serialize_i64(dt.timestamp())
+        }
+
+        /// TODO
+        pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
+            where D: de::Deserializer<'de>
+        {
+            Ok(try!(d.deserialize_i64(NaiveDateTimeFromNanoSecondsVisitor)))
+        }
+
+        struct NaiveDateTimeFromNanoSecondsVisitor;
+
+        impl<'de> de::Visitor<'de> for NaiveDateTimeFromNanoSecondsVisitor {
+            type Value = NaiveDateTime;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result
+            {
+                formatter.write_str("a unix timestamp")
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<NaiveDateTime, E>
+                where E: de::Error
+            {
+                NaiveDateTime::from_timestamp_opt(value / 1_000_000_000,
+                                                 (value % 1_000_000_000) as u32)
+                    .ok_or_else(|| E::custom(format!("value is not a legal timestamp: {}", value)))
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<NaiveDateTime, E>
+                where E: de::Error
+            {
+                NaiveDateTime::from_timestamp_opt(value as i64 / 1_000_000_000,
+                                                 (value as i64 % 1_000_000_000) as u32)
+                    .ok_or_else(|| E::custom(format!("value is not a legal timestamp: {}", value)))
+            }
+        }
+    }
+
+    /// TODO
+    pub mod ts_milliseconds {
+        use std::fmt;
+        use serdelib::{ser, de};
+
+        use NaiveDateTime;
+
+        /// TODO
+        pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
+            where S: ser::Serializer
+        {
+            serializer.serialize_i64(dt.timestamp())
+        }
+
+        /// TODO
+        pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
+            where D: de::Deserializer<'de>
+        {
+            Ok(try!(d.deserialize_i64(NaiveDateTimeFromMilliSecondsVisitor)))
+        }
+
+        struct NaiveDateTimeFromMilliSecondsVisitor;
+
+        impl<'de> de::Visitor<'de> for NaiveDateTimeFromMilliSecondsVisitor {
+            type Value = NaiveDateTime;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result
+            {
+                formatter.write_str("a unix timestamp")
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<NaiveDateTime, E>
+                where E: de::Error
+            {
+                NaiveDateTime::from_timestamp_opt(value / 1_000_000_000,
+                                                 (value % 1_000_000_000) as u32)
+                    .ok_or_else(|| E::custom(format!("value is not a legal timestamp: {}", value)))
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<NaiveDateTime, E>
+                where E: de::Error
+            {
+                NaiveDateTime::from_timestamp_opt(value as i64 / 1_000_000_000,
+                                                 (value as i64 % 1_000_000_000) as u32)
+                    .ok_or_else(|| E::custom(format!("value is not a legal timestamp: {}", value)))
+            }
+        }
+    }
+
     /// Used to serialize/deserialize from second-precision timestamps
     ///
     /// # Example:
@@ -1733,42 +1831,6 @@ pub mod serde {
 
         use NaiveDateTime;
 
-        /// Deserialize a `DateTime` from a seconds timestamp
-        ///
-        /// Intended for use with `serde`s `deserialize_with` attribute.
-        ///
-        /// # Example:
-        ///
-        /// ```rust
-        /// # // We mark this ignored so that we can test on 1.13 (which does not
-        /// # // support custom derive), and run tests with --ignored on beta and
-        /// # // nightly to actually trigger these.
-        /// #
-        /// # #[macro_use] extern crate serde_derive;
-        /// # #[macro_use] extern crate serde_json;
-        /// # extern crate serde;
-        /// # extern crate chrono;
-        /// # use chrono::{NaiveDateTime, Utc};
-        /// # use serde::Deserialize;
-        /// use chrono::naive::serde::ts_seconds::deserialize as from_ts;
-        /// #[derive(Deserialize)]
-        /// struct S {
-        ///     #[serde(deserialize_with = "from_ts")]
-        ///     time: NaiveDateTime
-        /// }
-        ///
-        /// # fn example() -> Result<S, serde_json::Error> {
-        /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
-        /// # Ok(my_s)
-        /// # }
-        /// # fn main() { example().unwrap(); }
-        /// ```
-        pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
-            where D: de::Deserializer<'de>
-        {
-            Ok(try!(d.deserialize_i64(NaiveDateTimeFromSecondsVisitor)))
-        }
-
         /// Serialize a UTC datetime into an integer number of seconds since the epoch
         ///
         /// Intended for use with `serde`s `serialize_with` attribute.
@@ -1809,6 +1871,42 @@ pub mod serde {
             serializer.serialize_i64(dt.timestamp())
         }
 
+        /// Deserialize a `DateTime` from a seconds timestamp
+        ///
+        /// Intended for use with `serde`s `deserialize_with` attribute.
+        ///
+        /// # Example:
+        ///
+        /// ```rust
+        /// # // We mark this ignored so that we can test on 1.13 (which does not
+        /// # // support custom derive), and run tests with --ignored on beta and
+        /// # // nightly to actually trigger these.
+        /// #
+        /// # #[macro_use] extern crate serde_derive;
+        /// # #[macro_use] extern crate serde_json;
+        /// # extern crate serde;
+        /// # extern crate chrono;
+        /// # use chrono::{NaiveDateTime, Utc};
+        /// # use serde::Deserialize;
+        /// use chrono::naive::serde::ts_seconds::deserialize as from_ts;
+        /// #[derive(Deserialize)]
+        /// struct S {
+        ///     #[serde(deserialize_with = "from_ts")]
+        ///     time: NaiveDateTime
+        /// }
+        ///
+        /// # fn example() -> Result<S, serde_json::Error> {
+        /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
+        /// # Ok(my_s)
+        /// # }
+        /// # fn main() { example().unwrap(); }
+        /// ```
+        pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
+            where D: de::Deserializer<'de>
+        {
+            Ok(try!(d.deserialize_i64(NaiveDateTimeFromSecondsVisitor)))
+        }
+
         struct NaiveDateTimeFromSecondsVisitor;
 
         impl<'de> de::Visitor<'de> for NaiveDateTimeFromSecondsVisitor {
@@ -1816,7 +1914,7 @@ pub mod serde {
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result
             {
-                write!(formatter, "a unix timestamp")
+                formatter.write_str("a unix timestamp")
             }
 
             fn visit_i64<E>(self, value: i64) -> Result<NaiveDateTime, E>
@@ -1833,7 +1931,6 @@ pub mod serde {
                     .ok_or_else(|| E::custom(format!("value is not a legal timestamp: {}", value)))
             }
         }
-
     }
 
     #[cfg(test)] extern crate serde_json;


### PR DESCRIPTION
Sorry this took so long; it kind of got pushed to the side for a while.

This fleshes out the `serde` modules for seconds, milliseconds and nanoseconds for both UTC `DataTime`s and `NaiveDateTime`s.

It also simplifies a few things that were shared across the modules.