### PR TITLE
Add Default implementation for naive date types

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,8 +238,8 @@ Chrono now also provides date formatting in almost any language without the
 help of an additional C library. This functionality is under the feature
 `unstable-locales`:
 
-```text
-chrono { version = "0.4", features = ["unstable-locales"]
+```toml
+chrono = { version = "0.4", features = ["unstable-locales"] }
 ```
 
 The `unstable-locales` feature requires and implies at least the `alloc` feature.
@@ -251,8 +251,8 @@ let dt = Utc.ymd(2014, 11, 28).and_hms(12, 0, 9);
 assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2014-11-28 12:00:09");
 assert_eq!(dt.format("%a %b %e %T %Y").to_string(), "Fri Nov 28 12:00:09 2014");
 assert_eq!(dt.format_localized("%A %e %B %Y, %T", Locale::fr_BE).to_string(), "vendredi 28 novembre 2014, 12:00:09");
-assert_eq!(dt.format("%a %b %e %T %Y").to_string(), dt.format("%c").to_string());
 
+assert_eq!(dt.format("%a %b %e %T %Y").to_string(), dt.format("%c").to_string());
 assert_eq!(dt.to_string(), "2014-11-28 12:00:09 UTC");
 assert_eq!(dt.to_rfc2822(), "Fri, 28 Nov 2014 12:00:09 +0000");
 assert_eq!(dt.to_rfc3339(), "2014-11-28T12:00:09+00:00");

--- a/src/date.rs
+++ b/src/date.rs
@@ -494,3 +494,17 @@ where
         write!(f, "{}{}", self.naive_local(), self.offset)
     }
 }
+
+/// The default value for a DateTime 1st of January 1970 00:00:00 UTC.
+///
+/// # Example
+///
+/// ~~~~
+/// let default_date = DateTime::default();
+/// assert_eq!(default_date, DateTime::from_utc(NaiveDateTime::default(), 0));
+/// ~~~~
+impl<Tz: TimeZone> Default for Date<Tz> {
+    fn default() -> Self {
+        Date::from_utc(NaiveDate::default(), 0)
+    }
+}

--- a/src/date.rs
+++ b/src/date.rs
@@ -494,17 +494,3 @@ where
         write!(f, "{}{}", self.naive_local(), self.offset)
     }
 }
-
-/// The default value for a DateTime 1st of January 1970 00:00:00 UTC.
-///
-/// # Example
-///
-/// ~~~~
-/// let default_date = DateTime::default();
-/// assert_eq!(default_date, DateTime::from_utc(NaiveDateTime::default(), 0));
-/// ~~~~
-impl<Tz: TimeZone> Default for Date<Tz> {
-    fn default() -> Self {
-        Date::from_utc(NaiveDate::default(), 0)
-    }
-}

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -316,6 +316,7 @@ impl Default for DateTime<Utc> {
     }
 }
 
+#[cfg(feature = "clock")]
 impl Default for DateTime<Local> {
     fn default() -> Self {
         Local.from_utc_datetime(&NaiveDateTime::default())

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -899,20 +899,6 @@ impl From<DateTime<Utc>> for js_sys::Date {
     }
 }
 
-/// The default value for a DateTime 1st of January 1970 00:00:00 UTC.
-///
-/// # Example
-///
-/// ~~~~
-/// let default_date = DateTime::default();
-/// assert_eq!(default_date, DateTime::from_utc(NaiveDateTime::default(), 0));
-/// ~~~~
-impl <Tz: TimeZone> Default for DateTime<Tz> {
-    fn default() -> Self {
-        DateTime::from_utc(NaiveDateTime::default(), 0)
-    }
-}
-
 #[test]
 fn test_auto_conversion() {
     let utc_dt = Utc.ymd(2018, 9, 5).and_hms(23, 58, 0);

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -899,6 +899,20 @@ impl From<DateTime<Utc>> for js_sys::Date {
     }
 }
 
+/// The default value for a DateTime 1st of January 1970 00:00:00 UTC.
+///
+/// # Example
+///
+/// ~~~~
+/// let default_date = DateTime::default();
+/// assert_eq!(default_date, DateTime::from_utc(NaiveDateTime::default(), 0));
+/// ~~~~
+impl <Tz: TimeZone> Default for DateTime<Tz> {
+    fn default() -> Self {
+        DateTime::from_utc(NaiveDateTime::default(), 0)
+    }
+}
+
 #[test]
 fn test_auto_conversion() {
     let utc_dt = Utc.ymd(2018, 9, 5).and_hms(23, 58, 0);

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -310,6 +310,24 @@ impl<Tz: TimeZone> DateTime<Tz> {
     }
 }
 
+impl Default for DateTime<Utc> {
+    fn default() -> Self {
+        Utc.from_utc_datetime(&NaiveDateTime::default())
+    }
+}
+
+impl Default for DateTime<Local> {
+    fn default() -> Self {
+        Local.from_utc_datetime(&NaiveDateTime::default())
+    }
+}
+
+impl Default for DateTime<FixedOffset> {
+    fn default() -> Self {
+        FixedOffset::west(0).from_utc_datetime(&NaiveDateTime::default())
+    }
+}
+
 /// Convert a `DateTime<Utc>` instance into a `DateTime<FixedOffset>` instance.
 impl From<DateTime<Utc>> for DateTime<FixedOffset> {
     /// Convert this `DateTime<Utc>` instance into a `DateTime<FixedOffset>` instance.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,34 +230,38 @@
 //! help of an additional C library. This functionality is under the feature
 //! `unstable-locales`:
 //!
-//! ```text
+//! ```toml
 //! chrono = { version = "0.4", features = ["unstable-locales"] }
 //! ```
