### PR TITLE
bump time to use winapi 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ clock = ["time"]
 time = { version = "0.1.39", optional = true }
 num-integer = { version = "0.1.36", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-rustc-serialize = { version = "0.3", optional = true }
+rustc-serialize = { version = "0.3.20", optional = true }
 serde = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ default = ["clock"]
 clock = ["time"]
 
 [dependencies]
-time = { version = "^0.1.36", optional = true }
+time = { version = "0.1.39", optional = true }
 num-integer = { version = "0.1.36", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3", optional = true }


### PR DESCRIPTION
This bumps the minimal acceptable versions in Cargo.toml to versions that build on modern rust. this gets `chrono` working with Cargos `-Z minimal-versions`. This is part of the process of seeing how hard this is for crates to use in preparation for getting it stabilized for use in CI, specifically upstreaming the changes required to get [criterion](https://github.com/japaric/criterion.rs/issues/183) working with it. It is easy to use if all of your dependencies support it, but much harder if trying to impose it on them.