### PR TITLE
#494 export Duration's OutOfRangeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versions with only mechanical changes will be omitted from the following list.
 
 ## 0.4.23
 * Impl Add<Month> + Sub<Month> for NaiveDateTime
+* Export `oldtime::OutOfRangeError` to the public API
 
 ## 0.4.22
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,7 +429,7 @@ extern crate time as oldtime;
 #[cfg(not(feature = "oldtime"))]
 mod oldtime;
 // this reexport is to aid the transition and should not be in the prelude!
-pub use oldtime::Duration;
+pub use oldtime::{Duration, OutOfRangeError};
 
 #[cfg(feature = "__doctest")]
 #[cfg_attr(feature = "__doctest", cfg(doctest))]


### PR DESCRIPTION
Resolves #494 
Exporting the error so that reliance on `mod oldtime` can be fixed and for the `time` crate to be unneeded when handling this error

- [x] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)

[changelog]: ../CHANGELOG.md
