### PR TITLE
change UTC::now() documentation to "date and time"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Implement `DurationRound` for `NaiveDateTime`
 * Add `DateTime::from_local()` to construct from given local date and time (#572)
 * Correct build for wasm32-unknown-emscripten target (#568)
+* Change `Local::now()` and `Utc::now()` documentation from "current date" to "current date and time" (#647)
 
 ## 0.4.19
 

--- a/src/offset/local.rs
+++ b/src/offset/local.rs
@@ -96,13 +96,13 @@ impl Local {
         Local::now().date()
     }
 
-    /// Returns a `DateTime` which corresponds to the current date.
+    /// Returns a `DateTime` which corresponds to the current date and time.
     #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind")))]
     pub fn now() -> DateTime<Local> {
         tm_to_datetime(Timespec::now().local())
     }
 
-    /// Returns a `DateTime` which corresponds to the current date.
+    /// Returns a `DateTime` which corresponds to the current date and time.
     #[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind"))]
     pub fn now() -> DateTime<Local> {
         use super::Utc;

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -51,7 +51,7 @@ impl Utc {
         DateTime::from_utc(naive, Utc)
     }
 
-    /// Returns a `DateTime` which corresponds to the current date.
+    /// Returns a `DateTime` which corresponds to the current date and time.
     #[cfg(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind"))]
     pub fn now() -> DateTime<Utc> {
         let now = js_sys::Date::new_0();

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -42,7 +42,7 @@ impl Utc {
         Utc::now().date()
     }
 
-    /// Returns a `DateTime` which corresponds to the current date.
+    /// Returns a `DateTime` which corresponds to the current date and time.
     #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"), feature = "wasmbind")))]
     pub fn now() -> DateTime<Utc> {
         let now =


### PR DESCRIPTION
At least I was confused for a moment reading that it returns the current date, looking at it in the documentation.

### Thanks for contributing to chrono!

- [x] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)


[changelog]: ../CHANGELOG.md
