### PR TITLE
Add AddAssign/SubAssign implementation to DateTime/Date

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -528,7 +528,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{Duration, Utc};
+    use super::Date;
+
+    use crate::oldtime::Duration;
+    use crate::{FixedOffset, NaiveDate, Utc};
 
     #[test]
     #[cfg(feature = "clock")]
@@ -546,5 +549,49 @@ mod tests {
         // If the given DateTime is later than now, the function will always return 0.
         let future = Utc::today() + Duration::weeks(12);
         assert_eq!(Utc::today().years_since(future), None);
+    }
+
+    #[test]
+    fn test_date_add_assign() {
+        let naivedate = NaiveDate::from_ymd(2000, 1, 1);
+        let date = Date::<Utc>::from_utc(naivedate, Utc);
+        let mut date_add = date;
+
+        date_add += Duration::days(5);
+        assert_eq!(date_add, date + Duration::days(5));
+
+        let timezone = FixedOffset::east(60 * 60);
+        let date = date.with_timezone(&timezone);
+        let date_add = date_add.with_timezone(&timezone);
+
+        assert_eq!(date_add, date + Duration::days(5));
+
+        let timezone = FixedOffset::west(2 * 60 * 60);
+        let date = date.with_timezone(&timezone);
+        let date_add = date_add.with_timezone(&timezone);
+
+        assert_eq!(date_add, date + Duration::days(5));
+    }
+
+    #[test]
+    fn test_date_sub_assign() {
+        let naivedate = NaiveDate::from_ymd(2000, 1, 1);
+        let date = Date::<Utc>::from_utc(naivedate, Utc);
+        let mut date_sub = date;
+
+        date_sub -= Duration::days(5);
+        assert_eq!(date_sub, date - Duration::days(5));
+
+        let timezone = FixedOffset::east(60 * 60);
+        let date = date.with_timezone(&timezone);
+        let date_sub = date_sub.with_timezone(&timezone);
+
+        assert_eq!(date_sub, date - Duration::days(5));
+
+        let timezone = FixedOffset::west(2 * 60 * 60);
+        let date = date.with_timezone(&timezone);
+        let date_sub = date_sub.with_timezone(&timezone);
+
+        assert_eq!(date_sub, date - Duration::days(5));
     }
 }

--- a/src/date.rs
+++ b/src/date.rs
@@ -531,7 +531,10 @@ mod tests {
     use super::Date;
 
     use crate::oldtime::Duration;
-    use crate::{FixedOffset, Local, NaiveDate, TimeZone, Utc};
+    use crate::{FixedOffset, NaiveDate, Utc};
+
+    #[cfg(feature = "clock")]
+    use crate::offset::{Local, TimeZone};
 
     #[test]
     #[cfg(feature = "clock")]
@@ -571,6 +574,12 @@ mod tests {
         let date_add = date_add.with_timezone(&timezone);
 
         assert_eq!(date_add, date + Duration::days(5));
+    }
+
+    #[test]
+    #[cfg(feature = "clock")]
+    fn test_date_add_assign_local() {
+        let naivedate = NaiveDate::from_ymd(2000, 1, 1);
 
         let date = Local.from_utc_date(&naivedate);
         let mut date_add = date;
@@ -599,6 +608,12 @@ mod tests {
         let date_sub = date_sub.with_timezone(&timezone);
 
         assert_eq!(date_sub, date - Duration::days(5));
+    }
+
+    #[test]
+    #[cfg(feature = "clock")]
+    fn test_date_sub_assign_local() {
+        let naivedate = NaiveDate::from_ymd(2000, 1, 1);
 
         let date = Local.from_utc_date(&naivedate);
         let mut date_sub = date;

--- a/src/date.rs
+++ b/src/date.rs
@@ -6,7 +6,7 @@
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::cmp::Ordering;
-use core::ops::{Add, Sub};
+use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::{fmt, hash};
 
 #[cfg(feature = "rkyv")]
@@ -479,12 +479,26 @@ impl<Tz: TimeZone> Add<OldDuration> for Date<Tz> {
     }
 }
 
+impl<Tz: TimeZone> AddAssign<OldDuration> for Date<Tz> {
+    #[inline]
+    fn add_assign(&mut self, rhs: OldDuration) {
+        self.date += rhs;
+    }
+}
+
 impl<Tz: TimeZone> Sub<OldDuration> for Date<Tz> {
     type Output = Date<Tz>;
 
     #[inline]
     fn sub(self, rhs: OldDuration) -> Date<Tz> {
         self.checked_sub_signed(rhs).expect("`Date - Duration` overflowed")
+    }
+}
+
+impl<Tz: TimeZone> SubAssign<OldDuration> for Date<Tz> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: OldDuration) {
+        self.date -= rhs;
     }
 }
 

