### PR TITLE
Removed a couple of zero-prefixed literals

### DIFF
--- a/benches/chrono.rs
+++ b/benches/chrono.rs
@@ -36,13 +36,13 @@ fn bench_datetime_from_str(c: &mut Criterion) {
 
 fn bench_datetime_to_rfc2822(c: &mut Criterion) {
     let pst = FixedOffset::east(8 * 60 * 60);
-    let dt = pst.ymd(2018, 1, 11).and_hms_nano(10, 5, 13, 084_660_000);
+    let dt = pst.ymd(2018, 1, 11).and_hms_nano(10, 5, 13, 84_660_000);
     c.bench_function("bench_datetime_to_rfc2822", |b| b.iter(|| black_box(dt).to_rfc2822()));
 }
 
 fn bench_datetime_to_rfc3339(c: &mut Criterion) {
     let pst = FixedOffset::east(8 * 60 * 60);
-    let dt = pst.ymd(2018, 1, 11).and_hms_nano(10, 5, 13, 084_660_000);
+    let dt = pst.ymd(2018, 1, 11).and_hms_nano(10, 5, 13, 84_660_000);
     c.bench_function("bench_datetime_to_rfc3339", |b| b.iter(|| black_box(dt).to_rfc3339()));
 }
 


### PR DESCRIPTION
Small change to remove a couple of clippy warnings. 
