### PR TITLE
Replace "cfg(test)" with "cfg(doctest)" for readme testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ std = []
 clock = ["time", "std"]
 wasmbind = ["wasm-bindgen", "js-sys"]
 __internal_bench = []
+__doctest = []
 
 [dependencies]
 time = { version = "0.1.39", optional = true }
@@ -48,7 +49,7 @@ serde_derive = { version = "1", default-features = false }
 bincode = { version = "0.8.0" }
 num-iter = { version = "0.1.35", default-features = false }
 criterion = { version = "0.3" }
-doc-comment = "0.3"
+doc-comment = { version = "0.3" }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]
 wasm-bindgen-test = "0.2"

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -97,6 +97,7 @@ build_and_test_nonwasm() {
   if [[ "$CHANNEL" == stable ]]; then
       channel build -v --no-default-features --features '__doctest'
       TZ=UTC0 channel test -v --no-default-features --features '__doctest' --lib
+  fi
 }
 
 build_and_test_wasm() {

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -93,6 +93,10 @@ build_and_test_nonwasm() {
 
   channel build -v --no-default-features --features 'alloc serde'
   TZ=UTC0 channel test -v --no-default-features --features 'alloc serde' --lib
+
+  if [[ "$CHANNEL" == stable ]]; then
+      channel build -v --no-default-features --features '__doctest'
+      TZ=UTC0 channel test -v --no-default-features --features '__doctest' --lib
 }
 
 build_and_test_wasm() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,7 +421,8 @@ extern crate num_traits;
 extern crate rustc_serialize;
 #[cfg(feature = "serde")]
 extern crate serde as serdelib;
-#[cfg(doctest)]
+#[cfg(feature = "__doctest")]
+#[cfg_attr(feature = "__doctest", cfg(doctest))]
 #[macro_use]
 extern crate doc_comment;
 #[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind"))]
@@ -431,7 +432,8 @@ extern crate js_sys;
 #[cfg(feature = "bench")]
 extern crate test;
 
-#[cfg(doctest)]
+#[cfg(feature = "__doctest")]
+#[cfg_attr(feature = "__doctest", cfg(doctest))]
 doctest!("../README.md");
 
 // this reexport is to aid the transition and should not be in the prelude!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,7 +421,7 @@ extern crate num_traits;
 extern crate rustc_serialize;
 #[cfg(feature = "serde")]
 extern crate serde as serdelib;
-#[cfg(test)]
+#[cfg(doctest)]
 #[macro_use]
 extern crate doc_comment;
 #[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind"))]
@@ -431,7 +431,7 @@ extern crate js_sys;
 #[cfg(feature = "bench")]
 extern crate test;
 
-#[cfg(test)]
+#[cfg(doctest)]
 doctest!("../README.md");
 
 // this reexport is to aid the transition and should not be in the prelude!


### PR DESCRIPTION
Rustdoc now passes "doctest" when running in test mode.