### PR TITLE
Patch 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Implement `DurationRound` for `NaiveDateTime`
 * Add `DateTime::from_local()` to construct from given local date and time (#572)
 * Correct build for wasm32-unknown-emscripten target (#568)
+* Make `Duration.seconds()` and siblings const fn
 
 ## 0.4.19
 


### PR DESCRIPTION
This commit updates `Duration::seconds` and siblings to be const. This
requires the const-panic api that only stabilized in 1.57, so it may be
best to hide this behid a feature flag somehow so as to not require a
MSRV of 1.57. This is my first pr so I don't know the policy around
this.

This pr also adds a bit of mess to the functions because we can't use
`.expect("error")` or `Datetime::partial_cmp`. I think it is worth it
because const durations would be really nice to have.

- [ x ] Added the change to the [changelog]? 
- [ x ] Added a test

[changelog]: ../CHANGELOG.md
