### PR TITLE
Check short/long weekday/month by char instead of byte

### DIFF
--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -637,6 +637,7 @@ fn test_parse() {
     check!("Aprill",    [fix!(LongMonthName), lit!("l")]; month: 4);
     check!("Aprl",      [fix!(LongMonthName), lit!("l")]; month: 4);
     check!("April",     [fix!(LongMonthName), lit!("il")]; TOO_SHORT); // do not backtrack
+    check!("AprilŽ",    [fix!(LongMonthName)]; TOO_LONG); // Just need to make sure it doesn't panic
     check!("thu",       [fix!(ShortWeekdayName)]; weekday: Weekday::Thu);
     check!("Thu",       [fix!(ShortWeekdayName)]; weekday: Weekday::Thu);
     check!("THU",       [fix!(ShortWeekdayName)]; weekday: Weekday::Thu);
@@ -653,6 +654,7 @@ fn test_parse() {
     check!("Thursdays", [fix!(LongWeekdayName), lit!("s")]; weekday: Weekday::Thu);
     check!("Thus",      [fix!(LongWeekdayName), lit!("s")]; weekday: Weekday::Thu);
     check!("Thursday",  [fix!(LongWeekdayName), lit!("rsday")]; TOO_SHORT); // do not backtrack
+    check!("MONYAŽA",   [fix!(LongWeekdayName)]; TOO_LONG); // Just need to make sure it doesn't panic
 
     // fixed: am/pm
     check!("am",  [fix!(LowerAmPm)]; hour_div_12: 0);

--- a/src/format/scan.rs
+++ b/src/format/scan.rs
@@ -152,7 +152,8 @@ pub fn short_or_long_month0(s: &str) -> ParseResult<(&str, u8)> {
 
     // tries to consume the suffix if possible
     let suffix = LONG_MONTH_SUFFIXES[month0 as usize];
-    if s.len() >= suffix.len() && equals(&s[..suffix.len()], suffix) {
+    if s.chars().count() >= suffix.chars().count() && s.chars().zip(suffix.chars()).all(|(a, b)| a == b) {
+        // At this point, the parts that matter are guaranteed to be ASCII
         s = &s[suffix.len()..];
     }
 
@@ -170,7 +171,8 @@ pub fn short_or_long_weekday(s: &str) -> ParseResult<(&str, Weekday)> {
 
     // tries to consume the suffix if possible
     let suffix = LONG_WEEKDAY_SUFFIXES[weekday.num_days_from_monday() as usize];
-    if s.len() >= suffix.len() && equals(&s[..suffix.len()], suffix) {
+    if s.chars().count() >= suffix.chars().count() && s.chars().zip(suffix.chars()).all(|(a, b)| a == b) {
+        // At this point, the parts that matter are guaranteed to be ASCII
         s = &s[suffix.len()..];
     }
 

--- a/src/format/scan.rs
+++ b/src/format/scan.rs
@@ -152,7 +152,7 @@ pub fn short_or_long_month0(s: &str) -> ParseResult<(&str, u8)> {
 
     // tries to consume the suffix if possible
     let suffix = LONG_MONTH_SUFFIXES[month0 as usize];
-    if s.chars().count() >= suffix.chars().count() && s.chars().zip(suffix.chars()).all(|(a, b)| a == b) {
+    if s.chars().count() >= suffix.chars().count() && s.chars().zip(suffix.chars()).all(|(a, b)| a.to_ascii_lowercase() == b.to_ascii_lowercase()) {
         // At this point, the parts that matter are guaranteed to be ASCII
         s = &s[suffix.len()..];
     }
@@ -171,7 +171,7 @@ pub fn short_or_long_weekday(s: &str) -> ParseResult<(&str, Weekday)> {
 
     // tries to consume the suffix if possible
     let suffix = LONG_WEEKDAY_SUFFIXES[weekday.num_days_from_monday() as usize];
-    if s.chars().count() >= suffix.chars().count() && s.chars().zip(suffix.chars()).all(|(a, b)| a == b) {
+    if s.chars().count() >= suffix.chars().count() && s.chars().zip(suffix.chars()).all(|(a, b)| a.to_ascii_lowercase() == b.to_ascii_lowercase()) {
         // At this point, the parts that matter are guaranteed to be ASCII
         s = &s[suffix.len()..];
     }


### PR DESCRIPTION
### Thanks for contributing to chrono!

- [ ] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)
- [x] If this pull request fixes a bug, does it add a test that verifies that
      we can't reintroduce it?

[changelog]: ../CHANGELOG.md

---

When looking at Issue #531, I saw that for some reason when parsing short/long months/weekdays, chrono checks the string byte by byte instead of char by char, which gives up the ghost when Unicode gets involved. I don't know if it is some weird optimisation thing I don't get, but I changed it to check by char instead.
