### PR TITLE
Add some documentation and examples for formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versions with only mechanical changes will be omitted from the following list.
 
 ## 0.4.20 (unreleased)
 
+* Add more formatting documentation and examples.
+
 ## 0.4.19
 
 * Correct build on solaris/illumos

--- a/src/date.rs
+++ b/src/date.rs
@@ -292,6 +292,15 @@ where
     /// Formats the date with the specified format string.
     /// See the [`format::strftime` module](./format/strftime/index.html)
     /// on the supported escape sequences.
+    ///
+    /// # Example
+    /// ```rust
+    /// use chrono::prelude::*;
+    ///
+    /// let date_time: Date<Utc> = Utc.ymd(2017, 04, 02);
+    /// let formatted = format!("{}", date_time.format("%d/%m/%Y"));
+    /// assert_eq!(formatted, "02/04/2017");
+    /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[inline]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -490,6 +490,15 @@ where
     /// Formats the combined date and time with the specified format string.
     /// See the [`format::strftime` module](./format/strftime/index.html)
     /// on the supported escape sequences.
+    ///
+    /// # Example
+    /// ```rust
+    /// use chrono::prelude::*;
+    ///
+    /// let date_time: DateTime<Utc> = Utc.ymd(2017, 04, 02).and_hms(12, 50, 32);
+    /// let formatted = format!("{}", date_time.format("%d/%m/%Y %H:%M"));
+    /// assert_eq!(formatted, "02/04/2017 12:50");
+    /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[inline]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -12,8 +12,26 @@
 //! which are just an [`Iterator`](https://doc.rust-lang.org/std/iter/trait.Iterator.html) of
 //! the [`Item`](./enum.Item.html) type.
 //! They are generated from more readable **format strings**;
-//! currently Chrono supports [one built-in syntax closely resembling
-//! C's `strftime` format](./strftime/index.html).
+//! currently Chrono supports a built-in syntax closely resembling
+//! C's `strftime` format. The available options can be found [here](./strftime/index.html).
+//!
+//! # Example
+//! ```rust
+//! # use std::error::Error;
+//! #
+//! # fn main() -> Result<(), Box<dyn Error>> {
+//! use chrono::prelude::*;
+//!
+//! let date_time = Utc.ymd(2020, 11, 10).and_hms(0, 1, 32);
+//!
+//! let formatted = format!("{}", date_time.format("%Y-%m-%d %H:%M:%S"));
+//! assert_eq!(formatted, "2020-11-10 00:01:32");
+//!
+//! let parsed = Utc.datetime_from_str(&formatted, "%Y-%m-%d %H:%M:%S")?;
+//! assert_eq!(parsed, date_time);
+//! # Ok(())
+//! # }
+//! ```
 
 #![allow(ellipsis_inclusive_range_patterns)]
 


### PR DESCRIPTION
This adds some more documentation to the formatting methods. I have checked, and the options are now mentioned in every parsing and formatting method. That means #259 can be closed. Except for the `format_with_items` methods, they also all have an example.

### Thanks for contributing to chrono!

- [x] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)
- [x] If this pull request fixes a bug, does it add a test that verifies that
      we can't reintroduce it?

[changelog]: ../CHANGELOG.md
