### PR TITLE
Mark `FixedOffset::{local_minus_utc, utc_minus_local}` as `#[inline]`.

### DIFF
--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -86,11 +86,13 @@ impl FixedOffset {
     }
 
     /// Returns the number of seconds to add to convert from UTC to the local time.
+    #[inline]
     pub fn local_minus_utc(&self) -> i32 {
         self.local_minus_utc
     }
 
     /// Returns the number of seconds to add to convert from the local time to UTC.
+    #[inline]
     pub fn utc_minus_local(&self) -> i32 {
         -self.local_minus_utc
     }


### PR DESCRIPTION
This ensures dependent crates using these functions could inline these calls into a trivial copy or negation. The current implementation won't allow the optimizer to elide the function call (perhaps unless LTO is enabled). Demo: https://play.rust-lang.org/?version=stable&mode=release&edition=2018&gist=3eb8be743dba200098ff43c4efa9a128
