### PR TITLE
Update absolute path to 2018 syntax for WASM/wasmbind feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,34 @@ jobs:
           RUST_VERSION: stable
           WASM: wasm_simple
 
+  wasm_emscripten:
+    strategy:
+      matrix:
+        os: [macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-emscripten
+          override: true
+
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12'
+
+      - name: Build and Test
+        run: bash ci/github.sh
+        env:
+          RUST_VERSION: stable
+          WASM: wasm_emscripten
+
   cross-targets:
     strategy:
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Add optional rkyv support.
 * Add support for microseconds timestamps serde serialization for `NaiveDateTime`.
 * Add support for optional timestamps serde serialization for `NaiveDateTime`.
+* Fix build for wasm32-unknown-emscripten (@yu-re-ka #593)
 
 ## 0.4.19
 

--- a/ci/github.sh
+++ b/ci/github.sh
@@ -34,6 +34,8 @@ meaningful in the github actions feature matrix UI.
             test_wasm
         elif [[ ${WASM:-} == wasm_simple ]]; then
             test_wasm_simple
+        elif [[ ${WASM:-} == wasm_emscripten ]]; then
+            test_wasm_emscripten
         elif [[ ${CORE:-} == no_std ]]; then
             test_core
         elif [[ ${EXHAUSTIVE_TZ:-} == all_tzs ]]; then
@@ -110,6 +112,10 @@ test_wasm_simple() {
         # so re-run the test in case it took too long
         runt env TZ="$(date +%z)" NOW="$(date +%s)" wasm-pack test --node -- --features wasmbind
     fi
+}
+
+test_wasm_emscripten() {
+    runt cargo build --target wasm32-unknown-emscripten
 }
 
 main "$@"

--- a/src/offset/local.rs
+++ b/src/offset/local.rs
@@ -155,7 +155,7 @@ impl TimeZone for Local {
         let mut local = local.clone();
         // Get the offset from the js runtime
         let offset = FixedOffset::west((js_sys::Date::new_0().get_timezone_offset() as i32) * 60);
-        local -= ::Duration::seconds(offset.local_minus_utc() as i64);
+        local -= crate::Duration::seconds(offset.local_minus_utc() as i64);
         LocalResult::Single(DateTime::from_utc(local, offset))
     }
 

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -430,6 +430,7 @@ pub trait TimeZone: Sized + Clone {
     fn offset_from_local_datetime(&self, local: &NaiveDateTime) -> LocalResult<Self::Offset>;
 
     /// Converts the local `NaiveDate` to the timezone-aware `Date` if possible.
+    #[allow(clippy::wrong_self_convention)]
     fn from_local_date(&self, local: &NaiveDate) -> LocalResult<Date<Self>> {
         self.offset_from_local_date(local).map(|offset| {
             // since FixedOffset is within +/- 1 day, the date is never affected
@@ -438,6 +439,7 @@ pub trait TimeZone: Sized + Clone {
     }
 
     /// Converts the local `NaiveDateTime` to the timezone-aware `DateTime` if possible.
+    #[allow(clippy::wrong_self_convention)]
     fn from_local_datetime(&self, local: &NaiveDateTime) -> LocalResult<DateTime<Self>> {
         self.offset_from_local_datetime(local)
             .map(|offset| DateTime::from_utc(*local - offset.fix(), offset))
@@ -451,12 +453,14 @@ pub trait TimeZone: Sized + Clone {
 
     /// Converts the UTC `NaiveDate` to the local time.
     /// The UTC is continuous and thus this cannot fail (but can give the duplicate local time).
+    #[allow(clippy::wrong_self_convention)]
     fn from_utc_date(&self, utc: &NaiveDate) -> Date<Self> {
         Date::from_utc(*utc, self.offset_from_utc_date(utc))
     }
 
     /// Converts the UTC `NaiveDateTime` to the local time.
     /// The UTC is continuous and thus this cannot fail (but can give the duplicate local time).
+    #[allow(clippy::wrong_self_convention)]
     fn from_utc_datetime(&self, utc: &NaiveDateTime) -> DateTime<Self> {
         DateTime::from_utc(*utc, self.offset_from_utc_datetime(utc))
     }

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -16,15 +16,15 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-#[cfg(any(target_arch = "wasm32", target_env = "sgx"))]
+#[cfg(all(not(unix), not(windows)))]
 #[path = "stub.rs"]
 mod inner;
 
-#[cfg(all(unix, not(target_arch = "wasm32"), not(target_env = "sgx")))]
+#[cfg(unix)]
 #[path = "unix.rs"]
 mod inner;
 
-#[cfg(all(windows, not(target_arch = "wasm32"), not(target_env = "sgx")))]
+#[cfg(windows)]
 #[path = "windows.rs"]
 mod inner;
 


### PR DESCRIPTION
Fixes a compile error where a struct path is in the 2015 format. Affected wasm32 targets with features "wasmbind" and "clock" enabled.