### PR TITLE
Bump time to 0.2.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Add support for microseconds timestamps serde serialization/deserialization (#304)
 * Fix `DurationRound` is not TZ aware (#495)
 * Implement `DurationRound` for `NaiveDateTime`
+* Bump `time` dependency to 0.2.23 (#567)
 
 ## 0.4.19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ __doctest = []
 
 [dependencies]
 libc = { version = "0.2.69", optional = true }
-time = { version = "0.1.43", optional = true }
+time = { version = "0.2", optional = true }
 num-integer = { version = "0.1.36", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -1110,15 +1110,15 @@ mod tests {
         let min_days_from_year_1970 =
             MIN_DATE.signed_duration_since(NaiveDate::from_ymd(1970, 1, 1));
         assert_eq!(
-            parse!(timestamp: min_days_from_year_1970.num_seconds()),
+            parse!(timestamp: min_days_from_year_1970.whole_seconds()),
             ymdhms(MIN_DATE.year(), 1, 1, 0, 0, 0)
         );
         assert_eq!(
-            parse!(timestamp: year_0_from_year_1970.num_seconds()),
+            parse!(timestamp: year_0_from_year_1970.whole_seconds()),
             ymdhms(0, 1, 1, 0, 0, 0)
         );
         assert_eq!(
-            parse!(timestamp: max_days_from_year_1970.num_seconds() + 86399),
+            parse!(timestamp: max_days_from_year_1970.whole_seconds() + 86399),
             ymdhms(MAX_DATE.year(), 12, 31, 23, 59, 59)
         );
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -124,7 +124,7 @@ fn test_date_bounds() {
 
     // let's also check that the entire range do not exceed 2^44 seconds
     // (sometimes used for bounding `Duration` against overflow)
-    let maxsecs = MAX_DATE.signed_duration_since(MIN_DATE).num_seconds();
+    let maxsecs = MAX_DATE.signed_duration_since(MIN_DATE).whole_seconds();
     let maxsecs = maxsecs + 86401; // also take care of DateTime
     assert!(
         maxsecs < (1 << MAX_BITS),
@@ -892,7 +892,7 @@ impl NaiveDate {
         let year = self.year();
         let (mut year_div_400, year_mod_400) = div_mod_floor(year, 400);
         let cycle = internals::yo_to_cycle(year_mod_400 as u32, self.of().ordinal());
-        let cycle = try_opt!((cycle as i32).checked_add(try_opt!(rhs.num_days().to_i32())));
+        let cycle = try_opt!((cycle as i32).checked_add(try_opt!(rhs.whole_days().to_i32())));
         let (cycle_div_400y, cycle) = div_mod_floor(cycle, 146_097);
         year_div_400 += cycle_div_400y;
 
@@ -926,7 +926,7 @@ impl NaiveDate {
         let year = self.year();
         let (mut year_div_400, year_mod_400) = div_mod_floor(year, 400);
         let cycle = internals::yo_to_cycle(year_mod_400 as u32, self.of().ordinal());
-        let cycle = try_opt!((cycle as i32).checked_sub(try_opt!(rhs.num_days().to_i32())));
+        let cycle = try_opt!((cycle as i32).checked_sub(try_opt!(rhs.whole_days().to_i32())));
         let (cycle_div_400y, cycle) = div_mod_floor(cycle, 146_097);
         year_div_400 += cycle_div_400y;
 
@@ -1578,7 +1578,7 @@ impl Iterator for NaiveDateDaysIterator {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let exact_size = MAX_DATE.signed_duration_since(self.value).num_days();
+        let exact_size = MAX_DATE.signed_duration_since(self.value).whole_days();
         (exact_size as usize, Some(exact_size as usize))
     }
 }
@@ -1603,7 +1603,7 @@ impl Iterator for NaiveDateWeeksIterator {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let exact_size = MAX_DATE.signed_duration_since(self.value).num_weeks();
+        let exact_size = MAX_DATE.signed_duration_since(self.value).whole_weeks();
         (exact_size as usize, Some(exact_size as usize))
     }
 }

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -2307,7 +2307,7 @@ mod tests {
                 result.map(|(y, m, d, h, n, s)| NaiveDate::from_ymd(y, m, d).and_hms(h, n, s));
             assert_eq!(lhs.checked_add_signed(rhs), sum);
             assert_eq!(lhs.checked_sub_signed(-rhs), sum);
-        };
+        }
 
         check(
             (2014, 5, 6, 7, 8, 9),
@@ -2513,7 +2513,7 @@ mod tests {
         let base = NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0);
         let t = -946684799990000;
         let time = base + Duration::microseconds(t);
-        assert_eq!(t, time.signed_duration_since(base).num_microseconds().unwrap());
+        assert_eq!(t, time.signed_duration_since(base).whole_microseconds() as i64);
     }
 
     #[test]

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -546,7 +546,7 @@ impl NaiveTime {
                 rhs = rhs + OldDuration::nanoseconds(i64::from(frac));
                 frac = 0;
             } else {
-                frac = (i64::from(frac) + rhs.num_nanoseconds().unwrap()) as u32;
+                frac = (i64::from(frac) + rhs.whole_nanoseconds() as i64) as u32;
                 debug_assert!(frac < 2_000_000_000);
                 return (NaiveTime { secs: secs, frac: frac }, 0);
             }
@@ -554,9 +554,12 @@ impl NaiveTime {
         debug_assert!(secs <= 86_400);
         debug_assert!(frac < 1_000_000_000);
 
-        let rhssecs = rhs.num_seconds();
-        let rhsfrac = (rhs - OldDuration::seconds(rhssecs)).num_nanoseconds().unwrap();
-        debug_assert_eq!(OldDuration::seconds(rhssecs) + OldDuration::nanoseconds(rhsfrac), rhs);
+        let rhssecs = rhs.whole_seconds();
+        let rhsfrac = (rhs - OldDuration::seconds(rhssecs)).whole_nanoseconds();
+        debug_assert_eq!(
+            OldDuration::seconds(rhssecs) + OldDuration::nanoseconds(rhsfrac as i64),
+            rhs
+        );
         let rhssecsinday = rhssecs % 86_400;
         let mut morerhssecs = rhssecs - rhssecsinday;
         let rhssecs = rhssecsinday as i32;


### PR DESCRIPTION
Fixes https://github.com/chronotope/chrono/issues/553

This updates the `time` dependency to `0.2.23`. The crate has been refactored to follow `time` API changes.

~~This is mostly done, but still requires some work. I'm seeing a failing test ([this](https://github.com/timvisee/chrono/blob/b8bdf5a13d50ba15573ccadf0e566c6c23527c44/src/naive/datetime.rs#L2343) case fails) for which I don't clearly see the problem nor a solution.~~

~~@ quodlibetor Do you have some insight on this failing test?~~

### Tasks:
- [x] Bump `time` to `0.2.23`
- [x] Refactor codebase for `time` API changes
- [x] Fix test `naive::datetime::tests::test_datetime_add` ([failing case](https://github.com/timvisee/chrono/blob/b8bdf5a13d50ba15573ccadf0e566c6c23527c44/src/naive/datetime.rs#L2343)) (thanks @blackghost1987!)
- [x] Have you added yourself and the change to the [changelog]? (Don't worry about adding the PR number)

[changelog]: ../CHANGELOG.md
