### PR TITLE
Serde: Deserialize units as None on optional value

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1279,7 +1279,7 @@ pub mod serde {
                 where
                     D: de::Deserializer<'de>,
             {
-                d.deserialize_i64(NanoSecondsTimestampVisitor).map(|val| Some(val))
+                d.deserialize_i64(NanoSecondsTimestampVisitor).map(Some)
             }
 
             /// Deserialize a timestamp in seconds since the epoch
@@ -1577,7 +1577,7 @@ pub mod serde {
                 where
                     D: de::Deserializer<'de>,
             {
-                d.deserialize_i64(MilliSecondsTimestampVisitor).map(|val| Some(val))
+                d.deserialize_i64(MilliSecondsTimestampVisitor).map(Some)
             }
 
             /// Deserialize a timestamp in seconds since the epoch
@@ -1871,7 +1871,7 @@ pub mod serde {
                 where
                     D: de::Deserializer<'de>,
             {
-                d.deserialize_i64(SecondsTimestampVisitor).map(|val| Some(val))
+                d.deserialize_i64(SecondsTimestampVisitor).map(Some)
             }
 
             /// Deserialize a timestamp in seconds since the epoch

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1542,17 +1542,22 @@ pub mod serde {
         /// # #[macro_use] extern crate serde_derive;
         /// # #[macro_use] extern crate serde_json;
         /// # extern crate chrono;
-        /// # use chrono::{DateTime, Utc};
+        /// # use chrono::prelude::*;
         /// use chrono::serde::ts_milliseconds_option::deserialize as from_milli_tsopt;
-        /// #[derive(Deserialize)]
+        /// #[derive(Deserialize, PartialEq)]
         /// struct S {
         ///     #[serde(deserialize_with = "from_milli_tsopt")]
         ///     time: Option<DateTime<Utc>>
         /// }
         ///
-        /// # fn example() -> Result<S, serde_json::Error> {
+        /// # fn example() -> Result<(), serde_json::Error> {
         /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
-        /// # Ok(my_s)
+        /// assert_eq!(my_s.time, Some(Utc.timestamp(1526522699, 918000000)));
+        /// let s: S = serde_json::from_str(r#"{ "time": null }"#)?;
+        /// assert!(s.time.is_none());
+        /// let t: S = serde_json::from_str(r#"{}"#)?;
+        /// assert!(t.time.is_none());
+        /// # Ok(())
         /// # }
         /// # fn main() { example().unwrap(); }
         /// ```

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1546,7 +1546,7 @@ pub mod serde {
         /// use chrono::serde::ts_milliseconds_option::deserialize as from_milli_tsopt;
         /// #[derive(Deserialize, PartialEq)]
         /// struct S {
-        ///     #[serde(deserialize_with = "from_milli_tsopt")]
+        ///     #[serde(default, deserialize_with = "from_milli_tsopt")]
         ///     time: Option<DateTime<Utc>>
         /// }
         ///
@@ -1587,13 +1587,6 @@ pub mod serde {
 
             /// Deserialize a timestamp in seconds since the epoch
             fn visit_none<E>(self) -> Result<Option<DateTime<Utc>>, E>
-                where E: de::Error
-            {
-                Ok(None)
-            }
-
-            /// Deserialize a timestamp in seconds since the epoch
-            fn visit_unit<E>(self) -> Result<Option<DateTime<Utc>>, E>
                 where E: de::Error
             {
                 Ok(None)

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1288,6 +1288,13 @@ pub mod serde {
             {
                 Ok(None)
             }
+
+            /// Deserialize a timestamp in seconds since the epoch
+            fn visit_unit<E>(self) -> Result<Option<DateTime<Utc>>, E>
+                where E: de::Error
+            {
+                Ok(None)
+            }
         }
     }
 
@@ -1579,6 +1586,13 @@ pub mod serde {
             {
                 Ok(None)
             }
+
+            /// Deserialize a timestamp in seconds since the epoch
+            fn visit_unit<E>(self) -> Result<Option<DateTime<Utc>>, E>
+                where E: de::Error
+            {
+                Ok(None)
+            }
         }
     }
 
@@ -1862,6 +1876,13 @@ pub mod serde {
 
             /// Deserialize a timestamp in seconds since the epoch
             fn visit_none<E>(self) -> Result<Option<DateTime<Utc>>, E>
+                where E: de::Error
+            {
+                Ok(None)
+            }
+
+            /// Deserialize a timestamp in seconds since the epoch
+            fn visit_unit<E>(self) -> Result<Option<DateTime<Utc>>, E>
                 where E: de::Error
             {
                 Ok(None)


### PR DESCRIPTION
This implements [`Visitor::visit_unit`](https://docs.serde.rs/serde/de/trait.Visitor.html#method.visit_unit) for all `Visitor`s of optional values, like serde does: [`impl<'de, T> Visitor<'de> for OptionVisitor<T>`](https://github.com/serde-rs/serde/blob/2b4355724e5f4ccb183b375645f62e0fc3c1f4b9/serde/src/de/impls.rs#L604-L609)

Deserialization of an optional field using [`#[serde(deserialize_with = "path", default)]`](https://serde.rs/field-attrs.html#deserialize_with) from `{ "value": null }` fails with `Error: Error("data did not match any variant of untagged enum UntaggedEnum", line: 0, column: 0)`, if matching an [untagged enum representation](https://serde.rs/enum-representations.html#untagged) and the `Visitor` does not implement [`Visitor::visit_unit`](https://docs.serde.rs/serde/de/trait.Visitor.html#method.visit_unit) as demonstrated here:

```rust
/// This demonstrates that deserialization of an optional field using
/// `#[serde(deserialize_with = "path", default)]` from `{ "value": null }`
/// fails if matching an untagged enum representation and the `Visitor` does
/// not implement `Visitor::visit_unit`.
use serde::de::{self, Visitor};
use serde::{Deserialize, Deserializer};
use std::fmt;

/// A visitor that deserializes a bool from the numbers 0 and 1
struct NumberBoolVisitor;

impl<'de> Visitor<'de> for NumberBoolVisitor {
    type Value = bool;

    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
        formatter.write_str("an integer of either 0 or 1")
    }

    fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
    where
        E: de::Error,
    {
        match value {
            0 => Ok(false),
            1 => Ok(true),
            _ => Err(E::custom(format!("bool out of range: {}", value))),
        }
    }
}

fn deserialize_number_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
where
    D: Deserializer<'de>,
{
    deserializer.deserialize_u64(NumberBoolVisitor)
}

/// A visitor that deserializes an optional bool from the numbers 0 and 1
struct NumberBoolOptionVisitor;

impl<'de> Visitor<'de> for NumberBoolOptionVisitor {
    type Value = Option<bool>;

    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
        formatter.write_str("an optional integer of either 0 or 1")
    }

    // Uncomment this to solve the problem
    // fn visit_unit<E>(self) -> Result<Self::Value, E>
    // where
    //     E: de::Error,
    // {
    //     Ok(None)
    // }

    fn visit_none<E>(self) -> Result<Self::Value, E>
    where
        E: de::Error,
    {
        Ok(None)
    }

    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
    where
        D: Deserializer<'de>,
    {
        deserialize_number_bool(deserializer).map(Some)
    }
}

fn deserialize_number_bool_option<'de, D>(deserializer: D) -> Result<Option<bool>, D::Error>
where
    D: Deserializer<'de>,
{
    deserializer.deserialize_option(NumberBoolOptionVisitor)
}

#[derive(Deserialize, Debug, PartialEq)]
#[serde(untagged)]
enum UntaggedEnum<T> {
    Variant(T),
}

#[derive(Deserialize, Debug, PartialEq)]
struct Bool {
    value: Option<bool>,
}

#[derive(Deserialize, Debug, PartialEq)]
struct NumberBool {
    #[serde(deserialize_with = "deserialize_number_bool_option", default)]
    value: Option<bool>,
}

#[cfg(test)]
mod tests {
    use super::*;
    use serde_json::json;

    #[test]
    fn test_match_deserialize() -> Result<(), serde_json::Error> {
        assert_eq!(
            UntaggedEnum::Variant(Bool { value: Some(false) }),
            serde_json::from_value::<UntaggedEnum<Bool>>(json!({
                "value": false,
            }))?
        );
        assert_eq!(
            UntaggedEnum::Variant(Bool { value: None }),
            serde_json::from_value::<UntaggedEnum<Bool>>(json!({
                "value": null,
            }))?
        );
        assert_eq!(
            UntaggedEnum::Variant(Bool { value: None }),
            serde_json::from_value::<UntaggedEnum<Bool>>(json!({}))?
        );
        Ok(())
    }

    #[test]
    fn test_working_match_with() -> Result<(), serde_json::Error> {
        assert_eq!(
            UntaggedEnum::Variant(NumberBool { value: Some(false) }),
            serde_json::from_value::<UntaggedEnum<NumberBool>>(json!({
                "value": 0,
            }))?
        );
        assert_eq!(
            UntaggedEnum::Variant(NumberBool { value: None }),
            serde_json::from_value::<UntaggedEnum<NumberBool>>(json!({}))?
        );
        Ok(())
    }

    #[test]
    fn test_unwrapped_with() -> Result<(), serde_json::Error> {
        assert_eq!(
            NumberBool { value: None },
            serde_json::from_value::<NumberBool>(json!({ "value": null }))?
        );
        Ok(())
    }

    #[test]
    fn test_failing_match_with() -> Result<(), serde_json::Error> {
        assert_eq!(
            UntaggedEnum::Variant(NumberBool { value: None }),
            // Fails with Error: Error("data did not match any variant of untagged enum UntaggedEnum", line: 0, column: 0)
            serde_json::from_value::<UntaggedEnum<NumberBool>>(json!({ "value": null }))?
        );
        Ok(())
    }
}
```

([Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=fa0bed0c92a72da25bb1a0db427f110c))

Output:

```

running 4 tests
test tests::test_match_deserialize ... ok
test tests::test_failing_match_with ... FAILED
test tests::test_working_match_with ... ok
test tests::test_unwrapped_with ... ok

failures:

---- tests::test_failing_match_with stdout ----
Error: Error("data did not match any variant of untagged enum UntaggedEnum", line: 0, column: 0)
thread 'tests::test_failing_match_with' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', <::std::macros::panic macros>:5:6
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::test_failing_match_with

test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out


```

Errors:

```
   Compiling playground v0.0.1 (/playground)
    Finished test [unoptimized + debuginfo] target(s) in 1.28s
     Running target/debug/deps/playground-3dc8340097600cd6
error: test failed, to rerun pass '--lib'

```

This fixes that issue and removes three redundant closures I noticed.

What do you think?