### PR TITLE
Make README.md match lib.rs mod documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   global:
     - LD_LIBRARY_PATH: /usr/local/lib
     - CLIPPY: n
-script: ./.travis.sh
+script: ./ci/travis.sh
 notifications:
   email: false
   irc:

--- a/Makefile
+++ b/Makefile
@@ -12,36 +12,11 @@ authors:
 	echo >> AUTHORS.txt
 	git log --format='%aN <%aE>' | grep -v 'Kang Seonghoon' | sort -u >> AUTHORS.txt
 
-.PHONY: readme
+.PHONY: readme README.md
 readme: README.md
 
 README.md: src/lib.rs
-	# really, really sorry for this mess.
-	( \
-		VERSION="$$(cargo pkgid | cut -d: -f3)"; \
-		awk '/^\/\/! # Chrono /{print "[Chrono][docsrs]",$$4}' $<; \
-		awk '/^\/\/! # Chrono /{print "[Chrono][docsrs]",$$4}' $< | sed 's/./=/g'; \
-		echo; \
-		echo '[![Chrono on Travis CI][travis-image]][travis]'; \
-		echo '[![Chrono on Appveyor][appveyor-image]][appveyor]'; \
-		echo '[![Chrono on crates.io][cratesio-image]][cratesio]'; \
-		echo '[![Chrono on docs.rs][docsrs-image]][docsrs]'; \
-		echo; \
-		echo '[travis-image]: https://travis-ci.org/chronotope/chrono.svg?branch=master'; \
-		echo '[travis]: https://travis-ci.org/chronotope/chrono'; \
-		echo '[appveyor-image]: https://ci.appveyor.com/api/projects/status/2ia91ofww4w31m2w/branch/master?svg=true'; \
-		echo '[appveyor]: https://ci.appveyor.com/project/chronotope/chrono'; \
-		echo '[cratesio-image]: https://img.shields.io/crates/v/chrono.svg'; \
-		echo '[cratesio]: https://crates.io/crates/chrono'; \
-		echo '[docsrs-image]: https://docs.rs/chrono/badge.svg?version='$$VERSION; \
-		echo '[docsrs]: https://docs.rs/chrono/'$$VERSION'/'; \
-		echo; \
-		awk '/^\/\/! # Chrono /,/^\/\/! ## /' $< | cut -b 5- | grep -v '^#' | \
-			sed 's/](\.\//](https:\/\/docs.rs\/chrono\/'$$VERSION'\/chrono\//g'; \
-		echo; \
-		awk '/^\/\/! ## /,!/^\/\/!/' $< | cut -b 5- | grep -v '^# ' | \
-			sed 's/](\.\//](https:\/\/docs.rs\/chrono\/'$$VERSION'\/chrono\//g' \
-	) > $@
+	( ./ci/fix-readme.sh $< ) > $@
 
 .PHONY: test
 test:

--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@
 [docsrs-image]: https://docs.rs/chrono/badge.svg
 [docsrs]: https://docs.rs/chrono
 [gitter-image]: https://badges.gitter.im/chrono-rs/chrono.svg
-[gitter]: https://gitter.im/chrono-rs/chrono?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+[gitter]: https://gitter.im/chrono-rs/chrono
 