--- a/src/date.rs
+++ b/src/date.rs
@@ -482,7 +482,7 @@ impl<Tz: TimeZone> Add<OldDuration> for Date<Tz> {
 impl<Tz: TimeZone> AddAssign<OldDuration> for Date<Tz> {
     #[inline]
     fn add_assign(&mut self, rhs: OldDuration) {
-        self.date += rhs;
+        self.date = self.date.checked_add_signed(rhs).expect("`Date + Duration` overflowed");
     }
 }
 
@@ -498,7 +498,7 @@ impl<Tz: TimeZone> Sub<OldDuration> for Date<Tz> {
 impl<Tz: TimeZone> SubAssign<OldDuration> for Date<Tz> {
     #[inline]
     fn sub_assign(&mut self, rhs: OldDuration) {
-        self.date -= rhs;
+        self.date = self.date.checked_sub_signed(rhs).expect("`Date - Duration` overflowed");
     }
 }
 
@@ -531,7 +531,7 @@ mod tests {
     use super::Date;
 
     use crate::oldtime::Duration;
-    use crate::{FixedOffset, NaiveDate, Utc};
+    use crate::{FixedOffset, Local, NaiveDate, TimeZone, Utc};
 
     #[test]
     #[cfg(feature = "clock")]
@@ -571,6 +571,12 @@ mod tests {
         let date_add = date_add.with_timezone(&timezone);
 
         assert_eq!(date_add, date + Duration::days(5));
+
+        let date = Local.from_utc_date(&naivedate);
+        let mut date_add = date;
+
+        date_add += Duration::days(5);
+        assert_eq!(date_add, date + Duration::days(5));
     }
 
     #[test]
@@ -592,6 +598,12 @@ mod tests {
         let date = date.with_timezone(&timezone);
         let date_sub = date_sub.with_timezone(&timezone);
 
+        assert_eq!(date_sub, date - Duration::days(5));
+
+        let date = Local.from_utc_date(&naivedate);
+        let mut date_sub = date;
+
+        date_sub -= Duration::days(5);
         assert_eq!(date_sub, date - Duration::days(5));
     }
 }

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -855,7 +855,10 @@ impl<Tz: TimeZone> Add<OldDuration> for DateTime<Tz> {
 impl<Tz: TimeZone> AddAssign<OldDuration> for DateTime<Tz> {
     #[inline]
     fn add_assign(&mut self, rhs: OldDuration) {
-        self.datetime += rhs;
+        let datetime =
+            self.datetime.checked_add_signed(rhs).expect("`DateTime + Duration` overflowed");
+        let tz = self.timezone();
+        *self = tz.from_utc_datetime(&datetime);
     }
 }
 
@@ -871,7 +874,10 @@ impl<Tz: TimeZone> Sub<OldDuration> for DateTime<Tz> {
 impl<Tz: TimeZone> SubAssign<OldDuration> for DateTime<Tz> {
     #[inline]
     fn sub_assign(&mut self, rhs: OldDuration) {
-        self.datetime -= rhs;
+        let datetime =
+            self.datetime.checked_sub_signed(rhs).expect("`DateTime - Duration` overflowed");
+        let tz = self.timezone();
+        *self = tz.from_utc_datetime(&datetime)
     }
 }
 

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -11,7 +11,7 @@ use alloc::string::{String, ToString};
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::cmp::Ordering;
-use core::ops::{Add, Sub};
+use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::{fmt, hash, str};
 #[cfg(feature = "std")]
 use std::string::ToString;
@@ -852,12 +852,26 @@ impl<Tz: TimeZone> Add<OldDuration> for DateTime<Tz> {
     }
 }
 
+impl<Tz: TimeZone> AddAssign<OldDuration> for DateTime<Tz> {
+    #[inline]
+    fn add_assign(&mut self, rhs: OldDuration) {
+        self.datetime += rhs;
+    }
+}
+
 impl<Tz: TimeZone> Sub<OldDuration> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
     #[inline]
     fn sub(self, rhs: OldDuration) -> DateTime<Tz> {
         self.checked_sub_signed(rhs).expect("`DateTime - Duration` overflowed")
+    }
+}
+
+impl<Tz: TimeZone> SubAssign<OldDuration> for DateTime<Tz> {
+    #[inline]
+    fn sub_assign(&mut self, rhs: OldDuration) {
+        self.datetime -= rhs;
     }
 }
 

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -447,6 +447,12 @@ fn test_datetime_add_assign() {
     let datetime_add = datetime_add.with_timezone(&timezone);
 
     assert_eq!(datetime_add, datetime + Duration::seconds(60));
+}
+
+#[test]
+#[cfg(feature = "clock")]
+fn test_datetime_add_assign_local() {
+    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0);
 
     let datetime = Local.from_utc_datetime(&naivedatetime);
     let mut datetime_add = datetime;
@@ -475,6 +481,12 @@ fn test_datetime_sub_assign() {
     let datetime_sub = datetime_sub.with_timezone(&timezone);
 
     assert_eq!(datetime_sub, datetime - Duration::minutes(90));
+}
+
+#[test]
+#[cfg(feature = "clock")]
+fn test_datetime_sub_assign_local() {
+    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).and_hms(12, 0, 0);
 
     let datetime = Local.from_utc_datetime(&naivedatetime);
     let mut datetime_sub = datetime;

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -452,13 +452,16 @@ fn test_datetime_add_assign() {
 #[test]
 #[cfg(feature = "clock")]
 fn test_datetime_add_assign_local() {
-    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0);
+    let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0);
 
     let datetime = Local.from_utc_datetime(&naivedatetime);
-    let mut datetime_add = datetime;
+    let mut datetime_add = Local.from_utc_datetime(&naivedatetime);
 
-    datetime_add += Duration::seconds(60);
-    assert_eq!(datetime_add, datetime + Duration::seconds(60));
+    // ensure we cross a DST transition
+    for i in 1..=365 {
+        datetime_add += Duration::days(1);
+        assert_eq!(datetime_add, datetime + Duration::days(i))
+    }
 }
 
 #[test]
@@ -486,11 +489,14 @@ fn test_datetime_sub_assign() {
 #[test]
 #[cfg(feature = "clock")]
 fn test_datetime_sub_assign_local() {
-    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).and_hms(12, 0, 0);
+    let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0);
 
     let datetime = Local.from_utc_datetime(&naivedatetime);
-    let mut datetime_sub = datetime;
+    let mut datetime_sub = Local.from_utc_datetime(&naivedatetime);
 
-    datetime_sub -= Duration::minutes(90);
-    assert_eq!(datetime_sub, datetime - Duration::minutes(90));
+    // ensure we cross a DST transition
+    for i in 1..=365 {
+        datetime_sub -= Duration::days(1);
+        assert_eq!(datetime_sub, datetime - Duration::days(i))
+    }
 }

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -447,6 +447,12 @@ fn test_datetime_add_assign() {
     let datetime_add = datetime_add.with_timezone(&timezone);
 
     assert_eq!(datetime_add, datetime + Duration::seconds(60));
+
+    let datetime = Local.from_utc_datetime(&naivedatetime);
+    let mut datetime_add = datetime;
+
+    datetime_add += Duration::seconds(60);
+    assert_eq!(datetime_add, datetime + Duration::seconds(60));
 }
 
 #[test]
