### PR TITLE
Simplify conversion between JS Date and DateTime<Utc>

### DIFF
--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -64,4 +64,18 @@ mod test {
         };
         assert_eq!(now, res);
     }
+
+    #[wasm_bindgen_test]
+    fn convert_all_parts_with_milliseconds() {
+        let time: DateTime<Utc> = "2020-12-01T03:01:55.974Z".parse().unwrap();
+        let js_date = js_sys::Date::from(time);
+
+        assert_eq!(js_date.get_utc_full_year(), 2020);
+        assert_eq!(js_date.get_utc_month(), 12);
+        assert_eq!(js_date.get_utc_date(), 1);
+        assert_eq!(js_date.get_utc_hours(), 3);
+        assert_eq!(js_date.get_utc_minutes(), 1);
+        assert_eq!(js_date.get_utc_seconds(), 55);
+        assert_eq!(js_date.get_utc_milliseconds(), 974);
+    }
 }


### PR DESCRIPTION
When using this library with wasm, it was difficult to test the result of what came out of chrono in JS since the result always had the milliseconds of whatever Date.now() was. This change makes it so the conversion is simpler and based on `DateTime::timestamp_millis`, which will make our milliseconds match up.