### PR TITLE
impl Error trait for ParseWeekdayError and ParseMonthError

### DIFF
--- a/src/month.rs
+++ b/src/month.rs
@@ -235,6 +235,16 @@ pub struct ParseMonthError {
     pub(crate) _dummy: (),
 }
 
+#[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+impl std::error::Error for ParseMonthError {}
+
+impl fmt::Display for ParseMonthError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "ParseMonthError {{ .. }}")
+    }
+}
+
 impl fmt::Debug for ParseMonthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ParseMonthError {{ .. }}")


### PR DESCRIPTION
Those two structs were missing Error implementation which made using `?` kinda hard in my code.

I also removed the dummy field, as it is not needed IMO.

I added feature="std" for the error and Display implementations, I hope that is okay like that.

ready to adapt the PR to your liking, just let me know.