-Date and time handling for Rust.
 It aims to be a feature-complete superset of
 the [time](https://github.com/rust-lang-deprecated/time) library.
 In particular,
@@ -48,8 +47,8 @@ Put this in your `Cargo.toml`:
 chrono = "0.4"
 ```
 
-Or, if you want [Serde](https://github.com/serde-rs/serde) include the feature
-like this:
+Or, if you want [Serde](https://github.com/serde-rs/serde) include the
+feature like this:
 
 ```toml
 [dependencies]
@@ -83,7 +82,7 @@ nanoseconds and does not represent "nominal" components such as days or
 months.
 
 Chrono does not yet natively support
-the standard [`Duration`](https://doc.rust-lang.org/std/time/struct.Duration.html) type,
+the standard [`Duration`](https://docs.rs/time/0.1.40/time/struct.Duration.html) type,
 but it will be supported in the future.
 Meanwhile you can convert between two types with
 [`Duration::from_std`](https://docs.rs/time/0.1.40/time/struct.Duration.html#method.from_std)
@@ -94,7 +93,7 @@ methods.
 ### Date and Time
 
 Chrono provides a
-[**`DateTime`**](https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html)
+[**`DateTime`**](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html)
 type to represent a date and a time in a timezone.
 
 For more abstract moment-in-time tracking such as internal timekeeping
@@ -105,15 +104,15 @@ which tracks your system clock, or
 is an opaque but monotonically-increasing representation of a moment in time.
 
 `DateTime` is timezone-aware and must be constructed from
-the [**`TimeZone`**](https://docs.rs/chrono/0.4.0/chrono/offset/trait.TimeZone.html) object,
+the [**`TimeZone`**](https://docs.rs/chrono/0.4.5/chrono/offset/trait.TimeZone.html) object,
 which defines how the local date is converted to and back from the UTC date.
 There are three well-known `TimeZone` implementations:
 
-* [**`Utc`**](https://docs.rs/chrono/0.4.0/chrono/offset/struct.Utc.html) specifies the UTC time zone. It is most efficient.
+* [**`Utc`**](https://docs.rs/chrono/0.4.5/chrono/offset/struct.Utc.html) specifies the UTC time zone. It is most efficient.
 
-* [**`Local`**](https://docs.rs/chrono/0.4.0/chrono/offset/struct.Local.html) specifies the system local time zone.
+* [**`Local`**](https://docs.rs/chrono/0.4.5/chrono/offset/struct.Local.html) specifies the system local time zone.
 
-* [**`FixedOffset`**](https://docs.rs/chrono/0.4.0/chrono/offset/struct.FixedOffset.html) specifies
+* [**`FixedOffset`**](https://docs.rs/chrono/0.4.5/chrono/offset/struct.FixedOffset.html) specifies
   an arbitrary, fixed time zone such as UTC+09:00 or UTC-10:30.
   This often results from the parsed textual date and time.
   Since it stores the most information and does not depend on the system environment,
@@ -121,12 +120,12 @@ There are three well-known `TimeZone` implementations:
 
 `DateTime`s with different `TimeZone` types are distinct and do not mix,
 but can be converted to each other using
-the [`DateTime::with_timezone`](https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html#method.with_timezone) method.
+the [`DateTime::with_timezone`](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html#method.with_timezone) method.
 
 You can get the current date and time in the UTC time zone
-([`Utc::now()`](https://docs.rs/chrono/0.4.0/chrono/offset/struct.Utc.html#method.now))
+([`Utc::now()`](https://docs.rs/chrono/0.4.5/chrono/offset/struct.Utc.html#method.now))
 or in the local time zone
-([`Local::now()`](https://docs.rs/chrono/0.4.0/chrono/offset/struct.Local.html#method.now)).
+([`Local::now()`](https://docs.rs/chrono/0.4.5/chrono/offset/struct.Local.html#method.now)).
 
 ```rust
 use chrono::prelude::*;
@@ -167,8 +166,8 @@ assert_eq!(dt, fixed_dt);
 ```
 
 Various properties are available to the date and time, and can be altered individually.
-Most of them are defined in the traits [`Datelike`](https://docs.rs/chrono/0.4.0/chrono/trait.Datelike.html) and
-[`Timelike`](https://docs.rs/chrono/0.4.0/chrono/trait.Timelike.html) which you should `use` before.
+Most of them are defined in the traits [`Datelike`](https://docs.rs/chrono/0.4.5/chrono/trait.Datelike.html) and
+[`Timelike`](https://docs.rs/chrono/0.4.5/chrono/trait.Timelike.html) which you should `use` before.
 Addition and subtraction is also supported.
 The following illustrates most supported operations to the date and time:
 
@@ -209,14 +208,17 @@ assert_eq!(Utc.ymd(1970, 1, 1).and_hms(0, 0, 0) - Duration::seconds(1_000_000_00
            Utc.ymd(1938, 4, 24).and_hms(22, 13, 20));
 ```
 
-Formatting is done via the [`format`](https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html#method.format) method,
+### Formatting and Parsing
+
+Formatting is done via the [`format`](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html#method.format) method,
 which format is equivalent to the familiar `strftime` format.
-(See the [`format::strftime` module documentation](https://docs.rs/chrono/0.4.0/chrono/format/strftime/index.html#specifiers)
-for full syntax.)
+
+See [`format::strftime`](https://docs.rs/chrono/0.4.5/chrono/format/strftime/index.html#specifiers)
+documentation for full syntax and list of specifiers.
 
 The default `to_string` method and `{:?}` specifier also give a reasonable representation.
-Chrono also provides [`to_rfc2822`](https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html#method.to_rfc2822) and
-[`to_rfc3339`](https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html#method.to_rfc3339) methods
+Chrono also provides [`to_rfc2822`](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html#method.to_rfc2822) and
+[`to_rfc3339`](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html#method.to_rfc3339) methods
 for well-known formats.
 
 ```rust
@@ -232,9 +234,9 @@ assert_eq!(dt.to_rfc2822(), "Fri, 28 Nov 2014 12:00:09 +0000");
 assert_eq!(dt.to_rfc3339(), "2014-11-28T12:00:09+00:00");
 assert_eq!(format!("{:?}", dt), "2014-11-28T12:00:09Z");
 
-let now = Utc::now();
-// Will display today's date with nanoseconds
-println!("{:?}", now); // 2018-1-24T12:00:00.000000000Z
+// Note that milli/nanoseconds are only printed if they are non-zero
+let dt_nano = Utc.ymd(2014, 11, 28).and_hms_nano(12, 0, 9, 1);
+assert_eq!(format!("{:?}", dt_nano), "2014-11-28T12:00:09.000000001Z");
 ```
 
 Parsing can be done with three methods:
@@ -246,23 +248,23 @@ Parsing can be done with three methods:
    ([`std::fmt::Debug`](https://doc.rust-lang.org/std/fmt/trait.Debug.html))
    format specifier prints, and requires the offset to be present.
 
-2. [`DateTime::parse_from_str`](https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html#method.parse_from_str) parses
+2. [`DateTime::parse_from_str`](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html#method.parse_from_str) parses
    a date and time with offsets and returns `DateTime<FixedOffset>`.
    This should be used when the offset is a part of input and the caller cannot guess that.
    It *cannot* be used when the offset can be missing.
-   [`DateTime::parse_from_rfc2822`](https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html#method.parse_from_rfc2822)
+   [`DateTime::parse_from_rfc2822`](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html#method.parse_from_rfc2822)
    and
-   [`DateTime::parse_from_rfc3339`](https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html#method.parse_from_rfc3339)
+   [`DateTime::parse_from_rfc3339`](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html#method.parse_from_rfc3339)
    are similar but for well-known formats.
 
-3. [`Offset::datetime_from_str`](https://docs.rs/chrono/0.4.0/chrono/offset/trait.TimeZone.html#method.datetime_from_str) is
+3. [`Offset::datetime_from_str`](https://docs.rs/chrono/0.4.5/chrono/offset/trait.TimeZone.html#method.datetime_from_str) is
    similar but returns `DateTime` of given offset.
    When the explicit offset is missing from the input, it simply uses given offset.
    It issues an error when the input contains an explicit offset different
    from the current offset.
 
 More detailed control over the parsing process is available via
-[`format`](https://docs.rs/chrono/0.4.0/chrono/format/index.html) module.
+[`format`](https://docs.rs/chrono/0.4.5/chrono/format/index.html) module.
 
 ```rust
 use chrono::prelude::*;
@@ -294,9 +296,36 @@ assert!(Utc.datetime_from_str("Fri Nov 28 12:00:09", "%a %b %e %T").is_err());
 assert!(Utc.datetime_from_str("Sat Nov 28 12:00:09 2014", "%a %b %e %T %Y").is_err());
 ```
 
+Again : See [`format::strftime`](https://docs.rs/chrono/0.4.5/chrono/format/strftime/index.html#specifiers)
+documentation for full syntax and list of specifiers.
+
+### Conversion from and to EPOCH timestamps
+
+Use [`Utc.timestamp(seconds, nanoseconds)`](https://docs.rs/chrono/0.4.5/chrono/offset/trait.TimeZone.html#method.timestamp)
+to construct a [`DateTime<Utc>`](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html) from a UNIX timestamp
+(seconds, nanoseconds that passed since January 1st 1970).
+
+Use [`DateTime.timestamp`](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html#method.timestamp) to get the timestamp (in seconds)
+from a [`DateTime`](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html). Additionally, you can use
+[`DateTime.timestamp_subsec_nanos`](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html#method.timestamp_subsec_nanos)
+to get the number of additional number of nanoseconds.
+
+```rust
+// We need the trait in scope to use Utc::timestamp().
+use chrono::TimeZone;
+
+// Construct a datetime from epoch:
+let dt = Utc.timestamp(1_500_000_000, 0);
+assert_eq!(dt.to_rfc2822(), "Fri, 14 Jul 2017 02:40:00 +0000");
+
+// Get epoch value from a datetime:
+let dt = DateTime::parse_from_rfc2822("Fri, 14 Jul 2017 02:40:00 +0000").unwrap();
+assert_eq!(dt.timestamp(), 1_500_000_000);
+```
+
 ### Individual date
 
-Chrono also provides an individual date type ([**`Date`**](https://docs.rs/chrono/0.4.0/chrono/struct.Date.html)).
+Chrono also provides an individual date type ([**`Date`**](https://docs.rs/chrono/0.4.5/chrono/struct.Date.html)).
 It also has time zones attached, and have to be constructed via time zones.
 Most operations available to `DateTime` are also available to `Date` whenever appropriate.
 
@@ -315,26 +344,26 @@ assert_eq!(Utc.ymd(2014, 11, 28).and_hms_milli(7, 8, 9, 10).format("%H%M%S").to_
 
 There is no timezone-aware `Time` due to the lack of usefulness and also the complexity.
 
-`DateTime` has [`date`](https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html#method.date) method
+`DateTime` has [`date`](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html#method.date) method
 which returns a `Date` which represents its date component.
-There is also a [`time`](https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html#method.time) method,
+There is also a [`time`](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html#method.time) method,
 which simply returns a naive local time described below.
 
 ### Naive date and time
 
 Chrono provides naive counterparts to `Date`, (non-existent) `Time` and `DateTime`
-as [**`NaiveDate`**](https://docs.rs/chrono/0.4.0/chrono/naive/struct.NaiveDate.html),
-[**`NaiveTime`**](https://docs.rs/chrono/0.4.0/chrono/naive/struct.NaiveTime.html) and
-[**`NaiveDateTime`**](https://docs.rs/chrono/0.4.0/chrono/naive/struct.NaiveDateTime.html) respectively.
+as [**`NaiveDate`**](https://docs.rs/chrono/0.4.5/chrono/naive/struct.NaiveDate.html),
+[**`NaiveTime`**](https://docs.rs/chrono/0.4.5/chrono/naive/struct.NaiveTime.html) and
+[**`NaiveDateTime`**](https://docs.rs/chrono/0.4.5/chrono/naive/struct.NaiveDateTime.html) respectively.
 
 They have almost equivalent interfaces as their timezone-aware twins,
 but are not associated to time zones obviously and can be quite low-level.
 They are mostly useful for building blocks for higher-level types.
 
 Timezone-aware `DateTime` and `Date` types have two methods returning naive versions:
-[`naive_local`](https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html#method.naive_local) returns
+[`naive_local`](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html#method.naive_local) returns
 a view to the naive local time,
-and [`naive_utc`](https://docs.rs/chrono/0.4.0/chrono/struct.DateTime.html#method.naive_utc) returns
+and [`naive_utc`](https://docs.rs/chrono/0.4.5/chrono/struct.DateTime.html#method.naive_utc) returns
 a view to the naive UTC time.
 
 ## Limitations
@@ -346,7 +375,7 @@ Date types are limited in about +/- 262,000 years from the common epoch.
 Time types are limited in the nanosecond accuracy.
 
 [Leap seconds are supported in the representation but
-Chrono doesn't try to make use of them](https://docs.rs/chrono/0.4.0/chrono/naive/struct.NaiveTime.html#leap-second-handling).
+Chrono doesn't try to make use of them](https://docs.rs/chrono/0.4.5/chrono/naive/struct.NaiveTime.html#leap-second-handling).
 (The main reason is that leap seconds are not really predictable.)
 Almost *every* operation over the possible leap seconds will ignore them.
 Consider using `NaiveDateTime` with the implicit TAI (International Atomic Time) scale

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,4 +18,4 @@ install:
 build: false
 
 test_script:
-  - sh -c 'PATH=`rustc --print sysroot`/bin:$PATH ./.travis.sh'
+  - sh -c 'PATH=`rustc --print sysroot`/bin:$PATH ./ci/travis.sh'

--- a/ci/fix-readme.sh
+++ b/ci/fix-readme.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+VERSION="$( cargo read-manifest | python -c 'import json, sys; print(json.load(sys.stdin)["version"])')"
+LIB="$1"
+
+# Make the Chrono in the header a link to the docs
+awk '/^\/\/! # Chrono: / { print "[Chrono][docsrs]:", substr($0, index($0, $4))}' "$LIB"
+awk '/^\/\/! # Chrono: / { print "[Chrono][docsrs]:", substr($0, index($0, $4))}' "$LIB" | sed 's/./=/g'
+# Add all the badges
+echo '
+[![Chrono on Travis CI][travis-image]][travis]
+[![Chrono on Appveyor][appveyor-image]][appveyor]
+[![Chrono on crates.io][cratesio-image]][cratesio]
+[![Chrono on docs.rs][docsrs-image]][docsrs]
+[![Join the chat at https://gitter.im/chrono-rs/chrono][gitter-image]][gitter]
+
+[travis-image]: https://travis-ci.org/chronotope/chrono.svg?branch=master
+[travis]: https://travis-ci.org/chronotope/chrono
+[appveyor-image]: https://ci.appveyor.com/api/projects/status/2ia91ofww4w31m2w/branch/master?svg=true
+[appveyor]: https://ci.appveyor.com/project/chronotope/chrono
+[cratesio-image]: https://img.shields.io/crates/v/chrono.svg
+[cratesio]: https://crates.io/crates/chrono
+[docsrs-image]: https://docs.rs/chrono/badge.svg
+[docsrs]: https://docs.rs/chrono
+[gitter-image]: https://badges.gitter.im/chrono-rs/chrono.svg
+[gitter]: https://gitter.im/chrono-rs/chrono'
+
+# print the section between the header and the usage
+awk '/^\/\/! # Chrono:/,/^\/\/! ## /' "$LIB" | cut -b 5- | grep -v '^#' | \
+    sed 's/](\.\//](https:\/\/docs.rs\/chrono\/'$VERSION'\/chrono\//g'
+echo
+# Replace relative doc links with links to this exact version of docs on
+# docs.rs
+awk '/^\/\/! ## /,!/^\/\/!/' "$LIB" | cut -b 5- | grep -v '^# ' | \
+    sed 's/](\.\//](https:\/\/docs.rs\/chrono\/'$VERSION'\/chrono\//g' \

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -47,6 +47,12 @@ build_and_test() {
   TZ=UTC0 channel test -v --no-default-features --features serde --lib
   channel build -v --no-default-features --features serde,rustc-serialize
   TZ=Asia/Katmandu channel test -v --no-default-features --features serde,rustc-serialize --lib
+
+  if [[ "$CHANNEL" == stable ]]; then
+      if [[ -n "$TRAVIS" ]] ; then
+          check_readme
+      fi
+  fi
 }
 
 build_only() {
@@ -67,6 +73,11 @@ run_clippy() {
     fi
 
     cargo clippy --features 'serde bincode rustc-serialize' -- -Dclippy
+}
+
+check_readme() {
+    make readme
+    (set -x; git diff --exit-code -- README.md) ; echo $?
 }
 
 rustc --version

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
 // This is a part of Chrono.
 // See README.md and LICENSE.txt for details.
 
-//! # Chrono 0.4.0
+//! # Chrono: Date and Time for Rust
 //!
-//! Date and time handling for Rust.
 //! It aims to be a feature-complete superset of
 //! the [time](https://github.com/rust-lang-deprecated/time) library.
 //! In particular,
@@ -32,20 +31,13 @@
 //! chrono = "0.4"
 //! ```
 //!
-//! Or, if you want [Serde](https://github.com/serde-rs/serde) or
-//! [rustc-serialize](https://github.com/rust-lang-nursery/rustc-serialize) support,
-//! include the features like this:
+//! Or, if you want [Serde](https://github.com/serde-rs/serde) include the
+//! feature like this:
 //!
 //! ```toml
 //! [dependencies]
-//! chrono = { version = "0.4", features = ["serde", "rustc-serialize"] }
+//! chrono = { version = "0.4", features = ["serde"] }
 //! ```
-//!
-//! > Note that Chrono's support for rustc-serialize is now considered deprecated.
-//! Starting from 0.4.0 there is no further guarantee that
-//! the features available in Serde will be also available to rustc-serialize,
-//! and the support can be removed in any future major version.
-//! **Rustc-serialize users are strongly recommended to migrate to Serde.**
 //!
 //! Then put this in your crate root:
 //!
@@ -65,7 +57,7 @@
 //! ### Duration
 //!
 //! Chrono currently uses
-//! the [`time::Duration`](https://doc.rust-lang.org/time/time/struct.Duration.html) type
+//! the [`time::Duration`](https://docs.rs/time/0.1.40/time/struct.Duration.html) type
 //! from the `time` crate to represent the magnitude of a time span.
 //! Since this has the same name to the newer, standard type for duration,
 //! the reference will refer this type as `OldDuration`.
@@ -74,12 +66,12 @@
 //! months.
 //!
 //! Chrono does not yet natively support
-//! the standard [`Duration`](https://doc.rust-lang.org/std/time/struct.Duration.html) type,
+//! the standard [`Duration`](https://docs.rs/time/0.1.40/time/struct.Duration.html) type,
 //! but it will be supported in the future.
 //! Meanwhile you can convert between two types with
-//! [`Duration::from_std`](https://doc.rust-lang.org/time/time/struct.Duration.html#method.from_std)
+//! [`Duration::from_std`](https://docs.rs/time/0.1.40/time/struct.Duration.html#method.from_std)
 //! and
-//! [`Duration::to_std`](https://doc.rust-lang.org/time/time/struct.Duration.html#method.to_std)
+//! [`Duration::to_std`](https://docs.rs/time/0.1.40/time/struct.Duration.html#method.to_std)
 //! methods.
 //!
 //! ### Date and Time
@@ -232,6 +224,10 @@
 //! assert_eq!(dt.to_rfc2822(), "Fri, 28 Nov 2014 12:00:09 +0000");
 //! assert_eq!(dt.to_rfc3339(), "2014-11-28T12:00:09+00:00");
 //! assert_eq!(format!("{:?}", dt), "2014-11-28T12:00:09Z");
+//!
+//! // Note that milli/nanoseconds are only printed if they are non-zero
+//! let dt_nano = Utc.ymd(2014, 11, 28).and_hms_nano(12, 0, 9, 1);
+//! assert_eq!(format!("{:?}", dt_nano), "2014-11-28T12:00:09.000000001Z");
 //! ```
 //!
 //! Parsing can be done with three methods:
@@ -387,7 +383,7 @@
 //! Advanced time zone handling is not yet supported.
 //! For now you can try the [Chrono-tz](https://github.com/chronotope/chrono-tz/) crate instead.
 
-#![doc(html_root_url = "https://docs.rs/chrono/0.4.0/")]
+#![doc(html_root_url = "https://docs.rs/chrono/latest/")]
 
 #![cfg_attr(bench, feature(test))] // lib stability features as per RFC #507
 #![deny(missing_docs)]


### PR DESCRIPTION
And fail CI in the future if `make readme` isn't run when it is needed.

CC conversation in #185, where the README didn't get updated for a year after
lib.rs was improved.