### PR TITLE
Update `time` dependency in order to mitigate CVE-2020-26235

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Implement `DurationRound` for `NaiveDateTime`
 * Add `DateTime::from_local()` to construct from given local date and time (#572)
 * Correct build for wasm32-unknown-emscripten target (#568)
+* Bump `time` version (#632)
 
 ## 0.4.19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ __doctest = []
 
 [dependencies]
 libc = { version = "0.2.69", optional = true }
-time = { version = "0.1.43", optional = true }
+time = { version = "0.2.23", optional = true }
 num-integer = { version = "0.1.36", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }


### PR DESCRIPTION
Fixes #629.

### Thanks for contributing to chrono!

- [x] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)
- [x] ~~If this pull request fixes a bug, does it add a test that verifies that
      we can't reintroduce it?~~

[changelog]: ../CHANGELOG.md