-#![cfg_attr(
-    feature = "unstable-locales",
-    doc = r##"
-The `unstable-locales` feature requires and implies at least the `alloc` feature.
-
-```rust
-use chrono::prelude::*;
-
-let dt = Utc.ymd(2014, 11, 28).and_hms(12, 0, 9);
-assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2014-11-28 12:00:09");
-assert_eq!(dt.format("%a %b %e %T %Y").to_string(), "Fri Nov 28 12:00:09 2014");
-assert_eq!(dt.format_localized("%A %e %B %Y, %T", Locale::fr_BE).to_string(), "vendredi 28 novembre 2014, 12:00:09");
-assert_eq!(dt.format("%a %b %e %T %Y").to_string(), dt.format("%c").to_string());
 //!
-assert_eq!(dt.to_string(), "2014-11-28 12:00:09 UTC");
-assert_eq!(dt.to_rfc2822(), "Fri, 28 Nov 2014 12:00:09 +0000");
-assert_eq!(dt.to_rfc3339(), "2014-11-28T12:00:09+00:00");
-assert_eq!(format!("{:?}", dt), "2014-11-28T12:00:09Z");
+//! The `unstable-locales` feature requires and implies at least the `alloc` feature.
 //!
-// Note that milli/nanoseconds are only printed if they are non-zero
-let dt_nano = Utc.ymd(2014, 11, 28).and_hms_nano(12, 0, 9, 1);
-assert_eq!(format!("{:?}", dt_nano), "2014-11-28T12:00:09.000000001Z");
-```
-"##
-)]
+//! ```rust
+//! use chrono::prelude::*;
+//!
+//! # #[cfg(feature = "unstable-locales")]
+//! # fn test() {
+//! let dt = Utc.ymd(2014, 11, 28).and_hms(12, 0, 9);
+//! assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2014-11-28 12:00:09");
+//! assert_eq!(dt.format("%a %b %e %T %Y").to_string(), "Fri Nov 28 12:00:09 2014");
+//! assert_eq!(dt.format_localized("%A %e %B %Y, %T", Locale::fr_BE).to_string(), "vendredi 28 novembre 2014, 12:00:09");
+//!
+//! assert_eq!(dt.format("%a %b %e %T %Y").to_string(), dt.format("%c").to_string());
+//! assert_eq!(dt.to_string(), "2014-11-28 12:00:09 UTC");
+//! assert_eq!(dt.to_rfc2822(), "Fri, 28 Nov 2014 12:00:09 +0000");
+//! assert_eq!(dt.to_rfc3339(), "2014-11-28T12:00:09+00:00");
+//! assert_eq!(format!("{:?}", dt), "2014-11-28T12:00:09Z");
+//!
+//! // Note that milli/nanoseconds are only printed if they are non-zero
+//! let dt_nano = Utc.ymd(2014, 11, 28).and_hms_nano(12, 0, 9, 1);
+//! assert_eq!(format!("{:?}", dt_nano), "2014-11-28T12:00:09.000000001Z");
+//! # }
+//! # #[cfg(not(feature = "unstable-locales"))]
+//! # fn test() {}
+//! # if cfg!(feature = "unstable-locales") {
+//! #    test();
+//! # }
+//! ```
 //!
 //! Parsing can be done with three methods:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,29 +231,33 @@
 //! `unstable-locales`:
 //!
 //! ```text
