### PR TITLE
Make NaiveTime::from_str support HH:MM as well as HH:MM:SS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Implement `DurationRound` for `NaiveDateTime`
 * Add `DateTime::from_local()` to construct from given local date and time (#572)
 * Correct build for wasm32-unknown-emscripten target (#568)
+* Add support for "HH:MM" format in `NaiveTime::from_str()`
 
 ## 0.4.19
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -294,6 +294,8 @@ pub enum Item<'a> {
     Numeric(Numeric, Pad),
     /// Fixed-format item.
     Fixed(Fixed),
+    /// Succeed if the entire input has been parsed.
+    Truncated,
     /// Issues a formatting error. Used to signal an invalid format string.
     Error,
 }
@@ -695,6 +697,8 @@ fn format_inner<'a>(
                 None => return Err(fmt::Error), // insufficient arguments for given format
             }
         }
+
+        Item::Truncated => (),
 
         Item::Error => return Err(fmt::Error),
     }

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -441,6 +441,10 @@ where
                 }
             }
 
+            Item::Truncated => {
+                if s.is_empty() { break }
+            },
+
             Item::Error => {
                 return Err((s, BAD_FORMAT));
             }

--- a/src/naive/time.rs
+++ b/src/naive/time.rs
@@ -1329,6 +1329,7 @@ impl str::FromStr for NaiveTime {
             Item::Literal(":"),
             Item::Numeric(Numeric::Minute, Pad::Zero),
             Item::Space(""),
+            Item::Truncated,
             Item::Literal(":"),
             Item::Numeric(Numeric::Second, Pad::Zero),
             Item::Fixed(Fixed::Nanosecond),
@@ -1777,12 +1778,17 @@ mod tests {
         assert!("".parse::<NaiveTime>().is_err());
         assert!("x".parse::<NaiveTime>().is_err());
         assert!("15".parse::<NaiveTime>().is_err());
-        assert!("15:8".parse::<NaiveTime>().is_err());
         assert!("15:8:x".parse::<NaiveTime>().is_err());
         assert!("15:8:9x".parse::<NaiveTime>().is_err());
         assert!("23:59:61".parse::<NaiveTime>().is_err());
         assert!("12:34:56.x".parse::<NaiveTime>().is_err());
         assert!("12:34:56. 0".parse::<NaiveTime>().is_err());
+    }
+
+    #[test]
+    fn test_time_from_str() {
+        assert_eq! ("23:58:59".parse::<NaiveTime> (), Ok (NaiveTime::from_hms (23, 58, 59)));
+        assert_eq! ("23:58".parse::<NaiveTime> (), Ok (NaiveTime::from_hms (23, 58, 0)));
     }
 
     #[test]


### PR DESCRIPTION
Times are commonly written without seconds, NaiveTime::from_str should recognise this format as well. This adds that functionality.

This makes parsing data structures which include times easier, since you would otherwise need to specify a format string or construct the NaiveTime yourself.