### PR TITLE
Remove or clarify references to time crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@
 [gitter-image]: https://badges.gitter.im/chrono-rs/chrono.svg
 [gitter]: https://gitter.im/chrono-rs/chrono
 
-It aims to be a feature-complete superset of
-the [time](https://github.com/rust-lang-deprecated/time) library.
-In particular,
+Chrono aims to be a feature-complete time library. In particular,
 
 * Chrono strictly adheres to ISO 8601.
 * Chrono is timezone-aware by default, with separate timezone-naive types.
@@ -74,7 +72,7 @@ use chrono::prelude::*;
 
 Chrono currently uses
 the [`time::Duration`](https://docs.rs/time/0.1.40/time/struct.Duration.html) type
-from the `time` crate to represent the magnitude of a time span.
+from the `time` crate (v0.1) to represent the magnitude of a time span.
 Since this has the same name to the newer, standard type for duration,
 the reference will refer this type as `OldDuration`.
 Note that this is an "accurate" duration represented as seconds and
@@ -98,9 +96,9 @@ type to represent a date and a time in a timezone.
 
 For more abstract moment-in-time tracking such as internal timekeeping
 that is unconcerned with timezones, consider
-[`time::SystemTime`](https://doc.rust-lang.org/std/time/struct.SystemTime.html),
+[`std::time::SystemTime`](https://doc.rust-lang.org/std/time/struct.SystemTime.html),
 which tracks your system clock, or
-[`time::Instant`](https://doc.rust-lang.org/std/time/struct.Instant.html), which
+[`std::time::Instant`](https://doc.rust-lang.org/std/time/struct.Instant.html), which
 is an opaque but monotonically-increasing representation of a moment in time.
 
 `DateTime` is timezone-aware and must be constructed from
@@ -172,7 +170,7 @@ Addition and subtraction is also supported.
 The following illustrates most supported operations to the date and time:
 
 ```rust
-extern crate time;
+extern crate time; // v0.1
 
 use chrono::prelude::*;
 use time::Duration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@
 //!
 //! ```rust
 //! # extern crate chrono;
-//! extern crate time;
+//! extern crate time; // v0.1
 //!
 //! # fn main() {
 //! use chrono::prelude::*;

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -791,7 +791,7 @@ impl NaiveDate {
     /// # extern crate chrono; extern crate time; fn main() {
     /// use chrono::NaiveDate;
     /// use chrono::naive::MAX_DATE;
-    /// use time::Duration;
+    /// use time::Duration; // v0.1
     ///
     /// let d = NaiveDate::from_ymd(2015, 9, 5);
     /// assert_eq!(d.checked_add_signed(Duration::days(40)),
@@ -827,7 +827,7 @@ impl NaiveDate {
     /// # extern crate chrono; extern crate time; fn main() {
     /// use chrono::NaiveDate;
     /// use chrono::naive::MIN_DATE;
-    /// use time::Duration;
+    /// use time::Duration; // v0.1
     ///
     /// let d = NaiveDate::from_ymd(2015, 9, 5);
     /// assert_eq!(d.checked_sub_signed(Duration::days(40)),
@@ -864,7 +864,7 @@ impl NaiveDate {
     /// ~~~~
     /// # extern crate chrono; extern crate time; fn main() {
     /// use chrono::NaiveDate;
-    /// use time::Duration;
+    /// use time::Duration; // v0.1
     ///
     /// let from_ymd = NaiveDate::from_ymd;
     /// let since = NaiveDate::signed_duration_since;
@@ -1313,7 +1313,7 @@ impl Datelike for NaiveDate {
 /// ~~~~
 /// # extern crate chrono; extern crate time; fn main() {
 /// use chrono::NaiveDate;
-/// use time::Duration;
+/// use time::Duration; // v0.1
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
@@ -1355,7 +1355,7 @@ impl AddAssign<OldDuration> for NaiveDate {
 /// ~~~~
 /// # extern crate chrono; extern crate time; fn main() {
 /// use chrono::NaiveDate;
-/// use time::Duration;
+/// use time::Duration; // v0.1
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
@@ -1399,7 +1399,7 @@ impl SubAssign<OldDuration> for NaiveDate {
 /// ~~~~
 /// # extern crate chrono; extern crate time; fn main() {
 /// use chrono::NaiveDate;
-/// use time::Duration;
+/// use time::Duration; // v0.1
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -416,7 +416,7 @@ impl NaiveDateTime {
     /// ~~~~
     /// # extern crate chrono; extern crate time; fn main() {
     /// use chrono::NaiveDate;
-    /// use time::Duration;
+    /// use time::Duration; // v0.1
     ///
     /// let from_ymd = NaiveDate::from_ymd;
     ///
@@ -502,7 +502,7 @@ impl NaiveDateTime {
     /// ~~~~
     /// # extern crate chrono; extern crate time; fn main() {
     /// use chrono::NaiveDate;
-    /// use time::Duration;
+    /// use time::Duration; // v0.1
     ///
     /// let from_ymd = NaiveDate::from_ymd;
     ///
@@ -584,7 +584,7 @@ impl NaiveDateTime {
     /// ~~~~
     /// # extern crate chrono; extern crate time; fn main() {
     /// use chrono::NaiveDate;
-    /// use time::Duration;
+    /// use time::Duration; // v0.1
     ///
     /// let from_ymd = NaiveDate::from_ymd;
     ///
@@ -1202,7 +1202,7 @@ impl hash::Hash for NaiveDateTime {
 /// ~~~~
 /// # extern crate chrono; extern crate time; fn main() {
 /// use chrono::NaiveDate;
-/// use time::Duration;
+/// use time::Duration; // v0.1
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
@@ -1274,7 +1274,7 @@ impl AddAssign<OldDuration> for NaiveDateTime {
 /// ~~~~
 /// # extern crate chrono; extern crate time; fn main() {
 /// use chrono::NaiveDate;
-/// use time::Duration;
+/// use time::Duration; // v0.1
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
@@ -1345,7 +1345,7 @@ impl SubAssign<OldDuration> for NaiveDateTime {
 /// ~~~~
 /// # extern crate chrono; extern crate time; fn main() {
 /// use chrono::NaiveDate;
-/// use time::Duration;
+/// use time::Duration; // v0.1
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -506,7 +506,7 @@ impl NaiveTime {
     /// ~~~~
     /// # extern crate chrono; extern crate time; fn main() {
     /// use chrono::NaiveTime;
-    /// use time::Duration;
+    /// use time::Duration; // v0.1
     ///
     /// let from_hms = NaiveTime::from_hms;
     ///
@@ -592,7 +592,7 @@ impl NaiveTime {
     /// ~~~~
     /// # extern crate chrono; extern crate time; fn main() {
     /// use chrono::NaiveTime;
-    /// use time::Duration;
+    /// use time::Duration; // v0.1
     ///
     /// let from_hms = NaiveTime::from_hms;
     ///
@@ -625,7 +625,7 @@ impl NaiveTime {
     /// ~~~~
     /// # extern crate chrono; extern crate time; fn main() {
     /// use chrono::NaiveTime;
-    /// use time::Duration;
+    /// use time::Duration; // v0.1
     ///
     /// let from_hmsm = NaiveTime::from_hms_milli;
     /// let since = NaiveTime::signed_duration_since;
@@ -1002,7 +1002,7 @@ impl hash::Hash for NaiveTime {
 /// ~~~~
 /// # extern crate chrono; extern crate time; fn main() {
 /// use chrono::NaiveTime;
-/// use time::Duration;
+/// use time::Duration; // v0.1
 ///
 /// let from_hmsm = NaiveTime::from_hms_milli;
 ///
@@ -1077,7 +1077,7 @@ impl AddAssign<OldDuration> for NaiveTime {
 /// ~~~~
 /// # extern crate chrono; extern crate time; fn main() {
 /// use chrono::NaiveTime;
-/// use time::Duration;
+/// use time::Duration; // v0.1
 ///
 /// let from_hmsm = NaiveTime::from_hms_milli;
 ///
@@ -1151,7 +1151,7 @@ impl SubAssign<OldDuration> for NaiveTime {
 /// ~~~~
 /// # extern crate chrono; extern crate time; fn main() {
 /// use chrono::NaiveTime;
-/// use time::Duration;
+/// use time::Duration; // v0.1
 ///
 /// let from_hmsm = NaiveTime::from_hms_milli;
 ///


### PR DESCRIPTION
The time crate will _hopefully_ have a v0.2 release coinciding with the
release of Rust 1.40. As such, all references to the time crate make
clear that it is the v0.1 crate, not the soon-to-be-released v0.2 crate.
The first line of the README was also changed, as it's not a strict
superset of the new version.