-//! chrono { version = "0.4", features = ["unstable-locales"]
+//! chrono = { version = "0.4", features = ["unstable-locales"] }
 //! ```
+#![cfg_attr(
+    feature = "unstable-locales",
+    doc = r##"
+The `unstable-locales` feature requires and implies at least the `alloc` feature.
+
+```rust
+use chrono::prelude::*;
+
+let dt = Utc.ymd(2014, 11, 28).and_hms(12, 0, 9);
+assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2014-11-28 12:00:09");
+assert_eq!(dt.format("%a %b %e %T %Y").to_string(), "Fri Nov 28 12:00:09 2014");
+assert_eq!(dt.format_localized("%A %e %B %Y, %T", Locale::fr_BE).to_string(), "vendredi 28 novembre 2014, 12:00:09");
+assert_eq!(dt.format("%a %b %e %T %Y").to_string(), dt.format("%c").to_string());
 //!
-//! The `unstable-locales` feature requires and implies at least the `alloc` feature.
+assert_eq!(dt.to_string(), "2014-11-28 12:00:09 UTC");
+assert_eq!(dt.to_rfc2822(), "Fri, 28 Nov 2014 12:00:09 +0000");
+assert_eq!(dt.to_rfc3339(), "2014-11-28T12:00:09+00:00");
+assert_eq!(format!("{:?}", dt), "2014-11-28T12:00:09Z");
 //!
-//! ```rust
-//! use chrono::prelude::*;
-//!
-//! let dt = Utc.ymd(2014, 11, 28).and_hms(12, 0, 9);
-//! assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2014-11-28 12:00:09");
-//! assert_eq!(dt.format("%a %b %e %T %Y").to_string(), "Fri Nov 28 12:00:09 2014");
-//! assert_eq!(dt.format_localized("%A %e %B %Y, %T", Locale::fr_BE).to_string(), "vendredi 28 novembre 2014, 12:00:09");
-//! assert_eq!(dt.format("%a %b %e %T %Y").to_string(), dt.format("%c").to_string());
-//!
-//! assert_eq!(dt.to_string(), "2014-11-28 12:00:09 UTC");
-//! assert_eq!(dt.to_rfc2822(), "Fri, 28 Nov 2014 12:00:09 +0000");
-//! assert_eq!(dt.to_rfc3339(), "2014-11-28T12:00:09+00:00");
-//! assert_eq!(format!("{:?}", dt), "2014-11-28T12:00:09Z");
-//!
-//! // Note that milli/nanoseconds are only printed if they are non-zero
-//! let dt_nano = Utc.ymd(2014, 11, 28).and_hms_nano(12, 0, 9, 1);
-//! assert_eq!(format!("{:?}", dt_nano), "2014-11-28T12:00:09.000000001Z");
-//! ```
+// Note that milli/nanoseconds are only printed if they are non-zero
+let dt_nano = Utc.ymd(2014, 11, 28).and_hms_nano(12, 0, 9, 1);
+assert_eq!(format!("{:?}", dt_nano), "2014-11-28T12:00:09.000000001Z");
+```
+"##
+)]
 //!
 //! Parsing can be done with three methods:
 //!

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1719,6 +1719,8 @@ impl str::FromStr for NaiveDate {
 /// # Example
 ///
 /// ~~~~
+/// use chrono::NaiveDate;
+///
 /// let default_date = NaiveDate::default();
 /// assert_eq!(default_date, NaiveDate::from_ymd(1970, 1, 1));
 /// ~~~~

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1714,16 +1714,16 @@ impl str::FromStr for NaiveDate {
     }
 }
 
-/// The default for a NaiveDate is 1st of January 1970.
+/// The default value for a NaiveDate is 1st of January 1970.
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```rust
 /// use chrono::NaiveDate;
 ///
 /// let default_date = NaiveDate::default();
 /// assert_eq!(default_date, NaiveDate::from_ymd(1970, 1, 1));
