### PR TITLE
Use backticks for documentation examples

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -83,12 +83,12 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{DateTime, TimeZone, NaiveDateTime, Utc};
     ///
     /// let dt = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(61, 0), Utc);
     /// assert_eq!(Utc.timestamp(61, 0), dt);
-    /// ~~~~
+    /// ```
     //
     // note: this constructor is purposely not named to `new` to discourage the direct usage.
     #[inline]
@@ -158,7 +158,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::Utc;
     /// use chrono::TimeZone;
     ///
@@ -167,7 +167,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// let dt = Utc.ymd(2001, 9, 9).and_hms_milli(1, 46, 40, 555);
     /// assert_eq!(dt.timestamp_millis(), 1_000_000_000_555);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn timestamp_millis(&self) -> i64 {
         self.datetime.timestamp_millis()
@@ -182,7 +182,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::Utc;
     /// use chrono::TimeZone;
     ///
@@ -191,7 +191,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// let dt = Utc.ymd(2001, 9, 9).and_hms_micro(1, 46, 40, 555);
     /// assert_eq!(dt.timestamp_micros(), 1_000_000_000_000_555);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn timestamp_micros(&self) -> i64 {
         self.datetime.timestamp_micros()
@@ -206,7 +206,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::Utc;
     /// use chrono::TimeZone;
     ///
@@ -215,7 +215,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// let dt = Utc.ymd(2001, 9, 9).and_hms_nano(1, 46, 40, 555);
     /// assert_eq!(dt.timestamp_nanos(), 1_000_000_000_000_000_555);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn timestamp_nanos(&self) -> i64 {
         self.datetime.timestamp_nanos()

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -835,26 +835,26 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> fmt::Display for De
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// use chrono::Weekday;
 ///
 /// assert_eq!("Sunday".parse::<Weekday>(), Ok(Weekday::Sun));
 /// assert!("any day".parse::<Weekday>().is_err());
-/// ~~~~
+/// ```
 ///
 /// The parsing is case-insensitive.
 ///
-/// ~~~~
+/// ```
 /// # use chrono::Weekday;
 /// assert_eq!("mON".parse::<Weekday>(), Ok(Weekday::Mon));
-/// ~~~~
+/// ```
 ///
 /// Only the shortest form (e.g. `sun`) and the longest form (e.g. `sunday`) is accepted.
 ///
-/// ~~~~
+/// ```
 /// # use chrono::Weekday;
 /// assert!("thurs".parse::<Weekday>().is_err());
