### PR TITLE
Fix cargo test with latest serde_json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ wasm-bindgen = { version = "0.2", optional = true }
 js-sys = { version = "0.3", optional = true } # contains FFI bindings for the JS Date API
 
 [dev-dependencies]
-serde_json = { version = "1", default-features = false }
+serde_json = { version = "1" }
 serde_derive = { version = "1", default-features = false }
 bincode = { version = "0.8.0" }
 num-iter = { version = "0.1.35", default-features = false }


### PR DESCRIPTION
```rust
[  117s] error: expected item, found `"serde_json requires that either `std` (default) or `alloc` feature is enabled"`
[  117s]  --> /usr/share/cargo/registry/serde_json-1.0.48/src/features_check/error.rs:1:1
[  117s]   |
[  117s] 1 | "serde_json requires that either `std` (default) or `alloc` feature is enabled"
[  117s]   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected item
```