### PR TITLE
Remove deprecated Error::description

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -318,32 +318,22 @@ enum ParseErrorKind {
 /// Same to `Result<T, ParseError>`.
 pub type ParseResult<T> = Result<T, ParseError>;
 
-impl ParseError {
-    fn description(&self) -> &str {
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0 {
-            ParseErrorKind::OutOfRange => "input is out of range",
-            ParseErrorKind::Impossible => "no possible date and time matching input",
-            ParseErrorKind::NotEnough => "input is not enough for unique date and time",
-            ParseErrorKind::Invalid => "input contains invalid characters",
-            ParseErrorKind::TooShort => "premature end of input",
-            ParseErrorKind::TooLong => "trailing input",
-            ParseErrorKind::BadFormat => "bad or unsupported format string",
+            ParseErrorKind::OutOfRange => write!(f, "input is out of range"),
+            ParseErrorKind::Impossible => write!(f, "no possible date and time matching input"),
+            ParseErrorKind::NotEnough => write!(f, "input is not enough for unique date and time"),
+            ParseErrorKind::Invalid => write!(f, "input contains invalid characters"),
+            ParseErrorKind::TooShort => write!(f, "premature end of input"),
+            ParseErrorKind::TooLong => write!(f, "trailing input"),
+            ParseErrorKind::BadFormat => write!(f, "bad or unsupported format string"),
         }
     }
 }
 
-impl fmt::Display for ParseError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.description().fmt(f)
-    }
-}
-
 #[cfg(any(feature = "std", test))]
-impl Error for ParseError {
-    fn description(&self) -> &str {
-        self.description()
-    }
-}
+impl Error for ParseError {}
 
 // to be used in this module and submodules
 const OUT_OF_RANGE: ParseError = ParseError(ParseErrorKind::OutOfRange);

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -333,7 +333,12 @@ impl fmt::Display for ParseError {
 }
 
 #[cfg(any(feature = "std", test))]
-impl Error for ParseError {}
+impl Error for ParseError {
+    #[allow(deprecated)]
+    fn description(&self) -> &str {
+        "parser error, see to_string() for details"
+    }
+}
 
 // to be used in this module and submodules
 const OUT_OF_RANGE: ParseError = ParseError(ParseErrorKind::OutOfRange);

--- a/src/oldtime.rs
+++ b/src/oldtime.rs
@@ -393,24 +393,14 @@ impl fmt::Display for Duration {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OutOfRangeError(());
 
-impl OutOfRangeError {
-    fn description(&self) -> &str {
-        "Source duration value is out of range for the target type"
-    }
-}
-
 impl fmt::Display for OutOfRangeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
+        write!(f, "Source duration value is out of range for the target type")
     }
 }
 
 #[cfg(any(feature = "std", test))]
-impl Error for OutOfRangeError {
-    fn description(&self) -> &str {
-        self.description()
-    }
-}
+impl Error for OutOfRangeError {}
 
 // Copied from libnum
 #[inline]

--- a/src/oldtime.rs
+++ b/src/oldtime.rs
@@ -400,7 +400,12 @@ impl fmt::Display for OutOfRangeError {
 }
 
 #[cfg(any(feature = "std", test))]
-impl Error for OutOfRangeError {}
+impl Error for OutOfRangeError {
+    #[allow(deprecated)]
+    fn description(&self) -> &str {
+        "out of range error"
+    }
+}
 
 // Copied from libnum
 #[inline]


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon.

This PR:
- Removes all implementations of `description` in all error types

Related PR: https://github.com/rust-lang/rust/pull/66919