### PR TITLE
Reword 'same to' → 'same as'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -451,7 +451,7 @@ and replaced by 0.2.25 very shortly. Duh.)
   They are glibc extensions which seem to be reasonably widespread (e.g. Ruby).
 
 - Added `%:z` specifier and corresponding formatting items
-  which is essentially same to `%z` but with a colon.
+  which is essentially the same as `%z` but with a colon.
 
 - Added a new specifier `%.f` which precision adapts from the input.
   This was added as a response to the UX problems in the original nanosecond specifier `%f`.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ use chrono::prelude::*;
 Chrono currently uses
 the [`time::Duration`](https://docs.rs/time/0.1.40/time/struct.Duration.html) type
 from the `time` crate to represent the magnitude of a time span.
-Since this has the same name to the newer, standard type for duration,
+Since this has the same name as the newer, standard type for duration,
 the reference will refer this type as `OldDuration`.
 Note that this is an "accurate" duration represented as seconds and
 nanoseconds and does not represent "nominal" components such as days or

--- a/src/date.rs
+++ b/src/date.rs
@@ -240,7 +240,7 @@ impl<Tz: TimeZone> Date<Tz> {
 
     /// Returns a view to the naive local date.
     ///
-    /// This is technically same to [`naive_utc`](#method.naive_utc)
+    /// This is technically the same as [`naive_utc`](#method.naive_utc)
     /// because the offset is restricted to never exceed one day,
     /// but provided for the consistency.
     #[inline]

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -184,11 +184,11 @@ pub enum Fixed {
     /// May print nothing, 3, 6 or 9 digits according to the available accuracy.
     /// See also [`Numeric::Nanosecond`](./enum.Numeric.html#variant.Nanosecond).
     Nanosecond,
-    /// Same to [`Nanosecond`](#variant.Nanosecond) but the accuracy is fixed to 3.
+    /// Same as [`Nanosecond`](#variant.Nanosecond) but the accuracy is fixed to 3.
     Nanosecond3,
-    /// Same to [`Nanosecond`](#variant.Nanosecond) but the accuracy is fixed to 6.
+    /// Same as [`Nanosecond`](#variant.Nanosecond) but the accuracy is fixed to 6.
     Nanosecond6,
-    /// Same to [`Nanosecond`](#variant.Nanosecond) but the accuracy is fixed to 9.
+    /// Same as [`Nanosecond`](#variant.Nanosecond) but the accuracy is fixed to 9.
     Nanosecond9,
     /// Timezone name.
     ///
@@ -198,19 +198,19 @@ pub enum Fixed {
     ///
     /// In the parser, the colon can be omitted and/or surrounded with any amount of whitespace.
     /// The offset is limited from `-24:00` to `+24:00`,
-    /// which is same to [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.
+    /// which is the same as [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.
     TimezoneOffsetColon,
     /// Offset from the local time to UTC (`+09:00` or `-04:00` or `Z`).
     ///
     /// In the parser, the colon can be omitted and/or surrounded with any amount of whitespace,
     /// and `Z` can be either in upper case or in lower case.
     /// The offset is limited from `-24:00` to `+24:00`,
-    /// which is same to [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.
+    /// which is the same as [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.
     TimezoneOffsetColonZ,
-    /// Same to [`TimezoneOffsetColon`](#variant.TimezoneOffsetColon) but prints no colon.
+    /// Same as [`TimezoneOffsetColon`](#variant.TimezoneOffsetColon) but prints no colon.
     /// Parsing allows an optional colon.
     TimezoneOffset,
-    /// Same to [`TimezoneOffsetColonZ`](#variant.TimezoneOffsetColonZ) but prints no colon.
+    /// Same as [`TimezoneOffsetColonZ`](#variant.TimezoneOffsetColonZ) but prints no colon.
     /// Parsing allows an optional colon.
     TimezoneOffsetZ,
     /// RFC 2822 date and time syntax. Commonly used for email and MIME date and time.
@@ -242,11 +242,11 @@ enum InternalInternal {
     ///
     /// [iso8601]: https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC
     TimezoneOffsetPermissive,
-    /// Same to [`Nanosecond`](#variant.Nanosecond) but the accuracy is fixed to 3 and there is no leading dot.
+    /// Same as [`Nanosecond`](#variant.Nanosecond) but the accuracy is fixed to 3 and there is no leading dot.
     Nanosecond3NoDot,
-    /// Same to [`Nanosecond`](#variant.Nanosecond) but the accuracy is fixed to 6 and there is no leading dot.
+    /// Same as [`Nanosecond`](#variant.Nanosecond) but the accuracy is fixed to 6 and there is no leading dot.
     Nanosecond6NoDot,
-    /// Same to [`Nanosecond`](#variant.Nanosecond) but the accuracy is fixed to 9 and there is no leading dot.
+    /// Same as [`Nanosecond`](#variant.Nanosecond) but the accuracy is fixed to 9 and there is no leading dot.
     Nanosecond9NoDot,
 }
 
@@ -255,12 +255,12 @@ enum InternalInternal {
 pub enum Item<'a> {
     /// A literally printed and parsed text.
     Literal(&'a str),
-    /// Same to `Literal` but with the string owned by the item.
+    /// Same as `Literal` but with the string owned by the item.
     #[cfg(any(feature = "alloc", feature = "std", test))]
     OwnedLiteral(Box<str>),
     /// Whitespace. Prints literally but reads zero or more whitespace.
     Space(&'a str),
-    /// Same to `Space` but with the string owned by the item.
+    /// Same as `Space` but with the string owned by the item.
     #[cfg(any(feature = "alloc", feature = "std", test))]
     OwnedSpace(Box<str>),
     /// Numeric item. Can be optionally padded to the maximal length (if any) when formatting;
@@ -315,7 +315,7 @@ enum ParseErrorKind {
     BadFormat,
 }
 
-/// Same to `Result<T, ParseError>`.
+/// Same as `Result<T, ParseError>`.
 pub type ParseResult<T> = Result<T, ParseError>;
 
 impl fmt::Display for ParseError {
@@ -565,7 +565,7 @@ pub fn format<'a, I, B>(
                         off.map(|&(_, off)| write_local_minus_utc(&mut result, off, true, false)),
                     &Internal(InternalFixed { val: InternalInternal::TimezoneOffsetPermissive }) =>
                         panic!("Do not try to write %#z it is undefined"),
-                    &RFC2822 => // same to `%a, %e %b %Y %H:%M:%S %z`
+                    &RFC2822 => // same as `%a, %e %b %Y %H:%M:%S %z`
                         if let (Some(d), Some(t), Some(&(_, off))) = (date, time, off) {
                             let sec = t.second() + t.nanosecond() / 1_000_000_000;
                             write!(
@@ -579,7 +579,7 @@ pub fn format<'a, I, B>(
                         } else {
                             None
                         },
-                    &RFC3339 => // same to `%Y-%m-%dT%H:%M:%S%.f%:z`
+                    &RFC3339 => // same as `%Y-%m-%dT%H:%M:%S%.f%:z`
                         if let (Some(d), Some(t), Some(&(_, off))) = (date, time, off) {
                             // reuse `Debug` impls which already print ISO 8601 format.
                             // this is faster in this way.

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -53,10 +53,10 @@ fn parse_rfc2822<'a>(parsed: &mut Parsed, mut s: &'a str) -> ParseResult<(&'a st
     // minute      = *S 2DIGIT *S
     // second      = *S 2DIGIT *S
     // zone        = ( "+" / "-" ) 4DIGIT /
-    //               "UT" / "GMT" /                  ; same to +0000
-    //               "EST" / "CST" / "MST" / "PST" / ; same to -0500 to -0800
-    //               "EDT" / "CDT" / "MDT" / "PDT" / ; same to -0400 to -0700
-    //               1*(%d65-90 / %d97-122)          ; same to -0000
+    //               "UT" / "GMT" /                  ; same as +0000
+    //               "EST" / "CST" / "MST" / "PST" / ; same as -0500 to -0800
+    //               "EDT" / "CDT" / "MDT" / "PDT" / ; same as -0400 to -0700
+    //               1*(%d65-90 / %d97-122)          ; same as -0000
     //
     // some notes:
     //

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -110,7 +110,7 @@ pub struct Parsed {
     _dummy: (),
 }
 
-/// Checks if `old` is either empty or has the same value to `new` (i.e. "consistent"),
+/// Checks if `old` is either empty or has the same value as `new` (i.e. "consistent"),
 /// and if it is empty, set `old` to `new` as well.
 #[inline]
 fn set_if_consistent<T: PartialEq>(old: &mut Option<T>, new: T) -> ParseResult<()> {

--- a/src/format/scan.rs
+++ b/src/format/scan.rs
@@ -257,7 +257,7 @@ fn timezone_offset_internal<F>(mut s: &str, mut consume_colon: F, allow_missing_
     Ok((s, if negative {-seconds} else {seconds}))
 }
 
-/// Same to `timezone_offset` but also allows for `z`/`Z` which is same to `+00:00`.
+/// Same as `timezone_offset` but also allows for `z`/`Z` which is the same as `+00:00`.
 pub fn timezone_offset_zulu<F>(s: &str, colon: F)
 -> ParseResult<(&str, i32)>
     where F: FnMut(&str) -> ParseResult<&str>
@@ -268,7 +268,7 @@ pub fn timezone_offset_zulu<F>(s: &str, colon: F)
     }
 }
 
-/// Same to `timezone_offset` but also allows for `z`/`Z` which is same to
+/// Same as `timezone_offset` but also allows for `z`/`Z` which is the same as
 /// `+00:00`, and allows missing minutes entirely.
 pub fn timezone_offset_permissive<F>(s: &str, colon: F)
 -> ParseResult<(&str, i32)>
@@ -280,7 +280,7 @@ pub fn timezone_offset_permissive<F>(s: &str, colon: F)
     }
 }
 
-/// Same to `timezone_offset` but also allows for RFC 2822 legacy timezones.
+/// Same as `timezone_offset` but also allows for RFC 2822 legacy timezones.
 /// May return `None` which indicates an insufficient offset data (i.e. `-0000`).
 pub fn timezone_offset_2822(s: &str) -> ParseResult<(&str, Option<i32>)> {
     // tries to parse legacy time zone names

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -18,10 +18,10 @@ The following specifiers are available both to formatting and parsing.
 | `%m`  | `07`     | Month number (01--12), zero-padded to 2 digits.                            |
 | `%b`  | `Jul`    | Abbreviated month name. Always 3 letters.                                  |
 | `%B`  | `July`   | Full month name. Also accepts corresponding abbreviation in parsing.       |
-| `%h`  | `Jul`    | Same to `%b`.                                                              |
+| `%h`  | `Jul`    | Same as `%b`.                                                              |
 |       |          |                                                                            |
 | `%d`  | `08`     | Day number (01--31), zero-padded to 2 digits.                              |
-| `%e`  | ` 8`     | Same to `%d` but space-padded. Same to `%_d`.                              |
+| `%e`  | ` 8`     | Same as `%d` but space-padded. Same as `%_d`.                              |
 |       |          |                                                                            |
 | `%a`  | `Sun`    | Abbreviated weekday name. Always 3 letters.                                |
 | `%A`  | `Sunday` | Full weekday name. Also accepts corresponding abbreviation in parsing.     |
@@ -29,24 +29,24 @@ The following specifiers are available both to formatting and parsing.
 | `%u`  | `7`      | Monday = 1, Tuesday = 2, ..., Sunday = 7. (ISO 8601)                       |
 |       |          |                                                                            |
 | `%U`  | `28`     | Week number starting with Sunday (00--53), zero-padded to 2 digits. [^3]   |
-| `%W`  | `27`     | Same to `%U`, but week 1 starts with the first Monday in that year instead.|
+| `%W`  | `27`     | Same as `%U`, but week 1 starts with the first Monday in that year instead.|
 |       |          |                                                                            |
-| `%G`  | `2001`   | Same to `%Y` but uses the year number in ISO 8601 week date. [^4]          |
-| `%g`  | `01`     | Same to `%y` but uses the year number in ISO 8601 week date. [^4]          |
-| `%V`  | `27`     | Same to `%U` but uses the week number in ISO 8601 week date (01--53). [^4] |
+| `%G`  | `2001`   | Same as `%Y` but uses the year number in ISO 8601 week date. [^4]          |
+| `%g`  | `01`     | Same as `%y` but uses the year number in ISO 8601 week date. [^4]          |
+| `%V`  | `27`     | Same as `%U` but uses the week number in ISO 8601 week date (01--53). [^4] |
 |       |          |                                                                            |
 | `%j`  | `189`    | Day of the year (001--366), zero-padded to 3 digits.                       |
 |       |          |                                                                            |
-| `%D`  | `07/08/01`    | Month-day-year format. Same to `%m/%d/%y`.                            |
-| `%x`  | `07/08/01`    | Same to `%D`.                                                         |
-| `%F`  | `2001-07-08`  | Year-month-day format (ISO 8601). Same to `%Y-%m-%d`.                 |
-| `%v`  | ` 8-Jul-2001` | Day-month-year format. Same to `%e-%b-%Y`.                            |
+| `%D`  | `07/08/01`    | Month-day-year format. Same as `%m/%d/%y`.                            |
+| `%x`  | `07/08/01`    | Same as `%D`.                                                         |
+| `%F`  | `2001-07-08`  | Year-month-day format (ISO 8601). Same as `%Y-%m-%d`.                 |
+| `%v`  | ` 8-Jul-2001` | Day-month-year format. Same as `%e-%b-%Y`.                            |
 |       |          |                                                                            |
 |       |          | **TIME SPECIFIERS:**                                                       |
 | `%H`  | `00`     | Hour number (00--23), zero-padded to 2 digits.                             |
-| `%k`  | ` 0`     | Same to `%H` but space-padded. Same to `%_H`.                              |
+| `%k`  | ` 0`     | Same as `%H` but space-padded. Same as `%_H`.                              |
 | `%I`  | `12`     | Hour number in 12-hour clocks (01--12), zero-padded to 2 digits.           |
-| `%l`  | `12`     | Same to `%I` but space-padded. Same to `%_I`.                              |
+| `%l`  | `12`     | Same as `%I` but space-padded. Same as `%_I`.                              |
 |       |          |                                                                            |
 | `%P`  | `am`     | `am` or `pm` in 12-hour clocks.                                            |
 | `%p`  | `AM`     | `AM` or `PM` in 12-hour clocks.                                            |
@@ -62,19 +62,19 @@ The following specifiers are available both to formatting and parsing.
 | `%6f` | `026490`      | Similar to `%.6f` but without the leading dot. [^8]                   |
 | `%9f` | `026490000`   | Similar to `%.9f` but without the leading dot. [^8]                   |
 |       |               |                                                                       |
-| `%R`  | `00:34`       | Hour-minute format. Same to `%H:%M`.                                  |
-| `%T`  | `00:34:60`    | Hour-minute-second format. Same to `%H:%M:%S`.                        |
-| `%X`  | `00:34:60`    | Same to `%T`.                                                         |
-| `%r`  | `12:34:60 AM` | Hour-minute-second format in 12-hour clocks. Same to `%I:%M:%S %p`.   |
+| `%R`  | `00:34`       | Hour-minute format. Same as `%H:%M`.                                  |
+| `%T`  | `00:34:60`    | Hour-minute-second format. Same as `%H:%M:%S`.                        |
+| `%X`  | `00:34:60`    | Same as `%T`.                                                         |
+| `%r`  | `12:34:60 AM` | Hour-minute-second format in 12-hour clocks. Same as `%I:%M:%S %p`.   |
 |       |          |                                                                            |
 |       |          | **TIME ZONE SPECIFIERS:**                                                  |
 | `%Z`  | `ACST`   | *Formatting only:* Local time zone name.                                   |
 | `%z`  | `+0930`  | Offset from the local time to UTC (with UTC being `+0000`).                |
-| `%:z` | `+09:30` | Same to `%z` but with a colon.                                             |
-| `%#z` | `+09`    | *Parsing only:* Same to `%z` but allows minutes to be missing or present.  |
+| `%:z` | `+09:30` | Same as `%z` but with a colon.                                             |
+| `%#z` | `+09`    | *Parsing only:* Same as `%z` but allows minutes to be missing or present.  |
 |       |          |                                                                            |
 |       |          | **DATE & TIME SPECIFIERS:**                                                |
-|`%c`|`Sun Jul  8 00:34:60 2001`|`ctime` date & time format. Same to `%a %b %e %T %Y` sans `\n`.|
+|`%c`|`Sun Jul  8 00:34:60 2001`|`ctime` date & time format. Same as `%a %b %e %T %Y` sans `\n`.|
 | `%+`  | `2001-07-08T00:34:60.026490+09:30` | ISO 8601 / RFC 3339 date & time format. [^6]     |
 |       |               |                                                                       |
 | `%s`  | `994518299`   | UNIX timestamp, the number of seconds since 1970-01-01 00:00 UTC. [^7]|

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@
 //! Chrono currently uses
 //! the [`time::Duration`](https://docs.rs/time/0.1.40/time/struct.Duration.html) type
 //! from the `time` crate to represent the magnitude of a time span.
-//! Since this has the same name to the newer, standard type for duration,
+//! Since this has the same name as the newer, standard type for duration,
 //! the reference will refer this type as `OldDuration`.
 //! Note that this is an "accurate" duration represented as seconds and
 //! nanoseconds and does not represent "nominal" components such as days or

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -94,7 +94,7 @@ const MAX_BITS: usize = 44;
 ///
 /// The ISO 8601 **ordinal date** is a pair of year number and day of the year ("ordinal").
 /// The ordinal number ranges from 1 to 365 or 366 depending on the year.
-/// The year number is same to that of the [calendar date](#calendar-date).
+/// The year number is the same as that of the [calendar date](#calendar-date).
 ///
 /// This is currently the internal format of Chrono's date types.
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone)]
@@ -943,7 +943,7 @@ impl NaiveDate {
     }
 
     /// Formats the date with the specified formatting items.
-    /// Otherwise it is same to the ordinary `format` method.
+    /// Otherwise it is the same as the ordinary `format` method.
     ///
     /// The `Iterator` of items should be `Clone`able,
     /// since the resulting `DelayedFormat` value may be formatted multiple times.
@@ -1400,7 +1400,7 @@ impl AddAssign<OldDuration> for NaiveDate {
 
 /// A subtraction of `Duration` from `NaiveDate` discards the fractional days,
 /// rounding to the closest integral number of days towards `Duration::zero()`.
-/// It is same to the addition with a negated `Duration`.
+/// It is the same as the addition with a negated `Duration`.
 ///
 /// Panics on underflow or overflow.
 /// Use [`NaiveDate::checked_sub_signed`](#method.checked_sub_signed) to detect that.
@@ -1476,7 +1476,7 @@ impl Sub<NaiveDate> for NaiveDate {
     }
 }
 
-/// The `Debug` output of the naive date `d` is same to
+/// The `Debug` output of the naive date `d` is the same as
 /// [`d.format("%Y-%m-%d")`](../format/strftime/index.html).
 ///
 /// The string printed can be readily parsed via the `parse` method on `str`.
@@ -1511,7 +1511,7 @@ impl fmt::Debug for NaiveDate {
     }
 }
 
-/// The `Display` output of the naive date `d` is same to
+/// The `Display` output of the naive date `d` is the same as
 /// [`d.format("%Y-%m-%d")`](../format/strftime/index.html).
 ///
 /// The string printed can be readily parsed via the `parse` method on `str`.

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -623,7 +623,7 @@ impl NaiveDateTime {
     }
 
     /// Formats the combined date and time with the specified formatting items.
-    /// Otherwise it is same to the ordinary [`format`](#method.format) method.
+    /// Otherwise it is the same as the ordinary [`format`](#method.format) method.
     ///
     /// The `Iterator` of items should be `Clone`able,
     /// since the resulting `DelayedFormat` value may be formatted multiple times.
@@ -1265,7 +1265,7 @@ impl AddAssign<OldDuration> for NaiveDateTime {
 }
 
 /// A subtraction of `Duration` from `NaiveDateTime` yields another `NaiveDateTime`.
-/// It is same to the addition with a negated `Duration`.
+/// It is the same as the addition with a negated `Duration`.
 ///
 /// As a part of Chrono's [leap second handling](./struct.NaiveTime.html#leap-second-handling),
 /// the addition assumes that **there is no leap second ever**,
@@ -1389,7 +1389,7 @@ impl Sub<NaiveDateTime> for NaiveDateTime {
     }
 }
 
-/// The `Debug` output of the naive date and time `dt` is same to
+/// The `Debug` output of the naive date and time `dt` is the same as
 /// [`dt.format("%Y-%m-%dT%H:%M:%S%.f")`](../format/strftime/index.html).
 ///
 /// The string printed can be readily parsed via the `parse` method on `str`.
@@ -1422,7 +1422,7 @@ impl fmt::Debug for NaiveDateTime {
     }
 }
 
-/// The `Debug` output of the naive date and time `dt` is same to
+/// The `Debug` output of the naive date and time `dt` is the same as
 /// [`dt.format("%Y-%m-%d %H:%M:%S%.f")`](../format/strftime/index.html).
 ///
 /// It should be noted that, for leap seconds not on the minute boundary,

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -104,7 +104,7 @@ impl IsoWeek {
     }
 }
 
-/// The `Debug` output of the ISO week `w` is same to
+/// The `Debug` output of the ISO week `w` is the same as
 /// [`d.format("%G-W%V")`](../format/strftime/index.html)
 /// where `d` is any `NaiveDate` value in that week.
 ///

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -701,7 +701,7 @@ impl NaiveTime {
     }
 
     /// Formats the time with the specified formatting items.
-    /// Otherwise it is same to the ordinary [`format`](#method.format) method.
+    /// Otherwise it is the same as the ordinary [`format`](#method.format) method.
     ///
     /// The `Iterator` of items should be `Clone`able,
     /// since the resulting `DelayedFormat` value may be formatted multiple times.
@@ -1071,7 +1071,7 @@ impl AddAssign<OldDuration> for NaiveTime {
 
 /// A subtraction of `Duration` from `NaiveTime` wraps around and never overflows or underflows.
 /// In particular the addition ignores integral number of days.
-/// It is same to the addition with a negated `Duration`.
+/// It is the same as the addition with a negated `Duration`.
 ///
 /// As a part of Chrono's [leap second handling](#leap-second-handling),
 /// the addition assumes that **there is no leap second ever**,
@@ -1199,7 +1199,7 @@ impl Sub<NaiveTime> for NaiveTime {
     }
 }
 
-/// The `Debug` output of the naive time `t` is same to
+/// The `Debug` output of the naive time `t` is the same as
 /// [`t.format("%H:%M:%S%.f")`](../format/strftime/index.html).
 ///
 /// The string printed can be readily parsed via the `parse` method on `str`.
@@ -1249,7 +1249,7 @@ impl fmt::Debug for NaiveTime {
     }
 }
 
-/// The `Display` output of the naive time `t` is same to
+/// The `Display` output of the naive time `t` is the same as
 /// [`t.format("%H:%M:%S%.f")`](../format/strftime/index.html).
 ///
 /// The string printed can be readily parsed via the `parse` method on `str`.

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -136,7 +136,7 @@ impl fmt::Display for FixedOffset {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Debug::fmt(self, f) }
 }
 
-// addition or subtraction of FixedOffset to/from Timelike values is same to
+// addition or subtraction of FixedOffset to/from Timelike values is the same as
 // adding or subtracting the offset's local_minus_utc value
 // but keep keeps the leap second information.
 // this should be implemented more efficiently, but for the time being, this is generic right now.


### PR DESCRIPTION
Fixed this expression across the codebase (mostly in code comments and documentation).