### PR TITLE
Implement .abs() for Duration

### DIFF
--- a/src/oldtime.rs
+++ b/src/oldtime.rs
@@ -229,6 +229,12 @@ impl Duration {
         if d < MIN || d > MAX { None } else { Some(d) }
     }
 
+    /// Returns the duration as an absolute (non-negative) value.
+    #[inline]
+    pub fn abs(&self) -> Duration {
+        Duration { secs: self.secs.abs(), nanos: self.nanos }
+    }
+
     /// The minimum possible `Duration`: `i64::MIN` milliseconds.
     #[inline]
     pub fn min_value() -> Duration { MIN }


### PR DESCRIPTION
This PR adds a method to get the absolute (modulus) of a `Duration`.

It is useful for checking how much two `DateTime`s diverge without having to fall back to `i64`s.