### PR TITLE
More cleanups (outdated comments, extern crate statements etc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,6 @@ Addition and subtraction is also supported.
 The following illustrates most supported operations to the date and time:
 
 ```rust
-
 use chrono::prelude::*;
 use chrono::Duration;
 

--- a/benches/chrono.rs
+++ b/benches/chrono.rs
@@ -1,9 +1,6 @@
 //! Benchmarks for chrono that just depend on std
 #![cfg(feature = "__internal_bench")]
 
-extern crate chrono;
-extern crate criterion;
-
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use chrono::prelude::*;

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -1,8 +1,5 @@
 #![cfg(feature = "__internal_bench")]
 
-extern crate chrono;
-extern crate criterion;
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use chrono::NaiveDateTime;

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -119,14 +119,8 @@ impl<'de> de::Deserialize<'de> for DateTime<Local> {
 /// # Example:
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # #[macro_use] extern crate serde_json;
-/// # extern crate chrono;
 /// # use chrono::{TimeZone, DateTime, Utc};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::serde::ts_nanoseconds;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -164,14 +158,8 @@ pub mod ts_nanoseconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::{TimeZone, DateTime, Utc};
+    /// # use serde_derive::Serialize;
     /// use chrono::serde::ts_nanoseconds::serialize as to_nano_ts;
     /// #[derive(Serialize)]
     /// struct S {
@@ -203,14 +191,8 @@ pub mod ts_nanoseconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::{DateTime, Utc};
+    /// # use serde_derive::Deserialize;
     /// use chrono::serde::ts_nanoseconds::deserialize as from_nano_ts;
     /// #[derive(Deserialize)]
     /// struct S {
@@ -269,14 +251,8 @@ pub mod ts_nanoseconds {
 /// # Example:
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # #[macro_use] extern crate serde_json;
-/// # extern crate chrono;
 /// # use chrono::{TimeZone, DateTime, Utc};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::serde::ts_nanoseconds_option;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -313,14 +289,8 @@ pub mod ts_nanoseconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::{TimeZone, DateTime, Utc};
+    /// # use serde_derive::Serialize;
     /// use chrono::serde::ts_nanoseconds_option::serialize as to_nano_tsopt;
     /// #[derive(Serialize)]
     /// struct S {
@@ -355,14 +325,8 @@ pub mod ts_nanoseconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::{DateTime, Utc};
+    /// # use serde_derive::Deserialize;
     /// use chrono::serde::ts_nanoseconds_option::deserialize as from_nano_tsopt;
     /// #[derive(Deserialize)]
     /// struct S {
@@ -425,14 +389,8 @@ pub mod ts_nanoseconds_option {
 /// # Example:
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # #[macro_use] extern crate serde_json;
-/// # extern crate chrono;
 /// # use chrono::{TimeZone, DateTime, Utc};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::serde::ts_microseconds;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -469,14 +427,8 @@ pub mod ts_microseconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::{TimeZone, DateTime, Utc};
+    /// # use serde_derive::Serialize;
     /// use chrono::serde::ts_microseconds::serialize as to_micro_ts;
     /// #[derive(Serialize)]
     /// struct S {
@@ -508,14 +460,8 @@ pub mod ts_microseconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::{DateTime, Utc};
+    /// # use serde_derive::Deserialize;
     /// use chrono::serde::ts_microseconds::deserialize as from_micro_ts;
     /// #[derive(Deserialize)]
     /// struct S {
@@ -574,14 +520,8 @@ pub mod ts_microseconds {
 /// # Example:
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # #[macro_use] extern crate serde_json;
-/// # extern crate chrono;
 /// # use chrono::{TimeZone, DateTime, Utc};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::serde::ts_microseconds_option;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -617,14 +557,8 @@ pub mod ts_microseconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::{TimeZone, DateTime, Utc};
+    /// # use serde_derive::Serialize;
     /// use chrono::serde::ts_microseconds_option::serialize as to_micro_tsopt;
     /// #[derive(Serialize)]
     /// struct S {
@@ -659,14 +593,8 @@ pub mod ts_microseconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::{DateTime, Utc};
+    /// # use serde_derive::Deserialize;
     /// use chrono::serde::ts_microseconds_option::deserialize as from_micro_tsopt;
     /// #[derive(Deserialize)]
     /// struct S {
@@ -729,14 +657,8 @@ pub mod ts_microseconds_option {
 /// # Example
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # #[macro_use] extern crate serde_json;
-/// # extern crate chrono;
 /// # use chrono::{TimeZone, DateTime, Utc};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::serde::ts_milliseconds;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -773,14 +695,8 @@ pub mod ts_milliseconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::{TimeZone, DateTime, Utc};
+    /// # use serde_derive::Serialize;
     /// use chrono::serde::ts_milliseconds::serialize as to_milli_ts;
     /// #[derive(Serialize)]
     /// struct S {
@@ -812,14 +728,8 @@ pub mod ts_milliseconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::{DateTime, Utc};
+    /// # use serde_derive::Deserialize;
     /// use chrono::serde::ts_milliseconds::deserialize as from_milli_ts;
     /// #[derive(Deserialize)]
     /// struct S {
@@ -875,14 +785,8 @@ pub mod ts_milliseconds {
 /// # Example
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # #[macro_use] extern crate serde_json;
-/// # extern crate chrono;
 /// # use chrono::{TimeZone, DateTime, Utc};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::serde::ts_milliseconds_option;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -918,14 +822,8 @@ pub mod ts_milliseconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::{TimeZone, DateTime, Utc};
+    /// # use serde_derive::Serialize;
     /// use chrono::serde::ts_milliseconds_option::serialize as to_milli_tsopt;
     /// #[derive(Serialize)]
     /// struct S {
@@ -960,14 +858,8 @@ pub mod ts_milliseconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
-    /// # use chrono::prelude::*;
+    /// # use chrono::{TimeZone, DateTime, Utc};
+    /// # use serde_derive::Deserialize;
     /// use chrono::serde::ts_milliseconds_option::deserialize as from_milli_tsopt;
     ///
     /// #[derive(Deserialize, PartialEq, Debug)]
@@ -1043,14 +935,8 @@ pub mod ts_milliseconds_option {
 /// # Example:
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # #[macro_use] extern crate serde_json;
-/// # extern crate chrono;
 /// # use chrono::{TimeZone, DateTime, Utc};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::serde::ts_seconds;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -1087,14 +973,8 @@ pub mod ts_seconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::{TimeZone, DateTime, Utc};
+    /// # use serde_derive::Serialize;
     /// use chrono::serde::ts_seconds::serialize as to_ts;
     /// #[derive(Serialize)]
     /// struct S {
@@ -1126,14 +1006,8 @@ pub mod ts_seconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::{DateTime, Utc};
+    /// # use serde_derive::Deserialize;
     /// use chrono::serde::ts_seconds::deserialize as from_ts;
     /// #[derive(Deserialize)]
     /// struct S {
@@ -1186,14 +1060,8 @@ pub mod ts_seconds {
 /// # Example:
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # #[macro_use] extern crate serde_json;
-/// # extern crate chrono;
 /// # use chrono::{TimeZone, DateTime, Utc};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::serde::ts_seconds_option;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -1229,14 +1097,8 @@ pub mod ts_seconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::{TimeZone, DateTime, Utc};
+    /// # use serde_derive::Serialize;
     /// use chrono::serde::ts_seconds_option::serialize as to_tsopt;
     /// #[derive(Serialize)]
     /// struct S {
@@ -1271,14 +1133,8 @@ pub mod ts_seconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::{DateTime, Utc};
+    /// # use serde_derive::Deserialize;
     /// use chrono::serde::ts_seconds_option::deserialize as from_tsopt;
     /// #[derive(Deserialize)]
     /// struct S {
@@ -1334,23 +1190,18 @@ pub mod ts_seconds_option {
     }
 }
 
-#[cfg(test)]
-extern crate bincode;
-#[cfg(test)]
-extern crate serde_json;
-
 #[test]
 fn test_serde_serialize() {
-    super::test_encodable_json(self::serde_json::to_string, self::serde_json::to_string);
+    super::test_encodable_json(serde_json::to_string, serde_json::to_string);
 }
 
 #[cfg(feature = "clock")]
 #[test]
 fn test_serde_deserialize() {
     super::test_decodable_json(
-        |input| self::serde_json::from_str(input),
-        |input| self::serde_json::from_str(input),
-        |input| self::serde_json::from_str(input),
+        |input| serde_json::from_str(input),
+        |input| serde_json::from_str(input),
+        |input| serde_json::from_str(input),
     );
 }
 
@@ -1358,7 +1209,7 @@ fn test_serde_deserialize() {
 fn test_serde_bincode() {
     // Bincode is relevant to test separately from JSON because
     // it is not self-describing.
-    use self::bincode::{deserialize, serialize, Infinite};
+    use bincode::{deserialize, serialize, Infinite};
 
     let dt = Utc.ymd(2014, 7, 24).and_hms(12, 34, 6);
     let encoded = serialize(&dt, Infinite).unwrap();

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -128,7 +128,6 @@ impl<'de> de::Deserialize<'de> for DateTime<Local> {
 ///     time: DateTime<Utc>
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = Utc.ymd(2018, 5, 17).and_hms_nano(02, 04, 59, 918355733);
 /// let my_s = S {
 ///     time: time.clone(),
@@ -138,9 +137,7 @@ impl<'de> de::Deserialize<'de> for DateTime<Local> {
 /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_nanoseconds {
     use core::fmt;
@@ -167,15 +164,12 @@ pub mod ts_nanoseconds {
     ///     time: DateTime<Utc>
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: Utc.ymd(2018, 5, 17).and_hms_nano(02, 04, 59, 918355733),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -200,11 +194,8 @@ pub mod ts_nanoseconds {
     ///     time: DateTime<Utc>
     /// }
     ///
-    /// # fn example() -> Result<S, serde_json::Error> {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
@@ -260,7 +251,6 @@ pub mod ts_nanoseconds {
 ///     time: Option<DateTime<Utc>>
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = Some(Utc.ymd(2018, 5, 17).and_hms_nano(02, 04, 59, 918355733));
 /// let my_s = S {
 ///     time: time.clone(),
@@ -270,9 +260,7 @@ pub mod ts_nanoseconds {
 /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_nanoseconds_option {
     use core::fmt;
@@ -298,15 +286,12 @@ pub mod ts_nanoseconds_option {
     ///     time: Option<DateTime<Utc>>
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: Some(Utc.ymd(2018, 5, 17).and_hms_nano(02, 04, 59, 918355733)),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -334,11 +319,8 @@ pub mod ts_nanoseconds_option {
     ///     time: Option<DateTime<Utc>>
     /// }
     ///
-    /// # fn example() -> Result<S, serde_json::Error> {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where
@@ -398,7 +380,6 @@ pub mod ts_nanoseconds_option {
 ///     time: DateTime<Utc>
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = Utc.ymd(2018, 5, 17).and_hms_micro(02, 04, 59, 918355);
 /// let my_s = S {
 ///     time: time.clone(),
@@ -408,9 +389,7 @@ pub mod ts_nanoseconds_option {
 /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_microseconds {
     use core::fmt;
@@ -436,15 +415,12 @@ pub mod ts_microseconds {
     ///     time: DateTime<Utc>
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: Utc.ymd(2018, 5, 17).and_hms_micro(02, 04, 59, 918355),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -469,11 +445,8 @@ pub mod ts_microseconds {
     ///     time: DateTime<Utc>
     /// }
     ///
-    /// # fn example() -> Result<S, serde_json::Error> {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
@@ -529,7 +502,6 @@ pub mod ts_microseconds {
 ///     time: Option<DateTime<Utc>>
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = Some(Utc.ymd(2018, 5, 17).and_hms_micro(02, 04, 59, 918355));
 /// let my_s = S {
 ///     time: time.clone(),
@@ -539,9 +511,7 @@ pub mod ts_microseconds {
 /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_microseconds_option {
     use core::fmt;
@@ -566,15 +536,12 @@ pub mod ts_microseconds_option {
     ///     time: Option<DateTime<Utc>>
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: Some(Utc.ymd(2018, 5, 17).and_hms_micro(02, 04, 59, 918355)),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -602,11 +569,8 @@ pub mod ts_microseconds_option {
     ///     time: Option<DateTime<Utc>>
     /// }
     ///
-    /// # fn example() -> Result<S, serde_json::Error> {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where
@@ -666,7 +630,6 @@ pub mod ts_microseconds_option {
 ///     time: DateTime<Utc>
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = Utc.ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918);
 /// let my_s = S {
 ///     time: time.clone(),
@@ -676,9 +639,7 @@ pub mod ts_microseconds_option {
 /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_milliseconds {
     use core::fmt;
@@ -704,15 +665,12 @@ pub mod ts_milliseconds {
     ///     time: DateTime<Utc>
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: Utc.ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -737,11 +695,8 @@ pub mod ts_milliseconds {
     ///     time: DateTime<Utc>
     /// }
     ///
-    /// # fn example() -> Result<S, serde_json::Error> {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
@@ -794,7 +749,6 @@ pub mod ts_milliseconds {
 ///     time: Option<DateTime<Utc>>
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = Some(Utc.ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918));
 /// let my_s = S {
 ///     time: time.clone(),
@@ -804,9 +758,7 @@ pub mod ts_milliseconds {
 /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_milliseconds_option {
     use core::fmt;
@@ -831,15 +783,12 @@ pub mod ts_milliseconds_option {
     ///     time: Option<DateTime<Utc>>
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: Some(Utc.ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918)),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -874,16 +823,13 @@ pub mod ts_milliseconds_option {
     ///     time: Option<DateTime<Utc>>
     /// }
     ///
-    /// # fn example() -> Result<(), serde_json::Error> {
     /// let my_s: E<S> = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
     /// assert_eq!(my_s, E::V(S { time: Some(Utc.timestamp(1526522699, 918000000)) }));
     /// let s: E<S> = serde_json::from_str(r#"{ "time": null }"#)?;
     /// assert_eq!(s, E::V(S { time: None }));
     /// let t: E<S> = serde_json::from_str(r#"{}"#)?;
     /// assert_eq!(t, E::V(S { time: None }));
-    /// # Ok(())
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where
@@ -944,7 +890,6 @@ pub mod ts_milliseconds_option {
 ///     time: DateTime<Utc>
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = Utc.ymd(2015, 5, 15).and_hms(10, 0, 0);
 /// let my_s = S {
 ///     time: time.clone(),
@@ -954,9 +899,7 @@ pub mod ts_milliseconds_option {
 /// assert_eq!(as_string, r#"{"time":1431684000}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_seconds {
     use core::fmt;
@@ -982,15 +925,12 @@ pub mod ts_seconds {
     ///     time: DateTime<Utc>
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: Utc.ymd(2015, 5, 15).and_hms(10, 0, 0),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -1015,11 +955,8 @@ pub mod ts_seconds {
     ///     time: DateTime<Utc>
     /// }
     ///
-    /// # fn example() -> Result<S, serde_json::Error> {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
@@ -1069,7 +1006,6 @@ pub mod ts_seconds {
 ///     time: Option<DateTime<Utc>>
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = Some(Utc.ymd(2015, 5, 15).and_hms(10, 0, 0));
 /// let my_s = S {
 ///     time: time.clone(),
@@ -1079,9 +1015,7 @@ pub mod ts_seconds {
 /// assert_eq!(as_string, r#"{"time":1431684000}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_seconds_option {
     use core::fmt;
@@ -1106,15 +1040,12 @@ pub mod ts_seconds_option {
     ///     time: Option<DateTime<Utc>>
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: Some(Utc.ymd(2015, 5, 15).and_hms(10, 0, 0)),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -1142,11 +1073,8 @@ pub mod ts_seconds_option {
     ///     time: Option<DateTime<Utc>>
     /// }
     ///
-    /// # fn example() -> Result<S, serde_json::Error> {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -18,8 +18,6 @@
 //! # Example
 //! ```rust
 //! # use std::error::Error;
-//! #
-//! # fn main() -> Result<(), Box<dyn Error>> {
 //! use chrono::prelude::*;
 //!
 //! let date_time = Utc.ymd(2020, 11, 10).and_hms(0, 1, 32);
@@ -29,8 +27,7 @@
 //!
 //! let parsed = Utc.datetime_from_str(&formatted, "%Y-%m-%d %H:%M:%S")?;
 //! assert_eq!(parsed, date_time);
-//! # Ok(())
-//! # }
+//! # Ok::<(), chrono::ParseError>(())
 //! ```
 
 #[cfg(feature = "alloc")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,8 +173,6 @@
 //! The following illustrates most supported operations to the date and time:
 //!
 //! ```rust
-//! # extern crate chrono;
-//!
 //! # fn main() {
 //! use chrono::prelude::*;
 //! use chrono::Duration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,6 @@
 //! The following illustrates most supported operations to the date and time:
 //!
 //! ```rust
-//! # fn main() {
 //! use chrono::prelude::*;
 //! use chrono::Duration;
 //!
@@ -208,7 +207,6 @@
 //!            Utc.ymd(2001, 9, 9).and_hms(1, 46, 40));
 //! assert_eq!(Utc.ymd(1970, 1, 1).and_hms(0, 0, 0) - Duration::seconds(1_000_000_000),
 //!            Utc.ymd(1938, 4, 24).and_hms(22, 13, 20));
-//! # }
 //! ```
 //!
 //! ### Formatting and Parsing

--- a/src/month.rs
+++ b/src/month.rs
@@ -7,7 +7,6 @@ use core::fmt;
 ///
 /// It is possible to convert from a date to a month independently
 /// ```
-/// # extern crate num_traits;
 /// use num_traits::FromPrimitive;
 /// use chrono::prelude::*;
 /// let date = Utc.ymd(2019, 10, 28).and_hms(9, 10, 11);

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -878,7 +878,7 @@ impl NaiveDate {
     /// # Example
     ///
     /// ```
-    /// # extern crate chrono; fn main() {
+    /// # fn main() {
     /// use chrono::{Duration, NaiveDate};
     /// use chrono::naive::MAX_DATE;
     ///
@@ -912,7 +912,7 @@ impl NaiveDate {
     /// # Example
     ///
     /// ```
-    /// # extern crate chrono; fn main() {
+    /// # fn main() {
     /// use chrono::{Duration, NaiveDate};
     /// use chrono::naive::MIN_DATE;
     ///
@@ -948,7 +948,7 @@ impl NaiveDate {
     /// # Example
     ///
     /// ```
-    /// # extern crate chrono; fn main() {
+    /// # fn main() {
     /// use chrono::{Duration, NaiveDate};
     ///
     /// let from_ymd = NaiveDate::from_ymd;
@@ -1454,7 +1454,7 @@ impl Datelike for NaiveDate {
 /// # Example
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
@@ -1495,7 +1495,7 @@ impl AddAssign<OldDuration> for NaiveDate {
 /// # Example
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
@@ -1538,7 +1538,7 @@ impl SubAssign<OldDuration> for NaiveDate {
 /// # Example
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -878,7 +878,6 @@ impl NaiveDate {
     /// # Example
     ///
     /// ```
-    /// # fn main() {
     /// use chrono::{Duration, NaiveDate};
     /// use chrono::naive::MAX_DATE;
     ///
@@ -890,7 +889,6 @@ impl NaiveDate {
     /// assert_eq!(d.checked_add_signed(Duration::days(1_000_000_000)), None);
     /// assert_eq!(d.checked_add_signed(Duration::days(-1_000_000_000)), None);
     /// assert_eq!(MAX_DATE.checked_add_signed(Duration::days(1)), None);
-    /// # }
     /// ```
     pub fn checked_add_signed(self, rhs: OldDuration) -> Option<NaiveDate> {
         let year = self.year();
@@ -912,7 +910,6 @@ impl NaiveDate {
     /// # Example
     ///
     /// ```
-    /// # fn main() {
     /// use chrono::{Duration, NaiveDate};
     /// use chrono::naive::MIN_DATE;
     ///
@@ -924,7 +921,6 @@ impl NaiveDate {
     /// assert_eq!(d.checked_sub_signed(Duration::days(1_000_000_000)), None);
     /// assert_eq!(d.checked_sub_signed(Duration::days(-1_000_000_000)), None);
     /// assert_eq!(MIN_DATE.checked_sub_signed(Duration::days(1)), None);
-    /// # }
     /// ```
     pub fn checked_sub_signed(self, rhs: OldDuration) -> Option<NaiveDate> {
         let year = self.year();
@@ -948,7 +944,6 @@ impl NaiveDate {
     /// # Example
     ///
     /// ```
-    /// # fn main() {
     /// use chrono::{Duration, NaiveDate};
     ///
     /// let from_ymd = NaiveDate::from_ymd;
@@ -961,7 +956,6 @@ impl NaiveDate {
     /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2013, 1, 1)), Duration::days(365));
     /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2010, 1, 1)), Duration::days(365*4 + 1));
     /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(1614, 1, 1)), Duration::days(365*400 + 97));
-    /// # }
     /// ```
     pub fn signed_duration_since(self, rhs: NaiveDate) -> OldDuration {
         let year1 = self.year();
@@ -1454,7 +1448,6 @@ impl Datelike for NaiveDate {
 /// # Example
 ///
 /// ```
-/// # fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
@@ -1467,7 +1460,6 @@ impl Datelike for NaiveDate {
 /// assert_eq!(from_ymd(2014, 1, 1) + Duration::days(364),          from_ymd(2014, 12, 31));
 /// assert_eq!(from_ymd(2014, 1, 1) + Duration::days(365*4 + 1),    from_ymd(2018, 1, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) + Duration::days(365*400 + 97), from_ymd(2414, 1, 1));
-/// # }
 /// ```
 impl Add<OldDuration> for NaiveDate {
     type Output = NaiveDate;
@@ -1495,7 +1487,6 @@ impl AddAssign<OldDuration> for NaiveDate {
 /// # Example
 ///
 /// ```
-/// # fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
@@ -1508,7 +1499,6 @@ impl AddAssign<OldDuration> for NaiveDate {
 /// assert_eq!(from_ymd(2014, 1, 1) - Duration::days(364),          from_ymd(2013, 1, 2));
 /// assert_eq!(from_ymd(2014, 1, 1) - Duration::days(365*4 + 1),    from_ymd(2010, 1, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) - Duration::days(365*400 + 97), from_ymd(1614, 1, 1));
-/// # }
 /// ```
 impl Sub<OldDuration> for NaiveDate {
     type Output = NaiveDate;
@@ -1538,7 +1528,6 @@ impl SubAssign<OldDuration> for NaiveDate {
 /// # Example
 ///
 /// ```
-/// # fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
@@ -1550,7 +1539,6 @@ impl SubAssign<OldDuration> for NaiveDate {
 /// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 1, 1), Duration::days(365));
 /// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2010, 1, 1), Duration::days(365*4 + 1));
 /// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(1614, 1, 1), Duration::days(365*400 + 97));
-/// # }
 /// ```
 impl Sub<NaiveDate> for NaiveDate {
     type Output = OldDuration;

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -468,7 +468,7 @@ impl NaiveDateTime {
     /// # Example
     ///
     /// ```
-    /// # extern crate chrono; fn main() {
+    /// # fn main() {
     /// use chrono::{Duration, NaiveDate};
     ///
     /// let from_ymd = NaiveDate::from_ymd;
@@ -495,7 +495,7 @@ impl NaiveDateTime {
     /// Overflow returns `None`.
     ///
     /// ```
-    /// # extern crate chrono; fn main() {
+    /// # fn main() {
     /// # use chrono::{Duration, NaiveDate};
     /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).and_hms(h, m, s);
     /// assert_eq!(hms(3, 5, 7).checked_add_signed(Duration::days(1_000_000_000)), None);
@@ -506,7 +506,7 @@ impl NaiveDateTime {
     /// but the addition assumes that it is the only leap second happened.
     ///
     /// ```
-    /// # extern crate chrono; fn main() {
+    /// # fn main() {
     /// # use chrono::{Duration, NaiveDate};
     /// # let from_ymd = NaiveDate::from_ymd;
     /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
@@ -551,7 +551,7 @@ impl NaiveDateTime {
     /// # Example
     ///
     /// ```
-    /// # extern crate chrono; fn main() {
+    /// # fn main() {
     /// use chrono::{Duration, NaiveDate};
     ///
     /// let from_ymd = NaiveDate::from_ymd;
@@ -578,7 +578,7 @@ impl NaiveDateTime {
     /// Overflow returns `None`.
     ///
     /// ```
-    /// # extern crate chrono; fn main() {
+    /// # fn main() {
     /// # use chrono::{Duration, NaiveDate};
     /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).and_hms(h, m, s);
     /// assert_eq!(hms(3, 5, 7).checked_sub_signed(Duration::days(1_000_000_000)), None);
@@ -589,7 +589,7 @@ impl NaiveDateTime {
     /// but the subtraction assumes that it is the only leap second happened.
     ///
     /// ```
-    /// # extern crate chrono; fn main() {
+    /// # fn main() {
     /// # use chrono::{Duration, NaiveDate};
     /// # let from_ymd = NaiveDate::from_ymd;
     /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
@@ -630,7 +630,7 @@ impl NaiveDateTime {
     /// # Example
     ///
     /// ```
-    /// # extern crate chrono; fn main() {
+    /// # fn main() {
     /// use chrono::{Duration, NaiveDate};
     ///
     /// let from_ymd = NaiveDate::from_ymd;
@@ -650,7 +650,7 @@ impl NaiveDateTime {
     /// there were no other leap seconds happened.
     ///
     /// ```
-    /// # extern crate chrono; fn main() {
+    /// # fn main() {
     /// # use chrono::{Duration, NaiveDate};
     /// # let from_ymd = NaiveDate::from_ymd;
     /// let leap = from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500);
@@ -1227,7 +1227,7 @@ impl Timelike for NaiveDateTime {
 /// # Example
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
@@ -1252,7 +1252,7 @@ impl Timelike for NaiveDateTime {
 /// but the addition assumes that it is the only leap second happened.
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// # use chrono::{Duration, NaiveDate};
 /// # let from_ymd = NaiveDate::from_ymd;
 /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
@@ -1297,7 +1297,7 @@ impl AddAssign<OldDuration> for NaiveDateTime {
 /// # Example
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
@@ -1322,7 +1322,7 @@ impl AddAssign<OldDuration> for NaiveDateTime {
 /// but the subtraction assumes that it is the only leap second happened.
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// # use chrono::{Duration, NaiveDate};
 /// # let from_ymd = NaiveDate::from_ymd;
 /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
@@ -1365,7 +1365,7 @@ impl SubAssign<OldDuration> for NaiveDateTime {
 /// # Example
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
@@ -1384,7 +1384,7 @@ impl SubAssign<OldDuration> for NaiveDateTime {
 /// seconds happened.
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// # use chrono::{Duration, NaiveDate};
 /// # let from_ymd = NaiveDate::from_ymd;
 /// let leap = from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500);

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -468,7 +468,6 @@ impl NaiveDateTime {
     /// # Example
     ///
     /// ```
-    /// # fn main() {
     /// use chrono::{Duration, NaiveDate};
     ///
     /// let from_ymd = NaiveDate::from_ymd;
@@ -489,24 +488,20 @@ impl NaiveDateTime {
     /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli);
     /// assert_eq!(hmsm(3, 5, 7, 980).checked_add_signed(Duration::milliseconds(450)),
     ///            Some(hmsm(3, 5, 8, 430)));
-    /// # }
     /// ```
     ///
     /// Overflow returns `None`.
     ///
     /// ```
-    /// # fn main() {
     /// # use chrono::{Duration, NaiveDate};
     /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).and_hms(h, m, s);
     /// assert_eq!(hms(3, 5, 7).checked_add_signed(Duration::days(1_000_000_000)), None);
-    /// # }
     /// ```
     ///
     /// Leap seconds are handled,
     /// but the addition assumes that it is the only leap second happened.
     ///
     /// ```
-    /// # fn main() {
     /// # use chrono::{Duration, NaiveDate};
     /// # let from_ymd = NaiveDate::from_ymd;
     /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
@@ -525,7 +520,6 @@ impl NaiveDateTime {
     ///            Some(hmsm(3, 5, 50, 300)));
     /// assert_eq!(leap.checked_add_signed(Duration::days(1)),
     ///            Some(from_ymd(2016, 7, 9).and_hms_milli(3, 5, 59, 300)));
-    /// # }
     /// ```
     pub fn checked_add_signed(self, rhs: OldDuration) -> Option<NaiveDateTime> {
         let (time, rhs) = self.time.overflowing_add_signed(rhs);
@@ -551,7 +545,6 @@ impl NaiveDateTime {
     /// # Example
     ///
     /// ```
-    /// # fn main() {
     /// use chrono::{Duration, NaiveDate};
     ///
     /// let from_ymd = NaiveDate::from_ymd;
@@ -572,24 +565,20 @@ impl NaiveDateTime {
     /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli);
     /// assert_eq!(hmsm(3, 5, 7, 450).checked_sub_signed(Duration::milliseconds(670)),
     ///            Some(hmsm(3, 5, 6, 780)));
-    /// # }
     /// ```
     ///
     /// Overflow returns `None`.
     ///
     /// ```
-    /// # fn main() {
     /// # use chrono::{Duration, NaiveDate};
     /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).and_hms(h, m, s);
     /// assert_eq!(hms(3, 5, 7).checked_sub_signed(Duration::days(1_000_000_000)), None);
-    /// # }
     /// ```
     ///
     /// Leap seconds are handled,
     /// but the subtraction assumes that it is the only leap second happened.
     ///
     /// ```
-    /// # fn main() {
     /// # use chrono::{Duration, NaiveDate};
     /// # let from_ymd = NaiveDate::from_ymd;
     /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
@@ -604,7 +593,6 @@ impl NaiveDateTime {
     ///            Some(hmsm(3, 5, 0, 300)));
     /// assert_eq!(leap.checked_sub_signed(Duration::days(1)),
     ///            Some(from_ymd(2016, 7, 7).and_hms_milli(3, 6, 0, 300)));
-    /// # }
     /// ```
     pub fn checked_sub_signed(self, rhs: OldDuration) -> Option<NaiveDateTime> {
         let (time, rhs) = self.time.overflowing_sub_signed(rhs);
@@ -630,7 +618,6 @@ impl NaiveDateTime {
     /// # Example
     ///
     /// ```
-    /// # fn main() {
     /// use chrono::{Duration, NaiveDate};
     ///
     /// let from_ymd = NaiveDate::from_ymd;
@@ -643,14 +630,12 @@ impl NaiveDateTime {
     /// let d0 = from_ymd(2016, 1, 1);
     /// assert_eq!(d.and_hms_milli(0, 7, 6, 500).signed_duration_since(d0.and_hms(0, 0, 0)),
     ///            Duration::seconds(189 * 86_400 + 7 * 60 + 6) + Duration::milliseconds(500));
-    /// # }
     /// ```
     ///
     /// Leap seconds are handled, but the subtraction assumes that
     /// there were no other leap seconds happened.
     ///
     /// ```
-    /// # fn main() {
     /// # use chrono::{Duration, NaiveDate};
     /// # let from_ymd = NaiveDate::from_ymd;
     /// let leap = from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500);
@@ -658,7 +643,6 @@ impl NaiveDateTime {
     ///            Duration::seconds(3600) + Duration::milliseconds(500));
     /// assert_eq!(from_ymd(2015, 7, 1).and_hms(1, 0, 0).signed_duration_since(leap),
     ///            Duration::seconds(3600) - Duration::milliseconds(500));
-    /// # }
     /// ```
     pub fn signed_duration_since(self, rhs: NaiveDateTime) -> OldDuration {
         self.date.signed_duration_since(rhs.date) + self.time.signed_duration_since(rhs.time)
@@ -1227,7 +1211,6 @@ impl Timelike for NaiveDateTime {
 /// # Example
 ///
 /// ```
-/// # fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
@@ -1245,14 +1228,12 @@ impl Timelike for NaiveDateTime {
 ///
 /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli);
 /// assert_eq!(hmsm(3, 5, 7, 980) + Duration::milliseconds(450), hmsm(3, 5, 8, 430));
-/// # }
 /// ```
 ///
 /// Leap seconds are handled,
 /// but the addition assumes that it is the only leap second happened.
 ///
 /// ```
-/// # fn main() {
 /// # use chrono::{Duration, NaiveDate};
 /// # let from_ymd = NaiveDate::from_ymd;
 /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
@@ -1265,7 +1246,6 @@ impl Timelike for NaiveDateTime {
 /// assert_eq!(leap + Duration::seconds(-10),       hmsm(3, 5, 50, 300));
 /// assert_eq!(leap + Duration::days(1),
 ///            from_ymd(2016, 7, 9).and_hms_milli(3, 5, 59, 300));
-/// # }
 /// ```
 impl Add<OldDuration> for NaiveDateTime {
     type Output = NaiveDateTime;
@@ -1297,7 +1277,6 @@ impl AddAssign<OldDuration> for NaiveDateTime {
 /// # Example
 ///
 /// ```
-/// # fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
@@ -1315,14 +1294,12 @@ impl AddAssign<OldDuration> for NaiveDateTime {
 ///
 /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli);
 /// assert_eq!(hmsm(3, 5, 7, 450) - Duration::milliseconds(670), hmsm(3, 5, 6, 780));
-/// # }
 /// ```
 ///
 /// Leap seconds are handled,
 /// but the subtraction assumes that it is the only leap second happened.
 ///
 /// ```
-/// # fn main() {
 /// # use chrono::{Duration, NaiveDate};
 /// # let from_ymd = NaiveDate::from_ymd;
 /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
@@ -1333,7 +1310,6 @@ impl AddAssign<OldDuration> for NaiveDateTime {
 /// assert_eq!(leap - Duration::seconds(60),       hmsm(3, 5, 0, 300));
 /// assert_eq!(leap - Duration::days(1),
 ///            from_ymd(2016, 7, 7).and_hms_milli(3, 6, 0, 300));
-/// # }
 /// ```
 impl Sub<OldDuration> for NaiveDateTime {
     type Output = NaiveDateTime;
@@ -1365,7 +1341,6 @@ impl SubAssign<OldDuration> for NaiveDateTime {
 /// # Example
 ///
 /// ```
-/// # fn main() {
 /// use chrono::{Duration, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
@@ -1377,14 +1352,12 @@ impl SubAssign<OldDuration> for NaiveDateTime {
 /// let d0 = from_ymd(2016, 1, 1);
 /// assert_eq!(d.and_hms_milli(0, 7, 6, 500) - d0.and_hms(0, 0, 0),
 ///            Duration::seconds(189 * 86_400 + 7 * 60 + 6) + Duration::milliseconds(500));
-/// # }
 /// ```
 ///
 /// Leap seconds are handled, but the subtraction assumes that no other leap
 /// seconds happened.
 ///
 /// ```
-/// # fn main() {
 /// # use chrono::{Duration, NaiveDate};
 /// # let from_ymd = NaiveDate::from_ymd;
 /// let leap = from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500);
@@ -1392,7 +1365,6 @@ impl SubAssign<OldDuration> for NaiveDateTime {
 ///            Duration::seconds(3600) + Duration::milliseconds(500));
 /// assert_eq!(from_ymd(2015, 7, 1).and_hms(1, 0, 0) - leap,
 ///            Duration::seconds(3600) - Duration::milliseconds(500));
-/// # }
 /// ```
 impl Sub<NaiveDateTime> for NaiveDateTime {
     type Output = OldDuration;

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -67,7 +67,6 @@ impl<'de> de::Deserialize<'de> for NaiveDateTime {
 ///     time: NaiveDateTime
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = NaiveDate::from_ymd(2018, 5, 17).and_hms_nano(02, 04, 59, 918355733);
 /// let my_s = S {
 ///     time: time.clone(),
@@ -77,9 +76,7 @@ impl<'de> de::Deserialize<'de> for NaiveDateTime {
 /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_nanoseconds {
     use core::fmt;
@@ -104,15 +101,12 @@ pub mod ts_nanoseconds {
     ///     time: NaiveDateTime
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: NaiveDate::from_ymd(2018, 5, 17).and_hms_nano(02, 04, 59, 918355733),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -137,11 +131,8 @@ pub mod ts_nanoseconds {
     ///     time: NaiveDateTime
     /// }
     ///
-    /// # fn example() -> Result<S, serde_json::Error> {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
     where
@@ -196,7 +187,6 @@ pub mod ts_nanoseconds {
 ///     time: Option<NaiveDateTime>
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = Some(NaiveDate::from_ymd(2018, 5, 17).and_hms_nano(02, 04, 59, 918355733));
 /// let my_s = S {
 ///     time: time.clone(),
@@ -206,9 +196,7 @@ pub mod ts_nanoseconds {
 /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_nanoseconds_option {
     use core::fmt;
@@ -233,15 +221,12 @@ pub mod ts_nanoseconds_option {
     ///     time: Option<NaiveDateTime>
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).and_hms_nano(02, 04, 59, 918355733)),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(opt: &Option<NaiveDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -269,11 +254,8 @@ pub mod ts_nanoseconds_option {
     ///     time: Option<NaiveDateTime>
     /// }
     ///
-    /// # fn example() -> Result<S, serde_json::Error> {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
     where
@@ -331,7 +313,6 @@ pub mod ts_nanoseconds_option {
 ///     time: NaiveDateTime
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = NaiveDate::from_ymd(2018, 5, 17).and_hms_micro(02, 04, 59, 918355);
 /// let my_s = S {
 ///     time: time.clone(),
@@ -341,9 +322,7 @@ pub mod ts_nanoseconds_option {
 /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_microseconds {
     use core::fmt;
@@ -368,15 +347,12 @@ pub mod ts_microseconds {
     ///     time: NaiveDateTime
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: NaiveDate::from_ymd(2018, 5, 17).and_hms_micro(02, 04, 59, 918355),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -401,11 +377,8 @@ pub mod ts_microseconds {
     ///     time: NaiveDateTime
     /// }
     ///
-    /// # fn example() -> Result<S, serde_json::Error> {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
     where
@@ -463,7 +436,6 @@ pub mod ts_microseconds {
 ///     time: Option<NaiveDateTime>
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = Some(NaiveDate::from_ymd(2018, 5, 17).and_hms_micro(02, 04, 59, 918355));
 /// let my_s = S {
 ///     time: time.clone(),
@@ -473,9 +445,7 @@ pub mod ts_microseconds {
 /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_microseconds_option {
     use core::fmt;
@@ -500,15 +470,12 @@ pub mod ts_microseconds_option {
     ///     time: Option<NaiveDateTime>
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).and_hms_micro(02, 04, 59, 918355)),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(opt: &Option<NaiveDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -536,11 +503,8 @@ pub mod ts_microseconds_option {
     ///     time: Option<NaiveDateTime>
     /// }
     ///
-    /// # fn example() -> Result<S, serde_json::Error> {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
     where
@@ -598,7 +562,6 @@ pub mod ts_microseconds_option {
 ///     time: NaiveDateTime
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = NaiveDate::from_ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918);
 /// let my_s = S {
 ///     time: time.clone(),
@@ -608,9 +571,7 @@ pub mod ts_microseconds_option {
 /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_milliseconds {
     use core::fmt;
@@ -635,15 +596,12 @@ pub mod ts_milliseconds {
     ///     time: NaiveDateTime
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: NaiveDate::from_ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -668,11 +626,8 @@ pub mod ts_milliseconds {
     ///     time: NaiveDateTime
     /// }
     ///
-    /// # fn example() -> Result<S, serde_json::Error> {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
     where
@@ -727,7 +682,6 @@ pub mod ts_milliseconds {
 ///     time: Option<NaiveDateTime>
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = Some(NaiveDate::from_ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918));
 /// let my_s = S {
 ///     time: time.clone(),
@@ -737,9 +691,7 @@ pub mod ts_milliseconds {
 /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_milliseconds_option {
     use core::fmt;
@@ -764,15 +716,12 @@ pub mod ts_milliseconds_option {
     ///     time: Option<NaiveDateTime>
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918)),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(opt: &Option<NaiveDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -800,11 +749,8 @@ pub mod ts_milliseconds_option {
     ///     time: Option<NaiveDateTime>
     /// }
     ///
-    /// # fn example() -> Result<S, serde_json::Error> {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
     where
@@ -862,7 +808,6 @@ pub mod ts_milliseconds_option {
 ///     time: NaiveDateTime
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = NaiveDate::from_ymd(2015, 5, 15).and_hms(10, 0, 0);
 /// let my_s = S {
 ///     time: time.clone(),
@@ -872,9 +817,7 @@ pub mod ts_milliseconds_option {
 /// assert_eq!(as_string, r#"{"time":1431684000}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_seconds {
     use core::fmt;
@@ -899,15 +842,12 @@ pub mod ts_seconds {
     ///     time: NaiveDateTime
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: NaiveDate::from_ymd(2015, 5, 15).and_hms(10, 0, 0),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -932,11 +872,8 @@ pub mod ts_seconds {
     ///     time: NaiveDateTime
     /// }
     ///
-    /// # fn example() -> Result<S, serde_json::Error> {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
     where
@@ -988,7 +925,6 @@ pub mod ts_seconds {
 ///     time: Option<NaiveDateTime>
 /// }
 ///
-/// # fn example() -> Result<S, serde_json::Error> {
 /// let time = Some(NaiveDate::from_ymd(2018, 5, 17).and_hms(02, 04, 59));
 /// let my_s = S {
 ///     time: time.clone(),
@@ -998,9 +934,7 @@ pub mod ts_seconds {
 /// assert_eq!(as_string, r#"{"time":1526522699}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok(my_s)
-/// # }
-/// # fn main() { example().unwrap(); }
+/// # Ok::<(), serde_json::Error>(())
 /// ```
 pub mod ts_seconds_option {
     use core::fmt;
@@ -1025,15 +959,12 @@ pub mod ts_seconds_option {
     ///     time: Option<NaiveDateTime>
     /// }
     ///
-    /// # fn example() -> Result<String, serde_json::Error> {
     /// let my_s = S {
     ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).and_hms(02, 04, 59)),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699}"#);
-    /// # Ok(as_string)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn serialize<S>(opt: &Option<NaiveDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -1061,11 +992,8 @@ pub mod ts_seconds_option {
     ///     time: Option<NaiveDateTime>
     /// }
     ///
-    /// # fn example() -> Result<S, serde_json::Error> {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
-    /// # Ok(my_s)
-    /// # }
-    /// # fn main() { example().unwrap(); }
+    /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
     where

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -58,15 +58,8 @@ impl<'de> de::Deserialize<'de> for NaiveDateTime {
 /// # Example:
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # extern crate serde_json;
-/// # extern crate serde;
-/// # extern crate chrono;
 /// # use chrono::{NaiveDate, NaiveDateTime};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::naive::serde::ts_nanoseconds;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -102,16 +95,8 @@ pub mod ts_nanoseconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # #[macro_use] extern crate serde;
-    /// # extern crate chrono;
     /// # use chrono::{NaiveDate, NaiveDateTime};
-    /// # use serde::Serialize;
+    /// # use serde_derive::Serialize;
     /// use chrono::naive::serde::ts_nanoseconds::serialize as to_nano_ts;
     /// #[derive(Serialize)]
     /// struct S {
@@ -143,16 +128,8 @@ pub mod ts_nanoseconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate serde;
-    /// # extern crate chrono;
     /// # use chrono::NaiveDateTime;
-    /// # use serde::Deserialize;
+    /// # use serde_derive::Deserialize;
     /// use chrono::naive::serde::ts_nanoseconds::deserialize as from_nano_ts;
     /// #[derive(Deserialize)]
     /// struct S {
@@ -210,14 +187,8 @@ pub mod ts_nanoseconds {
 /// # Example:
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # #[macro_use] extern crate serde_json;
-/// # extern crate chrono;
 /// # use chrono::naive::{NaiveDate, NaiveDateTime};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::naive::serde::ts_nanoseconds_option;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -253,14 +224,8 @@ pub mod ts_nanoseconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::naive::{NaiveDate, NaiveDateTime};
+    /// # use serde_derive::Serialize;
     /// use chrono::naive::serde::ts_nanoseconds_option::serialize as to_nano_tsopt;
     /// #[derive(Serialize)]
     /// struct S {
@@ -295,14 +260,8 @@ pub mod ts_nanoseconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::naive::{NaiveDate, NaiveDateTime};
+    /// # use serde_derive::Deserialize;
     /// use chrono::naive::serde::ts_nanoseconds_option::deserialize as from_nano_tsopt;
     /// #[derive(Deserialize)]
     /// struct S {
@@ -363,15 +322,8 @@ pub mod ts_nanoseconds_option {
 /// # Example:
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # extern crate serde_json;
-/// # extern crate serde;
-/// # extern crate chrono;
 /// # use chrono::{NaiveDate, NaiveDateTime};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::naive::serde::ts_microseconds;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -407,16 +359,8 @@ pub mod ts_microseconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # #[macro_use] extern crate serde;
-    /// # extern crate chrono;
     /// # use chrono::{NaiveDate, NaiveDateTime};
-    /// # use serde::Serialize;
+    /// # use serde_derive::Serialize;
     /// use chrono::naive::serde::ts_microseconds::serialize as to_micro_ts;
     /// #[derive(Serialize)]
     /// struct S {
@@ -448,16 +392,8 @@ pub mod ts_microseconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate serde;
-    /// # extern crate chrono;
     /// # use chrono::NaiveDateTime;
-    /// # use serde::Deserialize;
+    /// # use serde_derive::Deserialize;
     /// use chrono::naive::serde::ts_microseconds::deserialize as from_micro_ts;
     /// #[derive(Deserialize)]
     /// struct S {
@@ -518,14 +454,8 @@ pub mod ts_microseconds {
 /// # Example:
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # #[macro_use] extern crate serde_json;
-/// # extern crate chrono;
 /// # use chrono::naive::{NaiveDate, NaiveDateTime};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::naive::serde::ts_microseconds_option;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -561,14 +491,8 @@ pub mod ts_microseconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::naive::{NaiveDate, NaiveDateTime};
+    /// # use serde_derive::Serialize;
     /// use chrono::naive::serde::ts_microseconds_option::serialize as to_micro_tsopt;
     /// #[derive(Serialize)]
     /// struct S {
@@ -603,14 +527,8 @@ pub mod ts_microseconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::naive::{NaiveDate, NaiveDateTime};
+    /// # use serde_derive::Deserialize;
     /// use chrono::naive::serde::ts_microseconds_option::deserialize as from_micro_tsopt;
     /// #[derive(Deserialize)]
     /// struct S {
@@ -671,15 +589,8 @@ pub mod ts_microseconds_option {
 /// # Example:
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # extern crate serde_json;
-/// # extern crate serde;
-/// # extern crate chrono;
 /// # use chrono::{NaiveDate, NaiveDateTime};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::naive::serde::ts_milliseconds;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -715,16 +626,8 @@ pub mod ts_milliseconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # #[macro_use] extern crate serde;
-    /// # extern crate chrono;
     /// # use chrono::{NaiveDate, NaiveDateTime};
-    /// # use serde::Serialize;
+    /// # use serde_derive::Serialize;
     /// use chrono::naive::serde::ts_milliseconds::serialize as to_milli_ts;
     /// #[derive(Serialize)]
     /// struct S {
@@ -756,16 +659,8 @@ pub mod ts_milliseconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate serde;
-    /// # extern crate chrono;
     /// # use chrono::NaiveDateTime;
-    /// # use serde::Deserialize;
+    /// # use serde_derive::Deserialize;
     /// use chrono::naive::serde::ts_milliseconds::deserialize as from_milli_ts;
     /// #[derive(Deserialize)]
     /// struct S {
@@ -823,14 +718,8 @@ pub mod ts_milliseconds {
 /// # Example:
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # #[macro_use] extern crate serde_json;
-/// # extern crate chrono;
 /// # use chrono::naive::{NaiveDate, NaiveDateTime};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::naive::serde::ts_milliseconds_option;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -866,14 +755,8 @@ pub mod ts_milliseconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::naive::{NaiveDate, NaiveDateTime};
+    /// # use serde_derive::Serialize;
     /// use chrono::naive::serde::ts_milliseconds_option::serialize as to_milli_tsopt;
     /// #[derive(Serialize)]
     /// struct S {
@@ -908,14 +791,8 @@ pub mod ts_milliseconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::naive::{NaiveDate, NaiveDateTime};
+    /// # use serde_derive::Deserialize;
     /// use chrono::naive::serde::ts_milliseconds_option::deserialize as from_milli_tsopt;
     /// #[derive(Deserialize)]
     /// struct S {
@@ -976,15 +853,8 @@ pub mod ts_milliseconds_option {
 /// # Example:
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # extern crate serde_json;
-/// # extern crate serde;
-/// # extern crate chrono;
 /// # use chrono::{NaiveDate, NaiveDateTime};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::naive::serde::ts_seconds;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -1020,16 +890,8 @@ pub mod ts_seconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # #[macro_use] extern crate serde;
-    /// # extern crate chrono;
     /// # use chrono::{NaiveDate, NaiveDateTime};
-    /// # use serde::Serialize;
+    /// # use serde_derive::Serialize;
     /// use chrono::naive::serde::ts_seconds::serialize as to_ts;
     /// #[derive(Serialize)]
     /// struct S {
@@ -1061,16 +923,8 @@ pub mod ts_seconds {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate serde;
-    /// # extern crate chrono;
     /// # use chrono::NaiveDateTime;
-    /// # use serde::Deserialize;
+    /// # use serde_derive::Deserialize;
     /// use chrono::naive::serde::ts_seconds::deserialize as from_ts;
     /// #[derive(Deserialize)]
     /// struct S {
@@ -1125,14 +979,8 @@ pub mod ts_seconds {
 /// # Example:
 ///
 /// ```rust
-/// # // We mark this ignored so that we can test on 1.13 (which does not
-/// # // support custom derive), and run tests with --ignored on beta and
-/// # // nightly to actually trigger these.
-/// #
-/// # #[macro_use] extern crate serde_derive;
-/// # #[macro_use] extern crate serde_json;
-/// # extern crate chrono;
 /// # use chrono::naive::{NaiveDate, NaiveDateTime};
+/// # use serde_derive::{Deserialize, Serialize};
 /// use chrono::naive::serde::ts_seconds_option;
 /// #[derive(Deserialize, Serialize)]
 /// struct S {
@@ -1168,14 +1016,8 @@ pub mod ts_seconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::naive::{NaiveDate, NaiveDateTime};
+    /// # use serde_derive::Serialize;
     /// use chrono::naive::serde::ts_seconds_option::serialize as to_tsopt;
     /// #[derive(Serialize)]
     /// struct S {
@@ -1210,14 +1052,8 @@ pub mod ts_seconds_option {
     /// # Example:
     ///
     /// ```rust
-    /// # // We mark this ignored so that we can test on 1.13 (which does not
-    /// # // support custom derive), and run tests with --ignored on beta and
-    /// # // nightly to actually trigger these.
-    /// #
-    /// # #[macro_use] extern crate serde_derive;
-    /// # #[macro_use] extern crate serde_json;
-    /// # extern crate chrono;
     /// # use chrono::naive::{NaiveDate, NaiveDateTime};
+    /// # use serde_derive::Deserialize;
     /// use chrono::naive::serde::ts_seconds_option::deserialize as from_tsopt;
     /// #[derive(Deserialize)]
     /// struct S {

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -529,7 +529,7 @@ impl NaiveTime {
     /// # Example
     ///
     /// ```
-    /// # extern crate chrono; fn main() {
+    /// # fn main() {
     /// use chrono::{Duration, NaiveTime};
     ///
     /// let from_hms = NaiveTime::from_hms;
@@ -614,7 +614,7 @@ impl NaiveTime {
     /// # Example
     ///
     /// ```
-    /// # extern crate chrono; fn main() {
+    /// # fn main() {
     /// use chrono::{Duration, NaiveTime};
     ///
     /// let from_hms = NaiveTime::from_hms;
@@ -646,7 +646,7 @@ impl NaiveTime {
     /// # Example
     ///
     /// ```
-    /// # extern crate chrono; fn main() {
+    /// # fn main() {
     /// use chrono::{Duration, NaiveTime};
     ///
     /// let from_hmsm = NaiveTime::from_hms_milli;
@@ -675,7 +675,7 @@ impl NaiveTime {
     /// there were no other leap seconds happened.
     ///
     /// ```
-    /// # extern crate chrono; fn main() {
+    /// # fn main() {
     /// # use chrono::{Duration, NaiveTime};
     /// # let from_hmsm = NaiveTime::from_hms_milli;
     /// # let since = NaiveTime::signed_duration_since;
@@ -1034,7 +1034,7 @@ impl Timelike for NaiveTime {
 /// # Example
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// use chrono::{Duration, NaiveTime};
 ///
 /// let from_hmsm = NaiveTime::from_hms_milli;
@@ -1053,7 +1053,7 @@ impl Timelike for NaiveTime {
 /// The addition wraps around.
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::seconds(22*60*60), from_hmsm(1, 5, 7, 0));
@@ -1065,7 +1065,7 @@ impl Timelike for NaiveTime {
 /// Leap seconds are handled, but the addition assumes that it is the only leap second happened.
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
 /// let leap = from_hmsm(3, 5, 59, 1_300);
@@ -1106,7 +1106,7 @@ impl AddAssign<OldDuration> for NaiveTime {
 /// # Example
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// use chrono::{Duration, NaiveTime};
 ///
 /// let from_hmsm = NaiveTime::from_hms_milli;
@@ -1123,7 +1123,7 @@ impl AddAssign<OldDuration> for NaiveTime {
 /// The subtraction wraps around.
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::seconds(8*60*60), from_hmsm(19, 5, 7, 0));
@@ -1134,7 +1134,7 @@ impl AddAssign<OldDuration> for NaiveTime {
 /// Leap seconds are handled, but the subtraction assumes that it is the only leap second happened.
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
 /// let leap = from_hmsm(3, 5, 59, 1_300);
@@ -1177,7 +1177,7 @@ impl SubAssign<OldDuration> for NaiveTime {
 /// # Example
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// use chrono::{Duration, NaiveTime};
 ///
 /// let from_hmsm = NaiveTime::from_hms_milli;
@@ -1198,7 +1198,7 @@ impl SubAssign<OldDuration> for NaiveTime {
 /// there were no other leap seconds happened.
 ///
 /// ```
-/// # extern crate chrono; fn main() {
+/// # fn main() {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
 /// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(3, 0, 59, 0), Duration::seconds(1));

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -529,7 +529,6 @@ impl NaiveTime {
     /// # Example
     ///
     /// ```
-    /// # fn main() {
     /// use chrono::{Duration, NaiveTime};
     ///
     /// let from_hms = NaiveTime::from_hms;
@@ -540,7 +539,6 @@ impl NaiveTime {
     ///            (from_hms(2, 4, 5), 86_400));
     /// assert_eq!(from_hms(3, 4, 5).overflowing_add_signed(Duration::hours(-7)),
     ///            (from_hms(20, 4, 5), -86_400));
-    /// # }
     /// ```
     #[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
     pub fn overflowing_add_signed(&self, mut rhs: OldDuration) -> (NaiveTime, i64) {
@@ -614,7 +612,6 @@ impl NaiveTime {
     /// # Example
     ///
     /// ```
-    /// # fn main() {
     /// use chrono::{Duration, NaiveTime};
     ///
     /// let from_hms = NaiveTime::from_hms;
@@ -625,7 +622,6 @@ impl NaiveTime {
     ///            (from_hms(10, 4, 5), 86_400));
     /// assert_eq!(from_hms(3, 4, 5).overflowing_sub_signed(Duration::hours(-22)),
     ///            (from_hms(1, 4, 5), -86_400));
-    /// # }
     /// ```
     #[inline]
     pub fn overflowing_sub_signed(&self, rhs: OldDuration) -> (NaiveTime, i64) {
@@ -646,7 +642,6 @@ impl NaiveTime {
     /// # Example
     ///
     /// ```
-    /// # fn main() {
     /// use chrono::{Duration, NaiveTime};
     ///
     /// let from_hmsm = NaiveTime::from_hms_milli;
@@ -668,14 +663,12 @@ impl NaiveTime {
     ///            Duration::seconds(-3600));
     /// assert_eq!(since(from_hmsm(3, 5, 7, 900), from_hmsm(2, 4, 6, 800)),
     ///            Duration::seconds(3600 + 60 + 1) + Duration::milliseconds(100));
-    /// # }
     /// ```
     ///
     /// Leap seconds are handled, but the subtraction assumes that
     /// there were no other leap seconds happened.
     ///
     /// ```
-    /// # fn main() {
     /// # use chrono::{Duration, NaiveTime};
     /// # let from_hmsm = NaiveTime::from_hms_milli;
     /// # let since = NaiveTime::signed_duration_since;
@@ -689,7 +682,6 @@ impl NaiveTime {
     ///            Duration::seconds(1));
     /// assert_eq!(since(from_hmsm(3, 0, 59, 1_000), from_hmsm(2, 59, 59, 1_000)),
     ///            Duration::seconds(61));
-    /// # }
     /// ```
     pub fn signed_duration_since(self, rhs: NaiveTime) -> OldDuration {
         //     |    |    :leap|    |    |    |    |    |    |    :leap|    |
@@ -1034,7 +1026,6 @@ impl Timelike for NaiveTime {
 /// # Example
 ///
 /// ```
-/// # fn main() {
 /// use chrono::{Duration, NaiveTime};
 ///
 /// let from_hmsm = NaiveTime::from_hms_milli;
@@ -1047,25 +1038,21 @@ impl Timelike for NaiveTime {
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::milliseconds(80),        from_hmsm(3, 5, 7, 80));
 /// assert_eq!(from_hmsm(3, 5, 7, 950) + Duration::milliseconds(280),     from_hmsm(3, 5, 8, 230));
 /// assert_eq!(from_hmsm(3, 5, 7, 950) + Duration::milliseconds(-980),    from_hmsm(3, 5, 6, 970));
-/// # }
 /// ```
 ///
 /// The addition wraps around.
 ///
 /// ```
-/// # fn main() {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::seconds(22*60*60), from_hmsm(1, 5, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::seconds(-8*60*60), from_hmsm(19, 5, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::days(800),         from_hmsm(3, 5, 7, 0));
-/// # }
 /// ```
 ///
 /// Leap seconds are handled, but the addition assumes that it is the only leap second happened.
 ///
 /// ```
-/// # fn main() {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
 /// let leap = from_hmsm(3, 5, 59, 1_300);
@@ -1076,7 +1063,6 @@ impl Timelike for NaiveTime {
 /// assert_eq!(leap + Duration::seconds(10),        from_hmsm(3, 6, 9, 300));
 /// assert_eq!(leap + Duration::seconds(-10),       from_hmsm(3, 5, 50, 300));
 /// assert_eq!(leap + Duration::days(1),            from_hmsm(3, 5, 59, 300));
-/// # }
 /// ```
 impl Add<OldDuration> for NaiveTime {
     type Output = NaiveTime;
@@ -1106,7 +1092,6 @@ impl AddAssign<OldDuration> for NaiveTime {
 /// # Example
 ///
 /// ```
-/// # fn main() {
 /// use chrono::{Duration, NaiveTime};
 ///
 /// let from_hmsm = NaiveTime::from_hms_milli;
@@ -1117,24 +1102,20 @@ impl AddAssign<OldDuration> for NaiveTime {
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::seconds(2*60*60 + 6*60), from_hmsm(0, 59, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::milliseconds(80),        from_hmsm(3, 5, 6, 920));
 /// assert_eq!(from_hmsm(3, 5, 7, 950) - Duration::milliseconds(280),     from_hmsm(3, 5, 7, 670));
-/// # }
 /// ```
 ///
 /// The subtraction wraps around.
 ///
 /// ```
-/// # fn main() {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::seconds(8*60*60), from_hmsm(19, 5, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::days(800),        from_hmsm(3, 5, 7, 0));
-/// # }
 /// ```
 ///
 /// Leap seconds are handled, but the subtraction assumes that it is the only leap second happened.
 ///
 /// ```
-/// # fn main() {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
 /// let leap = from_hmsm(3, 5, 59, 1_300);
@@ -1143,7 +1124,6 @@ impl AddAssign<OldDuration> for NaiveTime {
 /// assert_eq!(leap - Duration::milliseconds(500), from_hmsm(3, 5, 59, 800));
 /// assert_eq!(leap - Duration::seconds(60),       from_hmsm(3, 5, 0, 300));
 /// assert_eq!(leap - Duration::days(1),           from_hmsm(3, 6, 0, 300));
-/// # }
 /// ```
 impl Sub<OldDuration> for NaiveTime {
     type Output = NaiveTime;
@@ -1177,7 +1157,6 @@ impl SubAssign<OldDuration> for NaiveTime {
 /// # Example
 ///
 /// ```
-/// # fn main() {
 /// use chrono::{Duration, NaiveTime};
 ///
 /// let from_hmsm = NaiveTime::from_hms_milli;
@@ -1191,14 +1170,12 @@ impl SubAssign<OldDuration> for NaiveTime {
 /// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(4, 5, 7, 900), Duration::seconds(-3600));
 /// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(2, 4, 6, 800),
 ///            Duration::seconds(3600 + 60 + 1) + Duration::milliseconds(100));
-/// # }
 /// ```
 ///
 /// Leap seconds are handled, but the subtraction assumes that
 /// there were no other leap seconds happened.
 ///
 /// ```
-/// # fn main() {
 /// # use chrono::{Duration, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
 /// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(3, 0, 59, 0), Duration::seconds(1));
@@ -1208,7 +1185,6 @@ impl SubAssign<OldDuration> for NaiveTime {
 /// assert_eq!(from_hmsm(3, 0, 0, 0) - from_hmsm(2, 59, 59, 1_000), Duration::seconds(1));
 /// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(2, 59, 59, 1_000),
 ///            Duration::seconds(61));
-/// # }
 /// ```
 impl Sub<NaiveTime> for NaiveTime {
     type Output = OldDuration;


### PR DESCRIPTION
The PR removes a bunch of outdated comments, `extern crate` statements and superfluous `fn main()` in the doc examples.