@@ -468,5 +474,11 @@ fn test_datetime_sub_assign() {
     let datetime = datetime.with_timezone(&timezone);
     let datetime_sub = datetime_sub.with_timezone(&timezone);
 
+    assert_eq!(datetime_sub, datetime - Duration::minutes(90));
+
+    let datetime = Local.from_utc_datetime(&naivedatetime);
+    let mut datetime_sub = datetime;
+
+    datetime_sub -= Duration::minutes(90);
     assert_eq!(datetime_sub, datetime - Duration::minutes(90));
 }

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -426,3 +426,47 @@ fn test_years_elapsed() {
     let future = Utc::today() + Duration::weeks(12);
     assert_eq!(Utc::today().years_since(future), None);
 }
+
+#[test]
+fn test_datetime_add_assign() {
+    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0);
+    let datetime = DateTime::<Utc>::from_utc(naivedatetime, Utc);
+    let mut datetime_add = datetime;
+
+    datetime_add += Duration::seconds(60);
+    assert_eq!(datetime_add, datetime + Duration::seconds(60));
+
+    let timezone = FixedOffset::east(60 * 60);
+    let datetime = datetime.with_timezone(&timezone);
+    let datetime_add = datetime_add.with_timezone(&timezone);
+
+    assert_eq!(datetime_add, datetime + Duration::seconds(60));
+
+    let timezone = FixedOffset::west(2 * 60 * 60);
+    let datetime = datetime.with_timezone(&timezone);
+    let datetime_add = datetime_add.with_timezone(&timezone);
+
+    assert_eq!(datetime_add, datetime + Duration::seconds(60));
+}
+
+#[test]
+fn test_datetime_sub_assign() {
+    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).and_hms(12, 0, 0);
+    let datetime = DateTime::<Utc>::from_utc(naivedatetime, Utc);
+    let mut datetime_sub = datetime;
+
+    datetime_sub -= Duration::minutes(90);
+    assert_eq!(datetime_sub, datetime - Duration::minutes(90));
+
+    let timezone = FixedOffset::east(60 * 60);
+    let datetime = datetime.with_timezone(&timezone);
+    let datetime_sub = datetime_sub.with_timezone(&timezone);
+
+    assert_eq!(datetime_sub, datetime - Duration::minutes(90));
+
+    let timezone = FixedOffset::west(2 * 60 * 60);
+    let datetime = datetime.with_timezone(&timezone);
+    let datetime_sub = datetime_sub.with_timezone(&timezone);
+
+    assert_eq!(datetime_sub, datetime - Duration::minutes(90));
+}


### PR DESCRIPTION
This implements the AddAsssign and SubAssign traits for the non-naive DateTime and Date structs.