### PR TITLE
Add support for compilation on wasm32-wasi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }
 serde = { version = "1.0.99", default-features = false, optional = true }
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 wasm-bindgen = { version = "0.2", optional = true }
 js-sys = { version = "0.3", optional = true } # contains FFI bindings for the JS Date API
 
@@ -49,7 +49,7 @@ bincode = { version = "0.8.0" }
 num-iter = { version = "0.1.35", default-features = false }
 doc-comment = "0.3"
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dev-dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]
 wasm-bindgen-test = "0.2"
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,9 +424,9 @@ extern crate serde as serdelib;
 #[cfg(test)]
 #[macro_use]
 extern crate doc_comment;
-#[cfg(all(target_arch = "wasm32", feature="wasmbind"))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind"))]
 extern crate wasm_bindgen;
-#[cfg(all(target_arch = "wasm32", feature="wasmbind"))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind"))]
 extern crate js_sys;
 #[cfg(feature = "bench")]
 extern crate test;

--- a/src/offset/local.rs
+++ b/src/offset/local.rs
@@ -87,13 +87,13 @@ impl Local {
     }
 
     /// Returns a `DateTime` which corresponds to the current date.
-    #[cfg(not(all(target_arch = "wasm32", feature = "wasmbind")))]
+    #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind")))]
     pub fn now() -> DateTime<Local> {
         tm_to_datetime(oldtime::now())
     }
 
     /// Returns a `DateTime` which corresponds to the current date.
-    #[cfg(all(target_arch = "wasm32", feature = "wasmbind"))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind"))]
     pub fn now() -> DateTime<Local> {
         use super::Utc;
         let now: DateTime<Utc> = super::Utc::now();

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -4,7 +4,10 @@
 //! The UTC (Coordinated Universal Time) time zone.
 
 use core::fmt;
-#[cfg(all(feature="clock", not(all(target_arch = "wasm32", feature = "wasmbind"))))]
+#[cfg(all(
+    feature = "clock",
+    not(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind"))
+))]
 use oldtime;
 
 use naive::{NaiveDate, NaiveDateTime};
@@ -38,7 +41,7 @@ impl Utc {
     pub fn today() -> Date<Utc> { Utc::now().date() }
 
     /// Returns a `DateTime` which corresponds to the current date.
-    #[cfg(not(all(target_arch = "wasm32", feature = "wasmbind")))]
+    #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind")))]
     pub fn now() -> DateTime<Utc> {
         let spec = oldtime::get_time();
         let naive = NaiveDateTime::from_timestamp(spec.sec, spec.nsec as u32);
@@ -46,7 +49,7 @@ impl Utc {
     }
 
     /// Returns a `DateTime` which corresponds to the current date.
-    #[cfg(all(target_arch = "wasm32", feature = "wasmbind"))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind"))]
     pub fn now() -> DateTime<Utc> {
         let now = js_sys::Date::new_0();
         let millisecs_since_unix_epoch: u64 = now.get_time() as u64;

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,4 +1,4 @@
-#[cfg(all(target_arch = "wasm32", feature = "wasmbind"))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind"))]
 mod test {
     extern crate chrono;
     extern crate wasm_bindgen_test;


### PR DESCRIPTION
This just disables `wasmbind` from taking effect on WASI. Resolves #352.