### PR TITLE
`NaiveDateTime` to `DateTime` helper method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,10 @@ Versions with only mechanical changes will be omitted from the following list.
 * Fix build for wasm32-unknown-emscripten (@yu-re-ka #593)
 * Make `ParseErrorKind` public and available through `ParseError::kind()` (#588)
 * Implement `DoubleEndedIterator` for `NaiveDateDaysIterator` and `NaiveDateWeeksIterator`
-<<<<<<< HEAD
 * Fix panicking when parsing a `DateTime` (@botahamec)
 * Add support for getting week bounds based on a specific `NaiveDate` and a `Weekday` (#666)
 * Remove libc dependency from Cargo.toml.
-* Add the `with_timezone` method to `NaiveDateTime`
+* Add the `and_timezone` method to `NaiveDateTime`
 
 ## 0.4.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Fix panicking when parsing a `DateTime` (@botahamec)
 * Add support for getting week bounds based on a specific `NaiveDate` and a `Weekday` (#666)
 * Remove libc dependency from Cargo.toml.
-* Add the `and_timezone` method to `NaiveDateTime`
+* Add the `and_local_timezone` method to `NaiveDateTime`
 
 ## 0.4.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,11 @@ Versions with only mechanical changes will be omitted from the following list.
 * Fix build for wasm32-unknown-emscripten (@yu-re-ka #593)
 * Make `ParseErrorKind` public and available through `ParseError::kind()` (#588)
 * Implement `DoubleEndedIterator` for `NaiveDateDaysIterator` and `NaiveDateWeeksIterator`
+<<<<<<< HEAD
 * Fix panicking when parsing a `DateTime` (@botahamec)
 * Add support for getting week bounds based on a specific `NaiveDate` and a `Weekday` (#666)
 * Remove libc dependency from Cargo.toml.
+* Add the `with_timezone` method to `NaiveDateTime`
 
 ## 0.4.19
 

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -732,7 +732,7 @@ impl NaiveDateTime {
     /// use chrono::{NaiveDate, Utc};
     /// let dt = NaiveDate::from_ymd(2015, 9, 5).and_hms(23, 56, 4).and_timezone(Utc).unwrap();
     /// assert_eq!(dt.timezone(), Utc);
-    pub fn and_timezone<Tz: TimeZone>(&self, tz: Tz) -> LocalResult<DateTime<Tz>> {
+    pub fn and_local_timezone<Tz: TimeZone>(&self, tz: Tz) -> LocalResult<DateTime<Tz>> {
         tz.from_local_datetime(self)
     }
 }

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -21,7 +21,7 @@ use crate::naive::date::{MAX_DATE, MIN_DATE};
 use crate::naive::time::{MAX_TIME, MIN_TIME};
 use crate::naive::{IsoWeek, NaiveDate, NaiveTime};
 use crate::oldtime::Duration as OldDuration;
-use crate::{Datelike, Timelike, Weekday};
+use crate::{Datelike, Timelike, Weekday, DateTime, LocalResult, TimeZone};
 
 #[cfg(feature = "rustc-serialize")]
 pub(super) mod rustc_serialize;
@@ -721,6 +721,19 @@ impl NaiveDateTime {
     #[inline]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
         self.format_with_items(StrftimeItems::new(fmt))
+    }
+
+    /// Converts the `NaiveDateTime` into the timezone-aware `DateTime<Tz>`
+    /// with the provided timezone, if possible.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use chrono::{NaiveDate, Utc};
+    /// let dt = NaiveDate::from_ymd(2015, 9, 5).and_hms(23, 56, 4).and_timezone(Utc).unwrap();
+    /// assert_eq!(dt.timezone(), Utc);
+    pub fn and_timezone<Tz: TimeZone>(&self, tz: Tz) -> LocalResult<DateTime<Tz>> {
+        tz.from_local_datetime(self)
     }
 }
 

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -726,11 +726,14 @@ impl NaiveDateTime {
     /// Converts the `NaiveDateTime` into the timezone-aware `DateTime<Tz>`
     /// with the provided timezone, if possible.
     ///
+    /// This is experimental and might be removed in the future. Feel free to
+    /// let us know what you think about this API.
+    ///
     /// # Example
     ///
     /// ```
     /// use chrono::{NaiveDate, Utc};
-    /// let dt = NaiveDate::from_ymd(2015, 9, 5).and_hms(23, 56, 4).and_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 9, 5).and_hms(23, 56, 4).and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timezone(), Utc);
     pub fn and_local_timezone<Tz: TimeZone>(&self, tz: Tz) -> LocalResult<DateTime<Tz>> {
         tz.from_local_datetime(self)

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -21,7 +21,7 @@ use crate::naive::date::{MAX_DATE, MIN_DATE};
 use crate::naive::time::{MAX_TIME, MIN_TIME};
 use crate::naive::{IsoWeek, NaiveDate, NaiveTime};
 use crate::oldtime::Duration as OldDuration;
-use crate::{Datelike, Timelike, Weekday, DateTime, LocalResult, TimeZone};
+use crate::{DateTime, Datelike, LocalResult, TimeZone, Timelike, Weekday};
 
 #[cfg(feature = "rustc-serialize")]
 pub(super) mod rustc_serialize;

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -1,7 +1,7 @@
 use super::NaiveDateTime;
 use crate::naive::{NaiveDate, MAX_DATE, MIN_DATE};
 use crate::oldtime::Duration;
-use crate::{Datelike, Utc, FixedOffset};
+use crate::{Datelike, FixedOffset, Utc};
 use std::i64;
 
 #[test]

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -1,7 +1,7 @@
 use super::NaiveDateTime;
 use crate::naive::{NaiveDate, MAX_DATE, MIN_DATE};
 use crate::oldtime::Duration;
-use crate::Datelike;
+use crate::{Datelike, Utc, FixedOffset};
 use std::i64;
 
 #[test]
@@ -239,4 +239,17 @@ fn test_nanosecond_range() {
         parsed,
         NaiveDateTime::from_timestamp(nanos / A_BILLION, (nanos % A_BILLION) as u32)
     );
+}
+
+#[test]
+fn test_and_timezone() {
+    let ndt = NaiveDate::from_ymd(2022, 6, 15).and_hms(18, 59, 36);
+    let dt_utc = ndt.and_timezone(Utc).unwrap();
+    assert_eq!(dt_utc.naive_local(), ndt);
+    assert_eq!(dt_utc.timezone(), Utc);
+
+    let offset_tz = FixedOffset::west(4 * 3600);
+    let dt_offset = ndt.and_timezone(offset_tz).unwrap();
+    assert_eq!(dt_offset.naive_local(), ndt);
+    assert_eq!(dt_offset.timezone(), offset_tz);
 }

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -244,12 +244,12 @@ fn test_nanosecond_range() {
 #[test]
 fn test_and_timezone() {
     let ndt = NaiveDate::from_ymd(2022, 6, 15).and_hms(18, 59, 36);
-    let dt_utc = ndt.and_timezone(Utc).unwrap();
+    let dt_utc = ndt.and_local_timezone(Utc).unwrap();
     assert_eq!(dt_utc.naive_local(), ndt);
     assert_eq!(dt_utc.timezone(), Utc);
 
     let offset_tz = FixedOffset::west(4 * 3600);
-    let dt_offset = ndt.and_timezone(offset_tz).unwrap();
+    let dt_offset = ndt.and_local_timezone(offset_tz).unwrap();
     assert_eq!(dt_offset.naive_local(), ndt);
     assert_eq!(dt_offset.timezone(), offset_tz);
 }


### PR DESCRIPTION
fixes #687

I chose `and_timezone` as the method name. The issue proposes using `to_datetime_local`. I can see pros and cons with both, so let me know if we want to use a different name