### PR TITLE
fix format panic problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Fix `DurationRound` is not TZ aware (#495)
 * Implement `DurationRound` for `NaiveDateTime`
 * Add `DateTime::from_local()` to construct from given local date and time (#572)
+* Fix the problem that format will panic when given invalid format string (#614)
 
 ## 0.4.19
 

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -3050,4 +3050,25 @@ mod tests {
         assert_eq!(datetime_east, datetime_utc.with_timezone(&timezone_east));
         assert_eq!(datetime_west, datetime_utc.with_timezone(&timezone_west));
     }
+
+    #[test]
+    fn test_format_to_string() {
+        // create a naive date
+        let naive_date = NaiveDate::from_ymd(2000, 1, 12);
+        assert_eq!(format!("{}", naive_date.format("%Y %b %d")), String::from("2000 Jan 12"));
+        assert_eq!(format!("{}", naive_date.format("%F")), String::from("2000-01-12"));
+        // try to format something that the instance doesn't have
+        assert_eq!(format!("{}", naive_date.format("%r")), String::from(":: "));
+        // pass a wrong format
+        assert_eq!(
+            format!("{}", naive_date.format("%Y %{whatever} %d")),
+            String::from("2000 whatever} 12")
+        );
+
+        // create a naive time
+        let naive_time = NaiveTime::from_hms(12, 43, 33);
+        assert_eq!(format!("{}", naive_time.format("%H:%M:%S %p")), String::from("12:43:33 PM"));
+        // try to format something that doesn't exist
+        assert_eq!(format!("{}", naive_time.format("%F %H:%M:%S")), String::from("-- 12:43:33"));
+    }
 }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -3050,25 +3050,4 @@ mod tests {
         assert_eq!(datetime_east, datetime_utc.with_timezone(&timezone_east));
         assert_eq!(datetime_west, datetime_utc.with_timezone(&timezone_west));
     }
-
-    #[test]
-    fn test_format_to_string() {
-        // create a naive date
-        let naive_date = NaiveDate::from_ymd(2000, 1, 12);
-        assert_eq!(format!("{}", naive_date.format("%Y %b %d")), String::from("2000 Jan 12"));
-        assert_eq!(format!("{}", naive_date.format("%F")), String::from("2000-01-12"));
-        // try to format something that the instance doesn't have
-        assert_eq!(format!("{}", naive_date.format("%r")), String::from(":: "));
-        // pass a wrong format
-        assert_eq!(
-            format!("{}", naive_date.format("%Y %{whatever} %d")),
-            String::from("2000 whatever} 12")
-        );
-
-        // create a naive time
-        let naive_time = NaiveTime::from_hms(12, 43, 33);
-        assert_eq!(format!("{}", naive_time.format("%H:%M:%S %p")), String::from("12:43:33 PM"));
-        // try to format something that doesn't exist
-        assert_eq!(format!("{}", naive_time.format("%F %H:%M:%S")), String::from("-- 12:43:33"));
-    }
 }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -295,7 +295,7 @@ pub enum Item<'a> {
     /// Fixed-format item.
     Fixed(Fixed),
     /// Issues a formatting error. Used to signal an invalid format string.
-    Error,
+    Error(&'a str),
 }
 
 macro_rules! lit {
@@ -534,7 +534,7 @@ fn format_inner<'a>(
                     }
                 }?
             }
-            // do nothing if the arguments is insufficent
+            // do nothing if insufficient
         }
 
         Item::Fixed(ref spec) => {
@@ -694,8 +694,7 @@ fn format_inner<'a>(
             }
         }
 
-        // do nothing, if the format is in wrong format
-        Item::Error => (),
+        Item::Error(str) => result.push_str(str),
     }
     Ok(())
 }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -533,9 +533,8 @@ fn format_inner<'a>(
                         Pad::Space => write!(result, "{:1$}", v, width),
                     }
                 }?
-            } else {
-                return Err(fmt::Error); // insufficient arguments for given format
             }
+            // do nothing if the arguments is insufficent
         }
 
         Item::Fixed(ref spec) => {
@@ -690,13 +689,13 @@ fn format_inner<'a>(
                     }
                 };
 
-            match ret {
-                Some(ret) => ret?,
-                None => return Err(fmt::Error), // insufficient arguments for given format
+            if let Some(ret) = ret {
+                ret?
             }
         }
 