-/// ~~~~
+/// ```
 impl Default for NaiveDate {
     fn default() -> Self {
         NaiveDate::from_ymd(1970, 1, 1)

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1714,6 +1714,20 @@ impl str::FromStr for NaiveDate {
     }
 }
 
+/// The default for a NaiveDate is 1st of January 1970.
+///
+/// # Example
+///
+/// ~~~~
+/// let default_date = NaiveDate::default();
+/// assert_eq!(default_date, NaiveDate::from_ymd(1970, 1, 1));
+/// ~~~~
+impl Default for NaiveDate {
+    fn default() -> Self {
+        NaiveDate::from_ymd(1970, 1, 1)
+    }
+}
+
 #[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
 fn test_encodable_json<F, E>(to_string: F)
 where

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -1511,6 +1511,21 @@ impl str::FromStr for NaiveDateTime {
     }
 }
 
+/// The default for a NaiveDateTime is one with epoch 0
+/// that is 1st of January 1970 at 00:00:00.
+///
+/// # Example
+///
+/// ~~~~
+/// let default_date = NaiveDateTime::default();
+/// assert_eq!(default_date, NaiveDateTime::from_timestamp(0, 0));
+/// ~~~~
+impl Default for NaiveDateTime {
+    fn default() -> Self {
+        NaiveDateTime::from_timestamp(0, 0)
+    }
+}
+
 #[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
 fn test_encodable_json<F, E>(to_string: F)
 where

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -1511,17 +1511,17 @@ impl str::FromStr for NaiveDateTime {
     }
 }
 
-/// The default for a NaiveDateTime is one with epoch 0
-/// that is 1st of January 1970 at 00:00:00.
+/// The default value for a NaiveDateTime is one with epoch 0
+/// that is, 1st of January 1970 at 00:00:00.
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```rust
 /// use chrono::NaiveDateTime;
 ///
 /// let default_date = NaiveDateTime::default();
 /// assert_eq!(default_date, NaiveDateTime::from_timestamp(0, 0));
-/// ~~~~
+/// ```
 impl Default for NaiveDateTime {
     fn default() -> Self {
         NaiveDateTime::from_timestamp(0, 0)

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -1517,6 +1517,8 @@ impl str::FromStr for NaiveDateTime {
 /// # Example
 ///
 /// ~~~~
+/// use chrono::NaiveDateTime;
+///
 /// let default_date = NaiveDateTime::default();
 /// assert_eq!(default_date, NaiveDateTime::from_timestamp(0, 0));
 /// ~~~~

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -1346,6 +1346,8 @@ impl str::FromStr for NaiveTime {
 /// # Example
 ///
 /// ~~~~
+/// use chrono::NaiveTime;
+///
 /// let default_time = NaiveTime::default();
 /// assert_eq!(default_time, NaiveTime::from_hms(0, 0, 0));
 /// ~~~~

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -1341,16 +1341,16 @@ impl str::FromStr for NaiveTime {
     }
 }
 
-/// The default for a NaiveTime is midnight, oo:oo:00 exactly.
+/// The default value for a NaiveTime is midnight, 00:00:00 exactly.
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```rust
 /// use chrono::NaiveTime;
 ///
 /// let default_time = NaiveTime::default();
 /// assert_eq!(default_time, NaiveTime::from_hms(0, 0, 0));
-/// ~~~~
+/// ```
 impl Default for NaiveTime {
     fn default() -> Self {
         NaiveTime::from_hms(0, 0, 0)

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -1341,6 +1341,20 @@ impl str::FromStr for NaiveTime {
     }
 }
 
+/// The default for a NaiveTime is midnight, oo:oo:00 exactly.
+///
+/// # Example
+///
+/// ~~~~
+/// let default_time = NaiveTime::default();
+/// assert_eq!(default_time, NaiveTime::from_hms(0, 0, 0));
+/// ~~~~
+impl Default for NaiveTime {
+    fn default() -> Self {
+        NaiveTime::from_hms(0, 0, 0)
+    }
+}
+
 #[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
 fn test_encodable_json<F, E>(to_string: F)
 where


### PR DESCRIPTION
This PR aims to add some [Default](https://doc.rust-lang.org/std/default/trait.Default.html) implementations for some of the naive types. The currently added defaults are the following:

* Default `NaiveDateTime` has been set to `1970-01-01 00:00:00`
* Default `NaiveDate` has been set to `1970-01-01`
* Default `NaiveTime` has been set to `00:00:00`

The main reason for the PR is to help in struct definitions that wish to simply `#derive[Default]` but currently are not able to because on of their attributes is of the previously mentioned types, adding this change would help simplify the code in that particular scenario.