### PR TITLE
fix docs: milliseconds -> seconds

### DIFF
--- a/src/oldtime.rs
+++ b/src/oldtime.rs
@@ -98,8 +98,8 @@ impl Duration {
     }
 
     /// Makes a new `Duration` with given number of seconds.
-    /// Panics when the duration is more than `i64::MAX` milliseconds
-    /// or less than `i64::MIN` milliseconds.
+    /// Panics when the duration is more than `i64::MAX` seconds
+    /// or less than `i64::MIN` seconds.
     #[inline]
     pub fn seconds(seconds: i64) -> Duration {
         let d = Duration { secs: seconds, nanos: 0 };


### PR DESCRIPTION
The argument for `seconds()` are seconds, not milliseconds.