### PR TITLE
docs: fix link to cargo docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Optional features:
 
 See the [cargo docs][] for examples of specifying features.
 
-[cargo-docs]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features
+[cargo docs]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features
 
 ## Overview
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 //!
 //! See the [cargo docs][] for examples of specifying features.
 //!
-//! [cargo-docs]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features
+//! [cargo docs]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features
 //!
 //! ## Overview
 //!


### PR DESCRIPTION
As per title
