### PR TITLE
support round tripping display <-> datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Versions with only mechanical changes will be omitted from the following list.
 
 ### Improvements
 
+* Support a space or `T` in `FromStr` for `DateTime<Tz>`, meaning that e.g.
+  `dt.to_string().parse::<DateTime<Utc>>()` now correctly works on round-trip.
+  (@quodlibetor in #378)
 * Support "negative UTC" in `parse_from_rfc2822` (@quodlibetor #368 reported in
   #102)
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -284,6 +284,7 @@ macro_rules! internal_fix { ($x:ident) => (Item::Fixed(Fixed::Internal(InternalF
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub struct ParseError(ParseErrorKind);
 
+/// The category of parse error
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 enum ParseErrorKind {
     /// Given field is out of permitted range.

--- a/src/format/scan.rs
+++ b/src/format/scan.rs
@@ -262,8 +262,20 @@ pub fn timezone_offset_zulu<F>(s: &str, colon: F)
 -> ParseResult<(&str, i32)>
     where F: FnMut(&str) -> ParseResult<&str>
 {
-    match s.as_bytes().first() {
+    let bytes = s.as_bytes();
+    match bytes.first() {
         Some(&b'z') | Some(&b'Z') => Ok((&s[1..], 0)),
+        Some(&b'u') | Some(&b'U') => {
+            if bytes.len() >= 3 {
+                let (b, c) = (bytes[1], bytes[2]);
+                match (b | 32, c | 32) {
+                    (b't', b'c') => Ok((&s[3..], 0)),
+                    _ => Err(INVALID),
+                }
+            } else {
+                Err(INVALID)
+            }
+        }
         _ => timezone_offset(s, colon),
     }
 }


### PR DESCRIPTION
This extens `FromStr` to allow either a `T` or a ` ` (space) as the delimiter
between the date and the time, and, because of the fact that the `Z`
parser-specifier is shared with the Fixed notation, extends the fixed notation
to support `UTC` in addition to `Z` as the zero-offset.

IMO this Fixes #147