### PR TITLE
Implement rockets FromFormValue for naive types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ num-integer = { version = "0.1.36", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }
 serde = { version = "1.0.99", default-features = false, optional = true }
+rocket = { version = "0.4", default-features = false, optional = true}
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
 wasm-bindgen = { version = "0.2", optional = true }

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,4 @@ test:
 
 .PHONY: doc
 doc: authors readme
-	cargo doc --features 'serde rustc-serialize bincode'
+	cargo doc --features 'serde rustc-serialize bincode rocket'

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -93,6 +93,14 @@ build_and_test_nonwasm() {
 
   channel build -v --no-default-features --features 'alloc serde'
   TZ=UTC0 channel test -v --no-default-features --features 'alloc serde' --lib
+
+  # rocket 0.4 only supports nightly
+  if [[ "$CHANNEL" == nightly ]]; then
+      channel build -v --features rocket
+      TZ=Asia/Katmandu channel test -v --features rocket
+      channel build -v --no-default-features --features std,serde,rocket,rustc-serialize
+      TZ=EST4 channel test -v --no-default-features --features std,serde,rocket,rustc-serialize --lib
+  fi
 }
 
 build_and_test_wasm() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,6 +420,8 @@ extern crate num_traits;
 extern crate rustc_serialize;
 #[cfg(feature = "serde")]
 extern crate serde as serdelib;
+#[cfg(feature = "rocket")]
+extern crate rocket;
 #[cfg(test)]
 #[macro_use]
 extern crate doc_comment;
@@ -504,6 +506,21 @@ pub mod naive {
     #[cfg(feature = "serde")]
     pub mod serde {
         pub use super::datetime::serde::*;
+    }
+
+
+    /// Parsing of naive types from form values
+    ///
+    /// The modules in here provide implementations for rockets [`FromFormValue`
+    /// ][1] trait. Implementations for date, time as well as local date and
+    /// time strings are provided. Descriptions of the different formats can be
+    /// fount [here][2].
+    ///
+    /// [1]: https://api.rocket.rs/v0.4/rocket/request/trait.FromFormValue.html
+    /// [2]: https://developer.mozilla.org/en-US/docs/Web/HTML/Date_and_time_formats#Time_strings
+    #[cfg(feature = "rocket")]
+    pub mod rocket {
+        pub use super::datetime::rocket::*;
     }
 }
 mod date;


### PR DESCRIPTION
Adds a new rocket feature that implements FromFormValue for
NaiveTime, NaiveDate and NaiveDateTime.