### PR TITLE
Tmin tmax

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -70,9 +70,9 @@ pub struct DateTime<Tz: TimeZone> {
 }
 
 /// The minimum possible `DateTime`.
-pub const MIN_UTC_DATETIME: Date<Utc> = Date { datetime: naive::MIN_DATE, offset: Utc };
+pub const MIN_UTC_DATETIME: DateTime<Utc> = DateTime { datetime: naive::MIN_DATETIME, offset: Utc };
 /// The maximum possible `DateTime`.
-pub const MAX_UTC_DATETIME: Date<Utc> = Date { datetime: naive::MAX_DATE, offset: Utc };
+pub const MAX_UTC_DATETIME: DateTime<Utc> = DateTime { datetime: naive::MAX_DATETIME, offset: Utc };
 
 impl<Tz: TimeZone> DateTime<Tz> {
     /// Makes a new `DateTime` with given *UTC* datetime and offset.

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -69,6 +69,11 @@ pub struct DateTime<Tz: TimeZone> {
     offset: Tz::Offset,
 }
 
+/// The minimum possible `DateTime`.
+pub const MIN_UTC_DATETIME: Date<Utc> = Date { datetime: naive::MIN_DATE, offset: Utc };
+/// The maximum possible `DateTime`.
+pub const MAX_UTC_DATETIME: Date<Utc> = Date { datetime: naive::MAX_DATE, offset: Utc };
+
 impl<Tz: TimeZone> DateTime<Tz> {
     /// Makes a new `DateTime` with given *UTC* datetime and offset.
     /// The local datetime should be constructed via the `TimeZone` trait.

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -19,7 +19,7 @@ use {Weekday, Timelike, Datelike};
 #[cfg(feature="clock")]
 use offset::Local;
 use offset::{TimeZone, Offset, Utc, FixedOffset};
-use naive::{NaiveTime, NaiveDateTime, IsoWeek};
+use naive::{self, NaiveTime, NaiveDateTime, IsoWeek};
 use Date;
 use format::{Item, Fixed};
 use format::{parse, Parsed, ParseError, ParseResult, StrftimeItems};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,7 +386,7 @@
 #![cfg_attr(feature = "bench", feature(test))] // lib stability features as per RFC #507
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
-//#![deny(dead_code)]
+#![deny(dead_code)]
 
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -442,7 +442,7 @@ pub use oldtime::Duration;
 #[doc(no_inline)] pub use offset::{TimeZone, Offset, LocalResult, Utc, FixedOffset};
 #[doc(no_inline)] pub use naive::{NaiveDate, IsoWeek, NaiveTime, NaiveDateTime};
 pub use date::{Date, MIN_DATE, MAX_DATE};
-pub use datetime::{DateTime, SecondsFormat};
+pub use datetime::{DateTime, SecondsFormat, MIN_UTC_DATETIME, MAX_UTC_DATETIME};
 #[cfg(feature = "rustc-serialize")]
 pub use datetime::rustc_serialize::TsSeconds;
 pub use format::{ParseError, ParseResult};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,7 +386,7 @@
 #![cfg_attr(feature = "bench", feature(test))] // lib stability features as per RFC #507
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
-#![deny(dead_code)]
+//#![deny(dead_code)]
 
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 
@@ -486,7 +486,7 @@ pub mod naive {
     pub use self::date::{NaiveDate, MIN_DATE, MAX_DATE};
     pub use self::isoweek::IsoWeek;
     pub use self::time::NaiveTime;
-    pub use self::datetime::NaiveDateTime;
+    pub use self::datetime::{NaiveDateTime, MIN_DATETIME, MAX_DATETIME};
     #[cfg(feature = "rustc-serialize")]
     #[allow(deprecated)]
     pub use self::datetime::rustc_serialize::TsSeconds;

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -57,6 +57,11 @@ pub struct NaiveDateTime {
     time: NaiveTime,
 }
 
+/// The minimum possible `NaiveDateTime` (Note MIN_DATE is January 1, 262145 BCE)
+pub const MIN_DATETIME: NaiveDateTime = NaiveDateTime { date: MIN_DATE, time: MIN_TIME};
+/// The maximum possible `NaiveDateTime` (Note MAX_DATE is December 31, 262143 CE)
+pub const MAX_DATETIME: NaiveDateTime = NaiveDateTime { date: MAX_DATE, time: MAX_TIME};
+
 impl NaiveDateTime {
     /// Makes a new `NaiveDateTime` from date and time components.
     /// Equivalent to [`date.and_time(time)`](./struct.NaiveDate.html#method.and_time)

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -12,7 +12,7 @@ use oldtime::Duration as OldDuration;
 
 use {Weekday, Timelike, Datelike};
 use div::div_mod_floor;
-use naive::{NaiveTime, NaiveDate, IsoWeek};
+use naive::{self, NaiveTime, NaiveDate, IsoWeek};
 use format::{Item, Numeric, Pad, Fixed};
 use format::{parse, Parsed, ParseError, ParseResult, StrftimeItems};
 #[cfg(any(feature = "alloc", feature = "std", test))]
@@ -58,9 +58,9 @@ pub struct NaiveDateTime {
 }
 
 /// The minimum possible `NaiveDateTime` (Note MIN_DATE is January 1, 262145 BCE)
-pub const MIN_DATETIME: NaiveDateTime = NaiveDateTime { date: MIN_DATE, time: MIN_TIME };
+pub const MIN_DATETIME: NaiveDateTime = NaiveDateTime { date: naive::date::MIN_DATE, time: naive::time::MIN_TIME };
 /// The maximum possible `NaiveDateTime` (Note MAX_DATE is December 31, 262143 CE)
-pub const MAX_DATETIME: NaiveDateTime = NaiveDateTime { date: MAX_DATE, time: MAX_TIME };
+pub const MAX_DATETIME: NaiveDateTime = NaiveDateTime { date: naive::date::MAX_DATE, time: naive::time::MAX_TIME };
 
 impl NaiveDateTime {
     /// Makes a new `NaiveDateTime` from date and time components.

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -58,9 +58,9 @@ pub struct NaiveDateTime {
 }
 
 /// The minimum possible `NaiveDateTime` (Note MIN_DATE is January 1, 262145 BCE)
-pub const MIN_DATETIME: NaiveDateTime = NaiveDateTime { date: MIN_DATE, time: MIN_TIME};
+pub const MIN_DATETIME: NaiveDateTime = NaiveDateTime { date: MIN_DATE, time: MIN_TIME };
 /// The maximum possible `NaiveDateTime` (Note MAX_DATE is December 31, 262143 CE)
-pub const MAX_DATETIME: NaiveDateTime = NaiveDateTime { date: MAX_DATE, time: MAX_TIME};
+pub const MAX_DATETIME: NaiveDateTime = NaiveDateTime { date: MAX_DATE, time: MAX_TIME };
 
 impl NaiveDateTime {
     /// Makes a new `NaiveDateTime` from date and time components.

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -182,9 +182,9 @@ pub struct NaiveTime {
 }
 
 /// The minimum possible 'NaiveTime' 
-pub const MIN_TIME: NaiveTime = { secs: 0, frac: 0 };
+pub const MIN_TIME: NaiveTime = NaiveTime { secs: 0, frac: 0 };
 /// The maximum possible 'NaiveTime'
-pub const MAX_TIME: NaiveTime = { secs: u32::Max, frac: u32::Max };
+pub const MAX_TIME: NaiveTime = NaiveTime { secs: u32::Max, frac: u32::Max };
 
 impl NaiveTime {
     /// Makes a new `NaiveTime` from hour, minute and second.

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -181,6 +181,11 @@ pub struct NaiveTime {
     frac: u32,
 }
 
+/// The minimum possible 'NaiveTime' 
+pub const MIN_TIME: NaiveTime = { secs: 0, frac: 0 };
+/// The maximum possible 'NaiveTime'
+pub const MAX_TIME: NaiveTime = { secs: u32::Max, frac: u32::Max };
+
 impl NaiveTime {
     /// Makes a new `NaiveTime` from hour, minute and second.
     ///

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -184,7 +184,7 @@ pub struct NaiveTime {
 /// The minimum possible 'NaiveTime' 
 pub const MIN_TIME: NaiveTime = NaiveTime { secs: 0, frac: 0 };
 /// The maximum possible 'NaiveTime'
-pub const MAX_TIME: NaiveTime = NaiveTime { secs: u32::Max, frac: u32::Max };
+pub const MAX_TIME: NaiveTime = NaiveTime { secs: std::u32::MAX, frac: std::u32::MAX };
 
 impl NaiveTime {
     /// Makes a new `NaiveTime` from hour, minute and second.


### PR DESCRIPTION
I added in MIN_UTC_DATETIME and MAX_UTC_DATETIME, its naive counterpart and MIN_TIME and MAX_TIME. However, when compiling the code, I get an error due to dead code as these variables aren't used anywhere in the code. In order to test the changes, I temporarily commented the line out and received the following failure shown below. I am not sure where the error is coming from as the inputted code is recognized as dead code so it shouldn't be changing anything. Any input on how to proceed would be appreciated!

failures:
```
---- datetime::tests::test_from_system_time stdout ----
  left: `2001-09-09T01:46:39.999999900Z`,
 right: `2001-09-09T01:46:39.999999999Z`', src\datetime.rs:2205:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.


failures:
    datetime::tests::test_from_system_time

test result: FAILED. 101 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```