### PR TITLE
Morph elapsed_years() API into years_since()

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -357,20 +357,19 @@ impl<Tz: TimeZone> DateTime<Tz> {
     }
 
     /// Retrieve the elapsed years from now to the given [`DateTime`].
-    #[cfg(feature = "clock")]
-    pub fn elapsed_years(&self) -> u32 {
-        let now = Utc::now().with_timezone(&self.timezone());
+    pub fn years_since(&self, base: Self) -> Option<u32> {
+        let mut years = self.year() - base.year();
+        let earlier_time =
+            (self.month(), self.day(), self.time()) < (base.month(), base.day(), base.time());
 
-        let years =
-            if (now.month(), now.day(), now.time()) < (self.month(), self.day(), self.time()) {
-                now.year() - self.year() - 1
-            } else {
-                now.year() - self.year()
-            };
-        if years.is_positive() {
-            years as u32
-        } else {
-            0
+        years -= match earlier_time {
+            true => 1,
+            false => 0,
+        };
+
+        match years >= 0 {
+            true => Some(years as u32),
+            false => None,
         }
     }
 }

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1,8 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::DateTime;
-#[cfg(feature = "clock")]
-use crate::consts::f64;
 use crate::naive::{NaiveDate, NaiveTime};
 #[cfg(feature = "clock")]
 use crate::offset::Local;
@@ -413,14 +411,17 @@ fn test_datetime_from_local() {
 #[test]
 #[cfg(feature = "clock")]
 fn test_years_elapsed() {
-    // This is always at least one year because 1 year = 52.1775 weeks.
-    let one_year_ago = Utc::today() - Duration::weeks((f64::WEEKS_PER_YEAR * 1.5).ceil() as i64);
-    // A bit more than 2 years.
-    let two_year_ago = Utc::today() - Duration::weeks((f64::WEEKS_PER_YEAR * 2.5).ceil() as i64);
+    const WEEKS_PER_YEAR: f32 = 52.1775;
 
-    assert_eq!(one_year_ago.elapsed_years(), 1);
-    assert_eq!(two_year_ago.elapsed_years(), 2);
+    // This is always at least one year because 1 year = 52.1775 weeks.
+    let one_year_ago = Utc::today() - Duration::weeks((WEEKS_PER_YEAR * 1.5).ceil() as i64);
+    // A bit more than 2 years.
+    let two_year_ago = Utc::today() - Duration::weeks((WEEKS_PER_YEAR * 2.5).ceil() as i64);
+
+    assert_eq!(Utc::today().years_since(one_year_ago), Some(1));
+    assert_eq!(Utc::today().years_since(two_year_ago), Some(2));
 
     // If the given DateTime is later than now, the function will always return 0.
-    assert_eq!((Utc::today() + Duration::weeks(12)).elapsed_years(), 0);
+    let future = Utc::today() + Duration::weeks(12);
+    assert_eq!(Utc::today().years_since(future), None);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -508,20 +508,6 @@ pub use month::{Month, ParseMonthError};
 mod traits;
 pub use traits::{Datelike, Timelike};
 
-/// Constants that can be used by all components.
-pub mod consts {
-    /// Constants of type `f32`.
-    pub mod f32 {
-        /// Number of weeks in a year.
-        pub const WEEKS_PER_YEAR: f32 = 52.1775;
-    }
-    /// Constants of type `f64`.
-    pub mod f64 {
-        /// Number of weeks in a year.
-        pub const WEEKS_PER_YEAR: f64 = 52.1775;
-    }
-}
-
 #[cfg(feature = "__internal_bench")]
 #[doc(hidden)]
 pub use naive::__BenchYearFlags;


### PR DESCRIPTION
@yozhgoor would you like to review? This:

* Is more flexible, since it allows you to provide both dates for the interval
* Is more precise, since it returns `None` if the `base` is in the future
* Doesn't have to be guarded with `[cfg(feature = "clock")]` since it doesn't rely on `Utc::today()`
* Does not expose imprecise new constants as part of the public API