### PR TITLE
Create `add_months()` method on `NaiveDate`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ target
 Cargo.lock
 .tool-versions
 
-# for jetrains users
+# for jetbrains users
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target
 Cargo.lock
 .tool-versions
+
+# for jetrains users
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Fix the behavior of `Duration::abs()` for negative durations with non-zero nanos
 * Add compatibility with rfc2822 comments (#733)
 * Make `js-sys` and `wasm-bindgen` enabled by default when target is `wasm32-unknown-unknown` for ease of API discovery
-* Add the `add_months` method to `NaiveDate`
+* Add the `Months` struct and associated `Add` and `Sub` impls
 
 ## 0.4.19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Fix the behavior of `Duration::abs()` for negative durations with non-zero nanos
 * Add compatibility with rfc2822 comments (#733)
 * Make `js-sys` and `wasm-bindgen` enabled by default when target is `wasm32-unknown-unknown` for ease of API discovery
+* Add the `add_months` method to `NaiveDate`
 
 ## 0.4.19
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,7 +507,7 @@ mod weekday;
 pub use weekday::{ParseWeekdayError, Weekday};
 
 mod month;
-pub use month::{Month, ParseMonthError};
+pub use month::{Month, ParseMonthError, Months};
 
 mod traits;
 pub use traits::{Datelike, Timelike};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,7 +507,7 @@ mod weekday;
 pub use weekday::{ParseWeekdayError, Weekday};
 
 mod month;
-pub use month::{Month, ParseMonthError, Months};
+pub use month::{Month, Months, ParseMonthError};
 
 mod traits;
 pub use traits::{Datelike, Timelike};

--- a/src/month.rs
+++ b/src/month.rs
@@ -189,6 +189,10 @@ impl num_traits::FromPrimitive for Month {
     }
 }
 
+/// A duration in calendar months
+#[derive(Clone, Debug, PartialEq)]
+pub struct Months(pub usize);
+
 /// An error resulting from reading `<Month>` value with `FromStr`.
 #[derive(Clone, PartialEq)]
 pub struct ParseMonthError {

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -5,9 +5,9 @@
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
+use core::convert::TryFrom;
 use core::ops::{Add, AddAssign, RangeInclusive, Sub, SubAssign};
 use core::{fmt, str};
-use std::convert::TryFrom;
 
 use num_integer::div_mod_floor;
 use num_traits::ToPrimitive;

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -5,7 +5,6 @@
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
-use core::convert::TryFrom;
 use core::ops::{Add, AddAssign, RangeInclusive, Sub, SubAssign};
 use core::{fmt, str};
 
@@ -631,10 +630,7 @@ impl NaiveDate {
     ///
     /// A new NaiveDate on the first day of the resulting year & month
     fn add_months_get_first_day(&self, delta: i32) -> NaiveDate {
-        let zeroed_months =
-            i32::try_from(self.month()) // zero-based for modulo operations
-                .expect("add_months_get_first_day does not support extreme values")
-                - 1;
+        let zeroed_months = self.month() as i32 - 1; // zero-based for modulo operations
         let res_months = zeroed_months + delta;
         let delta_years = if res_months < 0 {
             // no f32::floor when no_std
@@ -649,10 +645,7 @@ impl NaiveDate {
         let res_years = self.year() + delta_years;
         let res_months = res_months % 12;
         let res_months = if res_months < 0 { res_months + 12 } else { res_months };
-        let res_months = u32::try_from(res_months)
-            .expect("add_month_get_first_day should never have a negative result")
-            + 1;
-        NaiveDate::from_ymd(res_years, res_months, 1)
+        NaiveDate::from_ymd(res_years, res_months as u32 + 1, 1)
     }
 
     /// Makes a new `NaiveDateTime` from the current date and given `NaiveTime`.

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -610,7 +610,6 @@ impl NaiveDate {
         let zeroed_months = self.month() as i32 - 1; // zero-based for modulo operations
         let res_months = zeroed_months + delta;
         let delta_years = if res_months < 0 {
-            // no f32::floor when no_std
             if (-res_months) % 12 > 0 {
                 res_months / 12 - 1
             } else {


### PR DESCRIPTION
The Apache [arrow-datafusion](https://arrow.apache.org/datafusion/) project is a query engine that supports doing date math with arrow primitives like [IntervalYearMonth](https://docs.rs/arrow/latest/arrow/datatypes/struct.IntervalYearMonthType.html), which despite being a common part of SQL standards, adding months to a NaiveDate was surprisingly non-trivial to perform correctly.

Support is being added to `arrow-datafusion` in [this PR](https://github.com/apache/arrow-datafusion/pull/2797), but it seemed like logic like this might best make it's home in the `chrono` crate, so that others don't have to re-implement this logic. A quick search of issues reveals some demand:

- https://github.com/chronotope/chrono/issues/474
- https://github.com/chronotope/chrono/issues/290

Unfortunately, I realize there is no `Duration::Month` because it doesn't represent a fixed duration in time, so hopefully this is an acceptable compromise. If not, I defer to the maintainers on the best way to implement such functionality.