### PR TITLE
Fix localtime unsoundness using `rl_localtime`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ js-sys = { version = "0.3", optional = true } # contains FFI bindings for the JS
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.0", features = ["std", "minwinbase", "minwindef", "timezoneapi"], optional = true }
 
+[target.'cfg(unix)'.dependencies]
+rl_localtime = "0.1.1"
+
 [dev-dependencies]
 serde_json = { version = "1" }
 serde_derive = { version = "1", default-features = false }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -10,22 +10,7 @@
 
 use super::Tm;
 use libc::{self, time_t};
-use std::io;
 use std::mem;
-
-#[cfg(any(target_os = "solaris", target_os = "illumos"))]
-extern "C" {
-    static timezone: time_t;
-    static altzone: time_t;
-}
-
-#[cfg(any(target_os = "solaris", target_os = "illumos"))]
-fn tzset() {
-    extern "C" {
-        fn tzset();
-    }
-    unsafe { tzset() }
-}
 
 fn rust_tm_to_tm(rust_tm: &Tm, tm: &mut libc::tm) {
     tm.tm_sec = rust_tm.tm_sec;
@@ -52,75 +37,24 @@ fn tm_to_rust_tm(tm: &libc::tm, utcoff: i32, rust_tm: &mut Tm) {
     rust_tm.tm_utcoff = utcoff;
 }
 
-#[cfg(any(target_os = "nacl", target_os = "solaris", target_os = "illumos"))]
-unsafe fn timegm(tm: *mut libc::tm) -> time_t {
-    use std::env::{remove_var, set_var, var_os};
-    extern "C" {
-        fn tzset();
-    }
-
-    let ret;
-
-    let current_tz = var_os("TZ");
-    set_var("TZ", "UTC");
-    tzset();
-
-    ret = libc::mktime(tm);
-
-    if let Some(tz) = current_tz {
-        set_var("TZ", tz);
-    } else {
-        remove_var("TZ");
-    }
-    tzset();
-
-    ret
-}
-
 pub fn time_to_local_tm(sec: i64, tm: &mut Tm) {
-    unsafe {
-        let sec = sec as time_t;
-        let mut out = mem::zeroed();
-        if libc::localtime_r(&sec, &mut out).is_null() {
-            panic!("localtime_r failed: {}", io::Error::last_os_error());
-        }
-        #[cfg(any(target_os = "solaris", target_os = "illumos"))]
-        let gmtoff = {
-            tzset();
-            // < 0 means we don't know; assume we're not in DST.
-            if out.tm_isdst == 0 {
-                // timezone is seconds west of UTC, tm_gmtoff is seconds east
-                -timezone
-            } else if out.tm_isdst > 0 {
-                -altzone
-            } else {
-                -timezone
-            }
-        };
-        #[cfg(not(any(target_os = "solaris", target_os = "illumos")))]
-        let gmtoff = out.tm_gmtoff;
-        tm_to_rust_tm(&out, gmtoff as i32, tm);
-    }
+    let out = rl_localtime::localtime(sec as time_t)
+        .unwrap_or_else(|error| {
+            panic!("localtime_r failed: {}", error);
+        });
+
+    let gmtoff = out.tm_gmtoff;
+    tm_to_rust_tm(&out, gmtoff as i32, tm);
 }
 
 pub fn utc_tm_to_time(rust_tm: &Tm) -> i64 {
-    #[cfg(not(any(
-        all(target_os = "android", target_pointer_width = "32"),
-        target_os = "nacl",
-        target_os = "solaris",
-        target_os = "illumos"
-    )))]
-    use libc::timegm;
-    #[cfg(all(target_os = "android", target_pointer_width = "32"))]
-    use libc::timegm64 as timegm;
-
     let mut tm = unsafe { mem::zeroed() };
     rust_tm_to_tm(rust_tm, &mut tm);
-    unsafe { timegm(&mut tm) as i64 }
+    rl_localtime::timegm(tm) as i64
 }
 
 pub fn local_tm_to_time(rust_tm: &Tm) -> i64 {
     let mut tm = unsafe { mem::zeroed() };
     rust_tm_to_tm(rust_tm, &mut tm);
-    unsafe { libc::mktime(&mut tm) as i64 }
+    rl_localtime::mktime(tm) as i64
 }


### PR DESCRIPTION
This replaces current implementation with `rl_localtime` which is sound
thanks to it being a fork that calls to Rust `std` to get env vars.

**Important:** this is meant mainly as a demonstration how the change could look like.
I don't recommend merging until people check soundness of `rl_localtime` crate.

### Thanks for contributing to chrono!

- [ ] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)
- [x] If this pull request fixes a bug, does it add a test that verifies that
      we can't reintroduce it?

[changelog]: ../CHANGELOG.md