-        Item::Error => return Err(fmt::Error),
+        // do nothing, if the format is in wrong format
+        Item::Error => (),
     }
     Ok(())
 }

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -441,7 +441,7 @@ where
                 }
             }
 
-            Item::Error => {
+            Item::Error(_) => {
                 return Err((s, BAD_FORMAT));
             }
         }

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1019,8 +1019,7 @@ impl NaiveDate {
     /// (In this way it avoids the redundant memory allocation.)
     ///
     /// A wrong format string does *not* issue an error immediately.
-    /// Rather, converting or formatting the `DelayedFormat` fails.
-    /// You are recommended to immediately use `DelayedFormat` for this reason.
+    /// Rather, converting or formatting the `DelayedFormat` will return a wrong result.
     ///
     /// # Example
     ///
@@ -2388,6 +2387,15 @@ mod tests {
             NaiveDate::from_ymd(2010, 1, 3).format("%G,%g,%U,%W,%V").to_string(),
             "2009,09,01,00,53"
         );
+
+        // let's have some improper formats
+        assert_eq!(
+            NaiveDate::from_ymd(2007, 12, 31).format("%Y %{whatever} %d").to_string(),
+            "2007 %{whatever} 31"
+        );
+        assert_eq!(NaiveDate::from_ymd(2011, 3, 23).format("%").to_string(), "%");
+        // try to format something that the instance doesn't have
+        assert_eq!(NaiveDate::from_ymd(2010, 1, 3).format("%r").to_string(), String::from(":: "));
     }
 
     #[test]

--- a/src/naive/datetime.rs
+++ b/src/naive/datetime.rs
@@ -698,8 +698,7 @@ impl NaiveDateTime {
     /// (In this way it avoids the redundant memory allocation.)
     ///
     /// A wrong format string does *not* issue an error immediately.
-    /// Rather, converting or formatting the `DelayedFormat` fails.
-    /// You are recommended to immediately use `DelayedFormat` for this reason.
+    /// Rather, converting or formatting the `DelayedFormat` will return a wrong result.
     ///
     /// # Example
     ///
@@ -2501,6 +2500,10 @@ mod tests {
         let dt = NaiveDate::from_ymd(2012, 6, 30).and_hms_milli(23, 59, 59, 1_000);
         assert_eq!(dt.format("%c").to_string(), "Sat Jun 30 23:59:60 2012");
         assert_eq!(dt.format("%s").to_string(), "1341100799"); // not 1341100800, it's intentional.
+
+        // let's have some improper formats
+        assert_eq!(dt.format("%{whatever}").to_string(), "%{whatever}");
+        assert_eq!(dt.format("%%%").to_string(), "%%");
     }
 
     #[test]

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -763,8 +763,7 @@ impl NaiveTime {
     /// (In this way it avoids the redundant memory allocation.)
     ///
     /// A wrong format string does *not* issue an error immediately.
-    /// Rather, converting or formatting the `DelayedFormat` fails.
-    /// You are recommended to immediately use `DelayedFormat` for this reason.
+    /// Rather, converting or formatting the `DelayedFormat` will return a wrong result.
     ///
     /// # Example
     ///
@@ -1826,5 +1825,14 @@ mod tests {
             NaiveTime::from_hms_milli(23, 59, 59, 1_000).format("%X").to_string(),
             "23:59:60"
         );
+
+        // let's have some improper formats
+        assert_eq!(
+            NaiveTime::from_hms(4, 32, 8).format("%r%{whatever}").to_string(),
+            "04:32:08 AM%{whatever}"
+        );
+        assert_eq!(NaiveTime::from_hms(10, 3, 0).format("%%%").to_string(), "%%");
+        // try to format something that the instance doesn't have
+        assert_eq!(NaiveTime::from_hms(12, 0, 0).format("%F").to_string(), "--");
     }
 }


### PR DESCRIPTION
Add some modification to `format::inner_format()`, which will prevent the program from panic when an inproper format string is provided. This is the problem mentioned in issue #575 . 

The new strategy I'm using is to **skip those inproper format substrings**. You can find some of the examples in the test I add. I think this strategy is better than directly panic, especially when handling user input strings. Skipping the wrong parts will also indicate an invalid format string, and giving the programmer an opportunity to fix the problem while running, instead of panic and terminating the program. 
