### PR TITLE
Rust 2018 Edition, MSRV = 1.40 and Windows MSRV tests

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -31,10 +31,11 @@ jobs:
         - os: ubuntu-latest
           rust_version: nightly
         - os: ubuntu-16.04
-          rust_version: 1.13.0
+          rust_version: 1.40.0
         - os: macos-latest
-          rust_version: 1.13.0
-          # time doesn't work on windows with 1.13
+          rust_version: 1.40.0
+        - os: windows-latest
+          rust_version: 1.40.0
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,11 @@ jobs:
         - os: ubuntu-latest
           rust_version: nightly
         - os: ubuntu-16.04
-          rust_version: 1.13.0
+          rust_version: 1.40.0
         - os: macos-latest
-          rust_version: 1.13.0
-          # time doesn't work on windows with 1.13
+          rust_version: 1.40.0
+        - os: windows-latest
+          rust_version: 1.40.0
 
     runs-on: ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Versions with only mechanical changes will be omitted from the following list.
 * Add support for microseconds timestamps serde serialization/deserialization (#304)
 * Fix `DurationRound` is not TZ aware (#495)
 * Implement `DurationRound` for `NaiveDateTime`
+* Chrono now uses the Rust 2018 Edition
+* BREAKING - Update MSRV to 1.40
 
 ## 0.4.19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Kang Seonghoon <public+rust@mearie.org>",
     "Brandon W Maister <quodlibetor@gmail.com>",
 ]
-
+edition = "2018"
 description = "Date and time library for Rust"
 homepage = "https://github.com/chronotope/chrono"
 documentation = "https://docs.rs/chrono/"

--- a/ci/github.sh
+++ b/ci/github.sh
@@ -8,7 +8,7 @@ source "${BASH_SOURCE[0]%/*}/_shlib.sh"
 TEST_TZS=(ACST-9:30 EST4 UTC0 Asia/Katmandu)
 FEATURES=(std serde clock "alloc serde" unstable-locales)
 CHECK_FEATURES=(alloc "std unstable-locales" "serde clock" "clock unstable-locales")
-RUST_113_FEATURES=(rustc-serialize serde)
+RUST_140_FEATURES=(rustc-serialize serde)
 
 main() {
     if [[ "$*" =~ "-h" ]]; then
@@ -29,26 +29,22 @@ meaningful in the github actions feature matrix UI.
 
     runv cargo --version
 
-    if [[ ${RUST_VERSION:-} != 1.13.0 ]]; then
-        if [[ ${WASM:-} == yes_wasm ]]; then
-            test_wasm
-        elif [[ ${WASM:-} == wasm_simple ]]; then
-            test_wasm_simple
-        elif [[ ${CORE:-} == no_std ]]; then
-            test_core
-        elif [[ ${EXHAUSTIVE_TZ:-} == all_tzs ]]; then
-            test_all_tzs
-        elif [[ ${CHECK_COMBINATORIC:-} == combinatoric ]]; then
-            check_combinatoric
-        else
-            test_regular UTC0
-        fi
-    elif [[ ${RUST_VERSION:-} == 1.13.0 ]]; then
-        test_113
+
+    if [[ ${WASM:-} == yes_wasm ]]; then
+        test_wasm
+    elif [[ ${WASM:-} == wasm_simple ]]; then
+        test_wasm_simple
+    elif [[ ${CORE:-} == no_std ]]; then
+        test_core
+    elif [[ ${EXHAUSTIVE_TZ:-} == all_tzs ]]; then
+        test_all_tzs
+    elif [[ ${CHECK_COMBINATORIC:-} == combinatoric ]]; then
+        check_combinatoric
     else
-        echo "ERROR: didn't run any tests"
-        exit 1
+        test_regular UTC0
     fi
+
+    test_140
 }
 
 test_all_tzs() {
@@ -74,9 +70,9 @@ check_combinatoric() {
     done
 }
 
-test_113() {
+test_140() {
     runv cargo build --color=always
-    for feature in "${RUST_113_FEATURES[@]}"; do
+    for feature in "${RUST_140_FEATURES[@]}"; do
         runt cargo build --features "$feature" --color=always
     done
 }

--- a/src/date.rs
+++ b/src/date.rs
@@ -3,21 +3,21 @@
 
 //! ISO 8601 calendar date with time zone.
 
+use crate::oldtime::Duration as OldDuration;
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::ops::{Add, Sub};
 use core::{fmt, hash};
-use oldtime::Duration as OldDuration;
 
 #[cfg(feature = "unstable-locales")]
-use format::Locale;
+use crate::format::Locale;
 #[cfg(any(feature = "alloc", feature = "std", test))]
-use format::{DelayedFormat, Item, StrftimeItems};
-use naive::{self, IsoWeek, NaiveDate, NaiveTime};
-use offset::{TimeZone, Utc};
-use DateTime;
-use {Datelike, Weekday};
+use crate::format::{DelayedFormat, Item, StrftimeItems};
+use crate::naive::{self, IsoWeek, NaiveDate, NaiveTime};
+use crate::offset::{TimeZone, Utc};
+use crate::DateTime;
+use crate::{Datelike, Weekday};
 
 /// ISO 8601 calendar date with time zone.
 ///
@@ -36,7 +36,7 @@ use {Datelike, Weekday};
 ///   the corresponding local date should exist for at least a moment.
 ///   (It may still have a gap from the offset changes.)
 ///
-/// - The `TimeZone` is free to assign *any* [`Offset`](::offset::Offset) to the
+/// - The `TimeZone` is free to assign *any* [`Offset`](crate::offset::Offset) to the
 ///   local date, as long as that offset did occur in given day.
 ///
 ///   For example, if `2015-03-08T01:59-08:00` is followed by `2015-03-08T03:00-07:00`,
@@ -297,7 +297,7 @@ where
     }
 
     /// Formats the date with the specified format string.
-    /// See the [`::format::strftime`] module
+    /// See the [`crate::format::strftime`] module
     /// on the supported escape sequences.
     ///
     /// # Example
@@ -336,7 +336,7 @@ where
     }
 
     /// Formats the date with the specified format string and locale.
-    /// See the [`::format::strftime`] module
+    /// See the [`crate::format::strftime`] module
     /// on the supported escape sequences.
     #[cfg(feature = "unstable-locales")]
     #[inline]

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -3,10 +3,10 @@
 
 //! ISO 8601 date and time with time zone.
 
+use crate::oldtime::Duration as OldDuration;
 use core::cmp::Ordering;
 use core::ops::{Add, Sub};
 use core::{fmt, hash, str};
-use oldtime::Duration as OldDuration;
 #[cfg(any(feature = "std", test))]
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -16,19 +16,19 @@ use alloc::string::{String, ToString};
 use std::string::ToString;
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
-use core::borrow::Borrow;
-#[cfg(any(feature = "alloc", feature = "std", test))]
-use format::DelayedFormat;
+use crate::format::DelayedFormat;
 #[cfg(feature = "unstable-locales")]
-use format::Locale;
-use format::{parse, ParseError, ParseResult, Parsed, StrftimeItems};
-use format::{Fixed, Item};
-use naive::{self, IsoWeek, NaiveDate, NaiveDateTime, NaiveTime};
+use crate::format::Locale;
+use crate::format::{parse, ParseError, ParseResult, Parsed, StrftimeItems};
+use crate::format::{Fixed, Item};
+use crate::naive::{self, IsoWeek, NaiveDate, NaiveDateTime, NaiveTime};
 #[cfg(feature = "clock")]
-use offset::Local;
-use offset::{FixedOffset, Offset, TimeZone, Utc};
-use Date;
-use {Datelike, Timelike, Weekday};
+use crate::offset::Local;
+use crate::offset::{FixedOffset, Offset, TimeZone, Utc};
+use crate::Date;
+use crate::{Datelike, Timelike, Weekday};
+#[cfg(any(feature = "alloc", feature = "std", test))]
+use core::borrow::Borrow;
 
 /// Specific formatting options for seconds. This may be extended in the
 /// future, so exhaustive matching in external code is not recommended.
@@ -442,7 +442,7 @@ impl DateTime<FixedOffset> {
     /// Parses a string with the specified format string and returns a new
     /// [`DateTime`] with a parsed [`FixedOffset`].
     ///
-    /// See the [`::format::strftime`] module on the supported escape
+    /// See the [`crate::format::strftime`] module on the supported escape
     /// sequences.
     ///
     /// See also [`TimeZone::datetime_from_str`] which gives a local
@@ -512,8 +512,8 @@ where
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     pub fn to_rfc3339_opts(&self, secform: SecondsFormat, use_z: bool) -> String {
-        use format::Numeric::*;
-        use format::Pad::Zero;
+        use crate::format::Numeric::*;
+        use crate::format::Pad::Zero;
         use SecondsFormat::*;
 
         debug_assert!(secform != __NonExhaustive, "Do not use __NonExhaustive!");
@@ -566,7 +566,7 @@ where
     }
 
     /// Formats the combined date and time with the specified format string.
-    /// See the [`::format::strftime`] module
+    /// See the [`crate::format::strftime`] module
     /// on the supported escape sequences.
     ///
     /// # Example
@@ -608,7 +608,7 @@ where
     /// Formats the combined date and time with the specified format string and
     /// locale.
     ///
-    /// See the [`::format::strftime`] module on the supported escape
+    /// See the [`crate::format::strftime`] module on the supported escape
     /// sequences.
     #[cfg(feature = "unstable-locales")]
     #[inline]
@@ -1053,11 +1053,11 @@ fn test_decodable_json_timestamps<FUtc, FFixed, FLocal, E>(
 #[cfg(feature = "rustc-serialize")]
 pub mod rustc_serialize {
     use super::DateTime;
+    #[cfg(feature = "clock")]
+    use crate::offset::Local;
+    use crate::offset::{FixedOffset, LocalResult, TimeZone, Utc};
     use core::fmt;
     use core::ops::Deref;
-    #[cfg(feature = "clock")]
-    use offset::Local;
-    use offset::{FixedOffset, LocalResult, TimeZone, Utc};
     use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
     impl<Tz: TimeZone> Encodable for DateTime<Tz> {
@@ -1180,12 +1180,12 @@ pub mod rustc_serialize {
 #[cfg(feature = "serde")]
 pub mod serde {
     use super::DateTime;
-    use core::fmt;
     #[cfg(feature = "clock")]
-    use offset::Local;
-    use offset::{FixedOffset, LocalResult, TimeZone, Utc};
+    use crate::offset::Local;
+    use crate::offset::{FixedOffset, LocalResult, TimeZone, Utc};
+    use crate::{ne_timestamp, SerdeError};
+    use core::fmt;
     use serdelib::{de, ser};
-    use {ne_timestamp, SerdeError};
 
     #[doc(hidden)]
     #[derive(Debug)]
@@ -1255,8 +1255,8 @@ pub mod serde {
         use core::fmt;
         use serdelib::{de, ser};
 
-        use offset::TimeZone;
-        use {DateTime, Utc};
+        use crate::offset::TimeZone;
+        use crate::{DateTime, Utc};
 
         use super::{serde_from, NanoSecondsTimestampVisitor};
 
@@ -1409,8 +1409,8 @@ pub mod serde {
 
         use serdelib::{de, ser};
 
-        use offset::TimeZone;
-        use {DateTime, Utc};
+        use crate::offset::TimeZone;
+        use crate::{DateTime, Utc};
 
         use super::serde_from;
 
@@ -1486,7 +1486,7 @@ pub mod serde {
             D: de::Deserializer<'de>,
         {
             #[allow(deprecated)]
-            Ok(try!(d.deserialize_i64(MicroSecondsTimestampVisitor)))
+            Ok(d.deserialize_i64(MicroSecondsTimestampVisitor)?)
         }
 
         struct MicroSecondsTimestampVisitor;
@@ -1565,7 +1565,7 @@ pub mod serde {
         use core::fmt;
         use serdelib::{de, ser};
 
-        use {DateTime, Utc};
+        use crate::{DateTime, Utc};
 
         use super::NanoSecondsTimestampVisitor;
 
@@ -1721,8 +1721,8 @@ pub mod serde {
         use core::fmt;
         use serdelib::{de, ser};
 
-        use offset::TimeZone;
-        use {DateTime, Utc};
+        use crate::offset::TimeZone;
+        use crate::{DateTime, Utc};
 
         use super::{serde_from, MilliSecondsTimestampVisitor};
 
@@ -1871,7 +1871,7 @@ pub mod serde {
         use core::fmt;
         use serdelib::{de, ser};
 
-        use {DateTime, Utc};
+        use crate::{DateTime, Utc};
 
         use super::MilliSecondsTimestampVisitor;
 
@@ -2040,8 +2040,8 @@ pub mod serde {
         use core::fmt;
         use serdelib::{de, ser};
 
-        use offset::TimeZone;
-        use {DateTime, Utc};
+        use crate::offset::TimeZone;
+        use crate::{DateTime, Utc};
 
         use super::{serde_from, SecondsTimestampVisitor};
 
@@ -2184,7 +2184,7 @@ pub mod serde {
         use core::fmt;
         use serdelib::{de, ser};
 
-        use {DateTime, Utc};
+        use crate::{DateTime, Utc};
 
         use super::SecondsTimestampVisitor;
 
@@ -2337,7 +2337,7 @@ pub mod serde {
         where
             E: de::Error,
         {
-            value.parse().map_err(|err: ::format::ParseError| E::custom(err))
+            value.parse().map_err(|err: crate::format::ParseError| E::custom(err))
         }
     }
 
@@ -2426,14 +2426,14 @@ pub mod serde {
 #[cfg(test)]
 mod tests {
     use super::DateTime;
-    use naive::{NaiveDate, NaiveTime};
+    use crate::naive::{NaiveDate, NaiveTime};
     #[cfg(feature = "clock")]
-    use offset::Local;
-    use offset::{FixedOffset, TimeZone, Utc};
-    use oldtime::Duration;
+    use crate::offset::Local;
+    use crate::offset::{FixedOffset, TimeZone, Utc};
+    use crate::oldtime::Duration;
+    #[cfg(feature = "clock")]
+    use crate::Datelike;
     use std::time::{SystemTime, UNIX_EPOCH};
-    #[cfg(feature = "clock")]
-    use Datelike;
 
     #[test]
     #[allow(non_snake_case)]
@@ -2586,7 +2586,7 @@ mod tests {
 
     #[test]
     fn test_rfc3339_opts() {
-        use SecondsFormat::*;
+        use crate::SecondsFormat::*;
         let pst = FixedOffset::east(8 * 60 * 60);
         let dt = pst.ymd(2018, 1, 11).and_hms_nano(10, 5, 13, 084_660_000);
         assert_eq!(dt.to_rfc3339_opts(Secs, false), "2018-01-11T10:05:13+08:00");
@@ -2609,7 +2609,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_rfc3339_opts_nonexhaustive() {
-        use SecondsFormat;
+        use crate::SecondsFormat;
         let dt = Utc.ymd(1999, 10, 9).and_hms(1, 2, 3);
         dt.to_rfc3339_opts(SecondsFormat::__NonExhaustive, true);
     }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -47,12 +47,12 @@ use core::str::FromStr;
 use std::error::Error;
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
-use naive::{NaiveDate, NaiveTime};
+use crate::naive::{NaiveDate, NaiveTime};
 #[cfg(any(feature = "alloc", feature = "std", test))]
-use offset::{FixedOffset, Offset};
+use crate::offset::{FixedOffset, Offset};
 #[cfg(any(feature = "alloc", feature = "std", test))]
-use {Datelike, Timelike};
-use {Month, ParseMonthError, ParseWeekdayError, Weekday};
+use crate::{Datelike, Timelike};
+use crate::{Month, ParseMonthError, ParseWeekdayError, Weekday};
 
 #[cfg(feature = "unstable-locales")]
 pub(crate) mod locales;
@@ -465,8 +465,8 @@ fn format_inner<'a>(
         )
     };
 
+    use crate::div::{div_floor, mod_floor};
     use core::fmt::Write;
-    use div::{div_floor, mod_floor};
 
     match *item {
         Item::Literal(s) | Item::Space(s) => result.push_str(s),

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -14,7 +14,7 @@ use super::scan;
 use super::{Fixed, InternalFixed, InternalInternal, Item, Numeric, Pad, Parsed};
 use super::{ParseError, ParseErrorKind, ParseResult};
 use super::{BAD_FORMAT, INVALID, NOT_ENOUGH, OUT_OF_RANGE, TOO_LONG, TOO_SHORT};
-use {DateTime, FixedOffset, Weekday};
+use crate::{DateTime, FixedOffset, Weekday};
 
 fn set_weekday_with_num_days_from_sunday(p: &mut Parsed, v: i64) -> ParseResult<()> {
     p.set_weekday(match v {
@@ -809,7 +809,7 @@ fn test_parse() {
 fn test_rfc2822() {
     use super::NOT_ENOUGH;
     use super::*;
-    use offset::FixedOffset;
+    use crate::offset::FixedOffset;
     use DateTime;
 
     // Test data - (input, Ok(expected result after parse and format) or Err(error code))
@@ -864,7 +864,7 @@ fn test_rfc2822() {
 #[cfg(test)]
 #[test]
 fn parse_rfc850() {
-    use {TimeZone, Utc};
+    use crate::{TimeZone, Utc};
 
     static RFC850_FMT: &'static str = "%A, %d-%b-%y %T GMT";
 
@@ -897,7 +897,7 @@ fn parse_rfc850() {
 #[test]
 fn test_rfc3339() {
     use super::*;
-    use offset::FixedOffset;
+    use crate::offset::FixedOffset;
     use DateTime;
 
     // Test data - (input, Ok(expected result after parse and format) or Err(error code))

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -4,16 +4,16 @@
 //! A collection of parsed date and time items.
 //! They can be constructed incrementally while being checked for consistency.
 
+use crate::oldtime::Duration as OldDuration;
 use num_traits::ToPrimitive;
-use oldtime::Duration as OldDuration;
 
 use super::{ParseResult, IMPOSSIBLE, NOT_ENOUGH, OUT_OF_RANGE};
-use div::div_rem;
-use naive::{NaiveDate, NaiveDateTime, NaiveTime};
-use offset::{FixedOffset, LocalResult, Offset, TimeZone};
-use DateTime;
-use Weekday;
-use {Datelike, Timelike};
+use crate::div::div_rem;
+use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
+use crate::offset::{FixedOffset, LocalResult, Offset, TimeZone};
+use crate::DateTime;
+use crate::Weekday;
+use crate::{Datelike, Timelike};
 
 /// Parsed parts of date and time. There are two classes of methods:
 ///
@@ -721,10 +721,10 @@ impl Parsed {
 mod tests {
     use super::super::{IMPOSSIBLE, NOT_ENOUGH, OUT_OF_RANGE};
     use super::Parsed;
-    use naive::{NaiveDate, NaiveTime, MAX_DATE, MIN_DATE};
-    use offset::{FixedOffset, TimeZone, Utc};
-    use Datelike;
-    use Weekday::*;
+    use crate::naive::{NaiveDate, NaiveTime, MAX_DATE, MIN_DATE};
+    use crate::offset::{FixedOffset, TimeZone, Utc};
+    use crate::Datelike;
+    use crate::Weekday::*;
 
     #[test]
     fn test_parsed_set_fields() {

--- a/src/format/scan.rs
+++ b/src/format/scan.rs
@@ -8,7 +8,7 @@
 #![allow(deprecated)]
 
 use super::{ParseResult, INVALID, OUT_OF_RANGE, TOO_SHORT};
-use Weekday;
+use crate::Weekday;
 
 /// Returns true when two slices are equal case-insensitively (in ASCII).
 /// Assumes that the `pattern` is already converted to lower case.

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -540,7 +540,7 @@ fn test_strftime_items() {
 #[cfg(test)]
 #[test]
 fn test_strftime_docs() {
-    use {FixedOffset, TimeZone, Timelike};
+    use crate::{FixedOffset, TimeZone, Timelike};
 
     let dt = FixedOffset::east(34200).ymd(2001, 7, 8).and_hms_nano(0, 34, 59, 1_026_490_708);
 
@@ -618,7 +618,7 @@ fn test_strftime_docs() {
 #[cfg(feature = "unstable-locales")]
 #[test]
 fn test_strftime_docs_localized() {
-    use {FixedOffset, TimeZone};
+    use crate::{FixedOffset, TimeZone};
 
     let dt = FixedOffset::east(34200).ymd(2001, 7, 8).and_hms_nano(0, 34, 59, 1_026_490_708);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,7 +423,7 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![deny(dead_code)]
-// lints are added all the time, we test on 1.13
+// lints are added all the time, we test on 1.40
 #![allow(unknown_lints)]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![cfg_attr(feature = "cargo-clippy", allow(
@@ -518,25 +518,25 @@ pub use round::{DurationRound, RoundingError, SubsecRound};
 /// A convenience module appropriate for glob imports (`use chrono::prelude::*;`).
 pub mod prelude {
     #[doc(no_inline)]
-    pub use Date;
+    pub use crate::Date;
     #[cfg(feature = "clock")]
     #[doc(no_inline)]
-    pub use Local;
+    pub use crate::Local;
     #[cfg(feature = "unstable-locales")]
     #[doc(no_inline)]
-    pub use Locale;
+    pub use crate::Locale;
     #[doc(no_inline)]
-    pub use SubsecRound;
+    pub use crate::SubsecRound;
     #[doc(no_inline)]
-    pub use {DateTime, SecondsFormat};
+    pub use crate::{DateTime, SecondsFormat};
     #[doc(no_inline)]
-    pub use {Datelike, Month, Timelike, Weekday};
+    pub use crate::{Datelike, Month, Timelike, Weekday};
     #[doc(no_inline)]
-    pub use {FixedOffset, Utc};
+    pub use crate::{FixedOffset, Utc};
     #[doc(no_inline)]
-    pub use {NaiveDate, NaiveDateTime, NaiveTime};
+    pub use crate::{NaiveDate, NaiveDateTime, NaiveTime};
     #[doc(no_inline)]
-    pub use {Offset, TimeZone};
+    pub use crate::{Offset, TimeZone};
 }
 
 // useful throughout the codebase

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -3,20 +3,20 @@
 
 //! ISO 8601 calendar date without timezone.
 
+use crate::oldtime::Duration as OldDuration;
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::{fmt, str};
 use num_traits::ToPrimitive;
-use oldtime::Duration as OldDuration;
 
-use div::div_mod_floor;
+use crate::div::div_mod_floor;
 #[cfg(any(feature = "alloc", feature = "std", test))]
-use format::DelayedFormat;
-use format::{parse, ParseError, ParseResult, Parsed, StrftimeItems};
-use format::{Item, Numeric, Pad};
-use naive::{IsoWeek, NaiveDateTime, NaiveTime};
-use {Datelike, Weekday};
+use crate::format::DelayedFormat;
+use crate::format::{parse, ParseError, ParseResult, Parsed, StrftimeItems};
+use crate::format::{Item, Numeric, Pad};
+use crate::naive::{IsoWeek, NaiveDateTime, NaiveTime};
+use crate::{Datelike, Weekday};
 
 use super::internals::{self, DateImpl, Mdf, Of, YearFlags};
 use super::isoweek;
@@ -1906,9 +1906,9 @@ mod tests {
     use super::NaiveDate;
     use super::{MAX_DATE, MAX_DAYS_FROM_YEAR_0, MAX_YEAR};
     use super::{MIN_DATE, MIN_DAYS_FROM_YEAR_0, MIN_YEAR};
-    use oldtime::Duration;
+    use crate::oldtime::Duration;
+    use crate::{Datelike, Weekday};
     use std::{i32, u32};
-    use {Datelike, Weekday};
 
     #[test]
     fn test_date_from_ymd() {

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -3,22 +3,22 @@
 
 //! ISO 8601 date and time without timezone.
 
+use crate::oldtime::Duration as OldDuration;
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::{fmt, hash, str};
 use num_traits::ToPrimitive;
-use oldtime::Duration as OldDuration;
 
-use div::div_mod_floor;
+use crate::div::div_mod_floor;
 #[cfg(any(feature = "alloc", feature = "std", test))]
-use format::DelayedFormat;
-use format::{parse, ParseError, ParseResult, Parsed, StrftimeItems};
-use format::{Fixed, Item, Numeric, Pad};
-use naive::date::{MAX_DATE, MIN_DATE};
-use naive::time::{MAX_TIME, MIN_TIME};
-use naive::{IsoWeek, NaiveDate, NaiveTime};
-use {Datelike, Timelike, Weekday};
+use crate::format::DelayedFormat;
+use crate::format::{parse, ParseError, ParseResult, Parsed, StrftimeItems};
+use crate::format::{Fixed, Item, Numeric, Pad};
+use crate::naive::date::{MAX_DATE, MIN_DATE};
+use crate::naive::time::{MAX_TIME, MIN_TIME};
+use crate::naive::{IsoWeek, NaiveDate, NaiveTime};
+use crate::{Datelike, Timelike, Weekday};
 
 /// The tight upper bound guarantees that a duration with `|Duration| >= 2^MAX_SECS_BITS`
 /// will always overflow the addition with any date and time type.
@@ -1401,7 +1401,7 @@ impl Sub<NaiveDateTime> for NaiveDateTime {
 }
 
 /// The `Debug` output of the naive date and time `dt` is the same as
-/// [`dt.format("%Y-%m-%dT%H:%M:%S%.f")`](::format::strftime).
+/// [`dt.format("%Y-%m-%dT%H:%M:%S%.f")`](crate::format::strftime).
 ///
 /// The string printed can be readily parsed via the `parse` method on `str`.
 ///
@@ -1434,7 +1434,7 @@ impl fmt::Debug for NaiveDateTime {
 }
 
 /// The `Display` output of the naive date and time `dt` is the same as
-/// [`dt.format("%Y-%m-%d %H:%M:%S%.f")`](::format::strftime).
+/// [`dt.format("%Y-%m-%d %H:%M:%S%.f")`](crate::format::strftime).
 ///
 /// It should be noted that, for leap seconds not on the minute boundary,
 /// it may print a representation not distinguishable from non-leap seconds.
@@ -1465,7 +1465,7 @@ impl fmt::Display for NaiveDateTime {
 }
 
 /// Parsing a `str` into a `NaiveDateTime` uses the same format,
-/// [`%Y-%m-%dT%H:%M:%S%.f`](::format::strftime), as in `Debug`.
+/// [`%Y-%m-%dT%H:%M:%S%.f`](crate::format::strftime), as in `Debug`.
 ///
 /// # Example
 ///
@@ -1534,7 +1534,7 @@ where
     F: Fn(&NaiveDateTime) -> Result<String, E>,
     E: ::std::fmt::Debug,
 {
-    use naive::{MAX_DATE, MIN_DATE};
+    use crate::naive::{MAX_DATE, MIN_DATE};
 
     assert_eq!(
         to_string(&NaiveDate::from_ymd(2016, 7, 8).and_hms_milli(9, 10, 48, 90)).ok(),
@@ -1568,7 +1568,7 @@ where
     F: Fn(&str) -> Result<NaiveDateTime, E>,
     E: ::std::fmt::Debug,
 {
-    use naive::{MAX_DATE, MIN_DATE};
+    use crate::naive::{MAX_DATE, MIN_DATE};
 
     assert_eq!(
         from_str(r#""2016-07-08T09:10:48.090""#).ok(),
@@ -1814,7 +1814,7 @@ pub mod serde {
         use core::fmt;
         use serdelib::{de, ser};
 
-        use {ne_timestamp, NaiveDateTime};
+        use crate::{ne_timestamp, NaiveDateTime};
 
         /// Serialize a UTC datetime into an integer number of nanoseconds since the epoch
         ///
@@ -1966,7 +1966,7 @@ pub mod serde {
         use core::fmt;
         use serdelib::{de, ser};
 
-        use {ne_timestamp, NaiveDateTime};
+        use crate::{ne_timestamp, NaiveDateTime};
 
         /// Serialize a UTC datetime into an integer number of milliseconds since the epoch
         ///
@@ -2115,7 +2115,7 @@ pub mod serde {
         use core::fmt;
         use serdelib::{de, ser};
 
-        use {ne_timestamp, NaiveDateTime};
+        use crate::{ne_timestamp, NaiveDateTime};
 
         /// Serialize a UTC datetime into an integer number of seconds since the epoch
         ///
@@ -2244,7 +2244,7 @@ pub mod serde {
     #[test]
     fn test_serde_bincode() {
         use self::bincode::{deserialize, serialize, Infinite};
-        use naive::NaiveDate;
+        use crate::naive::NaiveDate;
 
         let dt = NaiveDate::from_ymd(2016, 7, 8).and_hms_milli(9, 10, 48, 90);
         let encoded = serialize(&dt, Infinite).unwrap();
@@ -2256,8 +2256,8 @@ pub mod serde {
     fn test_serde_bincode_optional() {
         use self::bincode::{deserialize, serialize, Infinite};
         use self::serde_derive::{Deserialize, Serialize};
-        use prelude::*;
-        use serde::ts_nanoseconds_option;
+        use crate::prelude::*;
+        use crate::serde::ts_nanoseconds_option;
 
         #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
         struct Test {
@@ -2277,10 +2277,10 @@ pub mod serde {
 #[cfg(test)]
 mod tests {
     use super::NaiveDateTime;
-    use naive::{NaiveDate, MAX_DATE, MIN_DATE};
-    use oldtime::Duration;
+    use crate::naive::{NaiveDate, MAX_DATE, MIN_DATE};
+    use crate::oldtime::Duration;
+    use crate::Datelike;
     use std::i64;
-    use Datelike;
 
     #[test]
     fn test_datetime_from_timestamp() {

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -16,10 +16,10 @@
 #![allow(dead_code)] // some internal methods have been left for consistency
 #![cfg_attr(feature = "__internal_bench", allow(missing_docs))]
 
+use crate::div::{div_rem, mod_floor};
+use crate::Weekday;
 use core::{fmt, i32};
-use div::{div_rem, mod_floor};
 use num_traits::FromPrimitive;
-use Weekday;
 
 /// The internal date representation. This also includes the packed `Mdf` value.
 pub type DateImpl = i32;
@@ -488,8 +488,8 @@ mod tests {
     use self::num_iter::range_inclusive;
     use super::{Mdf, Of};
     use super::{YearFlags, A, AG, B, BA, C, CB, D, DC, E, ED, F, FE, G, GF};
+    use crate::Weekday;
     use std::u32;
-    use Weekday;
 
     const NONLEAP_FLAGS: [YearFlags; 7] = [A, B, C, D, E, F, G];
     const LEAP_FLAGS: [YearFlags; 7] = [AG, BA, CB, DC, ED, FE, GF];

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -142,8 +142,8 @@ impl fmt::Debug for IsoWeek {
 
 #[cfg(test)]
 mod tests {
-    use naive::{internals, MAX_DATE, MIN_DATE};
-    use Datelike;
+    use crate::naive::{internals, MAX_DATE, MIN_DATE};
+    use crate::Datelike;
 
     #[test]
     fn test_iso_week_extremes() {

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -3,18 +3,18 @@
 
 //! ISO 8601 time without timezone.
 
+use crate::oldtime::Duration as OldDuration;
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::{fmt, hash, str};
-use oldtime::Duration as OldDuration;
 
-use div::div_mod_floor;
+use crate::div::div_mod_floor;
 #[cfg(any(feature = "alloc", feature = "std", test))]
-use format::DelayedFormat;
-use format::{parse, ParseError, ParseResult, Parsed, StrftimeItems};
-use format::{Fixed, Item, Numeric, Pad};
-use Timelike;
+use crate::format::DelayedFormat;
+use crate::format::{parse, ParseError, ParseResult, Parsed, StrftimeItems};
+use crate::format::{Fixed, Item, Numeric, Pad};
+use crate::Timelike;
 
 pub const MIN_TIME: NaiveTime = NaiveTime { secs: 0, frac: 0 };
 pub const MAX_TIME: NaiveTime = NaiveTime { secs: 23 * 3600 + 59 * 60 + 59, frac: 999_999_999 };
@@ -1541,9 +1541,9 @@ mod serde {
 #[cfg(test)]
 mod tests {
     use super::NaiveTime;
-    use oldtime::Duration;
+    use crate::oldtime::Duration;
+    use crate::Timelike;
     use std::u32;
-    use Timelike;
 
     #[test]
     fn test_time_from_hms_milli() {

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -3,15 +3,15 @@
 
 //! The time zone which has a fixed offset from UTC.
 
+use crate::oldtime::Duration as OldDuration;
 use core::fmt;
 use core::ops::{Add, Sub};
-use oldtime::Duration as OldDuration;
 
 use super::{LocalResult, Offset, TimeZone};
-use div::div_mod_floor;
-use naive::{NaiveDate, NaiveDateTime, NaiveTime};
-use DateTime;
-use Timelike;
+use crate::div::div_mod_floor;
+use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
+use crate::DateTime;
+use crate::Timelike;
 
 /// The time zone with fixed offset, from UTC-23:59:59 to UTC+23:59:59.
 ///
@@ -218,7 +218,7 @@ impl<Tz: TimeZone> Sub<FixedOffset> for DateTime<Tz> {
 #[cfg(test)]
 mod tests {
     use super::FixedOffset;
-    use offset::TimeZone;
+    use crate::offset::TimeZone;
 
     #[test]
     fn test_date_extreme_offset() {

--- a/src/offset/local.rs
+++ b/src/offset/local.rs
@@ -4,16 +4,16 @@
 //! The local (system) time zone.
 
 #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind")))]
-use sys::{self, Timespec};
+use crate::sys::{self, Timespec};
 
 use super::fixed::FixedOffset;
 use super::{LocalResult, TimeZone};
 #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind")))]
-use naive::NaiveTime;
-use naive::{NaiveDate, NaiveDateTime};
-use {Date, DateTime};
+use crate::naive::NaiveTime;
+use crate::naive::{NaiveDate, NaiveDateTime};
+use crate::{Date, DateTime};
 #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind")))]
-use {Datelike, Timelike};
+use crate::{Datelike, Timelike};
 
 /// Converts a `time::Tm` struct into the timezone-aware `DateTime`.
 /// This assumes that `time` is working correctly, i.e. any error is fatal.
@@ -196,8 +196,8 @@ impl TimeZone for Local {
 #[cfg(test)]
 mod tests {
     use super::Local;
-    use offset::TimeZone;
-    use Datelike;
+    use crate::offset::TimeZone;
+    use crate::Datelike;
 
     #[test]
     fn test_local_date_sanity_check() {

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -20,10 +20,10 @@
 
 use core::fmt;
 
-use format::{parse, ParseResult, Parsed, StrftimeItems};
-use naive::{NaiveDate, NaiveDateTime, NaiveTime};
-use Weekday;
-use {Date, DateTime};
+use crate::format::{parse, ParseResult, Parsed, StrftimeItems};
+use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
+use crate::Weekday;
+use crate::{Date, DateTime};
 
 /// The conversion result from the local time to the timezone-aware datetime types.
 #[derive(Clone, PartialEq, Debug, Copy, Eq, Hash)]
@@ -406,7 +406,7 @@ pub trait TimeZone: Sized + Clone {
     /// Parses a string with the specified format string and returns a
     /// `DateTime` with the current offset.
     ///
-    /// See the [`::format::strftime`] module on the
+    /// See the [`crate::format::strftime`] module on the
     /// supported escape sequences.
     ///
     /// If the to-be-parsed string includes an offset, it *must* match the

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -6,14 +6,14 @@
 use core::fmt;
 
 use super::{FixedOffset, LocalResult, Offset, TimeZone};
-use naive::{NaiveDate, NaiveDateTime};
+use crate::naive::{NaiveDate, NaiveDateTime};
+#[cfg(feature = "clock")]
+use crate::{Date, DateTime};
 #[cfg(all(
     feature = "clock",
     not(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind"))
 ))]
 use std::time::{SystemTime, UNIX_EPOCH};
-#[cfg(feature = "clock")]
-use {Date, DateTime};
 
 /// The UTC time zone. This is the most efficient time zone when you don't need the local time.
 /// It is also used as an offset (which is also a dummy type).

--- a/src/round.rs
+++ b/src/round.rs
@@ -1,17 +1,15 @@
 // This is a part of Chrono.
 // See README.md and LICENSE.txt for details.
 
+use crate::datetime::DateTime;
+use crate::naive::NaiveDateTime;
+use crate::oldtime::Duration;
+use crate::TimeZone;
+use crate::Timelike;
 use core::cmp::Ordering;
 use core::fmt;
 use core::marker::Sized;
 use core::ops::{Add, Sub};
-use datetime::DateTime;
-use naive::NaiveDateTime;
-use oldtime::Duration;
-#[cfg(any(feature = "std", test))]
-use std;
-use TimeZone;
-use Timelike;
 
 /// Extension trait for subsecond rounding or truncation to a maximum number
 /// of digits. Rounding can be used to decrease the error variance when
@@ -303,8 +301,8 @@ impl std::error::Error for RoundingError {
 #[cfg(test)]
 mod tests {
     use super::{Duration, DurationRound, SubsecRound};
-    use offset::{FixedOffset, TimeZone, Utc};
-    use Timelike;
+    use crate::offset::{FixedOffset, TimeZone, Utc};
+    use crate::Timelike;
 
     #[test]
     fn test_round_subsecs() {


### PR DESCRIPTION
### Thanks for contributing to chrono!

- [x] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)
- [ ] If this pull request fixes a bug, does it add a test that verifies that
      we can't reintroduce it?

[changelog]: ../CHANGELOG.md

This PR updates chrono to use the Rust 2018 edition. 99% of the code changes are to fix breakages due to 2018's module path specification changes. 

The edition update requires bumping the MSRV version of chrono as `1.16` was released long before the 2018 edition was a thing (it was released on 2016/11/10 according to the blog post). `1.40` was the oldest version I could get working without further changes as some dependencies would fail to compile on older versions.

Finally the new MSRV means that Windows MSRV tests can be reenabled. 

