### PR TITLE
add secs_nanos function to support nanoseconds > max i64 in constructor

### DIFF
--- a/src/oldtime.rs
+++ b/src/oldtime.rs
@@ -132,6 +132,19 @@ impl Duration {
         Duration { secs: secs, nanos: nanos as i32 }
     }
 
+    /// Makes a new `Duration` with the given number of seconds and nanoseconds.
+    /// 
+    /// `nanos` in excess of `999_999_999` are carried over into seconds.
+    #[inline]
+    pub fn seconds_nanos(secs: i64, nanos: i32) -> Duration {
+        let (secs_from_nanos, nanos) = div_mod_floor_64(nanos, NANOS_PER_SEC as i64);
+        let d = Duration { secs: secs + secs_from_nanos, nanos }
+        if d < MIN || d > MAX {
+            panic!("Duration::seconds out of bounds");
+        }
+        d
+    }
+
     /// Returns the total number of whole weeks in the duration.
     #[inline]
     pub fn num_weeks(&self) -> i64 {
@@ -617,6 +630,7 @@ mod tests {
     fn test_to_std() {
         assert_eq!(Duration::seconds(1).to_std(), Ok(StdDuration::new(1, 0)));
         assert_eq!(Duration::seconds(86401).to_std(), Ok(StdDuration::new(86401, 0)));
+        assert_eq!(Duration::secs_nanos(86401, 86401).to_std(), Ok(StdDuration::new(86401, 86401)));
         assert_eq!(Duration::milliseconds(123).to_std(), Ok(StdDuration::new(0, 123000000)));
         assert_eq!(Duration::milliseconds(123765).to_std(), Ok(StdDuration::new(123, 765000000)));
         assert_eq!(Duration::nanoseconds(777).to_std(), Ok(StdDuration::new(0, 777)));


### PR DESCRIPTION
`std::time::Duration`'s signature permits you to use a total number of nanoseconds > `i64`'s max value by "compressing" some of those nanos into seconds. This PR simply attempts to add a function mimicking that API.