### PR TITLE
Fix typo in month.rs

### DIFF
--- a/src/month.rs
+++ b/src/month.rs
@@ -81,7 +81,7 @@ impl Month {
     ///
     /// `m`:        | `January`  | `February` | `...` | `December`
     /// ----------- | ---------  | ---------- | --- | ---------
-    /// `m.succ()`: | `December` | `January`  | `...` | `November`
+    /// `m.pred()`: | `December` | `January`  | `...` | `November`
     #[inline]
     pub fn pred(&self) -> Month {
         match *self {


### PR DESCRIPTION
Fix a typo in the docs of pred() of month.rs (stumbled over it in reading the docs)
