### PR TITLE
Adds quickcheck::Arbitrary support for DateTime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ name = "chrono"
 [features]
 default = ["clock"]
 clock = ["time"]
+quickcheck-enabled = ["quickcheck"]
 
 [dependencies]
 time = { version = "0.1.39", optional = true }
@@ -33,6 +34,7 @@ num-integer = { version = "0.1.36", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }
 serde = { version = "1", optional = true }
+quickcheck = { version = "*", optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1" }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1402,6 +1402,20 @@ pub mod serde {
     }
 }
 
+#[cfg(feature = "quickcheck-enabled")]
+impl quickcheck::Arbitrary for DateTime<Utc> {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        Utc.timestamp(i64::arbitrary(g), u32::arbitrary(g))
+    }
+}
+
+#[cfg(feature = "quickcheck-enabled")]
+impl quickcheck::Arbitrary for DateTime<Local> {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        Local.timestamp(i64::arbitrary(g), u32::arbitrary(g))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::DateTime;
@@ -1644,4 +1658,17 @@ mod tests {
         assert_eq!(SystemTime::from(epoch.with_timezone(&FixedOffset::east(32400))), UNIX_EPOCH);
         assert_eq!(SystemTime::from(epoch.with_timezone(&FixedOffset::west(28800))), UNIX_EPOCH);
     }
+
+    #[cfg(feature = "quickcheck-enabled")]
+    quickcheck! {
+            #[test]
+            fn qc_test_quickcheck(original_time: DateTime<Utc>) -> quickcheck::TestResult {
+                let seconds = original_time.timestamp();
+                let nanoseconds = original_time.timestamp_subsec_nanos();
+                let reconstructed = Utc.timestamp(seconds, nanoseconds);
+                quickcheck::TestResult::from_bool(
+                    reconstructed == original_time
+                )
+            }
+        }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,6 +413,9 @@ extern crate num_traits;
 extern crate rustc_serialize;
 #[cfg(feature = "serde")]
 extern crate serde as serdelib;
+#[cfg(feature = "quickcheck-enabled")]
+#[macro_use]
+extern crate quickcheck;
 
 // this reexport is to aid the transition and should not be in the prelude!
 pub use oldtime::Duration;


### PR DESCRIPTION
Available under feature "quickcheck-enabled".

Test with:
  cargo test --features quickcheck-enabled qc_

Notes:
I'm not sure about the best way to include the quickcheck dependency. It now lives under `[dependencies]` as an optional feature.