### PR TITLE
Add doc-comment to test README examples and fix README examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ serde_json = { version = "1" }
 serde_derive = { version = "1" }
 bincode = { version = "0.8.0" }
 num-iter = { version = "0.1.35", default-features = false }
+doc-comment = "0.3"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -172,11 +172,13 @@ Addition and subtraction is also supported.
 The following illustrates most supported operations to the date and time:
 
 ```rust
+extern crate time;
+
 use chrono::prelude::*;
 use time::Duration;
 
 // assume this returned `2014-11-28T21:45:59.324310806+09:00`:
-let dt = Local::now();
+let dt = FixedOffset::east(9*3600).ymd(2014, 11, 28).and_hms_nano(21, 45, 59, 324310806);
 
 // property accessors
 assert_eq!((dt.year(), dt.month(), dt.day()), (2014, 11, 28));
@@ -312,7 +314,7 @@ to get the number of additional number of nanoseconds.
 
 ```rust
 // We need the trait in scope to use Utc::timestamp().
-use chrono::TimeZone;
+use chrono::{DateTime, TimeZone, Utc};
 
 // Construct a datetime from epoch:
 let dt = Utc.timestamp(1_500_000_000, 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,15 +158,15 @@
 //! The following illustrates most supported operations to the date and time:
 //!
 //! ```rust
-//! # extern crate chrono; extern crate time; fn main() {
+//! # extern crate chrono;
+//! extern crate time;
+//!
+//! # fn main() {
 //! use chrono::prelude::*;
 //! use time::Duration;
 //!
-//! # /* we intentionally fake the datetime...
 //! // assume this returned `2014-11-28T21:45:59.324310806+09:00`:
-//! let dt = Local::now();
-//! # */ // up to here. we now define a fixed datetime for the illustrative purpose.
-//! # let dt = FixedOffset::east(9*3600).ymd(2014, 11, 28).and_hms_nano(21, 45, 59, 324310806);
+//! let dt = FixedOffset::east(9*3600).ymd(2014, 11, 28).and_hms_nano(21, 45, 59, 324310806);
 //!
 //! // property accessors
 //! assert_eq!((dt.year(), dt.month(), dt.day()), (2014, 11, 28));
@@ -302,10 +302,8 @@
 //! to get the number of additional number of nanoseconds.
 //!
 //! ```rust
-//! # use chrono::DateTime;
-//! # use chrono::Utc;
 //! // We need the trait in scope to use Utc::timestamp().
-//! use chrono::TimeZone;
+//! use chrono::{DateTime, TimeZone, Utc};
 //!
 //! // Construct a datetime from epoch:
 //! let dt = Utc.timestamp(1_500_000_000, 0);
@@ -413,6 +411,12 @@ extern crate num_traits;
 extern crate rustc_serialize;
 #[cfg(feature = "serde")]
 extern crate serde as serdelib;
+#[cfg(test)]
+#[macro_use]
+extern crate doc_comment;
+
+#[cfg(test)]
+doctest!("../README.md");
 
 // this reexport is to aid the transition and should not be in the prelude!
 pub use oldtime::Duration;


### PR DESCRIPTION
Allows to keep in check the README file examples (and I fixed README examples at the same time).