### PR TITLE
Add a feature and methods to override `now`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Add support for microseconds timestamps serde serialization/deserialization (#304)
 * Fix `DurationRound` is not TZ aware (#495)
 * Implement `DurationRound` for `NaiveDateTime`
+* Add methods for overriding `Utc::now` and `Local::now` in tests
 
 ## 0.4.19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ clock = ["libc", "std", "winapi"]
 oldtime = ["time"]
 wasmbind = ["wasm-bindgen", "js-sys"]
 unstable-locales = ["pure-rust-locales", "alloc"]
+test-override = []
 __internal_bench = []
 __doctest = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,8 @@ doc-comment = { version = "0.3" }
 wasm-bindgen-test = "0.3"
 
 [package.metadata.docs.rs]
-features = ["serde"]
+rustdoc-args = ["--cfg", "docsrs"]
+features = ["serde", "test-override"]
 
 [package.metadata.playground]
 features = ["serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -449,6 +449,7 @@
     // Range contains was stabilized in 1.35.
     manual_range_contains,
 ))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "alloc")]
 extern crate alloc;

--- a/src/offset/local.rs
+++ b/src/offset/local.rs
@@ -212,6 +212,7 @@ thread_local!(static OVERRIDE: std::cell::RefCell<Option<DateTime<Local>>> = std
 
 #[cfg(all(feature = "test-override"))]
 impl Local {
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-override")))]
     /// Override the value that will be returned by `Local::now()`, for use in local tests.
     ///
     /// ```
@@ -231,6 +232,7 @@ impl Local {
         });
     }
 
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-override")))]
     /// Clear an override created by `Utc::test_override_now()`.
     pub fn test_clear_override() {
         OVERRIDE.with(|o| {
@@ -238,6 +240,7 @@ impl Local {
         });
     }
 
+    /// Get the overriden time to return for `Utc::now()`.
     #[inline]
     fn test_get_override() -> Option<DateTime<Local>> {
         OVERRIDE.with(|o| *o.borrow())

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -173,6 +173,7 @@ mod tests {
     #[cfg(feature = "test-override")]
     #[test]
     fn test_override_multiple_threads() {
+        // stub
         use std::sync::{Arc, Barrier};
         use std::thread::spawn;
 

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -118,6 +118,7 @@ thread_local!(static OVERRIDE: std::cell::RefCell<Option<DateTime<Utc>>> = std::
 
 #[cfg(all(feature = "clock", feature = "test-override"))]
 impl Utc {
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-override")))]
     /// Override the value that will be returned by `Utc::now()`, for use in local tests.
     ///
     /// ```
@@ -137,6 +138,7 @@ impl Utc {
         });
     }
 
+    #[cfg_attr(docsrs, doc(cfg(feature = "test-override")))]
     /// Clear an override created by `Utc::test_override_now()`.
     pub fn test_clear_override() {
         OVERRIDE.with(|o| {


### PR DESCRIPTION
Support more testing use cases by adding a way to override the current
time that is returned by `Utc::now()` and `Local::now()`.

```toml
[package]
resolver = "2"

[dependencies]
chrono = "0.4"

[dev-dependencies]
chrono = { version = "0.4", features = ["test-override"] }
```

```rust
use chrono::{Utc, Datelike};

pub fn is_today_leap_day() -> bool {
    let today = Utc::today();
    today.month() == 2 && today.day() == 29
}

#[cfg(test)]
mod tests {
    use super::is_today_leap_day;
    use chrono::{Utc, DateTime};

    #[test]
    fn returns_true_on_leap_day() {
        Utc::test_override_now(Utc.ymd(2020, 2, 29).and_hms(0, 0, 0));
        assert!(is_today_leap_day());
    }

    #[test]
    fn returns_false_on_other_days() {
        Utc::test_override_now(Utc.ymd(2020, 2, 28).and_hms(0, 0, 0));
        assert!(!is_today_leap_day());
        Utc::test_override_now(Utc.ymd(2020, 3, 1).and_hms(0, 0, 0));
        assert!(!is_today_leap_day());
    }
}
```

Fixes #105

### Thanks for contributing to chrono!

- [x] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)

[changelog]: ../CHANGELOG.md
