### PR TITLE
Fix emscripten target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Add support for microseconds timestamps serde serialization/deserialization (#304)
 * Fix `DurationRound` is not TZ aware (#495)
 * Implement `DurationRound` for `NaiveDateTime`
+* Fix wasm32-unknown-emscripten target
 
 ## 0.4.19
 

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -16,7 +16,7 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-#[cfg(any(target_arch = "wasm32", target_env = "sgx"))]
+#[cfg(all(any(target_arch = "wasm32", target_env = "sgx"), not(target_os = "emscripten")))]
 #[path = "sys/stub.rs"]
 mod inner;
 


### PR DESCRIPTION
Emscripten is effectively a unix system and so `inner` would be declared twice resulting in a compilation error.
This PR fixes such scenario.
