### PR TITLE
Add std::convert::From conversion between different DateTime offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ This documents all notable changes to [Chrono](https://github.com/chronotope/chr
 Chrono obeys the principle of [Semantic Versioning](http://semver.org/).
 
 There were/are numerous minor versions before 1.0 due to the language changes.
-Versions with only mechnical changes will be omitted from the following list.
+Versions with only mechanical changes will be omitted from the following list.
+
+## 0.4.6
+
+## Features
+
+* Add `std::convert::From` conversions between the different timezone formats (@mqudsi #271)
 
 ## 0.4.5
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -247,6 +247,7 @@ impl From<DateTime<Utc>> for DateTime<FixedOffset> {
 }
 
 /// Convert a `DateTime<Utc>` instance into a `DateTime<Local>` instance.
+#[cfg(feature="clock")]
 impl From<DateTime<Utc>> for DateTime<Local> {
     /// Convert this `DateTime<Utc>` instance into a `DateTime<Local>` instance.
     ///
@@ -268,6 +269,7 @@ impl From<DateTime<FixedOffset>> for DateTime<Utc> {
 }
 
 /// Convert a `DateTime<FixedOffset>` instance into a `DateTime<Local>` instance.
+#[cfg(feature="clock")]
 impl From<DateTime<FixedOffset>> for DateTime<Local> {
     /// Convert this `DateTime<FixedOffset>` instance into a `DateTime<Local>` instance.
     ///
@@ -279,6 +281,7 @@ impl From<DateTime<FixedOffset>> for DateTime<Local> {
 }
 
 /// Convert a `DateTime<Local>` instance into a `DateTime<Utc>` instance.
+#[cfg(feature="clock")]
 impl From<DateTime<Local>> for DateTime<Utc> {
     /// Convert this `DateTime<Local>` instance into a `DateTime<Utc>` instance.
     ///
@@ -290,6 +293,7 @@ impl From<DateTime<Local>> for DateTime<Utc> {
 }
 
 /// Convert a `DateTime<Local>` instance into a `DateTime<FixedOffset>` instance.
+#[cfg(feature="clock")]
 impl From<DateTime<Local>> for DateTime<FixedOffset> {
     /// Convert this `DateTime<Local>` instance into a `DateTime<FixedOffset>` instance.
     ///

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -681,6 +681,14 @@ impl<Tz: TimeZone> From<DateTime<Tz>> for SystemTime {
     }
 }
 
+#[test]
+fn test_auto_conversion() {
+    let utc_dt = Utc.ymd(2018, 9, 5).and_hms(23, 58, 0);
+    let cdt_dt = FixedOffset::west(5 * 60 * 60).ymd(2018, 9, 5).and_hms(18, 58, 0);
+    let utc_dt2: DateTime<Utc> = cdt_dt.into();
+    assert_eq!(utc_dt, utc_dt2);
+}
+
 #[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
 fn test_encodable_json<FUtc, FFixed, E>(to_string_utc: FUtc, to_string_fixed: FFixed)
     where FUtc: Fn(&DateTime<Utc>) -> Result<String, E>,

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -235,6 +235,43 @@ impl<Tz: TimeZone> DateTime<Tz> {
     }
 }
 
+impl From<DateTime<Utc>> for DateTime<FixedOffset> {
+    fn from(src: DateTime<Utc>) -> Self {
+        src.with_timezone(&FixedOffset::east(0))
+    }
+}
+
+impl From<DateTime<Utc>> for DateTime<Local> {
+    fn from(src: DateTime<Utc>) -> Self {
+        src.with_timezone(&Local)
+    }
+}
+
+impl From<DateTime<FixedOffset>> for DateTime<Utc> {
+    fn from(src: DateTime<FixedOffset>) -> Self {
+        src.with_timezone(&Utc)
+    }
+}
+
+impl From<DateTime<FixedOffset>> for DateTime<Local> {
+    fn from(src: DateTime<FixedOffset>) -> Self {
+        src.with_timezone(&Local)
+    }
+}
+
+impl From<DateTime<Local>> for DateTime<Utc> {
+    fn from(src: DateTime<Local>) -> Self {
+        src.with_timezone(&Utc)
+    }
+}
+
+impl From<DateTime<Local>> for DateTime<FixedOffset> {
+    fn from(src: DateTime<Local>) -> Self {
+        // todo: return in actual current local offset Tz
+        src.with_timezone(&FixedOffset::east(0))
+    }
+}
+
 /// Maps the local datetime to other datetime with given conversion function.
 fn map_local<Tz: TimeZone, F>(dt: &DateTime<Tz>, mut f: F) -> Option<DateTime<Tz>>
         where F: FnMut(NaiveDateTime) -> Option<NaiveDateTime> {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -235,39 +235,67 @@ impl<Tz: TimeZone> DateTime<Tz> {
     }
 }
 
+/// Convert a `DateTime<Utc>` instance into a `DateTime<FixedOffset>` instance.
 impl From<DateTime<Utc>> for DateTime<FixedOffset> {
+    /// Convert this `DateTime<Utc>` instance into a `DateTime<FixedOffset>` instance.
+    ///
+    /// Conversion is done via [`DateTime::with_timezone`]. Note that the converted value returned by
+    /// this will be created with a fixed timezone offset of 0.
     fn from(src: DateTime<Utc>) -> Self {
         src.with_timezone(&FixedOffset::east(0))
     }
 }
 
+/// Convert a `DateTime<Utc>` instance into a `DateTime<Local>` instance.
 impl From<DateTime<Utc>> for DateTime<Local> {
+    /// Convert this `DateTime<Utc>` instance into a `DateTime<Local>` instance.
+    ///
+    /// Conversion is performed via [`DateTime::with_timezone`], accounting for the difference in timezones.
     fn from(src: DateTime<Utc>) -> Self {
         src.with_timezone(&Local)
     }
 }
 
+/// Convert a `DateTime<FixedOffset>` instance into a `DateTime<Utc>` instance.
 impl From<DateTime<FixedOffset>> for DateTime<Utc> {
+    /// Convert this `DateTime<FixedOffset>` instance into a `DateTime<Utc>` instance.
+    ///
+    /// Conversion is performed via [`DateTime::with_timezone`], accounting for the timezone
+    /// difference.
     fn from(src: DateTime<FixedOffset>) -> Self {
         src.with_timezone(&Utc)
     }
 }
 
+/// Convert a `DateTime<FixedOffset>` instance into a `DateTime<Local>` instance.
 impl From<DateTime<FixedOffset>> for DateTime<Local> {
+    /// Convert this `DateTime<FixedOffset>` instance into a `DateTime<Local>` instance.
+    ///
+    /// Conversion is performed via [`DateTime::with_timezone`]. Returns the equivalent value in local
+    /// time.
     fn from(src: DateTime<FixedOffset>) -> Self {
         src.with_timezone(&Local)
     }
 }
 
+/// Convert a `DateTime<Local>` instance into a `DateTime<Utc>` instance.
 impl From<DateTime<Local>> for DateTime<Utc> {
+    /// Convert this `DateTime<Local>` instance into a `DateTime<Utc>` instance.
+    ///
+    /// Conversion is performed via [`DateTime::with_timezone`], accounting for the difference in
+    /// timezones.
     fn from(src: DateTime<Local>) -> Self {
         src.with_timezone(&Utc)
     }
 }
 
+/// Convert a `DateTime<Local>` instance into a `DateTime<FixedOffset>` instance.
 impl From<DateTime<Local>> for DateTime<FixedOffset> {
+    /// Convert this `DateTime<Local>` instance into a `DateTime<FixedOffset>` instance.
+    ///
+    /// Conversion is performed via [`DateTime::with_timezone`]. Note that the converted value returned
+    /// by this will be created with a fixed timezone offset of 0.
     fn from(src: DateTime<Local>) -> Self {
-        // todo: return in actual current local offset Tz
         src.with_timezone(&FixedOffset::east(0))
     }
 }


### PR DESCRIPTION
Adds conversion to/from Utc, Local, and FixedOffset. Originally planned
to go through NaiveDateTime, but it seems that is not necessary?

Ref #263