### PR TITLE
Remove unused libc dependency from Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Implement `DoubleEndedIterator` for `NaiveDateDaysIterator` and `NaiveDateWeeksIterator`
 * Fix panicking when parsing a `DateTime` (@botahamec)
 * Add support for getting week bounds based on a specific `NaiveDate` and a `Weekday` (#666)
+* Remove libc dependency from Cargo.toml.
 
 ## 0.4.19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "chrono"
 default = ["clock", "std", "oldtime"]
 alloc = []
 std = []
-clock = ["libc", "std", "winapi"]
+clock = ["std", "winapi"]
 oldtime = ["time"]
 wasmbind = ["wasm-bindgen", "js-sys"]
 unstable-locales = ["pure-rust-locales", "alloc"]
@@ -31,7 +31,6 @@ __internal_bench = ["criterion"]
 __doctest = []
 
 [dependencies]
-libc = { version = "0.2.69", optional = true }
 time = { version = "0.1.43", optional = true }
 num-integer = { version = "0.1.36", default-features = false }
 num-traits = { version = "0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ name = "chrono"
 [features]
 default = ["clock", "std", "oldtime"]
 alloc = []
+libc = []
 std = []
 clock = ["std", "winapi"]
 oldtime = ["time"]

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Default features:
 - `std`: Enables functionality that depends on the standard library. This
   is a superset of `alloc` and adds interoperation with standard library types
   and traits.
-- `clock`: enables reading the system time (`now`), independent of whether
-  `std::time::SystemTime` is present, depends on having a libc.
+- `clock`: Enables reading the system time (`now`) that depends on the standard library for
+UNIX-like operating systems and the Windows API (`winapi`) for Windows.
 
 Optional features:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,8 +42,8 @@
 //! - `std`: Enables functionality that depends on the standard library. This
 //!   is a superset of `alloc` and adds interoperation with standard library types
 //!   and traits.
-//! - `clock`: enables reading the system time (`now`), independent of whether
-//!   `std::time::SystemTime` is present, depends on having a libc.
+//! - `clock`: Enables reading the system time (`now`) that depends on the standard library for
+//! UNIX-like operating systems and the Windows API (`winapi`) for Windows.
 //!
 //! Optional features:
 //!


### PR DESCRIPTION
### Thanks for contributing to chrono!

- [x] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)
- [ ] If this pull request fixes a bug, does it add a test that verifies that
      we can't reintroduce it?

[changelog]: ../CHANGELOG.md

libc dependency should be removed as it is no longer directly used by chrono. I'm not sure whether the changelog should document this change.