-/// ~~~~
+/// ```
 impl FromStr for Weekday {
     type Err = ParseWeekdayError;
 
@@ -908,27 +908,27 @@ where
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// use chrono::Month;
 ///
 /// assert_eq!("January".parse::<Month>(), Ok(Month::January));
 /// assert!("any day".parse::<Month>().is_err());
-/// ~~~~
+/// ```
 ///
 /// The parsing is case-insensitive.
 ///
-/// ~~~~
+/// ```
 /// # use chrono::Month;
 /// assert_eq!("fEbruARy".parse::<Month>(), Ok(Month::February));
-/// ~~~~
+/// ```
 ///
 /// Only the shortest form (e.g. `jan`) and the longest form (e.g. `january`) is accepted.
 ///
-/// ~~~~
+/// ```
 /// # use chrono::Month;
 /// assert!("septem".parse::<Month>().is_err());
 /// assert!("Augustin".parse::<Month>().is_err());
-/// ~~~~
+/// ```
 impl FromStr for Month {
     type Err = ParseMonthError;
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -156,7 +156,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
     /// let d = NaiveDate::from_ymd(2015, 3, 14);
@@ -168,7 +168,7 @@ impl NaiveDate {
     /// assert_eq!(d.iso_week().week(), 11);
     /// assert_eq!(d.weekday(), Weekday::Sat);
     /// assert_eq!(d.num_days_from_ce(), 735671); // days since January 1, 1 CE
-    /// ~~~~
+    /// ```
     pub fn from_ymd(year: i32, month: u32, day: u32) -> NaiveDate {
         NaiveDate::from_ymd_opt(year, month, day).expect("invalid or out-of-range date")
     }
@@ -180,7 +180,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let from_ymd_opt = NaiveDate::from_ymd_opt;
@@ -191,7 +191,7 @@ impl NaiveDate {
     /// assert!(from_ymd_opt(-4, 2, 29).is_some()); // 5 BCE is a leap year
     /// assert!(from_ymd_opt(400000, 1, 1).is_none());
     /// assert!(from_ymd_opt(-400000, 1, 1).is_none());
-    /// ~~~~
+    /// ```
     pub fn from_ymd_opt(year: i32, month: u32, day: u32) -> Option<NaiveDate> {
         let flags = YearFlags::from_year(year);
         NaiveDate::from_mdf(year, Mdf::new(month, day, flags))
@@ -204,7 +204,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
     /// let d = NaiveDate::from_yo(2015, 73);
@@ -216,7 +216,7 @@ impl NaiveDate {
     /// assert_eq!(d.iso_week().week(), 11);
     /// assert_eq!(d.weekday(), Weekday::Sat);
     /// assert_eq!(d.num_days_from_ce(), 735671); // days since January 1, 1 CE
-    /// ~~~~
+    /// ```
     pub fn from_yo(year: i32, ordinal: u32) -> NaiveDate {
         NaiveDate::from_yo_opt(year, ordinal).expect("invalid or out-of-range date")
     }
@@ -228,7 +228,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let from_yo_opt = NaiveDate::from_yo_opt;
@@ -240,7 +240,7 @@ impl NaiveDate {
     /// assert!(from_yo_opt(-4, 366).is_some()); // 5 BCE is a leap year
     /// assert!(from_yo_opt(400000, 1).is_none());
     /// assert!(from_yo_opt(-400000, 1).is_none());
-    /// ~~~~
+    /// ```
     pub fn from_yo_opt(year: i32, ordinal: u32) -> Option<NaiveDate> {
         let flags = YearFlags::from_year(year);
         NaiveDate::from_of(year, Of::new(ordinal, flags))
@@ -254,7 +254,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
     /// let d = NaiveDate::from_isoywd(2015, 11, Weekday::Sat);
@@ -266,7 +266,7 @@ impl NaiveDate {
     /// assert_eq!(d.day(), 14);
     /// assert_eq!(d.ordinal(), 73); // day of year
     /// assert_eq!(d.num_days_from_ce(), 735671); // days since January 1, 1 CE
-    /// ~~~~
+    /// ```
     pub fn from_isoywd(year: i32, week: u32, weekday: Weekday) -> NaiveDate {
         NaiveDate::from_isoywd_opt(year, week, weekday).expect("invalid or out-of-range date")
     }
@@ -279,7 +279,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Weekday};
     ///
     /// let from_ymd = NaiveDate::from_ymd;
@@ -292,11 +292,11 @@ impl NaiveDate {
     ///
     /// assert_eq!(from_isoywd_opt(400000, 10, Weekday::Fri), None);
     /// assert_eq!(from_isoywd_opt(-400000, 10, Weekday::Sat), None);
-    /// ~~~~
+    /// ```
     ///
     /// The year number of ISO week date may differ from that of the calendar date.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::{NaiveDate, Weekday};
     /// # let from_ymd = NaiveDate::from_ymd;
     /// # let from_isoywd_opt = NaiveDate::from_isoywd_opt;
@@ -314,7 +314,7 @@ impl NaiveDate {
     /// assert_eq!(from_isoywd_opt(2015, 53, Weekday::Sun), Some(from_ymd(2016, 1, 3)));
     /// assert_eq!(from_isoywd_opt(2015, 54, Weekday::Mon), None);
     /// assert_eq!(from_isoywd_opt(2016, 1, Weekday::Mon), Some(from_ymd(2016, 1, 4)));
-    /// ~~~~
+    /// ```
     pub fn from_isoywd_opt(year: i32, week: u32, weekday: Weekday) -> Option<NaiveDate> {
         let flags = YearFlags::from_year(year);
         let nweeks = flags.nisoweeks();
@@ -353,7 +353,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
     /// let d = NaiveDate::from_num_days_from_ce(735671);
@@ -365,7 +365,7 @@ impl NaiveDate {
     /// assert_eq!(d.iso_week().year(), 2015);
     /// assert_eq!(d.iso_week().week(), 11);
     /// assert_eq!(d.weekday(), Weekday::Sat);
-    /// ~~~~
+    /// ```
     ///
     /// While not directly supported by Chrono,
     /// it is easy to convert from the Julian day number
@@ -373,7 +373,7 @@ impl NaiveDate {
     /// to Gregorian with this method.
     /// (Note that this panics when `jd` is out of range.)
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// fn jd_to_date(jd: i32) -> NaiveDate {
@@ -388,7 +388,7 @@ impl NaiveDate {
     /// assert_eq!(jd_to_date(1721426), NaiveDate::from_ymd(1, 1, 1));
     /// assert_eq!(jd_to_date(2450000), NaiveDate::from_ymd(1995, 10, 9));
     /// assert_eq!(jd_to_date(2451545), NaiveDate::from_ymd(2000, 1, 1));
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn from_num_days_from_ce(days: i32) -> NaiveDate {
         NaiveDate::from_num_days_from_ce_opt(days).expect("out-of-range date")
@@ -401,7 +401,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let from_ndays_opt = NaiveDate::from_num_days_from_ce_opt;
@@ -413,7 +413,7 @@ impl NaiveDate {
     /// assert_eq!(from_ndays_opt(-1),           Some(from_ymd(0, 12, 30)));
     /// assert_eq!(from_ndays_opt(100_000_000),  None);
     /// assert_eq!(from_ndays_opt(-100_000_000), None);
-    /// ~~~~
+    /// ```
     pub fn from_num_days_from_ce_opt(days: i32) -> Option<NaiveDate> {
         let days = days + 365; // make December 31, 1 BCE equal to day 0
         let (year_div_400, cycle) = div_mod_floor(days, 146_097);
@@ -435,7 +435,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Weekday};
     ///
     /// let from_weekday_of_month = NaiveDate::from_weekday_of_month;
@@ -446,7 +446,7 @@ impl NaiveDate {
     /// assert_eq!(from_weekday_of_month(2018, 8, Weekday::Tue, 2), from_ymd(2018, 8, 14));
     /// assert_eq!(from_weekday_of_month(2018, 8, Weekday::Fri, 4), from_ymd(2018, 8, 24));
     /// assert_eq!(from_weekday_of_month(2018, 8, Weekday::Fri, 5), from_ymd(2018, 8, 31));
-    /// ~~~~
+    /// ```
     pub fn from_weekday_of_month(year: i32, month: u32, weekday: Weekday, n: u8) -> NaiveDate {
         NaiveDate::from_weekday_of_month_opt(year, month, weekday, n).expect("out-of-range date")
     }
@@ -455,11 +455,11 @@ impl NaiveDate {
     /// since the beginning of the given month.  For instance, if you want the 2nd Friday of March
     /// 2017, you would use `NaiveDate::from_weekday_of_month(2017, 3, Weekday::Fri, 2)`.  `n` is 1-indexed.
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Weekday};
     /// assert_eq!(NaiveDate::from_weekday_of_month_opt(2017, 3, Weekday::Fri, 2),
     ///            NaiveDate::from_ymd_opt(2017, 3, 10))
-    /// ~~~~
+    /// ```
     ///
     /// Returns `None` if `n` out-of-range; ie. if `n` is larger than the number of `weekday` in
     /// `month` (eg. the 6th Friday of March 2017), or if `n == 0`.
@@ -484,7 +484,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let parse_from_str = NaiveDate::parse_from_str;
@@ -493,33 +493,33 @@ impl NaiveDate {
     ///            Ok(NaiveDate::from_ymd(2015, 9, 5)));
     /// assert_eq!(parse_from_str("5sep2015", "%d%b%Y"),
     ///            Ok(NaiveDate::from_ymd(2015, 9, 5)));
-    /// ~~~~
+    /// ```
     ///
     /// Time and offset is ignored for the purpose of parsing.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::NaiveDate;
     /// # let parse_from_str = NaiveDate::parse_from_str;
     /// assert_eq!(parse_from_str("2014-5-17T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
     ///            Ok(NaiveDate::from_ymd(2014, 5, 17)));
-    /// ~~~~
+    /// ```
     ///
     /// Out-of-bound dates or insufficient fields are errors.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::NaiveDate;
     /// # let parse_from_str = NaiveDate::parse_from_str;
     /// assert!(parse_from_str("2015/9", "%Y/%m").is_err());
     /// assert!(parse_from_str("2015/9/31", "%Y/%m/%d").is_err());
-    /// ~~~~
+    /// ```
     ///
     /// All parsed fields should be consistent to each other, otherwise it's an error.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::NaiveDate;
     /// # let parse_from_str = NaiveDate::parse_from_str;
     /// assert!(parse_from_str("Sat, 09 Aug 2013", "%a, %d %b %Y").is_err());
-    /// ~~~~
+    /// ```
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<NaiveDate> {
         let mut parsed = Parsed::new();
         parse(&mut parsed, s, StrftimeItems::new(fmt))?;
@@ -530,7 +530,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveTime, NaiveDateTime};
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3);
@@ -539,7 +539,7 @@ impl NaiveDate {
     /// let dt: NaiveDateTime = d.and_time(t);
     /// assert_eq!(dt.date(), d);
     /// assert_eq!(dt.time(), t);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn and_time(&self, time: NaiveTime) -> NaiveDateTime {
         NaiveDateTime::new(*self, time)
@@ -554,7 +554,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike, Timelike, Weekday};
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3);
@@ -563,7 +563,7 @@ impl NaiveDate {
     /// assert_eq!(dt.year(), 2015);
     /// assert_eq!(dt.weekday(), Weekday::Wed);
     /// assert_eq!(dt.second(), 56);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn and_hms(&self, hour: u32, min: u32, sec: u32) -> NaiveDateTime {
         self.and_hms_opt(hour, min, sec).expect("invalid time")
@@ -578,7 +578,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3);
@@ -586,7 +586,7 @@ impl NaiveDate {
     /// assert!(d.and_hms_opt(12, 34, 60).is_none()); // use `and_hms_milli_opt` instead
     /// assert!(d.and_hms_opt(12, 60, 56).is_none());
     /// assert!(d.and_hms_opt(24, 34, 56).is_none());
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn and_hms_opt(&self, hour: u32, min: u32, sec: u32) -> Option<NaiveDateTime> {
         NaiveTime::from_hms_opt(hour, min, sec).map(|time| self.and_time(time))
@@ -601,7 +601,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike, Timelike, Weekday};
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3);
@@ -611,7 +611,7 @@ impl NaiveDate {
     /// assert_eq!(dt.weekday(), Weekday::Wed);
     /// assert_eq!(dt.second(), 56);
     /// assert_eq!(dt.nanosecond(), 789_000_000);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn and_hms_milli(&self, hour: u32, min: u32, sec: u32, milli: u32) -> NaiveDateTime {
         self.and_hms_milli_opt(hour, min, sec, milli).expect("invalid time")
@@ -626,7 +626,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3);
@@ -636,7 +636,7 @@ impl NaiveDate {
     /// assert!(d.and_hms_milli_opt(12, 34, 60,   789).is_none());
     /// assert!(d.and_hms_milli_opt(12, 60, 56,   789).is_none());
     /// assert!(d.and_hms_milli_opt(24, 34, 56,   789).is_none());
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn and_hms_milli_opt(
         &self,
@@ -657,7 +657,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike, Timelike, Weekday};
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3);
@@ -667,7 +667,7 @@ impl NaiveDate {
     /// assert_eq!(dt.weekday(), Weekday::Wed);
     /// assert_eq!(dt.second(), 56);
     /// assert_eq!(dt.nanosecond(), 789_012_000);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn and_hms_micro(&self, hour: u32, min: u32, sec: u32, micro: u32) -> NaiveDateTime {
         self.and_hms_micro_opt(hour, min, sec, micro).expect("invalid time")
@@ -682,7 +682,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3);
@@ -692,7 +692,7 @@ impl NaiveDate {
     /// assert!(d.and_hms_micro_opt(12, 34, 60,   789_012).is_none());
     /// assert!(d.and_hms_micro_opt(12, 60, 56,   789_012).is_none());
     /// assert!(d.and_hms_micro_opt(24, 34, 56,   789_012).is_none());
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn and_hms_micro_opt(
         &self,
@@ -713,7 +713,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike, Timelike, Weekday};
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3);
@@ -723,7 +723,7 @@ impl NaiveDate {
     /// assert_eq!(dt.weekday(), Weekday::Wed);
     /// assert_eq!(dt.second(), 56);
     /// assert_eq!(dt.nanosecond(), 789_012_345);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn and_hms_nano(&self, hour: u32, min: u32, sec: u32, nano: u32) -> NaiveDateTime {
         self.and_hms_nano_opt(hour, min, sec, nano).expect("invalid time")
@@ -738,7 +738,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3);
@@ -748,7 +748,7 @@ impl NaiveDate {
     /// assert!(d.and_hms_nano_opt(12, 34, 60,   789_012_345).is_none());
     /// assert!(d.and_hms_nano_opt(12, 60, 56,   789_012_345).is_none());
     /// assert!(d.and_hms_nano_opt(24, 34, 56,   789_012_345).is_none());
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn and_hms_nano_opt(
         &self,
@@ -799,13 +799,13 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015,  6,  3).succ(), NaiveDate::from_ymd(2015, 6, 4));
     /// assert_eq!(NaiveDate::from_ymd(2015,  6, 30).succ(), NaiveDate::from_ymd(2015, 7, 1));
     /// assert_eq!(NaiveDate::from_ymd(2015, 12, 31).succ(), NaiveDate::from_ymd(2016, 1, 1));
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn succ(&self) -> NaiveDate {
         self.succ_opt().expect("out of bound")
@@ -817,14 +817,14 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     /// use chrono::naive::MAX_DATE;
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 6, 3).succ_opt(),
     ///            Some(NaiveDate::from_ymd(2015, 6, 4)));
     /// assert_eq!(MAX_DATE.succ_opt(), None);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn succ_opt(&self) -> Option<NaiveDate> {
         self.with_of(self.of().succ()).or_else(|| NaiveDate::from_ymd_opt(self.year() + 1, 1, 1))
@@ -836,13 +836,13 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 6, 3).pred(), NaiveDate::from_ymd(2015,  6,  2));
     /// assert_eq!(NaiveDate::from_ymd(2015, 6, 1).pred(), NaiveDate::from_ymd(2015,  5, 31));
     /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1).pred(), NaiveDate::from_ymd(2014, 12, 31));
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn pred(&self) -> NaiveDate {
         self.pred_opt().expect("out of bound")
@@ -854,14 +854,14 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     /// use chrono::naive::MIN_DATE;
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 6, 3).pred_opt(),
     ///            Some(NaiveDate::from_ymd(2015, 6, 2)));
     /// assert_eq!(MIN_DATE.pred_opt(), None);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn pred_opt(&self) -> Option<NaiveDate> {
         self.with_of(self.of().pred()).or_else(|| NaiveDate::from_ymd_opt(self.year() - 1, 12, 31))
@@ -873,7 +873,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// # extern crate chrono; fn main() {
     /// use chrono::{Duration, NaiveDate};
     /// use chrono::naive::MAX_DATE;
@@ -887,7 +887,7 @@ impl NaiveDate {
     /// assert_eq!(d.checked_add_signed(Duration::days(-1_000_000_000)), None);
     /// assert_eq!(MAX_DATE.checked_add_signed(Duration::days(1)), None);
     /// # }
-    /// ~~~~
+    /// ```
     pub fn checked_add_signed(self, rhs: OldDuration) -> Option<NaiveDate> {
         let year = self.year();
         let (mut year_div_400, year_mod_400) = div_mod_floor(year, 400);
@@ -907,7 +907,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// # extern crate chrono; fn main() {
     /// use chrono::{Duration, NaiveDate};
     /// use chrono::naive::MIN_DATE;
@@ -921,7 +921,7 @@ impl NaiveDate {
     /// assert_eq!(d.checked_sub_signed(Duration::days(-1_000_000_000)), None);
     /// assert_eq!(MIN_DATE.checked_sub_signed(Duration::days(1)), None);
     /// # }
-    /// ~~~~
+    /// ```
     pub fn checked_sub_signed(self, rhs: OldDuration) -> Option<NaiveDate> {
         let year = self.year();
         let (mut year_div_400, year_mod_400) = div_mod_floor(year, 400);
@@ -943,7 +943,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// # extern crate chrono; fn main() {
     /// use chrono::{Duration, NaiveDate};
     ///
@@ -958,7 +958,7 @@ impl NaiveDate {
     /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2010, 1, 1)), Duration::days(365*4 + 1));
     /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(1614, 1, 1)), Duration::days(365*400 + 97));
     /// # }
-    /// ~~~~
+    /// ```
     pub fn signed_duration_since(self, rhs: NaiveDate) -> OldDuration {
         let year1 = self.year();
         let year2 = rhs.year();
@@ -979,7 +979,7 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     /// use chrono::format::strftime::StrftimeItems;
     ///
@@ -987,17 +987,17 @@ impl NaiveDate {
     /// let d = NaiveDate::from_ymd(2015, 9, 5);
     /// assert_eq!(d.format_with_items(fmt.clone()).to_string(), "2015-09-05");
     /// assert_eq!(d.format("%Y-%m-%d").to_string(),             "2015-09-05");
-    /// ~~~~
+    /// ```
     ///
     /// The resulting `DelayedFormat` can be formatted directly via the `Display` trait.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::NaiveDate;
     /// # use chrono::format::strftime::StrftimeItems;
     /// # let fmt = StrftimeItems::new("%Y-%m-%d").clone();
     /// # let d = NaiveDate::from_ymd(2015, 9, 5);
     /// assert_eq!(format!("{}", d.format_with_items(fmt)), "2015-09-05");
-    /// ~~~~
+    /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[inline]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
@@ -1024,22 +1024,22 @@ impl NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let d = NaiveDate::from_ymd(2015, 9, 5);
     /// assert_eq!(d.format("%Y-%m-%d").to_string(), "2015-09-05");
     /// assert_eq!(d.format("%A, %-d %B, %C%y").to_string(), "Saturday, 5 September, 2015");
-    /// ~~~~
+    /// ```
     ///
     /// The resulting `DelayedFormat` can be formatted directly via the `Display` trait.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::NaiveDate;
     /// # let d = NaiveDate::from_ymd(2015, 9, 5);
     /// assert_eq!(format!("{}", d.format("%Y-%m-%d")), "2015-09-05");
     /// assert_eq!(format!("{}", d.format("%A, %-d %B, %C%y")), "Saturday, 5 September, 2015");
-    /// ~~~~
+    /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[inline]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
@@ -1104,12 +1104,12 @@ impl Datelike for NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).year(), 2015);
     /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).year(), -308); // 309 BCE
-    /// ~~~~
+    /// ```
     #[inline]
     fn year(&self) -> i32 {
         self.ymdf >> 13
@@ -1121,12 +1121,12 @@ impl Datelike for NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).month(), 9);
     /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).month(), 3);
-    /// ~~~~
+    /// ```
     #[inline]
     fn month(&self) -> u32 {
         self.mdf().month()
@@ -1138,12 +1138,12 @@ impl Datelike for NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).month0(), 8);
     /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).month0(), 2);
-    /// ~~~~
+    /// ```
     #[inline]
     fn month0(&self) -> u32 {
         self.mdf().month() - 1
@@ -1155,18 +1155,18 @@ impl Datelike for NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).day(), 8);
     /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).day(), 14);
-    /// ~~~~
+    /// ```
     ///
     /// Combined with [`NaiveDate::pred`](#method.pred),
     /// one can determine the number of days in a particular month.
     /// (Note that this panics when `year` is out of range.)
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// fn ndays_in_month(year: i32, month: u32) -> u32 {
@@ -1183,7 +1183,7 @@ impl Datelike for NaiveDate {
     /// assert_eq!(ndays_in_month(2015, 12), 31);
     /// assert_eq!(ndays_in_month(2016, 2), 29);
     /// assert_eq!(ndays_in_month(2017, 2), 28);
-    /// ~~~~
+    /// ```
     #[inline]
     fn day(&self) -> u32 {
         self.mdf().day()
@@ -1195,12 +1195,12 @@ impl Datelike for NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).day0(), 7);
     /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).day0(), 13);
-    /// ~~~~
+    /// ```
     #[inline]
     fn day0(&self) -> u32 {
         self.mdf().day() - 1
@@ -1212,18 +1212,18 @@ impl Datelike for NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).ordinal(), 251);
     /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).ordinal(), 74);
