### PR TITLE
Update patch version of time to add Redox support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ wasmbind = ["wasm-bindgen", "js-sys"]
 __internal_bench = []
 
 [dependencies]
-time = { version = "0.1.39", optional = true }
+time = { version = "0.1.43", optional = true }
 num-integer = { version = "0.1.36", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }


### PR DESCRIPTION
The 0.1 version of the time crates supports Redox up from version 0.1.43.
Update the dependency to allow redox to use chrono.

From what I can gather, chrono will either no longer use the time crate or rely on version 0.2, but on the mean time this should allow easy inclusion of the Redox target.