### PR TITLE
Add parse_from_* to DateTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versions with only mechanical changes will be omitted from the following list.
 ## Features
 
 * Add `std::convert::From` conversions between the different timezone formats (@mqudsi #271)
+* Add `parse_from_rfc2822()`, `parse_from_rfc3339()`, and `parse_from_str()` methods to `DateTime`
+objects (@mqudsi #278)
 
 ## 0.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ This documents all notable changes to [Chrono](https://github.com/chronotope/chr
 Chrono obeys the principle of [Semantic Versioning](http://semver.org/).
 
 There were/are numerous minor versions before 1.0 due to the language changes.
-Versions with only mechnical changes will be omitted from the following list.
+Versions with only mechanical changes will be omitted from the following list.
+
+## 0.4.6
+
+## Features
+
+* Add `std::convert::From` conversions between the different timezone formats (@mqudsi #271)
 
 ## 0.4.5
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -247,6 +247,7 @@ impl From<DateTime<Utc>> for DateTime<FixedOffset> {
 }
 
 /// Convert a `DateTime<Utc>` instance into a `DateTime<Local>` instance.
+#[cfg(feature="clock")]
 impl From<DateTime<Utc>> for DateTime<Local> {
     /// Convert this `DateTime<Utc>` instance into a `DateTime<Local>` instance.
     ///
@@ -268,6 +269,7 @@ impl From<DateTime<FixedOffset>> for DateTime<Utc> {
 }
 
 /// Convert a `DateTime<FixedOffset>` instance into a `DateTime<Local>` instance.
+#[cfg(feature="clock")]
 impl From<DateTime<FixedOffset>> for DateTime<Local> {
     /// Convert this `DateTime<FixedOffset>` instance into a `DateTime<Local>` instance.
     ///
@@ -279,6 +281,7 @@ impl From<DateTime<FixedOffset>> for DateTime<Local> {
 }
 
 /// Convert a `DateTime<Local>` instance into a `DateTime<Utc>` instance.
+#[cfg(feature="clock")]
 impl From<DateTime<Local>> for DateTime<Utc> {
     /// Convert this `DateTime<Local>` instance into a `DateTime<Utc>` instance.
     ///
@@ -290,6 +293,7 @@ impl From<DateTime<Local>> for DateTime<Utc> {
 }
 
 /// Convert a `DateTime<Local>` instance into a `DateTime<FixedOffset>` instance.
+#[cfg(feature="clock")]
 impl From<DateTime<Local>> for DateTime<FixedOffset> {
     /// Convert this `DateTime<Local>` instance into a `DateTime<FixedOffset>` instance.
     ///

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -681,6 +681,14 @@ impl<Tz: TimeZone> From<DateTime<Tz>> for SystemTime {
     }
 }
 
+#[test]
+fn test_auto_conversion() {
+    let utc_dt = Utc.ymd(2018, 9, 5).and_hms(23, 58, 0);
+    let cdt_dt = FixedOffset::west(5 * 60 * 60).ymd(2018, 9, 5).and_hms(18, 58, 0);
+    let utc_dt2: DateTime<Utc> = cdt_dt.into();
+    assert_eq!(utc_dt, utc_dt2);
+}
+
 #[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
 fn test_encodable_json<FUtc, FFixed, E>(to_string_utc: FUtc, to_string_fixed: FFixed)
     where FUtc: Fn(&DateTime<Utc>) -> Result<String, E>,

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -235,6 +235,43 @@ impl<Tz: TimeZone> DateTime<Tz> {
     }
 }
 
+impl From<DateTime<Utc>> for DateTime<FixedOffset> {
+    fn from(src: DateTime<Utc>) -> Self {
+        src.with_timezone(&FixedOffset::east(0))
+    }
+}
+
+impl From<DateTime<Utc>> for DateTime<Local> {
+    fn from(src: DateTime<Utc>) -> Self {
+        src.with_timezone(&Local)
+    }
+}
+
+impl From<DateTime<FixedOffset>> for DateTime<Utc> {
+    fn from(src: DateTime<FixedOffset>) -> Self {
+        src.with_timezone(&Utc)
+    }
+}
+
+impl From<DateTime<FixedOffset>> for DateTime<Local> {
+    fn from(src: DateTime<FixedOffset>) -> Self {
+        src.with_timezone(&Local)
+    }
+}
+
+impl From<DateTime<Local>> for DateTime<Utc> {
+    fn from(src: DateTime<Local>) -> Self {
+        src.with_timezone(&Utc)
+    }
+}
+
+impl From<DateTime<Local>> for DateTime<FixedOffset> {
+    fn from(src: DateTime<Local>) -> Self {
+        // todo: return in actual current local offset Tz
+        src.with_timezone(&FixedOffset::east(0))
+    }
+}
+
 /// Maps the local datetime to other datetime with given conversion function.
 fn map_local<Tz: TimeZone, F>(dt: &DateTime<Tz>, mut f: F) -> Option<DateTime<Tz>>
         where F: FnMut(NaiveDateTime) -> Option<NaiveDateTime> {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -235,39 +235,67 @@ impl<Tz: TimeZone> DateTime<Tz> {
     }
 }
 
+/// Convert a `DateTime<Utc>` instance into a `DateTime<FixedOffset>` instance.
 impl From<DateTime<Utc>> for DateTime<FixedOffset> {
+    /// Convert this `DateTime<Utc>` instance into a `DateTime<FixedOffset>` instance.
+    ///
+    /// Conversion is done via [`DateTime::with_timezone`]. Note that the converted value returned by
+    /// this will be created with a fixed timezone offset of 0.
     fn from(src: DateTime<Utc>) -> Self {
         src.with_timezone(&FixedOffset::east(0))
     }
 }
 
+/// Convert a `DateTime<Utc>` instance into a `DateTime<Local>` instance.
 impl From<DateTime<Utc>> for DateTime<Local> {
+    /// Convert this `DateTime<Utc>` instance into a `DateTime<Local>` instance.
+    ///
+    /// Conversion is performed via [`DateTime::with_timezone`], accounting for the difference in timezones.
     fn from(src: DateTime<Utc>) -> Self {
         src.with_timezone(&Local)
     }
 }
 
+/// Convert a `DateTime<FixedOffset>` instance into a `DateTime<Utc>` instance.
 impl From<DateTime<FixedOffset>> for DateTime<Utc> {
+    /// Convert this `DateTime<FixedOffset>` instance into a `DateTime<Utc>` instance.
+    ///
+    /// Conversion is performed via [`DateTime::with_timezone`], accounting for the timezone
+    /// difference.
     fn from(src: DateTime<FixedOffset>) -> Self {
         src.with_timezone(&Utc)
     }
 }
 
+/// Convert a `DateTime<FixedOffset>` instance into a `DateTime<Local>` instance.
 impl From<DateTime<FixedOffset>> for DateTime<Local> {
+    /// Convert this `DateTime<FixedOffset>` instance into a `DateTime<Local>` instance.
+    ///
+    /// Conversion is performed via [`DateTime::with_timezone`]. Returns the equivalent value in local
+    /// time.
     fn from(src: DateTime<FixedOffset>) -> Self {
         src.with_timezone(&Local)
     }
 }
 
+/// Convert a `DateTime<Local>` instance into a `DateTime<Utc>` instance.
 impl From<DateTime<Local>> for DateTime<Utc> {
+    /// Convert this `DateTime<Local>` instance into a `DateTime<Utc>` instance.
+    ///
+    /// Conversion is performed via [`DateTime::with_timezone`], accounting for the difference in
+    /// timezones.
     fn from(src: DateTime<Local>) -> Self {
         src.with_timezone(&Utc)
     }
 }
 
+/// Convert a `DateTime<Local>` instance into a `DateTime<FixedOffset>` instance.
 impl From<DateTime<Local>> for DateTime<FixedOffset> {
+    /// Convert this `DateTime<Local>` instance into a `DateTime<FixedOffset>` instance.
+    ///
+    /// Conversion is performed via [`DateTime::with_timezone`]. Note that the converted value returned
+    /// by this will be created with a fixed timezone offset of 0.
     fn from(src: DateTime<Local>) -> Self {
-        // todo: return in actual current local offset Tz
         src.with_timezone(&FixedOffset::east(0))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,11 +273,11 @@
 //! assert_eq!("2014-11-28T21:00:09+09:00".parse::<DateTime<FixedOffset>>(), Ok(fixed_dt.clone()));
 //!
 //! // method 2
-//! assert_eq!(DateTime::parse_from_str("2014-11-28 21:00:09 +09:00", "%Y-%m-%d %H:%M:%S %z"),
+//! assert_eq!(DateTime::<FixedOffset>::parse_from_str("2014-11-28 21:00:09 +09:00", "%Y-%m-%d %H:%M:%S %z"),
 //!            Ok(fixed_dt.clone()));
-//! assert_eq!(DateTime::parse_from_rfc2822("Fri, 28 Nov 2014 21:00:09 +0900"),
+//! assert_eq!(DateTime::<FixedOffset>::parse_from_rfc2822("Fri, 28 Nov 2014 21:00:09 +0900"),
 //!            Ok(fixed_dt.clone()));
-//! assert_eq!(DateTime::parse_from_rfc3339("2014-11-28T21:00:09+09:00"), Ok(fixed_dt.clone()));
+//! assert_eq!(DateTime::<FixedOffset>::parse_from_rfc3339("2014-11-28T21:00:09+09:00"), Ok(fixed_dt.clone()));
 //!
 //! // method 3
 //! assert_eq!(Utc.datetime_from_str("2014-11-28 12:00:09", "%Y-%m-%d %H:%M:%S"), Ok(dt.clone()));
@@ -307,7 +307,7 @@
 //!
 //! ```rust
 //! # use chrono::DateTime;
-//! # use chrono::Utc;
+//! # use chrono::{FixedOffset, Utc};
 //! // We need the trait in scope to use Utc::timestamp().
 //! use chrono::TimeZone;
 //!
@@ -316,7 +316,7 @@
 //! assert_eq!(dt.to_rfc2822(), "Fri, 14 Jul 2017 02:40:00 +0000");
 //!
 //! // Get epoch value from a datetime:
-//! let dt = DateTime::parse_from_rfc2822("Fri, 14 Jul 2017 02:40:00 +0000").unwrap();
+//! let dt = DateTime::<FixedOffset>::parse_from_rfc2822("Fri, 14 Jul 2017 02:40:00 +0000").unwrap();
 //! assert_eq!(dt.timestamp(), 1_500_000_000);
 //! ```
 //!

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -159,14 +159,14 @@ use format::{parse, Parsed, ParseError, ParseResult, DelayedFormat, StrftimeItem
 /// and would be read back to the next non-leap second.
 ///
 /// ~~~~
-/// use chrono::{DateTime, Utc, TimeZone};
+/// use chrono::{DateTime, Utc, FixedOffset, TimeZone};
 ///
 /// let dt = Utc.ymd(2015, 6, 30).and_hms_milli(23, 56, 4, 1_000);
 /// assert_eq!(format!("{:?}", dt), "2015-06-30T23:56:05Z");
 ///
 /// let dt = Utc.ymd(2015, 6, 30).and_hms(23, 56, 5);
 /// assert_eq!(format!("{:?}", dt), "2015-06-30T23:56:05Z");
-/// assert_eq!(DateTime::parse_from_rfc3339("2015-06-30T23:56:05Z").unwrap(), dt);
+/// assert_eq!(DateTime::<FixedOffset>::parse_from_rfc3339("2015-06-30T23:56:05Z").unwrap(), dt);
 /// ~~~~
 ///
 /// Since Chrono alone cannot determine any existence of leap seconds,
@@ -1431,7 +1431,7 @@ mod serde {
     impl<'de> de::Visitor<'de> for NaiveTimeVisitor {
         type Value = NaiveTime;
 
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result 
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result
         {
             write!(formatter, "a formatted time string")
         }


### PR DESCRIPTION
As discussed in #263. Note that this breaks existing code that did not
explicitly specify the offset in calls to `DateTime::parse_from_*`, as
they are now ambiguous.

Relies on #271 for conversion back into `DateTime<Utc>` from
`DateTime<FixedOffset>` as the latter is used under the hood.