-    /// ~~~~
+    /// ```
     ///
     /// Combined with [`NaiveDate::pred`](#method.pred),
     /// one can determine the number of days in a particular year.
     /// (Note that this panics when `year` is out of range.)
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// fn ndays_in_year(year: i32) -> u32 {
@@ -1239,7 +1239,7 @@ impl Datelike for NaiveDate {
     /// assert_eq!(ndays_in_year(2017), 365);
     /// assert_eq!(ndays_in_year(2000), 366);
     /// assert_eq!(ndays_in_year(2100), 365);
-    /// ~~~~
+    /// ```
     #[inline]
     fn ordinal(&self) -> u32 {
         self.of().ordinal()
@@ -1251,12 +1251,12 @@ impl Datelike for NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).ordinal0(), 250);
     /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).ordinal0(), 73);
-    /// ~~~~
+    /// ```
     #[inline]
     fn ordinal0(&self) -> u32 {
         self.of().ordinal() - 1
@@ -1266,12 +1266,12 @@ impl Datelike for NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).weekday(), Weekday::Tue);
     /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).weekday(), Weekday::Fri);
-    /// ~~~~
+    /// ```
     #[inline]
     fn weekday(&self) -> Weekday {
         self.of().weekday()
@@ -1288,22 +1288,22 @@ impl Datelike for NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_year(2016),
     ///            Some(NaiveDate::from_ymd(2016, 9, 8)));
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_year(-308),
     ///            Some(NaiveDate::from_ymd(-308, 9, 8)));
-    /// ~~~~
+    /// ```
     ///
     /// A leap day (February 29) is a good example that this method can return `None`.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::{NaiveDate, Datelike};
     /// assert!(NaiveDate::from_ymd(2016, 2, 29).with_year(2015).is_none());
     /// assert!(NaiveDate::from_ymd(2016, 2, 29).with_year(2020).is_some());
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_year(&self, year: i32) -> Option<NaiveDate> {
         // we need to operate with `mdf` since we should keep the month and day number as is
@@ -1322,14 +1322,14 @@ impl Datelike for NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_month(10),
     ///            Some(NaiveDate::from_ymd(2015, 10, 8)));
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_month(13), None); // no month 13
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 30).with_month(2), None); // no February 30
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_month(&self, month: u32) -> Option<NaiveDate> {
         self.with_mdf(self.mdf().with_month(month))
@@ -1341,14 +1341,14 @@ impl Datelike for NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_month0(9),
     ///            Some(NaiveDate::from_ymd(2015, 10, 8)));
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_month0(12), None); // no month 13
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 30).with_month0(1), None); // no February 30
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_month0(&self, month0: u32) -> Option<NaiveDate> {
         self.with_mdf(self.mdf().with_month(month0 + 1))
@@ -1360,14 +1360,14 @@ impl Datelike for NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_day(30),
     ///            Some(NaiveDate::from_ymd(2015, 9, 30)));
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_day(31),
     ///            None); // no September 31
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_day(&self, day: u32) -> Option<NaiveDate> {
         self.with_mdf(self.mdf().with_day(day))
@@ -1379,14 +1379,14 @@ impl Datelike for NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_day0(29),
     ///            Some(NaiveDate::from_ymd(2015, 9, 30)));
     /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_day0(30),
     ///            None); // no September 31
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_day0(&self, day0: u32) -> Option<NaiveDate> {
         self.with_mdf(self.mdf().with_day(day0 + 1))
@@ -1398,7 +1398,7 @@ impl Datelike for NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1).with_ordinal(60),
@@ -1410,7 +1410,7 @@ impl Datelike for NaiveDate {
     ///            Some(NaiveDate::from_ymd(2016, 2, 29)));
     /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1).with_ordinal(366),
     ///            Some(NaiveDate::from_ymd(2016, 12, 31)));
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_ordinal(&self, ordinal: u32) -> Option<NaiveDate> {
         self.with_of(self.of().with_ordinal(ordinal))
@@ -1422,7 +1422,7 @@ impl Datelike for NaiveDate {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1).with_ordinal0(59),
@@ -1434,7 +1434,7 @@ impl Datelike for NaiveDate {
     ///            Some(NaiveDate::from_ymd(2016, 2, 29)));
     /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1).with_ordinal0(365),
     ///            Some(NaiveDate::from_ymd(2016, 12, 31)));
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_ordinal0(&self, ordinal0: u32) -> Option<NaiveDate> {
         self.with_of(self.of().with_ordinal(ordinal0 + 1))
@@ -1449,7 +1449,7 @@ impl Datelike for NaiveDate {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
@@ -1464,7 +1464,7 @@ impl Datelike for NaiveDate {
 /// assert_eq!(from_ymd(2014, 1, 1) + Duration::days(365*4 + 1),    from_ymd(2018, 1, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) + Duration::days(365*400 + 97), from_ymd(2414, 1, 1));
 /// # }
-/// ~~~~
+/// ```
 impl Add<OldDuration> for NaiveDate {
     type Output = NaiveDate;
 
@@ -1490,7 +1490,7 @@ impl AddAssign<OldDuration> for NaiveDate {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
@@ -1505,7 +1505,7 @@ impl AddAssign<OldDuration> for NaiveDate {
 /// assert_eq!(from_ymd(2014, 1, 1) - Duration::days(365*4 + 1),    from_ymd(2010, 1, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) - Duration::days(365*400 + 97), from_ymd(1614, 1, 1));
 /// # }
-/// ~~~~
+/// ```
 impl Sub<OldDuration> for NaiveDate {
     type Output = NaiveDate;
 
@@ -1533,7 +1533,7 @@ impl SubAssign<OldDuration> for NaiveDate {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
@@ -1547,7 +1547,7 @@ impl SubAssign<OldDuration> for NaiveDate {
 /// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2010, 1, 1), Duration::days(365*4 + 1));
 /// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(1614, 1, 1), Duration::days(365*400 + 97));
 /// # }
-/// ~~~~
+/// ```
 impl Sub<NaiveDate> for NaiveDate {
     type Output = OldDuration;
 
@@ -1621,21 +1621,21 @@ impl ExactSizeIterator for NaiveDateWeeksIterator {}
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// use chrono::NaiveDate;
 ///
 /// assert_eq!(format!("{:?}", NaiveDate::from_ymd(2015,  9,  5)), "2015-09-05");
 /// assert_eq!(format!("{:?}", NaiveDate::from_ymd(   0,  1,  1)), "0000-01-01");
 /// assert_eq!(format!("{:?}", NaiveDate::from_ymd(9999, 12, 31)), "9999-12-31");
-/// ~~~~
+/// ```
 ///
 /// ISO 8601 requires an explicit sign for years before 1 BCE or after 9999 CE.
 ///
-/// ~~~~
+/// ```
 /// # use chrono::NaiveDate;
 /// assert_eq!(format!("{:?}", NaiveDate::from_ymd(   -1,  1,  1)),  "-0001-01-01");
 /// assert_eq!(format!("{:?}", NaiveDate::from_ymd(10000, 12, 31)), "+10000-12-31");
-/// ~~~~
+/// ```
 impl fmt::Debug for NaiveDate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let year = self.year();
@@ -1656,21 +1656,21 @@ impl fmt::Debug for NaiveDate {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// use chrono::NaiveDate;
 ///
 /// assert_eq!(format!("{}", NaiveDate::from_ymd(2015,  9,  5)), "2015-09-05");
 /// assert_eq!(format!("{}", NaiveDate::from_ymd(   0,  1,  1)), "0000-01-01");
 /// assert_eq!(format!("{}", NaiveDate::from_ymd(9999, 12, 31)), "9999-12-31");
-/// ~~~~
+/// ```
 ///
 /// ISO 8601 requires an explicit sign for years before 1 BCE or after 9999 CE.
 ///
-/// ~~~~
+/// ```
 /// # use chrono::NaiveDate;
 /// assert_eq!(format!("{}", NaiveDate::from_ymd(   -1,  1,  1)),  "-0001-01-01");
 /// assert_eq!(format!("{}", NaiveDate::from_ymd(10000, 12, 31)), "+10000-12-31");
-/// ~~~~
+/// ```
 impl fmt::Display for NaiveDate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(self, f)
@@ -1682,7 +1682,7 @@ impl fmt::Display for NaiveDate {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// use chrono::NaiveDate;
 ///
 /// let d = NaiveDate::from_ymd(2015, 9, 18);
@@ -1692,7 +1692,7 @@ impl fmt::Display for NaiveDate {
 /// assert_eq!("+12345-6-7".parse::<NaiveDate>(), Ok(d));
 ///
 /// assert!("foo".parse::<NaiveDate>().is_err());
-/// ~~~~
+/// ```
 impl str::FromStr for NaiveDate {
     type Err = ParseError;
 

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -39,25 +39,25 @@ pub const MAX_DATETIME: NaiveDateTime = NaiveDateTime { date: MAX_DATE, time: MA
 ///
 /// `NaiveDateTime` is commonly created from [`NaiveDate`](./struct.NaiveDate.html).
 ///
-/// ~~~~
+/// ```
 /// use chrono::{NaiveDate, NaiveDateTime};
 ///
 /// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 7, 8).and_hms(9, 10, 11);
 /// # let _ = dt;
-/// ~~~~
+/// ```
 ///
 /// You can use typical [date-like](../trait.Datelike.html) and
 /// [time-like](../trait.Timelike.html) methods,
 /// provided that relevant traits are in the scope.
 ///
-/// ~~~~
+/// ```
 /// # use chrono::{NaiveDate, NaiveDateTime};
 /// # let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 7, 8).and_hms(9, 10, 11);
 /// use chrono::{Datelike, Timelike, Weekday};
 ///
 /// assert_eq!(dt.weekday(), Weekday::Fri);
 /// assert_eq!(dt.num_seconds_from_midnight(), 33011);
-/// ~~~~
+/// ```
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
 pub struct NaiveDateTime {
     date: NaiveDate,
@@ -71,7 +71,7 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveTime, NaiveDateTime};
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3);
@@ -80,7 +80,7 @@ impl NaiveDateTime {
     /// let dt = NaiveDateTime::new(d, t);
     /// assert_eq!(dt.date(), d);
     /// assert_eq!(dt.time(), t);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn new(date: NaiveDate, time: NaiveTime) -> NaiveDateTime {
         NaiveDateTime { date: date, time: time }
@@ -102,7 +102,7 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDateTime, NaiveDate};
     ///
     /// let dt = NaiveDateTime::from_timestamp(0, 42_000_000);
@@ -110,7 +110,7 @@ impl NaiveDateTime {
     ///
     /// let dt = NaiveDateTime::from_timestamp(1_000_000_000, 0);
     /// assert_eq!(dt, NaiveDate::from_ymd(2001, 9, 9).and_hms(1, 46, 40));
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn from_timestamp(secs: i64, nsecs: u32) -> NaiveDateTime {
         let datetime = NaiveDateTime::from_timestamp_opt(secs, nsecs);
@@ -130,7 +130,7 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDateTime, NaiveDate};
     /// use std::i64;
     ///
@@ -141,7 +141,7 @@ impl NaiveDateTime {
     /// assert!(from_timestamp_opt(0, 1_500_000_000).is_some()); // leap second
     /// assert!(from_timestamp_opt(0, 2_000_000_000).is_none());
     /// assert!(from_timestamp_opt(i64::MAX, 0).is_none());
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn from_timestamp_opt(secs: i64, nsecs: u32) -> Option<NaiveDateTime> {
         let (days, secs) = div_mod_floor(secs, 86_400);
@@ -162,7 +162,7 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDateTime, NaiveDate};
     ///
     /// let parse_from_str = NaiveDateTime::parse_from_str;
@@ -171,32 +171,32 @@ impl NaiveDateTime {
     ///            Ok(NaiveDate::from_ymd(2015, 9, 5).and_hms(23, 56, 4)));
     /// assert_eq!(parse_from_str("5sep2015pm012345.6789", "%d%b%Y%p%I%M%S%.f"),
     ///            Ok(NaiveDate::from_ymd(2015, 9, 5).and_hms_micro(13, 23, 45, 678_900)));
-    /// ~~~~
+    /// ```
     ///
     /// Offset is ignored for the purpose of parsing.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::{NaiveDateTime, NaiveDate};
     /// # let parse_from_str = NaiveDateTime::parse_from_str;
     /// assert_eq!(parse_from_str("2014-5-17T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
     ///            Ok(NaiveDate::from_ymd(2014, 5, 17).and_hms(12, 34, 56)));
-    /// ~~~~
+    /// ```
     ///
     /// [Leap seconds](./struct.NaiveTime.html#leap-second-handling) are correctly handled by
     /// treating any time of the form `hh:mm:60` as a leap second.
     /// (This equally applies to the formatting, so the round trip is possible.)
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::{NaiveDateTime, NaiveDate};
     /// # let parse_from_str = NaiveDateTime::parse_from_str;
     /// assert_eq!(parse_from_str("2015-07-01 08:59:60.123", "%Y-%m-%d %H:%M:%S%.f"),
     ///            Ok(NaiveDate::from_ymd(2015, 7, 1).and_hms_milli(8, 59, 59, 1_123)));
-    /// ~~~~
+    /// ```
     ///
     /// Missing seconds are assumed to be zero,
     /// but out-of-bound times or insufficient fields are errors otherwise.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::{NaiveDateTime, NaiveDate};
     /// # let parse_from_str = NaiveDateTime::parse_from_str;
     /// assert_eq!(parse_from_str("94/9/4 7:15", "%y/%m/%d %H:%M"),
@@ -206,17 +206,17 @@ impl NaiveDateTime {
     /// assert!(parse_from_str("94/9/4 12", "%y/%m/%d %H").is_err());
     /// assert!(parse_from_str("94/9/4 17:60", "%y/%m/%d %H:%M").is_err());
     /// assert!(parse_from_str("94/9/4 24:00:00", "%y/%m/%d %H:%M:%S").is_err());
-    /// ~~~~
+    /// ```
     ///
     /// All parsed fields should be consistent to each other, otherwise it's an error.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::NaiveDateTime;
     /// # let parse_from_str = NaiveDateTime::parse_from_str;
     /// let fmt = "%Y-%m-%d %H:%M:%S = UNIX timestamp %s";
     /// assert!(parse_from_str("2001-09-09 01:46:39 = UNIX timestamp 999999999", fmt).is_ok());
     /// assert!(parse_from_str("1970-01-01 00:00:00 = UNIX timestamp 1", fmt).is_err());
-    /// ~~~~
+    /// ```
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<NaiveDateTime> {
         let mut parsed = Parsed::new();
         parse(&mut parsed, s, StrftimeItems::new(fmt))?;
@@ -227,12 +227,12 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let dt = NaiveDate::from_ymd(2016, 7, 8).and_hms(9, 10, 11);
     /// assert_eq!(dt.date(), NaiveDate::from_ymd(2016, 7, 8));
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn date(&self) -> NaiveDate {
         self.date
@@ -242,12 +242,12 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveTime};
     ///
     /// let dt = NaiveDate::from_ymd(2016, 7, 8).and_hms(9, 10, 11);
     /// assert_eq!(dt.time(), NaiveTime::from_hms(9, 10, 11));
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn time(&self) -> NaiveTime {
         self.time
@@ -260,7 +260,7 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let dt = NaiveDate::from_ymd(1970, 1, 1).and_hms_milli(0, 0, 1, 980);
@@ -274,7 +274,7 @@ impl NaiveDateTime {
     ///
     /// let dt = NaiveDate::from_ymd(-1, 1, 1).and_hms(0, 0, 0);
     /// assert_eq!(dt.timestamp(), -62198755200);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn timestamp(&self) -> i64 {
         const UNIX_EPOCH_DAY: i64 = 719_163;
@@ -295,7 +295,7 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let dt = NaiveDate::from_ymd(1970, 1, 1).and_hms_milli(0, 0, 1, 444);
@@ -306,7 +306,7 @@ impl NaiveDateTime {
     ///
     /// let dt = NaiveDate::from_ymd(1969, 12, 31).and_hms_milli(23, 59, 59, 100);
     /// assert_eq!(dt.timestamp_millis(), -900);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn timestamp_millis(&self) -> i64 {
         let as_ms = self.timestamp() * 1000;
@@ -325,7 +325,7 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let dt = NaiveDate::from_ymd(1970, 1, 1).and_hms_micro(0, 0, 1, 444);
@@ -333,7 +333,7 @@ impl NaiveDateTime {
     ///
     /// let dt = NaiveDate::from_ymd(2001, 9, 9).and_hms_micro(1, 46, 40, 555);
     /// assert_eq!(dt.timestamp_micros(), 1_000_000_000_000_555);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn timestamp_micros(&self) -> i64 {
         let as_us = self.timestamp() * 1_000_000;
@@ -357,7 +357,7 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime};
     ///
     /// let dt = NaiveDate::from_ymd(1970, 1, 1).and_hms_nano(0, 0, 1, 444);
@@ -372,7 +372,7 @@ impl NaiveDateTime {
     ///     dt,
     ///     NaiveDateTime::from_timestamp(nanos / A_BILLION, (nanos % A_BILLION) as u32)
     /// );
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn timestamp_nanos(&self) -> i64 {
         let as_ns = self.timestamp() * 1_000_000_000;
@@ -386,7 +386,7 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let dt = NaiveDate::from_ymd(2016, 7, 8).and_hms_nano(9, 10, 11, 123_456_789);
@@ -394,7 +394,7 @@ impl NaiveDateTime {
     ///
     /// let dt = NaiveDate::from_ymd(2015, 7, 1).and_hms_nano(8, 59, 59, 1_234_567_890);
     /// assert_eq!(dt.timestamp_subsec_millis(), 1_234);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn timestamp_subsec_millis(&self) -> u32 {
         self.timestamp_subsec_nanos() / 1_000_000
@@ -407,7 +407,7 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let dt = NaiveDate::from_ymd(2016, 7, 8).and_hms_nano(9, 10, 11, 123_456_789);
@@ -415,7 +415,7 @@ impl NaiveDateTime {
     ///
     /// let dt = NaiveDate::from_ymd(2015, 7, 1).and_hms_nano(8, 59, 59, 1_234_567_890);
     /// assert_eq!(dt.timestamp_subsec_micros(), 1_234_567);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn timestamp_subsec_micros(&self) -> u32 {
         self.timestamp_subsec_nanos() / 1_000
@@ -428,7 +428,7 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let dt = NaiveDate::from_ymd(2016, 7, 8).and_hms_nano(9, 10, 11, 123_456_789);
@@ -436,7 +436,7 @@ impl NaiveDateTime {
     ///
     /// let dt = NaiveDate::from_ymd(2015, 7, 1).and_hms_nano(8, 59, 59, 1_234_567_890);
     /// assert_eq!(dt.timestamp_subsec_nanos(), 1_234_567_890);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn timestamp_subsec_nanos(&self) -> u32 {
         self.time.nanosecond()
@@ -453,7 +453,7 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// # extern crate chrono; fn main() {
     /// use chrono::{Duration, NaiveDate};
     ///
@@ -476,22 +476,22 @@ impl NaiveDateTime {
     /// assert_eq!(hmsm(3, 5, 7, 980).checked_add_signed(Duration::milliseconds(450)),
     ///            Some(hmsm(3, 5, 8, 430)));
     /// # }
-    /// ~~~~
+    /// ```
     ///
     /// Overflow returns `None`.
     ///
-    /// ~~~~
+    /// ```
     /// # extern crate chrono; fn main() {
     /// # use chrono::{Duration, NaiveDate};
     /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).and_hms(h, m, s);
     /// assert_eq!(hms(3, 5, 7).checked_add_signed(Duration::days(1_000_000_000)), None);
     /// # }
-    /// ~~~~
+    /// ```
     ///
     /// Leap seconds are handled,
     /// but the addition assumes that it is the only leap second happened.
     ///
-    /// ~~~~
+    /// ```
     /// # extern crate chrono; fn main() {
     /// # use chrono::{Duration, NaiveDate};
     /// # let from_ymd = NaiveDate::from_ymd;
@@ -512,7 +512,7 @@ impl NaiveDateTime {
     /// assert_eq!(leap.checked_add_signed(Duration::days(1)),
     ///            Some(from_ymd(2016, 7, 9).and_hms_milli(3, 5, 59, 300)));
     /// # }
-    /// ~~~~
+    /// ```
     pub fn checked_add_signed(self, rhs: OldDuration) -> Option<NaiveDateTime> {
         let (time, rhs) = self.time.overflowing_add_signed(rhs);
 
@@ -536,7 +536,7 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// # extern crate chrono; fn main() {
     /// use chrono::{Duration, NaiveDate};
     ///
@@ -559,22 +559,22 @@ impl NaiveDateTime {
     /// assert_eq!(hmsm(3, 5, 7, 450).checked_sub_signed(Duration::milliseconds(670)),
     ///            Some(hmsm(3, 5, 6, 780)));
     /// # }
-    /// ~~~~
+    /// ```
     ///
     /// Overflow returns `None`.
     ///
-    /// ~~~~
+    /// ```
     /// # extern crate chrono; fn main() {
     /// # use chrono::{Duration, NaiveDate};
     /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).and_hms(h, m, s);
     /// assert_eq!(hms(3, 5, 7).checked_sub_signed(Duration::days(1_000_000_000)), None);
     /// # }
-    /// ~~~~
+    /// ```
     ///
     /// Leap seconds are handled,
     /// but the subtraction assumes that it is the only leap second happened.
     ///
-    /// ~~~~
+    /// ```
     /// # extern crate chrono; fn main() {
     /// # use chrono::{Duration, NaiveDate};
     /// # let from_ymd = NaiveDate::from_ymd;
@@ -591,7 +591,7 @@ impl NaiveDateTime {
     /// assert_eq!(leap.checked_sub_signed(Duration::days(1)),
     ///            Some(from_ymd(2016, 7, 7).and_hms_milli(3, 6, 0, 300)));
     /// # }
-    /// ~~~~
+    /// ```
     pub fn checked_sub_signed(self, rhs: OldDuration) -> Option<NaiveDateTime> {
         let (time, rhs) = self.time.overflowing_sub_signed(rhs);
 
@@ -615,7 +615,7 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// # extern crate chrono; fn main() {
     /// use chrono::{Duration, NaiveDate};
     ///
@@ -630,12 +630,12 @@ impl NaiveDateTime {
     /// assert_eq!(d.and_hms_milli(0, 7, 6, 500).signed_duration_since(d0.and_hms(0, 0, 0)),
     ///            Duration::seconds(189 * 86_400 + 7 * 60 + 6) + Duration::milliseconds(500));
     /// # }
-    /// ~~~~
+    /// ```
     ///
     /// Leap seconds are handled, but the subtraction assumes that
     /// there were no other leap seconds happened.
     ///
-    /// ~~~~
+    /// ```
     /// # extern crate chrono; fn main() {
     /// # use chrono::{Duration, NaiveDate};
     /// # let from_ymd = NaiveDate::from_ymd;
@@ -645,7 +645,7 @@ impl NaiveDateTime {
     /// assert_eq!(from_ymd(2015, 7, 1).and_hms(1, 0, 0).signed_duration_since(leap),
     ///            Duration::seconds(3600) - Duration::milliseconds(500));
     /// # }
-    /// ~~~~
+    /// ```
     pub fn signed_duration_since(self, rhs: NaiveDateTime) -> OldDuration {
         self.date.signed_duration_since(rhs.date) + self.time.signed_duration_since(rhs.time)
     }
@@ -658,7 +658,7 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     /// use chrono::format::strftime::StrftimeItems;
     ///
@@ -666,17 +666,17 @@ impl NaiveDateTime {
     /// let dt = NaiveDate::from_ymd(2015, 9, 5).and_hms(23, 56, 4);
     /// assert_eq!(dt.format_with_items(fmt.clone()).to_string(), "2015-09-05 23:56:04");
     /// assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(),    "2015-09-05 23:56:04");
-    /// ~~~~
+    /// ```
     ///
     /// The resulting `DelayedFormat` can be formatted directly via the `Display` trait.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::NaiveDate;
     /// # use chrono::format::strftime::StrftimeItems;
     /// # let fmt = StrftimeItems::new("%Y-%m-%d %H:%M:%S").clone();
     /// # let dt = NaiveDate::from_ymd(2015, 9, 5).and_hms(23, 56, 4);
     /// assert_eq!(format!("{}", dt.format_with_items(fmt)), "2015-09-05 23:56:04");
-    /// ~~~~
+    /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[inline]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
@@ -703,22 +703,22 @@ impl NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveDate;
     ///
     /// let dt = NaiveDate::from_ymd(2015, 9, 5).and_hms(23, 56, 4);
     /// assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2015-09-05 23:56:04");
     /// assert_eq!(dt.format("around %l %p on %b %-d").to_string(), "around 11 PM on Sep 5");
-    /// ~~~~
+    /// ```
     ///
     /// The resulting `DelayedFormat` can be formatted directly via the `Display` trait.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::NaiveDate;
     /// # let dt = NaiveDate::from_ymd(2015, 9, 5).and_hms(23, 56, 4);
     /// assert_eq!(format!("{}", dt.format("%Y-%m-%d %H:%M:%S")), "2015-09-05 23:56:04");
     /// assert_eq!(format!("{}", dt.format("around %l %p on %b %-d")), "around 11 PM on Sep 5");
-    /// ~~~~
+    /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[inline]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
@@ -733,12 +733,12 @@ impl Datelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).and_hms(12, 34, 56);
     /// assert_eq!(dt.year(), 2015);
-    /// ~~~~
+    /// ```
     #[inline]
     fn year(&self) -> i32 {
         self.date.year()
@@ -752,12 +752,12 @@ impl Datelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).and_hms(12, 34, 56);
     /// assert_eq!(dt.month(), 9);
-    /// ~~~~
+    /// ```
     #[inline]
     fn month(&self) -> u32 {
         self.date.month()
@@ -771,12 +771,12 @@ impl Datelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).and_hms(12, 34, 56);
     /// assert_eq!(dt.month0(), 8);
-    /// ~~~~
+    /// ```
     #[inline]
     fn month0(&self) -> u32 {
         self.date.month0()
@@ -790,12 +790,12 @@ impl Datelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).and_hms(12, 34, 56);
     /// assert_eq!(dt.day(), 25);
-    /// ~~~~
+    /// ```
     #[inline]
     fn day(&self) -> u32 {
         self.date.day()
@@ -809,12 +809,12 @@ impl Datelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).and_hms(12, 34, 56);
     /// assert_eq!(dt.day0(), 24);
-    /// ~~~~
+    /// ```
     #[inline]
     fn day0(&self) -> u32 {
         self.date.day0()
@@ -828,12 +828,12 @@ impl Datelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).and_hms(12, 34, 56);
     /// assert_eq!(dt.ordinal(), 268);
-    /// ~~~~
+    /// ```
     #[inline]
     fn ordinal(&self) -> u32 {
         self.date.ordinal()
@@ -847,12 +847,12 @@ impl Datelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).and_hms(12, 34, 56);
     /// assert_eq!(dt.ordinal0(), 267);
-    /// ~~~~
+    /// ```
     #[inline]
     fn ordinal0(&self) -> u32 {
         self.date.ordinal0()
@@ -864,12 +864,12 @@ impl Datelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike, Weekday};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).and_hms(12, 34, 56);
     /// assert_eq!(dt.weekday(), Weekday::Fri);
-    /// ~~~~
+    /// ```
     #[inline]
     fn weekday(&self) -> Weekday {
         self.date.weekday()
@@ -888,13 +888,13 @@ impl Datelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).and_hms(12, 34, 56);
     /// assert_eq!(dt.with_year(2016), Some(NaiveDate::from_ymd(2016, 9, 25).and_hms(12, 34, 56)));
     /// assert_eq!(dt.with_year(-308), Some(NaiveDate::from_ymd(-308, 9, 25).and_hms(12, 34, 56)));
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_year(&self, year: i32) -> Option<NaiveDateTime> {
         self.date.with_year(year).map(|d| NaiveDateTime { date: d, ..*self })
@@ -908,14 +908,14 @@ impl Datelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 30).and_hms(12, 34, 56);
     /// assert_eq!(dt.with_month(10), Some(NaiveDate::from_ymd(2015, 10, 30).and_hms(12, 34, 56)));
     /// assert_eq!(dt.with_month(13), None); // no month 13
     /// assert_eq!(dt.with_month(2), None); // no February 30
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_month(&self, month: u32) -> Option<NaiveDateTime> {
         self.date.with_month(month).map(|d| NaiveDateTime { date: d, ..*self })
@@ -929,14 +929,14 @@ impl Datelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 30).and_hms(12, 34, 56);
     /// assert_eq!(dt.with_month0(9), Some(NaiveDate::from_ymd(2015, 10, 30).and_hms(12, 34, 56)));
     /// assert_eq!(dt.with_month0(12), None); // no month 13
     /// assert_eq!(dt.with_month0(1), None); // no February 30
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_month0(&self, month0: u32) -> Option<NaiveDateTime> {
         self.date.with_month0(month0).map(|d| NaiveDateTime { date: d, ..*self })
@@ -950,13 +950,13 @@ impl Datelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).and_hms(12, 34, 56);
     /// assert_eq!(dt.with_day(30), Some(NaiveDate::from_ymd(2015, 9, 30).and_hms(12, 34, 56)));
     /// assert_eq!(dt.with_day(31), None); // no September 31
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_day(&self, day: u32) -> Option<NaiveDateTime> {
         self.date.with_day(day).map(|d| NaiveDateTime { date: d, ..*self })
@@ -970,13 +970,13 @@ impl Datelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).and_hms(12, 34, 56);
     /// assert_eq!(dt.with_day0(29), Some(NaiveDate::from_ymd(2015, 9, 30).and_hms(12, 34, 56)));
     /// assert_eq!(dt.with_day0(30), None); // no September 31
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_day0(&self, day0: u32) -> Option<NaiveDateTime> {
         self.date.with_day0(day0).map(|d| NaiveDateTime { date: d, ..*self })
@@ -990,7 +990,7 @@ impl Datelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).and_hms(12, 34, 56);
@@ -1003,7 +1003,7 @@ impl Datelike for NaiveDateTime {
     ///            Some(NaiveDate::from_ymd(2016, 2, 29).and_hms(12, 34, 56)));
     /// assert_eq!(dt.with_ordinal(366),
     ///            Some(NaiveDate::from_ymd(2016, 12, 31).and_hms(12, 34, 56)));
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_ordinal(&self, ordinal: u32) -> Option<NaiveDateTime> {
         self.date.with_ordinal(ordinal).map(|d| NaiveDateTime { date: d, ..*self })
@@ -1017,7 +1017,7 @@ impl Datelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).and_hms(12, 34, 56);
@@ -1030,7 +1030,7 @@ impl Datelike for NaiveDateTime {
     ///            Some(NaiveDate::from_ymd(2016, 2, 29).and_hms(12, 34, 56)));
     /// assert_eq!(dt.with_ordinal0(365),
     ///            Some(NaiveDate::from_ymd(2016, 12, 31).and_hms(12, 34, 56)));
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_ordinal0(&self, ordinal0: u32) -> Option<NaiveDateTime> {
         self.date.with_ordinal0(ordinal0).map(|d| NaiveDateTime { date: d, ..*self })
@@ -1044,12 +1044,12 @@ impl Timelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).and_hms_milli(12, 34, 56, 789);
     /// assert_eq!(dt.hour(), 12);
-    /// ~~~~
+    /// ```
     #[inline]
     fn hour(&self) -> u32 {
         self.time.hour()
@@ -1061,12 +1061,12 @@ impl Timelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).and_hms_milli(12, 34, 56, 789);
     /// assert_eq!(dt.minute(), 34);
-    /// ~~~~
+    /// ```
     #[inline]
     fn minute(&self) -> u32 {
         self.time.minute()
@@ -1078,12 +1078,12 @@ impl Timelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).and_hms_milli(12, 34, 56, 789);
     /// assert_eq!(dt.second(), 56);
-    /// ~~~~
+    /// ```
     #[inline]
     fn second(&self) -> u32 {
         self.time.second()
@@ -1097,12 +1097,12 @@ impl Timelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).and_hms_milli(12, 34, 56, 789);
     /// assert_eq!(dt.nanosecond(), 789_000_000);
-    /// ~~~~
+    /// ```
     #[inline]
     fn nanosecond(&self) -> u32 {
         self.time.nanosecond()
@@ -1116,14 +1116,14 @@ impl Timelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).and_hms_milli(12, 34, 56, 789);
     /// assert_eq!(dt.with_hour(7),
     ///            Some(NaiveDate::from_ymd(2015, 9, 8).and_hms_milli(7, 34, 56, 789)));
     /// assert_eq!(dt.with_hour(24), None);
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_hour(&self, hour: u32) -> Option<NaiveDateTime> {
         self.time.with_hour(hour).map(|t| NaiveDateTime { time: t, ..*self })
@@ -1138,14 +1138,14 @@ impl Timelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).and_hms_milli(12, 34, 56, 789);
     /// assert_eq!(dt.with_minute(45),
     ///            Some(NaiveDate::from_ymd(2015, 9, 8).and_hms_milli(12, 45, 56, 789)));
     /// assert_eq!(dt.with_minute(60), None);
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_minute(&self, min: u32) -> Option<NaiveDateTime> {
         self.time.with_minute(min).map(|t| NaiveDateTime { time: t, ..*self })
@@ -1161,14 +1161,14 @@ impl Timelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).and_hms_milli(12, 34, 56, 789);
     /// assert_eq!(dt.with_second(17),
     ///            Some(NaiveDate::from_ymd(2015, 9, 8).and_hms_milli(12, 34, 17, 789)));
     /// assert_eq!(dt.with_second(60), None);
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_second(&self, sec: u32) -> Option<NaiveDateTime> {
         self.time.with_second(sec).map(|t| NaiveDateTime { time: t, ..*self })
@@ -1184,7 +1184,7 @@ impl Timelike for NaiveDateTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).and_hms_milli(12, 34, 56, 789);
@@ -1193,7 +1193,7 @@ impl Timelike for NaiveDateTime {
     /// assert_eq!(dt.with_nanosecond(1_333_333_333), // leap second
     ///            Some(NaiveDate::from_ymd(2015, 9, 8).and_hms_nano(12, 34, 56, 1_333_333_333)));
     /// assert_eq!(dt.with_nanosecond(2_000_000_000), None);
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_nanosecond(&self, nano: u32) -> Option<NaiveDateTime> {
         self.time.with_nanosecond(nano).map(|t| NaiveDateTime { time: t, ..*self })
@@ -1223,7 +1223,7 @@ impl hash::Hash for NaiveDateTime {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
@@ -1243,12 +1243,12 @@ impl hash::Hash for NaiveDateTime {
 /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli);
 /// assert_eq!(hmsm(3, 5, 7, 980) + Duration::milliseconds(450), hmsm(3, 5, 8, 430));
 /// # }
-/// ~~~~
+/// ```
 ///
 /// Leap seconds are handled,
 /// but the addition assumes that it is the only leap second happened.
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// # use chrono::{Duration, NaiveDate};
 /// # let from_ymd = NaiveDate::from_ymd;
@@ -1263,7 +1263,7 @@ impl hash::Hash for NaiveDateTime {
 /// assert_eq!(leap + Duration::days(1),
 ///            from_ymd(2016, 7, 9).and_hms_milli(3, 5, 59, 300));
 /// # }
-/// ~~~~
+/// ```
 impl Add<OldDuration> for NaiveDateTime {
     type Output = NaiveDateTime;
 
@@ -1293,7 +1293,7 @@ impl AddAssign<OldDuration> for NaiveDateTime {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
@@ -1313,12 +1313,12 @@ impl AddAssign<OldDuration> for NaiveDateTime {
 /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli);
 /// assert_eq!(hmsm(3, 5, 7, 450) - Duration::milliseconds(670), hmsm(3, 5, 6, 780));
 /// # }
-/// ~~~~
+/// ```
 ///
 /// Leap seconds are handled,
 /// but the subtraction assumes that it is the only leap second happened.
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// # use chrono::{Duration, NaiveDate};
 /// # let from_ymd = NaiveDate::from_ymd;
@@ -1331,7 +1331,7 @@ impl AddAssign<OldDuration> for NaiveDateTime {
 /// assert_eq!(leap - Duration::days(1),
 ///            from_ymd(2016, 7, 7).and_hms_milli(3, 6, 0, 300));
 /// # }
-/// ~~~~
+/// ```
 impl Sub<OldDuration> for NaiveDateTime {
     type Output = NaiveDateTime;
 
@@ -1361,7 +1361,7 @@ impl SubAssign<OldDuration> for NaiveDateTime {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
@@ -1375,12 +1375,12 @@ impl SubAssign<OldDuration> for NaiveDateTime {
 /// assert_eq!(d.and_hms_milli(0, 7, 6, 500) - d0.and_hms(0, 0, 0),
 ///            Duration::seconds(189 * 86_400 + 7 * 60 + 6) + Duration::milliseconds(500));
 /// # }
-/// ~~~~
+/// ```
 ///
 /// Leap seconds are handled, but the subtraction assumes that no other leap
 /// seconds happened.
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// # use chrono::{Duration, NaiveDate};
 /// # let from_ymd = NaiveDate::from_ymd;
@@ -1390,7 +1390,7 @@ impl SubAssign<OldDuration> for NaiveDateTime {
 /// assert_eq!(from_ymd(2015, 7, 1).and_hms(1, 0, 0) - leap,
 ///            Duration::seconds(3600) - Duration::milliseconds(500));
 /// # }
-/// ~~~~
+/// ```
 impl Sub<NaiveDateTime> for NaiveDateTime {
     type Output = OldDuration;
 
@@ -1413,20 +1413,20 @@ impl Sub<NaiveDateTime> for NaiveDateTime {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// use chrono::NaiveDate;
 ///
 /// let dt = NaiveDate::from_ymd(2016, 11, 15).and_hms(7, 39, 24);
 /// assert_eq!(format!("{:?}", dt), "2016-11-15T07:39:24");
-/// ~~~~
+/// ```
 ///
 /// Leap seconds may also be used.
 ///
-/// ~~~~
+/// ```
 /// # use chrono::NaiveDate;
 /// let dt = NaiveDate::from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500);
 /// assert_eq!(format!("{:?}", dt), "2015-06-30T23:59:60.500");
-/// ~~~~
+/// ```
 impl fmt::Debug for NaiveDateTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}T{:?}", self.date, self.time)
@@ -1444,20 +1444,20 @@ impl fmt::Debug for NaiveDateTime {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// use chrono::NaiveDate;
 ///
 /// let dt = NaiveDate::from_ymd(2016, 11, 15).and_hms(7, 39, 24);
 /// assert_eq!(format!("{}", dt), "2016-11-15 07:39:24");
-/// ~~~~
+/// ```
 ///
 /// Leap seconds may also be used.
 ///
-/// ~~~~
+/// ```
 /// # use chrono::NaiveDate;
 /// let dt = NaiveDate::from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500);
 /// assert_eq!(format!("{}", dt), "2015-06-30 23:59:60.500");
-/// ~~~~
+/// ```
 impl fmt::Display for NaiveDateTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} {}", self.date, self.time)
@@ -1469,7 +1469,7 @@ impl fmt::Display for NaiveDateTime {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// use chrono::{NaiveDateTime, NaiveDate};
 ///
 /// let dt = NaiveDate::from_ymd(2015, 9, 18).and_hms(23, 56, 4);
@@ -1479,7 +1479,7 @@ impl fmt::Display for NaiveDateTime {
 /// assert_eq!("+12345-6-7T7:59:60.5".parse::<NaiveDateTime>(), Ok(dt));
 ///
 /// assert!("foo".parse::<NaiveDateTime>().is_err());
-/// ~~~~
+/// ```
 impl str::FromStr for NaiveDateTime {
     type Err = ParseError;
 

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -50,22 +50,22 @@ impl IsoWeek {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
     /// let d = NaiveDate::from_isoywd(2015, 1, Weekday::Mon);
     /// assert_eq!(d.iso_week().year(), 2015);
-    /// ~~~~
+    /// ```
     ///
     /// This year number might not match the calendar year number.
     /// Continuing the example...
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::{NaiveDate, Datelike, Weekday};
     /// # let d = NaiveDate::from_isoywd(2015, 1, Weekday::Mon);
     /// assert_eq!(d.year(), 2014);
     /// assert_eq!(d, NaiveDate::from_ymd(2014, 12, 29));
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn year(&self) -> i32 {
         self.ywf >> 10
@@ -77,12 +77,12 @@ impl IsoWeek {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
     /// let d = NaiveDate::from_isoywd(2015, 15, Weekday::Mon);
     /// assert_eq!(d.iso_week().week(), 15);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn week(&self) -> u32 {
         ((self.ywf >> 4) & 0x3f) as u32
@@ -94,12 +94,12 @@ impl IsoWeek {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
     /// let d = NaiveDate::from_isoywd(2015, 15, Weekday::Mon);
     /// assert_eq!(d.iso_week().week0(), 14);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn week0(&self) -> u32 {
         ((self.ywf >> 4) & 0x3f) as u32 - 1
@@ -112,21 +112,21 @@ impl IsoWeek {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// use chrono::{NaiveDate, Datelike};
 ///
 /// assert_eq!(format!("{:?}", NaiveDate::from_ymd(2015,  9,  5).iso_week()), "2015-W36");
 /// assert_eq!(format!("{:?}", NaiveDate::from_ymd(   0,  1,  3).iso_week()), "0000-W01");
 /// assert_eq!(format!("{:?}", NaiveDate::from_ymd(9999, 12, 31).iso_week()), "9999-W52");
-/// ~~~~
+/// ```
 ///
 /// ISO 8601 requires an explicit sign for years before 1 BCE or after 9999 CE.
 ///
-/// ~~~~
+/// ```
 /// # use chrono::{NaiveDate, Datelike};
 /// assert_eq!(format!("{:?}", NaiveDate::from_ymd(    0,  1,  2).iso_week()),  "-0001-W52");
 /// assert_eq!(format!("{:?}", NaiveDate::from_ymd(10000, 12, 31).iso_week()), "+10000-W52");
-/// ~~~~
+/// ```
 impl fmt::Debug for IsoWeek {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let year = self.year();

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -64,7 +64,7 @@ pub const MAX_TIME: NaiveTime = NaiveTime { secs: 23 * 3600 + 59 * 60 + 59, frac
 ///
 /// All methods accepting fractional seconds will accept such values.
 ///
-/// ~~~~
+/// ```
 /// use chrono::{NaiveDate, NaiveTime, Utc, TimeZone};
 ///
 /// let t = NaiveTime::from_hms_milli(8, 59, 59, 1_000);
@@ -73,7 +73,7 @@ pub const MAX_TIME: NaiveTime = NaiveTime { secs: 23 * 3600 + 59 * 60 + 59, frac
 ///
 /// let dt2 = Utc.ymd(2015, 6, 30).and_hms_nano(23, 59, 59, 1_000_000_000);
 /// # let _ = (t, dt1, dt2);
-/// ~~~~
+/// ```
 ///
 /// Note that the leap second can happen anytime given an appropriate time zone;
 /// 2015-07-01 01:23:60 would be a proper leap second if UTC+01:24 had existed.
@@ -151,12 +151,12 @@ pub const MAX_TIME: NaiveTime = NaiveTime { secs: 23 * 3600 + 59 * 60 + 59, frac
 /// The leap second in the human-readable representation
 /// will be represented as the second part being 60, as required by ISO 8601.
 ///
-/// ~~~~
+/// ```
 /// use chrono::{Utc, TimeZone};
 ///
 /// let dt = Utc.ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_000);
 /// assert_eq!(format!("{:?}", dt), "2015-06-30T23:59:60Z");
-/// ~~~~
+/// ```
 ///
 /// There are hypothetical leap seconds not on the minute boundary
 /// nevertheless supported by Chrono.
@@ -165,7 +165,7 @@ pub const MAX_TIME: NaiveTime = NaiveTime { secs: 23 * 3600 + 59 * 60 + 59, frac
 /// For such cases the human-readable representation is ambiguous
 /// and would be read back to the next non-leap second.
 ///
-/// ~~~~
+/// ```
 /// use chrono::{DateTime, Utc, TimeZone};
 ///
 /// let dt = Utc.ymd(2015, 6, 30).and_hms_milli(23, 56, 4, 1_000);
@@ -174,7 +174,7 @@ pub const MAX_TIME: NaiveTime = NaiveTime { secs: 23 * 3600 + 59 * 60 + 59, frac
 /// let dt = Utc.ymd(2015, 6, 30).and_hms(23, 56, 5);
 /// assert_eq!(format!("{:?}", dt), "2015-06-30T23:56:05Z");
 /// assert_eq!(DateTime::parse_from_rfc3339("2015-06-30T23:56:05Z").unwrap(), dt);
-/// ~~~~
+/// ```
 ///
 /// Since Chrono alone cannot determine any existence of leap seconds,
 /// **there is absolutely no guarantee that the leap second read has actually happened**.
@@ -194,7 +194,7 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// let t = NaiveTime::from_hms(23, 56, 4);
@@ -202,7 +202,7 @@ impl NaiveTime {
     /// assert_eq!(t.minute(), 56);
     /// assert_eq!(t.second(), 4);
     /// assert_eq!(t.nanosecond(), 0);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn from_hms(hour: u32, min: u32, sec: u32) -> NaiveTime {
         NaiveTime::from_hms_opt(hour, min, sec).expect("invalid time")
@@ -217,7 +217,7 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveTime;
     ///
     /// let from_hms_opt = NaiveTime::from_hms_opt;
@@ -227,7 +227,7 @@ impl NaiveTime {
     /// assert!(from_hms_opt(24, 0, 0).is_none());
     /// assert!(from_hms_opt(23, 60, 0).is_none());
     /// assert!(from_hms_opt(23, 59, 60).is_none());
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn from_hms_opt(hour: u32, min: u32, sec: u32) -> Option<NaiveTime> {
         NaiveTime::from_hms_nano_opt(hour, min, sec, 0)
@@ -242,7 +242,7 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// let t = NaiveTime::from_hms_milli(23, 56, 4, 12);
@@ -250,7 +250,7 @@ impl NaiveTime {
     /// assert_eq!(t.minute(), 56);
     /// assert_eq!(t.second(), 4);
     /// assert_eq!(t.nanosecond(), 12_000_000);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn from_hms_milli(hour: u32, min: u32, sec: u32, milli: u32) -> NaiveTime {
         NaiveTime::from_hms_milli_opt(hour, min, sec, milli).expect("invalid time")
@@ -265,7 +265,7 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveTime;
     ///
     /// let from_hmsm_opt = NaiveTime::from_hms_milli_opt;
@@ -277,7 +277,7 @@ impl NaiveTime {
     /// assert!(from_hmsm_opt(23, 60, 0, 0).is_none());
     /// assert!(from_hmsm_opt(23, 59, 60, 0).is_none());
     /// assert!(from_hmsm_opt(23, 59, 59, 2_000).is_none());
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn from_hms_milli_opt(hour: u32, min: u32, sec: u32, milli: u32) -> Option<NaiveTime> {
         milli
@@ -294,7 +294,7 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// let t = NaiveTime::from_hms_micro(23, 56, 4, 12_345);
@@ -302,7 +302,7 @@ impl NaiveTime {
     /// assert_eq!(t.minute(), 56);
     /// assert_eq!(t.second(), 4);
     /// assert_eq!(t.nanosecond(), 12_345_000);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn from_hms_micro(hour: u32, min: u32, sec: u32, micro: u32) -> NaiveTime {
         NaiveTime::from_hms_micro_opt(hour, min, sec, micro).expect("invalid time")
@@ -317,7 +317,7 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveTime;
     ///
     /// let from_hmsu_opt = NaiveTime::from_hms_micro_opt;
@@ -329,7 +329,7 @@ impl NaiveTime {
     /// assert!(from_hmsu_opt(23, 60, 0, 0).is_none());
     /// assert!(from_hmsu_opt(23, 59, 60, 0).is_none());
     /// assert!(from_hmsu_opt(23, 59, 59, 2_000_000).is_none());
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn from_hms_micro_opt(hour: u32, min: u32, sec: u32, micro: u32) -> Option<NaiveTime> {
         micro.checked_mul(1_000).and_then(|nano| NaiveTime::from_hms_nano_opt(hour, min, sec, nano))
@@ -344,7 +344,7 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// let t = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678);
@@ -352,7 +352,7 @@ impl NaiveTime {
     /// assert_eq!(t.minute(), 56);
     /// assert_eq!(t.second(), 4);
     /// assert_eq!(t.nanosecond(), 12_345_678);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn from_hms_nano(hour: u32, min: u32, sec: u32, nano: u32) -> NaiveTime {
         NaiveTime::from_hms_nano_opt(hour, min, sec, nano).expect("invalid time")
@@ -367,7 +367,7 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveTime;
     ///
     /// let from_hmsn_opt = NaiveTime::from_hms_nano_opt;
@@ -379,7 +379,7 @@ impl NaiveTime {
     /// assert!(from_hmsn_opt(23, 60, 0, 0).is_none());
     /// assert!(from_hmsn_opt(23, 59, 60, 0).is_none());
     /// assert!(from_hmsn_opt(23, 59, 59, 2_000_000_000).is_none());
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn from_hms_nano_opt(hour: u32, min: u32, sec: u32, nano: u32) -> Option<NaiveTime> {
         if hour >= 24 || min >= 60 || sec >= 60 || nano >= 2_000_000_000 {
@@ -398,7 +398,7 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// let t = NaiveTime::from_num_seconds_from_midnight(86164, 12_345_678);
@@ -406,7 +406,7 @@ impl NaiveTime {
     /// assert_eq!(t.minute(), 56);
     /// assert_eq!(t.second(), 4);
     /// assert_eq!(t.nanosecond(), 12_345_678);
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn from_num_seconds_from_midnight(secs: u32, nano: u32) -> NaiveTime {
         NaiveTime::from_num_seconds_from_midnight_opt(secs, nano).expect("invalid time")
@@ -421,7 +421,7 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveTime;
     ///
     /// let from_nsecs_opt = NaiveTime::from_num_seconds_from_midnight_opt;
@@ -431,7 +431,7 @@ impl NaiveTime {
     /// assert!(from_nsecs_opt(86399, 1_999_999_999).is_some()); // a leap second after 23:59:59
     /// assert!(from_nsecs_opt(86_400, 0).is_none());
     /// assert!(from_nsecs_opt(86399, 2_000_000_000).is_none());
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn from_num_seconds_from_midnight_opt(secs: u32, nano: u32) -> Option<NaiveTime> {
         if secs >= 86_400 || nano >= 2_000_000_000 {
@@ -446,7 +446,7 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveTime;
     ///
     /// let parse_from_str = NaiveTime::parse_from_str;
@@ -455,32 +455,32 @@ impl NaiveTime {
     ///            Ok(NaiveTime::from_hms(23, 56, 4)));
     /// assert_eq!(parse_from_str("pm012345.6789", "%p%I%M%S%.f"),
     ///            Ok(NaiveTime::from_hms_micro(13, 23, 45, 678_900)));
-    /// ~~~~
+    /// ```
     ///
     /// Date and offset is ignored for the purpose of parsing.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::NaiveTime;
     /// # let parse_from_str = NaiveTime::parse_from_str;
     /// assert_eq!(parse_from_str("2014-5-17T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
     ///            Ok(NaiveTime::from_hms(12, 34, 56)));
-    /// ~~~~
+    /// ```
     ///
     /// [Leap seconds](#leap-second-handling) are correctly handled by
     /// treating any time of the form `hh:mm:60` as a leap second.
     /// (This equally applies to the formatting, so the round trip is possible.)
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::NaiveTime;
     /// # let parse_from_str = NaiveTime::parse_from_str;
     /// assert_eq!(parse_from_str("08:59:60.123", "%H:%M:%S%.f"),
     ///            Ok(NaiveTime::from_hms_milli(8, 59, 59, 1_123)));
-    /// ~~~~
+    /// ```
     ///
     /// Missing seconds are assumed to be zero,
     /// but out-of-bound times or insufficient fields are errors otherwise.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::NaiveTime;
     /// # let parse_from_str = NaiveTime::parse_from_str;
     /// assert_eq!(parse_from_str("7:15", "%H:%M"),
@@ -490,17 +490,17 @@ impl NaiveTime {
     /// assert!(parse_from_str("12", "%H").is_err());
     /// assert!(parse_from_str("17:60", "%H:%M").is_err());
     /// assert!(parse_from_str("24:00:00", "%H:%M:%S").is_err());
-    /// ~~~~
+    /// ```
     ///
     /// All parsed fields should be consistent to each other, otherwise it's an error.
     /// Here `%H` is for 24-hour clocks, unlike `%I`,
     /// and thus can be independently determined without AM/PM.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::NaiveTime;
     /// # let parse_from_str = NaiveTime::parse_from_str;
     /// assert!(parse_from_str("13:07 AM", "%H:%M %p").is_err());
-    /// ~~~~
+    /// ```
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<NaiveTime> {
         let mut parsed = Parsed::new();
         parse(&mut parsed, s, StrftimeItems::new(fmt))?;
@@ -514,7 +514,7 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// # extern crate chrono; fn main() {
     /// use chrono::{Duration, NaiveTime};
     ///
@@ -527,7 +527,7 @@ impl NaiveTime {
     /// assert_eq!(from_hms(3, 4, 5).overflowing_add_signed(Duration::hours(-7)),
     ///            (from_hms(20, 4, 5), -86_400));
     /// # }
-    /// ~~~~
+    /// ```
     #[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
     pub fn overflowing_add_signed(&self, mut rhs: OldDuration) -> (NaiveTime, i64) {
         let mut secs = self.secs;
@@ -599,7 +599,7 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// # extern crate chrono; fn main() {
     /// use chrono::{Duration, NaiveTime};
     ///
@@ -612,7 +612,7 @@ impl NaiveTime {
     /// assert_eq!(from_hms(3, 4, 5).overflowing_sub_signed(Duration::hours(-22)),
     ///            (from_hms(1, 4, 5), -86_400));
     /// # }
-    /// ~~~~
+    /// ```
     #[inline]
     pub fn overflowing_sub_signed(&self, rhs: OldDuration) -> (NaiveTime, i64) {
         let (time, rhs) = self.overflowing_add_signed(-rhs);
@@ -631,7 +631,7 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// # extern crate chrono; fn main() {
     /// use chrono::{Duration, NaiveTime};
     ///
@@ -655,12 +655,12 @@ impl NaiveTime {
     /// assert_eq!(since(from_hmsm(3, 5, 7, 900), from_hmsm(2, 4, 6, 800)),
     ///            Duration::seconds(3600 + 60 + 1) + Duration::milliseconds(100));
     /// # }
-    /// ~~~~
+    /// ```
     ///
     /// Leap seconds are handled, but the subtraction assumes that
     /// there were no other leap seconds happened.
     ///
-    /// ~~~~
+    /// ```
     /// # extern crate chrono; fn main() {
     /// # use chrono::{Duration, NaiveTime};
     /// # let from_hmsm = NaiveTime::from_hms_milli;
@@ -676,7 +676,7 @@ impl NaiveTime {
     /// assert_eq!(since(from_hmsm(3, 0, 59, 1_000), from_hmsm(2, 59, 59, 1_000)),
     ///            Duration::seconds(61));
     /// # }
-    /// ~~~~
+    /// ```
     pub fn signed_duration_since(self, rhs: NaiveTime) -> OldDuration {
         //     |    |    :leap|    |    |    |    |    |    |    :leap|    |
         //     |    |    :    |    |    |    |    |    |    |    :    |    |
@@ -723,7 +723,7 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveTime;
     /// use chrono::format::strftime::StrftimeItems;
     ///
@@ -731,17 +731,17 @@ impl NaiveTime {
     /// let t = NaiveTime::from_hms(23, 56, 4);
     /// assert_eq!(t.format_with_items(fmt.clone()).to_string(), "23:56:04");
     /// assert_eq!(t.format("%H:%M:%S").to_string(),             "23:56:04");
-    /// ~~~~
+    /// ```
     ///
     /// The resulting `DelayedFormat` can be formatted directly via the `Display` trait.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::NaiveTime;
     /// # use chrono::format::strftime::StrftimeItems;
     /// # let fmt = StrftimeItems::new("%H:%M:%S").clone();
     /// # let t = NaiveTime::from_hms(23, 56, 4);
     /// assert_eq!(format!("{}", t.format_with_items(fmt)), "23:56:04");
-    /// ~~~~
+    /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[inline]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
@@ -768,24 +768,24 @@ impl NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::NaiveTime;
     ///
     /// let t = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678);
     /// assert_eq!(t.format("%H:%M:%S").to_string(), "23:56:04");
     /// assert_eq!(t.format("%H:%M:%S%.6f").to_string(), "23:56:04.012345");
     /// assert_eq!(t.format("%-I:%M %p").to_string(), "11:56 PM");
-    /// ~~~~
+    /// ```
     ///
     /// The resulting `DelayedFormat` can be formatted directly via the `Display` trait.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::NaiveTime;
     /// # let t = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678);
     /// assert_eq!(format!("{}", t.format("%H:%M:%S")), "23:56:04");
     /// assert_eq!(format!("{}", t.format("%H:%M:%S%.6f")), "23:56:04.012345");
     /// assert_eq!(format!("{}", t.format("%-I:%M %p")), "11:56 PM");
-    /// ~~~~
+    /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[inline]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
@@ -805,12 +805,12 @@ impl Timelike for NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// assert_eq!(NaiveTime::from_hms(0, 0, 0).hour(), 0);
     /// assert_eq!(NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).hour(), 23);
-    /// ~~~~
+    /// ```
     #[inline]
     fn hour(&self) -> u32 {
         self.hms().0
@@ -820,12 +820,12 @@ impl Timelike for NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// assert_eq!(NaiveTime::from_hms(0, 0, 0).minute(), 0);
     /// assert_eq!(NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).minute(), 56);
-    /// ~~~~
+    /// ```
     #[inline]
     fn minute(&self) -> u32 {
         self.hms().1
@@ -835,23 +835,23 @@ impl Timelike for NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// assert_eq!(NaiveTime::from_hms(0, 0, 0).second(), 0);
     /// assert_eq!(NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).second(), 4);
-    /// ~~~~
+    /// ```
     ///
     /// This method never returns 60 even when it is a leap second.
     /// ([Why?](#leap-second-handling))
     /// Use the proper [formatting method](#method.format) to get a human-readable representation.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::{NaiveTime, Timelike};
     /// let leap = NaiveTime::from_hms_milli(23, 59, 59, 1_000);
     /// assert_eq!(leap.second(), 59);
     /// assert_eq!(leap.format("%H:%M:%S").to_string(), "23:59:60");
-    /// ~~~~
+    /// ```
     #[inline]
     fn second(&self) -> u32 {
         self.hms().2
@@ -863,23 +863,23 @@ impl Timelike for NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// assert_eq!(NaiveTime::from_hms(0, 0, 0).nanosecond(), 0);
     /// assert_eq!(NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).nanosecond(), 12_345_678);
-    /// ~~~~
+    /// ```
     ///
     /// Leap seconds may have seemingly out-of-range return values.
     /// You can reduce the range with `time.nanosecond() % 1_000_000_000`, or
     /// use the proper [formatting method](#method.format) to get a human-readable representation.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::{NaiveTime, Timelike};
     /// let leap = NaiveTime::from_hms_milli(23, 59, 59, 1_000);
     /// assert_eq!(leap.nanosecond(), 1_000_000_000);
     /// assert_eq!(leap.format("%H:%M:%S%.9f").to_string(), "23:59:60.000000000");
-    /// ~~~~
+    /// ```
     #[inline]
     fn nanosecond(&self) -> u32 {
         self.frac
@@ -891,13 +891,13 @@ impl Timelike for NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678);
     /// assert_eq!(dt.with_hour(7), Some(NaiveTime::from_hms_nano(7, 56, 4, 12_345_678)));
     /// assert_eq!(dt.with_hour(24), None);
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_hour(&self, hour: u32) -> Option<NaiveTime> {
         if hour >= 24 {
@@ -913,13 +913,13 @@ impl Timelike for NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678);
     /// assert_eq!(dt.with_minute(45), Some(NaiveTime::from_hms_nano(23, 45, 4, 12_345_678)));
     /// assert_eq!(dt.with_minute(60), None);
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_minute(&self, min: u32) -> Option<NaiveTime> {
         if min >= 60 {
@@ -937,13 +937,13 @@ impl Timelike for NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678);
     /// assert_eq!(dt.with_second(17), Some(NaiveTime::from_hms_nano(23, 56, 17, 12_345_678)));
     /// assert_eq!(dt.with_second(60), None);
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_second(&self, sec: u32) -> Option<NaiveTime> {
         if sec >= 60 {
@@ -961,26 +961,26 @@ impl Timelike for NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678);
     /// assert_eq!(dt.with_nanosecond(333_333_333),
     ///            Some(NaiveTime::from_hms_nano(23, 56, 4, 333_333_333)));
     /// assert_eq!(dt.with_nanosecond(2_000_000_000), None);
-    /// ~~~~
+    /// ```
     ///
     /// Leap seconds can theoretically follow *any* whole second.
     /// The following would be a proper leap second at the time zone offset of UTC-00:03:57
     /// (there are several historical examples comparable to this "non-sense" offset),
     /// and therefore is allowed.
     ///
-    /// ~~~~
+    /// ```
     /// # use chrono::{NaiveTime, Timelike};
     /// # let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678);
     /// assert_eq!(dt.with_nanosecond(1_333_333_333),
     ///            Some(NaiveTime::from_hms_nano(23, 56, 4, 1_333_333_333)));
-    /// ~~~~
+    /// ```
     #[inline]
     fn with_nanosecond(&self, nano: u32) -> Option<NaiveTime> {
         if nano >= 2_000_000_000 {
@@ -993,7 +993,7 @@ impl Timelike for NaiveTime {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// assert_eq!(NaiveTime::from_hms(1, 2, 3).num_seconds_from_midnight(),
@@ -1002,7 +1002,7 @@ impl Timelike for NaiveTime {
     ///            86164);
     /// assert_eq!(NaiveTime::from_hms_milli(23, 59, 59, 1_000).num_seconds_from_midnight(),
     ///            86399);
-    /// ~~~~
+    /// ```
     #[inline]
     fn num_seconds_from_midnight(&self) -> u32 {
         self.secs // do not repeat the calculation!
@@ -1030,7 +1030,7 @@ impl hash::Hash for NaiveTime {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// use chrono::{Duration, NaiveTime};
 ///
@@ -1045,11 +1045,11 @@ impl hash::Hash for NaiveTime {
 /// assert_eq!(from_hmsm(3, 5, 7, 950) + Duration::milliseconds(280),     from_hmsm(3, 5, 8, 230));
 /// assert_eq!(from_hmsm(3, 5, 7, 950) + Duration::milliseconds(-980),    from_hmsm(3, 5, 6, 970));
 /// # }
-/// ~~~~
+/// ```
 ///
 /// The addition wraps around.
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
@@ -1057,11 +1057,11 @@ impl hash::Hash for NaiveTime {
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::seconds(-8*60*60), from_hmsm(19, 5, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::days(800),         from_hmsm(3, 5, 7, 0));
 /// # }
-/// ~~~~
+/// ```
 ///
 /// Leap seconds are handled, but the addition assumes that it is the only leap second happened.
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
@@ -1074,7 +1074,7 @@ impl hash::Hash for NaiveTime {
 /// assert_eq!(leap + Duration::seconds(-10),       from_hmsm(3, 5, 50, 300));
 /// assert_eq!(leap + Duration::days(1),            from_hmsm(3, 5, 59, 300));
 /// # }
-/// ~~~~
+/// ```
 impl Add<OldDuration> for NaiveTime {
     type Output = NaiveTime;
 
@@ -1102,7 +1102,7 @@ impl AddAssign<OldDuration> for NaiveTime {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// use chrono::{Duration, NaiveTime};
 ///
@@ -1115,22 +1115,22 @@ impl AddAssign<OldDuration> for NaiveTime {
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::milliseconds(80),        from_hmsm(3, 5, 6, 920));
 /// assert_eq!(from_hmsm(3, 5, 7, 950) - Duration::milliseconds(280),     from_hmsm(3, 5, 7, 670));
 /// # }
-/// ~~~~
+/// ```
 ///
 /// The subtraction wraps around.
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::seconds(8*60*60), from_hmsm(19, 5, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::days(800),        from_hmsm(3, 5, 7, 0));
 /// # }
-/// ~~~~
+/// ```
 ///
 /// Leap seconds are handled, but the subtraction assumes that it is the only leap second happened.
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
@@ -1141,7 +1141,7 @@ impl AddAssign<OldDuration> for NaiveTime {
 /// assert_eq!(leap - Duration::seconds(60),       from_hmsm(3, 5, 0, 300));
 /// assert_eq!(leap - Duration::days(1),           from_hmsm(3, 6, 0, 300));
 /// # }
-/// ~~~~
+/// ```
 impl Sub<OldDuration> for NaiveTime {
     type Output = NaiveTime;
 
@@ -1173,7 +1173,7 @@ impl SubAssign<OldDuration> for NaiveTime {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// use chrono::{Duration, NaiveTime};
 ///
@@ -1189,12 +1189,12 @@ impl SubAssign<OldDuration> for NaiveTime {
 /// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(2, 4, 6, 800),
 ///            Duration::seconds(3600 + 60 + 1) + Duration::milliseconds(100));
 /// # }
-/// ~~~~
+/// ```
 ///
 /// Leap seconds are handled, but the subtraction assumes that
 /// there were no other leap seconds happened.
 ///
-/// ~~~~
+/// ```
 /// # extern crate chrono; fn main() {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
@@ -1206,7 +1206,7 @@ impl SubAssign<OldDuration> for NaiveTime {
 /// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(2, 59, 59, 1_000),
 ///            Duration::seconds(61));
 /// # }
-/// ~~~~
+/// ```
 impl Sub<NaiveTime> for NaiveTime {
     type Output = OldDuration;
 
@@ -1229,21 +1229,21 @@ impl Sub<NaiveTime> for NaiveTime {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// use chrono::NaiveTime;
 ///
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms(23, 56, 4)),              "23:56:04");
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms_milli(23, 56, 4, 12)),    "23:56:04.012");
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms_micro(23, 56, 4, 1234)),  "23:56:04.001234");
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms_nano(23, 56, 4, 123456)), "23:56:04.000123456");
-/// ~~~~
+/// ```
 ///
 /// Leap seconds may also be used.
 ///
-/// ~~~~
+/// ```
 /// # use chrono::NaiveTime;
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms_milli(6, 59, 59, 1_500)), "06:59:60.500");
-/// ~~~~
+/// ```
 impl fmt::Debug for NaiveTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (hour, min, sec) = self.hms();
@@ -1279,21 +1279,21 @@ impl fmt::Debug for NaiveTime {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// use chrono::NaiveTime;
 ///
 /// assert_eq!(format!("{}", NaiveTime::from_hms(23, 56, 4)),              "23:56:04");
 /// assert_eq!(format!("{}", NaiveTime::from_hms_milli(23, 56, 4, 12)),    "23:56:04.012");
 /// assert_eq!(format!("{}", NaiveTime::from_hms_micro(23, 56, 4, 1234)),  "23:56:04.001234");
 /// assert_eq!(format!("{}", NaiveTime::from_hms_nano(23, 56, 4, 123456)), "23:56:04.000123456");
-/// ~~~~
+/// ```
 ///
 /// Leap seconds may also be used.
 ///
-/// ~~~~
+/// ```
 /// # use chrono::NaiveTime;
 /// assert_eq!(format!("{}", NaiveTime::from_hms_milli(6, 59, 59, 1_500)), "06:59:60.500");
-/// ~~~~
+/// ```
 impl fmt::Display for NaiveTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::Debug::fmt(self, f)
@@ -1305,7 +1305,7 @@ impl fmt::Display for NaiveTime {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// use chrono::NaiveTime;
 ///
 /// let t = NaiveTime::from_hms(23, 56, 4);
@@ -1318,7 +1318,7 @@ impl fmt::Display for NaiveTime {
 /// assert_eq!("23:59:60.23456789".parse::<NaiveTime>(), Ok(t));
 ///
 /// assert!("foo".parse::<NaiveTime>().is_err());
-/// ~~~~
+/// ```
 impl str::FromStr for NaiveTime {
     type Err = ParseError;
 

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -32,13 +32,13 @@ impl FixedOffset {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
     /// let datetime = FixedOffset::east(5 * hour).ymd(2016, 11, 08)
     ///                                           .and_hms(0, 0, 0);
     /// assert_eq!(&datetime.to_rfc3339(), "2016-11-08T00:00:00+05:00")
-    /// ~~~~
+    /// ```
     pub fn east(secs: i32) -> FixedOffset {
         FixedOffset::east_opt(secs).expect("FixedOffset::east out of bounds")
     }
@@ -62,13 +62,13 @@ impl FixedOffset {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
     /// let datetime = FixedOffset::west(5 * hour).ymd(2016, 11, 08)
     ///                                           .and_hms(0, 0, 0);
     /// assert_eq!(&datetime.to_rfc3339(), "2016-11-08T00:00:00-05:00")
-    /// ~~~~
+    /// ```
     pub fn west(secs: i32) -> FixedOffset {
         FixedOffset::west_opt(secs).expect("FixedOffset::west out of bounds")
     }

--- a/src/offset/local.rs
+++ b/src/offset/local.rs
@@ -81,12 +81,12 @@ fn datetime_to_timespec(d: &NaiveDateTime, local: bool) -> sys::Timespec {
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// use chrono::{Local, DateTime, TimeZone};
 ///
 /// let dt: DateTime<Local> = Local::now();
 /// let dt: DateTime<Local> = Local.timestamp(0, 0);
-/// ~~~~
+/// ```
 #[derive(Copy, Clone, Debug)]
 pub struct Local;
 

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -205,11 +205,11 @@ pub trait TimeZone: Sized + Clone {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{Utc, TimeZone};
     ///
     /// assert_eq!(Utc.ymd(2015, 5, 15).to_string(), "2015-05-15UTC");
-    /// ~~~~
+    /// ```
     fn ymd(&self, year: i32, month: u32, day: u32) -> Date<Self> {
         self.ymd_opt(year, month, day).unwrap()
     }
@@ -224,12 +224,12 @@ pub trait TimeZone: Sized + Clone {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{Utc, LocalResult, TimeZone};
     ///
     /// assert_eq!(Utc.ymd_opt(2015, 5, 15).unwrap().to_string(), "2015-05-15UTC");
     /// assert_eq!(Utc.ymd_opt(2000, 0, 0), LocalResult::None);
-    /// ~~~~
+    /// ```
     fn ymd_opt(&self, year: i32, month: u32, day: u32) -> LocalResult<Date<Self>> {
         match NaiveDate::from_ymd_opt(year, month, day) {
             Some(d) => self.from_local_date(&d),
@@ -247,11 +247,11 @@ pub trait TimeZone: Sized + Clone {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{Utc, TimeZone};
     ///
     /// assert_eq!(Utc.yo(2015, 135).to_string(), "2015-05-15UTC");
-    /// ~~~~
+    /// ```
     fn yo(&self, year: i32, ordinal: u32) -> Date<Self> {
         self.yo_opt(year, ordinal).unwrap()
     }
@@ -282,11 +282,11 @@ pub trait TimeZone: Sized + Clone {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{Utc, Weekday, TimeZone};
     ///
     /// assert_eq!(Utc.isoywd(2015, 20, Weekday::Fri).to_string(), "2015-05-15UTC");
-    /// ~~~~
+    /// ```
     fn isoywd(&self, year: i32, week: u32, weekday: Weekday) -> Date<Self> {
         self.isoywd_opt(year, week, weekday).unwrap()
     }
@@ -316,11 +316,11 @@ pub trait TimeZone: Sized + Clone {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{Utc, TimeZone};
     ///
     /// assert_eq!(Utc.timestamp(1431648000, 0).to_string(), "2015-05-15 00:00:00 UTC");
-    /// ~~~~
+    /// ```
     fn timestamp(&self, secs: i64, nsecs: u32) -> DateTime<Self> {
         self.timestamp_opt(secs, nsecs).unwrap()
     }
@@ -346,11 +346,11 @@ pub trait TimeZone: Sized + Clone {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{Utc, TimeZone};
     ///
     /// assert_eq!(Utc.timestamp_millis(1431648000).timestamp(), 1431648);
-    /// ~~~~
+    /// ```
     fn timestamp_millis(&self, millis: i64) -> DateTime<Self> {
         self.timestamp_millis_opt(millis).unwrap()
     }
@@ -365,13 +365,13 @@ pub trait TimeZone: Sized + Clone {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{Utc, TimeZone, LocalResult};
     /// match Utc.timestamp_millis_opt(1431648000) {
     ///     LocalResult::Single(dt) => assert_eq!(dt.timestamp(), 1431648),
     ///     _ => panic!("Incorrect timestamp_millis"),
     /// };
-    /// ~~~~
+    /// ```
     fn timestamp_millis_opt(&self, millis: i64) -> LocalResult<DateTime<Self>> {
         let (mut secs, mut millis) = (millis / 1000, millis % 1000);
         if millis < 0 {
@@ -389,11 +389,11 @@ pub trait TimeZone: Sized + Clone {
     ///
     /// # Example
     ///
-    /// ~~~~
+    /// ```
     /// use chrono::{Utc, TimeZone};
     ///
     /// assert_eq!(Utc.timestamp_nanos(1431648000000000).timestamp(), 1431648);
-    /// ~~~~
+    /// ```
     fn timestamp_nanos(&self, nanos: i64) -> DateTime<Self> {
         let (mut secs, mut nanos) = (nanos / 1_000_000_000, nanos % 1_000_000_000);
         if nanos < 0 {

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -24,14 +24,14 @@ use {Date, DateTime};
 ///
 /// # Example
 ///
-/// ~~~~
+/// ```
 /// use chrono::{DateTime, TimeZone, NaiveDateTime, Utc};
 ///
 /// let dt = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(61, 0), Utc);
 ///
 /// assert_eq!(Utc.timestamp(61, 0), dt);
 /// assert_eq!(Utc.ymd(1970, 1, 1).and_hms(0, 1, 1), dt);
-/// ~~~~
+/// ```
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Utc;
 


### PR DESCRIPTION
The rustdoc documentation and the book only show examples as escaped with backticks.

I could not find any reference to tilde escaped examples, although tildes are a bit of a hard character to search for. They seem to work but for the sake of consistency and following the documentation I feel like the change is worth it.