### PR TITLE
Fix issue #658 duration_round by zero panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Add `DateTime::from_local()` to construct from given local date and time (#572)
 * Correct build for wasm32-unknown-emscripten target (#568)
 * Change `Local::now()` and `Utc::now()` documentation from "current date" to "current date and time" (#647)
+* Fix `duration_round` panic on rounding by `Duration::zero()` (#658)
 
 ## 0.4.19
 

--- a/src/round.rs
+++ b/src/round.rs
@@ -186,7 +186,7 @@ where
             return Err(RoundingError::DurationExceedsTimestamp);
         }
         if span == 0 {
-            return Ok(original)
+            return Ok(original);
         }
         let delta_down = stamp % span;
         if delta_down == 0 {

--- a/src/round.rs
+++ b/src/round.rs
@@ -185,6 +185,9 @@ where
         if span > stamp.abs() {
             return Err(RoundingError::DurationExceedsTimestamp);
         }
+        if span == 0 {
+            return Ok(original)
+        }
         let delta_down = stamp % span;
         if delta_down == 0 {
             Ok(original)
@@ -395,6 +398,11 @@ mod tests {
         let dt = Utc.ymd(2016, 12, 31).and_hms_nano(23, 59, 59, 175_500_000);
 
         assert_eq!(
+            dt.duration_round(Duration::zero()).unwrap().to_string(),
+            "2016-12-31 23:59:59.175500 UTC"
+        );
+
+        assert_eq!(
             dt.duration_round(Duration::milliseconds(10)).unwrap().to_string(),
             "2016-12-31 23:59:59.180 UTC"
         );
@@ -455,6 +463,11 @@ mod tests {
     #[test]
     fn test_duration_round_naive() {
         let dt = Utc.ymd(2016, 12, 31).and_hms_nano(23, 59, 59, 175_500_000).naive_utc();
+
+        assert_eq!(
+            dt.duration_round(Duration::zero()).unwrap().to_string(),
+            "2016-12-31 23:59:59.175500"
+        );
 
         assert_eq!(
             dt.duration_round(Duration::milliseconds(10)).unwrap().to_string(),


### PR DESCRIPTION
The `duration_round` function does a remainder operation which panics when called with 0. Rounding by zero should (reasoning from rounding by ever smaller durations) just return the original value itself.

This PR implements that and adds two tests that failed (panicked) in the old case and succeed now.