### PR TITLE
Clarify localtime and oldtime's docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,15 +38,22 @@
 //!
 //! Default features:
 //!
-//! - `alloc`: Enable features that depend on allocation (primarily string formatting)
 //! - `std`: Enables functionality that depends on the standard library. This
 //!   is a superset of `alloc` and adds interoperation with standard library types
 //!   and traits.
 //! - `clock`: enables reading the system time (`now`), independent of whether
 //!   `std::time::SystemTime` is present, depends on having a libc.
+//! - `oldtime`: **deprecated** Cause the `chrono::Duration` time to be exactly
+//!   the `Duration` in `time` 0.1's Duration.
+//!
+//!    It is recommended to disable default features and to not rely on this,
+//!    instead manually converting between the two Duration types in your own
+//!    code if necessary.
 //!
 //! Optional features:
 //!
+//! - `alloc`: If the `std` feature is disabled, this can be used to re-enable string
+//!   formatting and some other items that require the alloc crate.
 //! - `wasmbind`: Enable integration with [wasm-bindgen][] and its `js-sys` project
 //! - [`serde`][]: Enable serialization/deserialization via serde.
 //! - `unstable-locales`: Enable localization. This adds various methods with a

--- a/src/offset/local.rs
+++ b/src/offset/local.rs
@@ -97,12 +97,32 @@ impl Local {
     }
 
     /// Returns a `DateTime` which corresponds to the current date.
+    ///
+    /// # Thread Safety Warning
+    ///
+    /// If, on a Unix OS, a thread sets any environment variable while another
+    /// thread tries to determine the local time your program may get a
+    /// segfault or crash in other interesting ways. Conversation in [chrono]
+    /// and [rust-std].
+    ///
+    /// [chrono]: https://github.com/chronotope/chrono/pull/578
+    /// [rust-std]: https://github.com/rust-lang/rust/issues/27970
     #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind")))]
     pub fn now() -> DateTime<Local> {
         tm_to_datetime(Timespec::now().local())
     }
 
     /// Returns a `DateTime` which corresponds to the current date.
+    ///
+    /// # Thread Safety Warning
+    ///
+    /// If, on a Unix OS, a thread sets any environment variable while another
+    /// thread tries to determine the local time your program may get a
+    /// segfault or crash in other interesting ways. Conversation in [chrono]
+    /// and [rust-std].
+    ///
+    /// [chrono]: https://github.com/chronotope/chrono/pull/578
+    /// [rust-std]: https://github.com/rust-lang/rust/issues/27970
     #[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind"))]
     pub fn now() -> DateTime<Local> {
         use super::Utc;

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -47,6 +47,16 @@ impl Timespec {
     }
 
     /// Converts this timespec into the system's local time.
+    ///
+    /// # Thread Safety Warning
+    ///
+    /// If, on a Unix OS, a thread sets any environment variable while another
+    /// thread tries to determine the local time your program may get a
+    /// segfault or crash in other interesting ways. Conversation in [chrono]
+    /// and [rust-std].
+    ///
+    /// [chrono]: https://github.com/chronotope/chrono/pull/578
+    /// [rust-std]: https://github.com/rust-lang/rust/issues/27970
     pub fn local(self) -> Tm {
         let mut tm = Tm {
             tm_sec: 0,


### PR DESCRIPTION
In response to #578, there really isn't anything Chrono can do to actually prevent the invalid
memory accesses in libc -- all we can do is tell people not to set env vars. In my experience and
from conversations surrounding this issue, setting env vars is rare and definitely just shouldn't
be done once the process has more than one thread running. Hopefully isn't an an awful burden on
users, either in terms of feature reduction or of security scanning.