### PR TITLE
The wasm-bindgen code refers to oldtime::Duration and is failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,20 @@ ChangeLog for Chrono
 
 This documents all notable changes to [Chrono](https://github.com/chronotope/chrono).
 
-Chrono obeys the principle of [Semantic Versioning](http://semver.org/).
+Chrono obeys the principle of [Semantic Versioning](http://semver.org/), with one caveat: we may
+move previously-existing code behind a feature gate and put it behind a new feature. This new
+feature will always be placed in the `previously-default` feature, which you can use to prevent
+breakage if you use `no-default-features`.
 
 There were/are numerous minor versions before 1.0 due to the language changes.
 Versions with only mechanical changes will be omitted from the following list.
 
-## 0.4.17 (unreleased)
+## 0.4.18 (unreleased)
+
+## 0.4.17
+
+* Fix a name resolution error in wasm-bindgen code introduced by removing the dependency on time
+  v0.1
 
 ## 0.4.16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono"
-version = "0.4.16"
+version = "0.4.17"
 authors = [
     "Kang Seonghoon <public+rust@mearie.org>",
     "Brandon W Maister <quodlibetor@gmail.com>",

--- a/src/offset/local.rs
+++ b/src/offset/local.rs
@@ -152,7 +152,7 @@ impl TimeZone for Local {
         let mut local = local.clone();
         // Get the offset from the js runtime
         let offset = FixedOffset::west((js_sys::Date::new_0().get_timezone_offset() as i32) * 60);
-        local -= oldtime::Duration::seconds(offset.local_minus_utc() as i64);
+        local -= ::Duration::seconds(offset.local_minus_utc() as i64);
         LocalResult::Single(DateTime::from_utc(local, offset))
     }
 


### PR DESCRIPTION
wasm only works on new-enough rust that we can unconditionally use the crate
keyword in that method, so let's try that.

https://github.com/chronotope/chrono/pull/286#issuecomment-699146233