### PR TITLE
Bump version to 0.4.20-beta.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.20-beta.1"
 description = "Date and time library for Rust"
 homepage = "https://github.com/chronotope/chrono"
 documentation = "https://docs.rs/chrono/"


### PR DESCRIPTION
In the context of #674, it would be nice to make it easier for people to test the current state of the main branch.