### PR TITLE
Add support for microseconds & optional timestamps serde serialization for `NaiveDateTime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Change `Local::now()` and `Utc::now()` documentation from "current date" to "current date and time" (#647)
 * Fix `duration_round` panic on rounding by `Duration::zero()` (#658)
 * Add optional rkyv support.
+* Add support for microseconds timestamps serde serialization for `NaiveDateTime`.
 
 ## 0.4.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Fix `duration_round` panic on rounding by `Duration::zero()` (#658)
 * Add optional rkyv support.
 * Add support for microseconds timestamps serde serialization for `NaiveDateTime`.
+* Add support for optional timestamps serde serialization for `NaiveDateTime`.
 
 ## 0.4.19
 


### PR DESCRIPTION
This PR brings the `naive::datetime::serde` module on par with the `datetime::serde` module.