### PR TITLE
Bump time to 0.3

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -31,9 +31,9 @@ jobs:
         - os: ubuntu-latest
           rust_version: nightly
         - os: ubuntu-18.04
-          rust_version: 1.13.0
+          rust_version: 1.51.0
         - os: macos-latest
-          rust_version: 1.13.0
+          rust_version: 1.51.0
           # time doesn't work on windows with 1.13
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,11 @@ jobs:
         - os: ubuntu-latest
           rust_version: nightly
         - os: ubuntu-18.04
-          rust_version: 1.48.0
+          rust_version: 1.51.0
         - os: macos-latest
-          rust_version: 1.48.0
-          # time doesn't work on windows with 1.48
+          rust_version: 1.51.0
+        - os: windows-latest
+          rust_version: 1.51.0
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,10 @@ jobs:
         - os: ubuntu-latest
           rust_version: nightly
         - os: ubuntu-18.04
-          rust_version: 1.13.0
+          rust_version: 1.48.0
         - os: macos-latest
-          rust_version: 1.13.0
-          # time doesn't work on windows with 1.13
+          rust_version: 1.48.0
+          # time doesn't work on windows with 1.48
 
     runs-on: ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Add support for microseconds timestamps serde serialization/deserialization (#304)
 * Fix `DurationRound` is not TZ aware (#495)
 * Implement `DurationRound` for `NaiveDateTime`
+* Bump `time` dependency to 0.3 (#578)
 
 ## 0.4.19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ __doctest = []
 
 [dependencies]
 libc = { version = "0.2.69", optional = true }
-time = { version = "^0.2.23", optional = true }
+time = { version = "0.3", optional = true }
 num-integer = { version = "0.1.36", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ __doctest = []
 
 [dependencies]
 libc = { version = "0.2.69", optional = true }
-time = { version = "0.1.43", optional = true }
+time = { version = "0.2", optional = true }
 num-integer = { version = "0.1.36", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ __doctest = []
 
 [dependencies]
 libc = { version = "0.2.69", optional = true }
-time = { version = "0.2", optional = true }
+time = { version = "^0.2.23", optional = true }
 num-integer = { version = "0.1.36", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You can get the current date and time in the UTC time zone
 or in the local time zone
 ([`Local::now()`](https://docs.rs/chrono/0.4/chrono/offset/struct.Local.html#method.now)).
 
-```rust
+```rust,ignore
 use chrono::prelude::*;
 
 let utc: DateTime<Utc> = Utc::now();       // e.g. `2014-11-28T12:45:59.324310806Z`
@@ -150,7 +150,7 @@ Alternatively, you can create your own date and time.
 This is a bit verbose due to Rust's lack of function and method overloading,
 but in turn we get a rich combination of initialization methods.
 
-```rust
+```rust,ignore
 use chrono::prelude::*;
 use chrono::offset::LocalResult;
 
@@ -334,7 +334,7 @@ from a [`DateTime`](https://docs.rs/chrono/0.4/chrono/struct.DateTime.html). Add
 [`DateTime.timestamp_subsec_nanos`](https://docs.rs/chrono/0.4/chrono/struct.DateTime.html#method.timestamp_subsec_nanos)
 to get the number of additional number of nanoseconds.
 
-```rust
+```rust,ignore
 // We need the trait in scope to use Utc::timestamp().
 use chrono::{DateTime, TimeZone, Utc};
 
@@ -353,7 +353,7 @@ Chrono also provides an individual date type ([**`Date`**](https://docs.rs/chron
 It also has time zones attached, and have to be constructed via time zones.
 Most operations available to `DateTime` are also available to `Date` whenever appropriate.
 
-```rust
+```rust,ignore
 use chrono::prelude::*;
 use chrono::offset::LocalResult;
 

--- a/ci/github.sh
+++ b/ci/github.sh
@@ -29,7 +29,7 @@ meaningful in the github actions feature matrix UI.
 
     runv cargo --version
 
-    if [[ ${RUST_VERSION:-} != 1.13.0 ]]; then
+    if [[ ${RUST_VERSION:-} != 1.48.0 ]]; then
         if [[ ${WASM:-} == yes_wasm ]]; then
             test_wasm
         elif [[ ${WASM:-} == wasm_simple ]]; then
@@ -43,7 +43,7 @@ meaningful in the github actions feature matrix UI.
         else
             test_regular UTC0
         fi
-    elif [[ ${RUST_VERSION:-} == 1.13.0 ]]; then
+    elif [[ ${RUST_VERSION:-} == 1.48.0 ]]; then
         test_113
     else
         echo "ERROR: didn't run any tests"

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -16,7 +16,7 @@
 //! C's `strftime` format. The available options can be found [here](./strftime/index.html).
 //!
 //! # Example
-//! ```rust
+//! ```rust,ignore
 //! # use std::error::Error;
 //! #
 //! # fn main() -> Result<(), Box<dyn Error>> {

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -1110,15 +1110,15 @@ mod tests {
         let min_days_from_year_1970 =
             MIN_DATE.signed_duration_since(NaiveDate::from_ymd(1970, 1, 1));
         assert_eq!(
-            parse!(timestamp: min_days_from_year_1970.num_seconds()),
+            parse!(timestamp: min_days_from_year_1970.whole_seconds()),
             ymdhms(MIN_DATE.year(), 1, 1, 0, 0, 0)
         );
         assert_eq!(
-            parse!(timestamp: year_0_from_year_1970.num_seconds()),
+            parse!(timestamp: year_0_from_year_1970.whole_seconds()),
             ymdhms(0, 1, 1, 0, 0, 0)
         );
         assert_eq!(
-            parse!(timestamp: max_days_from_year_1970.num_seconds() + 86399),
+            parse!(timestamp: max_days_from_year_1970.whole_seconds() + 86399),
             ymdhms(MAX_DATE.year(), 12, 31, 23, 59, 59)
         );
 

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -1109,16 +1109,34 @@ mod tests {
             NaiveDate::from_ymd(0, 1, 1).signed_duration_since(NaiveDate::from_ymd(1970, 1, 1));
         let min_days_from_year_1970 =
             MIN_DATE.signed_duration_since(NaiveDate::from_ymd(1970, 1, 1));
+        #[cfg(feature = "oldtime")]
         assert_eq!(
             parse!(timestamp: min_days_from_year_1970.whole_seconds()),
             ymdhms(MIN_DATE.year(), 1, 1, 0, 0, 0)
         );
+        #[cfg(not(feature = "oldtime"))]
+        assert_eq!(
+            parse!(timestamp: min_days_from_year_1970.num_seconds()),
+            ymdhms(MIN_DATE.year(), 1, 1, 0, 0, 0)
+        );
+        #[cfg(feature = "oldtime")]
         assert_eq!(
             parse!(timestamp: year_0_from_year_1970.whole_seconds()),
             ymdhms(0, 1, 1, 0, 0, 0)
         );
+        #[cfg(not(feature = "oldtime"))]
+        assert_eq!(
+            parse!(timestamp: year_0_from_year_1970.num_seconds()),
+            ymdhms(0, 1, 1, 0, 0, 0)
+        );
+        #[cfg(feature = "oldtime")]
         assert_eq!(
             parse!(timestamp: max_days_from_year_1970.whole_seconds() + 86399),
+            ymdhms(MAX_DATE.year(), 12, 31, 23, 59, 59)
+        );
+        #[cfg(not(feature = "oldtime"))]
+        assert_eq!(
+            parse!(timestamp: max_days_from_year_1970.num_seconds() + 86399),
             ymdhms(MAX_DATE.year(), 12, 31, 23, 59, 59)
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@
 //! or in the local time zone
 //! ([`Local::now()`](./offset/struct.Local.html#method.now)).
 //!
-//! ```rust
+//! ```rust,ignore
 //! use chrono::prelude::*;
 //!
 //! let utc: DateTime<Utc> = Utc::now();       // e.g. `2014-11-28T12:45:59.324310806Z`
@@ -138,7 +138,7 @@
 //! This is a bit verbose due to Rust's lack of function and method overloading,
 //! but in turn we get a rich combination of initialization methods.
 //!
-//! ```rust
+//! ```rust,ignore
 //! use chrono::prelude::*;
 //! use chrono::offset::LocalResult;
 //!
@@ -334,7 +334,7 @@
 //! [`DateTime.timestamp_subsec_nanos`](./struct.DateTime.html#method.timestamp_subsec_nanos)
 //! to get the number of additional number of nanoseconds.
 //!
-//! ```rust
+//! ```rust,ignore
 //! // We need the trait in scope to use Utc::timestamp().
 //! use chrono::{DateTime, TimeZone, Utc};
 //!
@@ -353,7 +353,7 @@
 //! It also has time zones attached, and have to be constructed via time zones.
 //! Most operations available to `DateTime` are also available to `Date` whenever appropriate.
 //!
-//! ```rust
+//! ```rust,ignore
 //! use chrono::prelude::*;
 //! use chrono::offset::LocalResult;
 //!

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -124,7 +124,7 @@ fn test_date_bounds() {
 
     // let's also check that the entire range do not exceed 2^44 seconds
     // (sometimes used for bounding `Duration` against overflow)
-    let maxsecs = MAX_DATE.signed_duration_since(MIN_DATE).num_seconds();
+    let maxsecs = MAX_DATE.signed_duration_since(MIN_DATE).whole_seconds();
     let maxsecs = maxsecs + 86401; // also take care of DateTime
     assert!(
         maxsecs < (1 << MAX_BITS),
@@ -892,7 +892,7 @@ impl NaiveDate {
         let year = self.year();
         let (mut year_div_400, year_mod_400) = div_mod_floor(year, 400);
         let cycle = internals::yo_to_cycle(year_mod_400 as u32, self.of().ordinal());
-        let cycle = try_opt!((cycle as i32).checked_add(try_opt!(rhs.num_days().to_i32())));
+        let cycle = try_opt!((cycle as i32).checked_add(try_opt!(rhs.whole_days().to_i32())));
         let (cycle_div_400y, cycle) = div_mod_floor(cycle, 146_097);
         year_div_400 += cycle_div_400y;
 
@@ -926,7 +926,7 @@ impl NaiveDate {
         let year = self.year();
         let (mut year_div_400, year_mod_400) = div_mod_floor(year, 400);
         let cycle = internals::yo_to_cycle(year_mod_400 as u32, self.of().ordinal());
-        let cycle = try_opt!((cycle as i32).checked_sub(try_opt!(rhs.num_days().to_i32())));
+        let cycle = try_opt!((cycle as i32).checked_sub(try_opt!(rhs.whole_days().to_i32())));
         let (cycle_div_400y, cycle) = div_mod_floor(cycle, 146_097);
         year_div_400 += cycle_div_400y;
 
@@ -1578,7 +1578,7 @@ impl Iterator for NaiveDateDaysIterator {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let exact_size = MAX_DATE.signed_duration_since(self.value).num_days();
+        let exact_size = MAX_DATE.signed_duration_since(self.value).whole_days();
         (exact_size as usize, Some(exact_size as usize))
     }
 }
@@ -1603,7 +1603,7 @@ impl Iterator for NaiveDateWeeksIterator {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let exact_size = MAX_DATE.signed_duration_since(self.value).num_weeks();
+        let exact_size = MAX_DATE.signed_duration_since(self.value).whole_weeks();
         (exact_size as usize, Some(exact_size as usize))
     }
 }

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -2200,7 +2200,9 @@ mod tests {
             let lhs = NaiveDate::from_ymd(y1, m1, d1);
             let sum = ymd.map(|(y, m, d)| NaiveDate::from_ymd(y, m, d));
             assert_eq!(lhs.checked_add_signed(rhs), sum);
-            assert_eq!(lhs.checked_sub_signed(-rhs), sum);
+            if let Some(rhs) = rhs.checked_mul(-1) {
+                assert_eq!(lhs.checked_sub_signed(rhs), sum);
+            }
         }
 
         check((2014, 1, 1), Duration::ZERO, Some((2014, 1, 1)));

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -950,7 +950,7 @@ impl NaiveDate {
     /// let from_ymd = NaiveDate::from_ymd;
     /// let since = NaiveDate::signed_duration_since;
     ///
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2014, 1, 1)), Duration::zero());
+    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2014, 1, 1)), Duration::ZERO);
     /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2013, 12, 31)), Duration::days(1));
     /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2014, 1, 2)), Duration::days(-1));
     /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2013, 9, 23)), Duration::days(100));
@@ -1442,7 +1442,7 @@ impl Datelike for NaiveDate {
 }
 
 /// An addition of `Duration` to `NaiveDate` discards the fractional days,
-/// rounding to the closest integral number of days towards `Duration::zero()`.
+/// rounding to the closest integral number of days towards `Duration::ZERO`.
 ///
 /// Panics on underflow or overflow.
 /// Use [`NaiveDate::checked_add_signed`](#method.checked_add_signed) to detect that.
@@ -1455,7 +1455,7 @@ impl Datelike for NaiveDate {
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
-/// assert_eq!(from_ymd(2014, 1, 1) + Duration::zero(),             from_ymd(2014, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1) + Duration::ZERO,               from_ymd(2014, 1, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) + Duration::seconds(86399),     from_ymd(2014, 1, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) + Duration::seconds(-86399),    from_ymd(2014, 1, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) + Duration::days(1),            from_ymd(2014, 1, 2));
@@ -1482,7 +1482,7 @@ impl AddAssign<OldDuration> for NaiveDate {
 }
 
 /// A subtraction of `Duration` from `NaiveDate` discards the fractional days,
-/// rounding to the closest integral number of days towards `Duration::zero()`.
+/// rounding to the closest integral number of days towards `Duration::ZERO`.
 /// It is the same as the addition with a negated `Duration`.
 ///
 /// Panics on underflow or overflow.
@@ -1496,7 +1496,7 @@ impl AddAssign<OldDuration> for NaiveDate {
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
-/// assert_eq!(from_ymd(2014, 1, 1) - Duration::zero(),             from_ymd(2014, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1) - Duration::ZERO,               from_ymd(2014, 1, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) - Duration::seconds(86399),     from_ymd(2014, 1, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) - Duration::seconds(-86399),    from_ymd(2014, 1, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) - Duration::days(1),            from_ymd(2013, 12, 31));
@@ -1539,7 +1539,7 @@ impl SubAssign<OldDuration> for NaiveDate {
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2014, 1, 1), Duration::zero());
+/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2014, 1, 1), Duration::ZERO);
 /// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 12, 31), Duration::days(1));
 /// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2014, 1, 2), Duration::days(-1));
 /// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 9, 23), Duration::days(100));
@@ -2203,7 +2203,7 @@ mod tests {
             assert_eq!(lhs.checked_sub_signed(-rhs), sum);
         }
 
-        check((2014, 1, 1), Duration::zero(), Some((2014, 1, 1)));
+        check((2014, 1, 1), Duration::ZERO, Some((2014, 1, 1)));
         check((2014, 1, 1), Duration::seconds(86399), Some((2014, 1, 1)));
         // always round towards zero
         check((2014, 1, 1), Duration::seconds(-86399), Some((2014, 1, 1)));
@@ -2218,10 +2218,10 @@ mod tests {
         // overflow check
         check((0, 1, 1), Duration::days(MAX_DAYS_FROM_YEAR_0 as i64), Some((MAX_YEAR, 12, 31)));
         check((0, 1, 1), Duration::days(MAX_DAYS_FROM_YEAR_0 as i64 + 1), None);
-        check((0, 1, 1), Duration::max_value(), None);
+        check((0, 1, 1), Duration::MAX, None);
         check((0, 1, 1), Duration::days(MIN_DAYS_FROM_YEAR_0 as i64), Some((MIN_YEAR, 1, 1)));
         check((0, 1, 1), Duration::days(MIN_DAYS_FROM_YEAR_0 as i64 - 1), None);
-        check((0, 1, 1), Duration::min_value(), None);
+        check((0, 1, 1), Duration::MIN, None);
     }
 
     #[test]
@@ -2233,7 +2233,7 @@ mod tests {
             assert_eq!(rhs.signed_duration_since(lhs), -diff);
         }
 
-        check((2014, 1, 1), (2014, 1, 1), Duration::zero());
+        check((2014, 1, 1), (2014, 1, 1), Duration::ZERO);
         check((2014, 1, 2), (2014, 1, 1), Duration::days(1));
         check((2014, 12, 31), (2014, 1, 1), Duration::days(364));
         check((2015, 1, 3), (2014, 1, 1), Duration::days(365 + 2));

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -461,7 +461,7 @@ impl NaiveDateTime {
     ///
     /// let d = from_ymd(2016, 7, 8);
     /// let hms = |h, m, s| d.and_hms(h, m, s);
-    /// assert_eq!(hms(3, 5, 7).checked_add_signed(Duration::zero()),
+    /// assert_eq!(hms(3, 5, 7).checked_add_signed(Duration::ZERO),
     ///            Some(hms(3, 5, 7)));
     /// assert_eq!(hms(3, 5, 7).checked_add_signed(Duration::seconds(1)),
     ///            Some(hms(3, 5, 8)));
@@ -497,7 +497,7 @@ impl NaiveDateTime {
     /// # let from_ymd = NaiveDate::from_ymd;
     /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
     /// let leap = hmsm(3, 5, 59, 1_300);
-    /// assert_eq!(leap.checked_add_signed(Duration::zero()),
+    /// assert_eq!(leap.checked_add_signed(Duration::ZERO),
     ///            Some(hmsm(3, 5, 59, 1_300)));
     /// assert_eq!(leap.checked_add_signed(Duration::milliseconds(-500)),
     ///            Some(hmsm(3, 5, 59, 800)));
@@ -549,7 +549,7 @@ impl NaiveDateTime {
     ///
     /// let d = from_ymd(2016, 7, 8);
     /// let hms = |h, m, s| d.and_hms(h, m, s);
-    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(Duration::zero()),
+    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(Duration::ZERO),
     ///            Some(hms(3, 5, 7)));
     /// assert_eq!(hms(3, 5, 7).checked_sub_signed(Duration::seconds(1)),
     ///            Some(hms(3, 5, 6)));
@@ -585,7 +585,7 @@ impl NaiveDateTime {
     /// # let from_ymd = NaiveDate::from_ymd;
     /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
     /// let leap = hmsm(3, 5, 59, 1_300);
-    /// assert_eq!(leap.checked_sub_signed(Duration::zero()),
+    /// assert_eq!(leap.checked_sub_signed(Duration::ZERO),
     ///            Some(hmsm(3, 5, 59, 1_300)));
     /// assert_eq!(leap.checked_sub_signed(Duration::milliseconds(200)),
     ///            Some(hmsm(3, 5, 59, 1_100)));
@@ -1236,7 +1236,7 @@ impl hash::Hash for NaiveDateTime {
 ///
 /// let d = from_ymd(2016, 7, 8);
 /// let hms = |h, m, s| d.and_hms(h, m, s);
-/// assert_eq!(hms(3, 5, 7) + Duration::zero(),             hms(3, 5, 7));
+/// assert_eq!(hms(3, 5, 7) + Duration::ZERO,               hms(3, 5, 7));
 /// assert_eq!(hms(3, 5, 7) + Duration::seconds(1),         hms(3, 5, 8));
 /// assert_eq!(hms(3, 5, 7) + Duration::seconds(-1),        hms(3, 5, 6));
 /// assert_eq!(hms(3, 5, 7) + Duration::seconds(3600 + 60), hms(4, 6, 7));
@@ -1259,7 +1259,7 @@ impl hash::Hash for NaiveDateTime {
 /// # let from_ymd = NaiveDate::from_ymd;
 /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
 /// let leap = hmsm(3, 5, 59, 1_300);
-/// assert_eq!(leap + Duration::zero(),             hmsm(3, 5, 59, 1_300));
+/// assert_eq!(leap + Duration::ZERO,               hmsm(3, 5, 59, 1_300));
 /// assert_eq!(leap + Duration::milliseconds(-500), hmsm(3, 5, 59, 800));
 /// assert_eq!(leap + Duration::milliseconds(500),  hmsm(3, 5, 59, 1_800));
 /// assert_eq!(leap + Duration::milliseconds(800),  hmsm(3, 6, 0, 100));
@@ -1306,7 +1306,7 @@ impl AddAssign<OldDuration> for NaiveDateTime {
 ///
 /// let d = from_ymd(2016, 7, 8);
 /// let hms = |h, m, s| d.and_hms(h, m, s);
-/// assert_eq!(hms(3, 5, 7) - Duration::zero(),             hms(3, 5, 7));
+/// assert_eq!(hms(3, 5, 7) - Duration::ZERO,               hms(3, 5, 7));
 /// assert_eq!(hms(3, 5, 7) - Duration::seconds(1),         hms(3, 5, 6));
 /// assert_eq!(hms(3, 5, 7) - Duration::seconds(-1),        hms(3, 5, 8));
 /// assert_eq!(hms(3, 5, 7) - Duration::seconds(3600 + 60), hms(2, 4, 7));
@@ -1329,7 +1329,7 @@ impl AddAssign<OldDuration> for NaiveDateTime {
 /// # let from_ymd = NaiveDate::from_ymd;
 /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
 /// let leap = hmsm(3, 5, 59, 1_300);
-/// assert_eq!(leap - Duration::zero(),            hmsm(3, 5, 59, 1_300));
+/// assert_eq!(leap - Duration::ZERO,              hmsm(3, 5, 59, 1_300));
 /// assert_eq!(leap - Duration::milliseconds(200), hmsm(3, 5, 59, 1_100));
 /// assert_eq!(leap - Duration::milliseconds(500), hmsm(3, 5, 59, 800));
 /// assert_eq!(leap - Duration::seconds(60),       hmsm(3, 5, 0, 300));
@@ -2340,22 +2340,19 @@ mod tests {
             Some((MAX_DATE.year(), 12, 31, 23, 59, 59)),
         );
         check((0, 1, 1, 0, 0, 0), max_days_from_year_0 + Duration::seconds(86_400), None);
-        check((0, 1, 1, 0, 0, 0), Duration::max_value(), None);
+        check((0, 1, 1, 0, 0, 0), Duration::MAX, None);
 
         let min_days_from_year_0 = MIN_DATE.signed_duration_since(NaiveDate::from_ymd(0, 1, 1));
         check((0, 1, 1, 0, 0, 0), min_days_from_year_0, Some((MIN_DATE.year(), 1, 1, 0, 0, 0)));
         check((0, 1, 1, 0, 0, 0), min_days_from_year_0 - Duration::seconds(1), None);
-        check((0, 1, 1, 0, 0, 0), Duration::min_value(), None);
+        check((0, 1, 1, 0, 0, 0), Duration::MIN, None);
     }
 
     #[test]
     fn test_datetime_sub() {
         let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).and_hms(h, n, s);
         let since = NaiveDateTime::signed_duration_since;
-        assert_eq!(
-            since(ymdhms(2014, 5, 6, 7, 8, 9), ymdhms(2014, 5, 6, 7, 8, 9)),
-            Duration::zero()
-        );
+        assert_eq!(since(ymdhms(2014, 5, 6, 7, 8, 9), ymdhms(2014, 5, 6, 7, 8, 9)), Duration::ZERO);
         assert_eq!(
             since(ymdhms(2014, 5, 6, 7, 8, 10), ymdhms(2014, 5, 6, 7, 8, 9)),
             Duration::seconds(1)

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -2311,7 +2311,9 @@ mod tests {
             let sum =
                 result.map(|(y, m, d, h, n, s)| NaiveDate::from_ymd(y, m, d).and_hms(h, n, s));
             assert_eq!(lhs.checked_add_signed(rhs), sum);
-            assert_eq!(lhs.checked_sub_signed(-rhs), sum);
+            if let Some(rhs) = rhs.checked_mul(-1) {
+                assert_eq!(lhs.checked_sub_signed(rhs), sum);
+            }
         }
 
         check(

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -2513,7 +2513,7 @@ mod tests {
         let base = NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0);
         let t = -946684799990000;
         let time = base + Duration::microseconds(t);
-        assert_eq!(t, time.signed_duration_since(base).num_microseconds().unwrap());
+        assert_eq!(t, time.signed_duration_since(base).whole_microseconds() as i64);
     }
 
     #[test]

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -642,7 +642,7 @@ impl NaiveTime {
     /// let since = NaiveTime::signed_duration_since;
     ///
     /// assert_eq!(since(from_hmsm(3, 5, 7, 900), from_hmsm(3, 5, 7, 900)),
-    ///            Duration::zero());
+    ///            Duration::ZERO);
     /// assert_eq!(since(from_hmsm(3, 5, 7, 900), from_hmsm(3, 5, 7, 875)),
     ///            Duration::milliseconds(25));
     /// assert_eq!(since(from_hmsm(3, 5, 7, 900), from_hmsm(3, 5, 6, 925)),
@@ -1039,7 +1039,7 @@ impl hash::Hash for NaiveTime {
 ///
 /// let from_hmsm = NaiveTime::from_hms_milli;
 ///
-/// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::zero(),                  from_hmsm(3, 5, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::ZERO,                    from_hmsm(3, 5, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::seconds(1),              from_hmsm(3, 5, 8, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::seconds(-1),             from_hmsm(3, 5, 6, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::seconds(60 + 4),         from_hmsm(3, 6, 11, 0));
@@ -1069,7 +1069,7 @@ impl hash::Hash for NaiveTime {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
 /// let leap = from_hmsm(3, 5, 59, 1_300);
-/// assert_eq!(leap + Duration::zero(),             from_hmsm(3, 5, 59, 1_300));
+/// assert_eq!(leap + Duration::ZERO,               from_hmsm(3, 5, 59, 1_300));
 /// assert_eq!(leap + Duration::milliseconds(-500), from_hmsm(3, 5, 59, 800));
 /// assert_eq!(leap + Duration::milliseconds(500),  from_hmsm(3, 5, 59, 1_800));
 /// assert_eq!(leap + Duration::milliseconds(800),  from_hmsm(3, 6, 0, 100));
@@ -1111,7 +1111,7 @@ impl AddAssign<OldDuration> for NaiveTime {
 ///
 /// let from_hmsm = NaiveTime::from_hms_milli;
 ///
-/// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::zero(),                  from_hmsm(3, 5, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::ZERO,                    from_hmsm(3, 5, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::seconds(1),              from_hmsm(3, 5, 6, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::seconds(60 + 5),         from_hmsm(3, 4, 2, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::seconds(2*60*60 + 6*60), from_hmsm(0, 59, 7, 0));
@@ -1138,7 +1138,7 @@ impl AddAssign<OldDuration> for NaiveTime {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
 /// let leap = from_hmsm(3, 5, 59, 1_300);
-/// assert_eq!(leap - Duration::zero(),            from_hmsm(3, 5, 59, 1_300));
+/// assert_eq!(leap - Duration::ZERO,              from_hmsm(3, 5, 59, 1_300));
 /// assert_eq!(leap - Duration::milliseconds(200), from_hmsm(3, 5, 59, 1_100));
 /// assert_eq!(leap - Duration::milliseconds(500), from_hmsm(3, 5, 59, 800));
 /// assert_eq!(leap - Duration::seconds(60),       from_hmsm(3, 5, 0, 300));
@@ -1182,7 +1182,7 @@ impl SubAssign<OldDuration> for NaiveTime {
 ///
 /// let from_hmsm = NaiveTime::from_hms_milli;
 ///
-/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 7, 900), Duration::zero());
+/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 7, 900), Duration::ZERO);
 /// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 7, 875), Duration::milliseconds(25));
 /// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 6, 925), Duration::milliseconds(975));
 /// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 0, 900), Duration::seconds(7));
@@ -1628,7 +1628,7 @@ mod tests {
 
         let hmsm = |h, m, s, mi| NaiveTime::from_hms_milli(h, m, s, mi);
 
-        check!(hmsm(3, 5, 7, 900), Duration::zero(), hmsm(3, 5, 7, 900));
+        check!(hmsm(3, 5, 7, 900), Duration::ZERO, hmsm(3, 5, 7, 900));
         check!(hmsm(3, 5, 7, 900), Duration::milliseconds(100), hmsm(3, 5, 8, 0));
         check!(hmsm(3, 5, 7, 1_300), Duration::milliseconds(-1800), hmsm(3, 5, 6, 500));
         check!(hmsm(3, 5, 7, 1_300), Duration::milliseconds(-800), hmsm(3, 5, 7, 500));
@@ -1707,7 +1707,7 @@ mod tests {
 
         let hmsm = |h, m, s, mi| NaiveTime::from_hms_milli(h, m, s, mi);
 
-        check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 900), Duration::zero());
+        check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 900), Duration::ZERO);
         check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 600), Duration::milliseconds(300));
         check!(hmsm(3, 5, 7, 200), hmsm(2, 4, 6, 200), Duration::seconds(3600 + 60 + 1));
         check!(

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -546,7 +546,7 @@ impl NaiveTime {
                 rhs = rhs + OldDuration::nanoseconds(i64::from(frac));
                 frac = 0;
             } else {
-                frac = (i64::from(frac) + rhs.num_nanoseconds().unwrap()) as u32;
+                frac = (i64::from(frac) + rhs.whole_nanoseconds() as i64) as u32;
                 debug_assert!(frac < 2_000_000_000);
                 return (NaiveTime { secs: secs, frac: frac }, 0);
             }
@@ -554,9 +554,12 @@ impl NaiveTime {
         debug_assert!(secs <= 86_400);
         debug_assert!(frac < 1_000_000_000);
 
-        let rhssecs = rhs.num_seconds();
-        let rhsfrac = (rhs - OldDuration::seconds(rhssecs)).num_nanoseconds().unwrap();
-        debug_assert_eq!(OldDuration::seconds(rhssecs) + OldDuration::nanoseconds(rhsfrac), rhs);
+        let rhssecs = rhs.whole_seconds();
+        let rhsfrac = (rhs - OldDuration::seconds(rhssecs)).whole_nanoseconds();
+        debug_assert_eq!(
+            OldDuration::seconds(rhssecs) + OldDuration::nanoseconds(rhsfrac as i64),
+            rhs
+        );
         let rhssecsinday = rhssecs % 86_400;
         let mut morerhssecs = rhssecs - rhssecsinday;
         let rhssecs = rhssecsinday as i32;

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -555,7 +555,7 @@ impl NaiveTime {
         debug_assert!(frac < 1_000_000_000);
 
         let rhssecs = rhs.whole_seconds();
-        let rhsfrac = (rhs - OldDuration::seconds(rhssecs)).whole_nanoseconds();
+        let rhsfrac = rhs.subsec_nanoseconds();
         debug_assert_eq!(
             OldDuration::seconds(rhssecs) + OldDuration::nanoseconds(rhsfrac as i64),
             rhs

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -32,7 +32,7 @@ impl FixedOffset {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```rust,ignore
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
     /// let datetime = FixedOffset::east(5 * hour).ymd(2016, 11, 08)
@@ -62,7 +62,7 @@ impl FixedOffset {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```rust,ignore
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
     /// let datetime = FixedOffset::west(5 * hour).ymd(2016, 11, 08)

--- a/src/round.rs
+++ b/src/round.rs
@@ -96,7 +96,7 @@ fn span_for_digits(digits: u16) -> u32 {
 /// Extension trait for rounding or truncating a DateTime by a Duration.
 ///
 /// # Limitations
-/// Both rounding and truncating are done via [`Duration::num_nanoseconds`] and
+/// Both rounding and truncating are done via [`Duration::whole_nanoseconds`] and
 /// [`DateTime::timestamp_nanos`]. This means that they will fail if either the
 /// `Duration` or the `DateTime` are too big to represented as nanoseconds. They
 /// will also fail if the `Duration` is bigger than the timestamp.
@@ -179,7 +179,10 @@ fn duration_round<T>(
 where
     T: Timelike + Add<Duration, Output = T> + Sub<Duration, Output = T>,
 {
+    #[cfg(feature = "oldtime")]
     let span = duration.whole_nanoseconds();
+    #[cfg(not(feature = "oldtime"))]
+    let span = duration.num_nanoseconds().ok_or(RoundingError::DurationExceedsLimit)? as i128;
     if span > i64::MAX as i128 || span < i64::MIN as i128 {
         return Err(RoundingError::DurationExceedsLimit);
     }
@@ -217,7 +220,10 @@ fn duration_trunc<T>(
 where
     T: Timelike + Add<Duration, Output = T> + Sub<Duration, Output = T>,
 {
+    #[cfg(feature = "oldtime")]
     let span = duration.whole_nanoseconds();
+    #[cfg(not(feature = "oldtime"))]
+    let span = duration.num_nanoseconds().ok_or(RoundingError::DurationExceedsLimit)? as i128;
     if span > i64::MAX as i128 || span < i64::MIN as i128 {
         return Err(RoundingError::DurationExceedsLimit);
     }


### PR DESCRIPTION
Fixes https://github.com/chronotope/chrono/issues/553, https://github.com/chronotope/chrono/pull/567

This updates the `time` dependency to `0.3`. The crate has been refactored to follow `time` API changes.

This includes not-yet-merged changes made in https://github.com/chronotope/chrono/pull/567.

### Tasks:
- [x] Bump `time` to `0.3` when released (see https://github.com/time-rs/time/issues/248)
- [x] Refactor codebase for `time` API changes
- [x] Fix test `naive::date::tests::test_date_add` ([failing case](https://github.com/timvisee/chrono/blob/eff91806cbe009caebc9bbf3b3879764d4d45271/src/naive/date.rs#L2224))
- [x] Fix test `naive::datetime::tests::test_datetime_add` ([failing case](https://github.com/timvisee/chrono/blob/eff91806cbe009caebc9bbf3b3879764d4d45271/src/naive/datetime.rs#L2348))
- [x] Have you added yourself and the change to the [changelog]? (Don't worry about adding the PR number)

[changelog]: ../CHANGELOG.md
