### PR TITLE
docs: add `deps.rs` badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![Chrono GitHub Actions][gh-image]][gh-checks]
 [![Chrono on crates.io][cratesio-image]][cratesio]
+[![Chrono Dependencies][depsrs-image]][depsrs]
 [![Chrono on docs.rs][docsrs-image]][docsrs]
 [![Join the chat at https://gitter.im/chrono-rs/chrono][gitter-image]][gitter]
 
@@ -10,6 +11,8 @@
 [gh-checks]: https://github.com/chronotope/chrono/actions?query=workflow%3Atest
 [cratesio-image]: https://img.shields.io/crates/v/chrono.svg
 [cratesio]: https://crates.io/crates/chrono
+[depsrs-image]: https://deps.rs/repo/github/chronotope/chrono/status.svg
+[depsrs]: https://deps.rs/repo/github/chronotope/chrono
 [docsrs-image]: https://docs.rs/chrono/badge.svg
 [docsrs]: https://docs.rs/chrono
 [gitter-image]: https://badges.gitter.im/chrono-rs/chrono.svg


### PR DESCRIPTION
Adds the `deps.rs` badge to give some more awareness of the dependency status of the repository.

<hr>

### Thanks for contributing to chrono!

> - [ ] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)

Does it make sense to add myself to the changelog in this case?

[changelog]: ../CHANGELOG.md