### PR TITLE
Fix compiling for wasm32-unknown-emscripten target #519

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Add support for microseconds timestamps serde serialization/deserialization (#304)
 * Fix `DurationRound` is not TZ aware (#495)
 * Implement `DurationRound` for `NaiveDateTime`
+* Correct build for wasm32-unknown-emscripten target
 
 ## 0.4.19
 

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -20,11 +20,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 #[path = "sys/stub.rs"]
 mod inner;
 
-#[cfg(unix)]
+#[cfg(all(unix, not(target_arch = "wasm32"), not(target_env = "sgx")))]
 #[path = "sys/unix.rs"]
 mod inner;
 
-#[cfg(windows)]
+#[cfg(all(windows, not(target_arch = "wasm32"), not(target_env = "sgx")))]
 #[path = "sys/windows.rs"]
 mod inner;
 


### PR DESCRIPTION
I encountered a bug while compiling for the wasm32-unknown-emscripten target (https://github.com/orion78fr/godot_keepass_rust_totp/runs/2742402148?check_suite_focus=true) and it seems I wasn't the only one :  #519 

I don't know if you really need (and how to do) a test for this as it seems that it haven't been caught by your CI.
