### PR TITLE
Fix a small typo in NaiveDateTime's Display impl

### DIFF
--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -1419,7 +1419,7 @@ impl fmt::Debug for NaiveDateTime {
     }
 }
 
-/// The `Debug` output of the naive date and time `dt` is the same as
+/// The `Display` output of the naive date and time `dt` is the same as
 /// [`dt.format("%Y-%m-%d %H:%M:%S%.f")`](../format/strftime/index.html).
 ///
 /// It should be noted that, for leap seconds not on the minute boundary,


### PR DESCRIPTION
Fix a small typo in the documentation of NaiveDateTime's Display
implementation to say Display instead of Debug.