### PR TITLE
Add '0' to RFC2822

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -511,7 +511,7 @@ pub fn format<'a, I>(w: &mut fmt::Formatter, date: Option<&NaiveDate>, time: Opt
                     RFC2822 => // same to `%a, %e %b %Y %H:%M:%S %z`
                         if let (Some(d), Some(t), Some(&(_, off))) = (date, time, off) {
                             let sec = t.second() + t.nanosecond() / 1_000_000_000;
-                            try!(write!(w, "{}, {:2} {} {:04} {:02}:{:02}:{:02} ",
+                            try!(write!(w, "{}, {:02} {} {:04} {:02}:{:02}:{:02} ",
                                         SHORT_WEEKDAYS[d.weekday().num_days_from_monday() as usize],
                                         d.day(), SHORT_MONTHS[d.month0() as usize], d.year(),
                                         t.hour(), t.minute(), sec));


### PR DESCRIPTION

```rust
dbg!(Utc::now().to_rfc2822());
```

🙅‍♂️
```
 "Thu,  6 Jun 2019 03:12:47 +0000"
```

🙆‍♂️
```bash
 "Thu, 06 Jun 2019 03:12:47 +0000"
```