### PR TITLE
Allow clippy::manual-non-exhaustive

### DIFF
--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -7,7 +7,7 @@ source "${BASH_SOURCE[0]%/*}/_shlib.sh"
 
 main() {
     # rustflags are present because of: https://github.com/rust-lang/rust-clippy/issues/5749
-    runt env RUSTFLAGS="-Dwarnings" cargo clippy --color=always -- -D warnings
+    runt env RUSTFLAGS="-Dwarnings" cargo clippy --color=always -- -D warnings -A clippy::manual-non-exhaustive
     runt cargo fmt -- --check --color=always
     runt make readme
     runv git diff --exit-code -- README.md


### PR DESCRIPTION
These are needed in order to compile on 1.13.0. It seems unwise to have different non-exhaustive measures for different versions.

This should fix the broken linting.