### PR TITLE
#560: Unable to parse millisecond unix timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Add support for microseconds timestamps serde serialization/deserialization (#304)
 * Fix `DurationRound` is not TZ aware (#495)
 * Implement `DurationRound` for `NaiveDateTime`
+* Fix 'Unable to parse millisecond unix timestamps' (#560)
 
 ## 0.4.19
 


### PR DESCRIPTION
### Thanks for contributing to chrono!

- [X] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)
- [X] If this pull request fixes a bug, does it add a test that verifies that
      we can't reintroduce it?

[changelog]: ../CHANGELOG.md

This PR tries to solve #560.
When parsing Timestamps, it allows to check the next item fixed length to avoid Timestamp consuming all the remain digits (see #560  example with nanoseconds **"%s%3f"**).
It groups items in tuples (current and next item) inside parse_internal, using slice windows.

