### PR TITLE
Fix "can't leak crate-private type in stub.rs" #662

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,7 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
           override: true
+          default: true
       - uses: Swatinem/rust-cache@v1
 
       - name: Install node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,6 +149,29 @@ jobs:
           RUST_VERSION: stable
           WASM: wasm_emscripten
 
+  wasm_unknown:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+
+      - name: Build and Test
+        run: bash ci/github.sh
+        env:
+          RUST_VERSION: stable
+          WASM: wasm_unknown
+
   cross-targets:
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,6 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
           override: true
-          default: true
       - uses: Swatinem/rust-cache@v1
 
       - name: Install node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,6 +165,7 @@ jobs:
           toolchain: stable
           target: wasm32-unknown-unknown
           override: true
+          default: true
 
       - name: Build and Test
         run: bash ci/github.sh

--- a/ci/github.sh
+++ b/ci/github.sh
@@ -36,6 +36,8 @@ meaningful in the github actions feature matrix UI.
             test_wasm_simple
         elif [[ ${WASM:-} == wasm_emscripten ]]; then
             test_wasm_emscripten
+        elif [[ ${WASM:-} == wasm_unknown ]]; then
+            test_wasm_unknown
         elif [[ ${CORE:-} == no_std ]]; then
             test_core
         elif [[ ${EXHAUSTIVE_TZ:-} == all_tzs ]]; then
@@ -116,6 +118,10 @@ test_wasm_simple() {
 
 test_wasm_emscripten() {
     runt cargo build --target wasm32-unknown-emscripten
+}
+
+test_wasm_unknown() {
+    runt cargo build --target wasm32-unknown-unknown
 }
 
 main "$@"

--- a/src/offset/sys/stub.rs
+++ b/src/offset/sys/stub.rs
@@ -65,16 +65,16 @@ fn tm_to_time(tm: &Tm) -> i64 {
         + s
 }
 
-pub(super) fn time_to_local_tm(sec: i64, tm: &mut Tm) {
+pub fn time_to_local_tm(sec: i64, tm: &mut Tm) {
     // FIXME: Add timezone logic
     time_to_tm(sec, tm);
 }
 
-pub(super) fn utc_tm_to_time(tm: &Tm) -> i64 {
+pub fn utc_tm_to_time(tm: &Tm) -> i64 {
     tm_to_time(tm)
 }
 
-pub(super) fn local_tm_to_time(tm: &Tm) -> i64 {
+pub fn local_tm_to_time(tm: &Tm) -> i64 {
     // FIXME: Add timezone logic
     tm_to_time(tm)
 }

--- a/src/offset/sys/stub.rs
+++ b/src/offset/sys/stub.rs
@@ -65,16 +65,16 @@ fn tm_to_time(tm: &Tm) -> i64 {
         + s
 }
 
-pub fn time_to_local_tm(sec: i64, tm: &mut Tm) {
+pub(super) fn time_to_local_tm(sec: i64, tm: &mut Tm) {
     // FIXME: Add timezone logic
     time_to_tm(sec, tm);
 }
 
-pub fn utc_tm_to_time(tm: &Tm) -> i64 {
+pub(super) fn utc_tm_to_time(tm: &Tm) -> i64 {
     tm_to_time(tm)
 }
 
-pub fn local_tm_to_time(tm: &Tm) -> i64 {
+pub(super) fn local_tm_to_time(tm: &Tm) -> i64 {
     // FIXME: Add timezone logic
     tm_to_time(tm)
 }


### PR DESCRIPTION
First attempt to fix this issue for wasm32-unknown-* targets by
changing visibility of functions not to leak crate-private types.

Tested and it builds correctly for wasm32-unknown-unknown.

### Thanks for contributing to chrono!

- [ ] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)
- [ ] If this pull request fixes a bug, does it add a test that verifies that
      we can't reintroduce it?

[changelog]: ../CHANGELOG.md
