### PR TITLE
Add flexible format supports to DateTime::parse_from_rfc3339

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -2575,11 +2575,23 @@ mod tests {
             Ok(FixedOffset::east(0).ymd(2015, 2, 18).and_hms(23, 16, 9))
         );
         assert_eq!(
+            DateTime::parse_from_rfc3339("2015-02-18T23+00:00"),
+            Ok(FixedOffset::east(0).ymd(2015, 2, 18).and_hms(23, 0, 0))
+        );
+        assert_eq!(
+            DateTime::parse_from_rfc3339("2015-02-18T23:16+00:00"),
+            Ok(FixedOffset::east(0).ymd(2015, 2, 18).and_hms(23, 16, 0))
+        );
+        assert_eq!(
             DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:60 +0500"),
             Ok(EDT.ymd(2015, 2, 18).and_hms_milli(23, 59, 59, 1_000))
         );
         assert_eq!(
             DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00"),
+            Ok(EDT.ymd(2015, 2, 18).and_hms_micro(23, 59, 59, 1_234_567))
+        );
+        assert_eq!(
+            DateTime::parse_from_rfc3339("2015-02-18T23:59:60,234567+05:00"),
             Ok(EDT.ymd(2015, 2, 18).and_hms_micro(23, 59, 59, 1_234_567))
         );
     }

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -197,11 +197,18 @@ fn parse_rfc3339<'a>(parsed: &mut Parsed, mut s: &'a str) -> ParseResult<(&'a st
     };
 
     parsed.set_hour(try_consume!(scan::number(s, 2, 2)))?;
-    s = scan::char(s, b':')?;
-    parsed.set_minute(try_consume!(scan::number(s, 2, 2)))?;
-    s = scan::char(s, b':')?;
-    parsed.set_second(try_consume!(scan::number(s, 2, 2)))?;
-    if s.starts_with('.') {
+
+    if s.starts_with(':') {
+        parsed.set_minute(try_consume!(scan::number(&s[1..], 2, 2)))?;
+    } else {
+        parsed.set_minute(0)?;
+    }
+
+    if s.starts_with(':') {
+        parsed.set_second(try_consume!(scan::number(&s[1..], 2, 2)))?;
+    }
+
+    if s.starts_with('.') || s.starts_with(',') {
         let nanosecond = try_consume!(scan::nanosecond(&s[1..]));
         parsed.set_nanosecond(nanosecond)?;
     }

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -2307,7 +2307,7 @@ mod tests {
                 result.map(|(y, m, d, h, n, s)| NaiveDate::from_ymd(y, m, d).and_hms(h, n, s));
             assert_eq!(lhs.checked_add_signed(rhs), sum);
             assert_eq!(lhs.checked_sub_signed(-rhs), sum);
-        };
+        }
 
         check(
             (2014, 5, 6, 7, 8, 9),


### PR DESCRIPTION
DateTime::parse_from_rfc3339 lacks of some iso-8601 format supports which
makes it very hard to collaborate with tools such as GNU date.

This commit adds support for thoses formats generated by GNU data:

date --iso-8601=ns
2021-04-15T09:49:00,321433476+08:00

date --iso-8601=minutes
2021-04-15T09:49+08:00

date --iso-8601=hours
2021-04-15T09+08:00

Signed-off-by: foxhlchen <foxhlchen@gmail.com>

### Thanks for contributing to chrono!

- [ ] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)
- [ ] If this pull request fixes a bug, does it add a test that verifies that
      we can't reintroduce it?

[changelog]: ../CHANGELOG.md
