### PR TITLE
Some experiments around formatting using constants

### DIFF
--- a/src/format/literal.rs
+++ b/src/format/literal.rs
@@ -1,0 +1,246 @@
+use super::{Fixed, Item, Numeric, Pad};
+
+/// Useful macro
+#[macro_export]
+macro_rules! items {
+
+    ( $pad:expr;   $( $i:tt ),+  ) => {
+        &[
+            $(
+                __item_with_pad!($pad, $i),
+            )*
+        ]
+    };
+
+    ( $pad:expr;   $( $i:tt ),+  ,) => {
+        &[
+            $(
+                item_with_pad!($pad, $i),
+            )*
+        ]
+    };
+
+    ( $( $i:expr ),+ ) => {
+        &[
+            $(
+                __item!($i),
+            )*
+        ]
+    };
+    ( $( $i:expr ),+ ,) => {
+        &[
+            $(
+                __item!($i),
+            )*
+        ]
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __item_with_pad {
+    // plugs in the default padding
+    // eg year, month
+    ( $pad:expr, $item:ident ) => {
+        $crate::format::literal::$item($pad)
+    };
+
+    // user provided padding
+    // eg year(Pad::Zero), etc
+    ( $_:expr, $item:literal ) => {
+        $crate::format::Item::Literal($item)
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __item {
+    // user provided padding
+    // eg year(Pad::Zero), etc
+    ( $item:literal ) => {
+        $crate::format::Item::Literal($item)
+    };
+
+    // user provided padding
+    // eg year(Pad::Zero), etc
+    ( $item:expr ) => {
+        $item
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::format::{Item, Numeric, Pad, StrftimeItems};
+
+    const ISO8601_A: &[Item<'static>] = items![
+        Pad::Zero; year, "-", month, "-", day, "T", hour, ":", minute, ":", second, "Z"
+    ];
+
+    const ISO8601_B: &[Item<'static>] = items![
+        super::year(Pad::Zero),
+        "-",
+        super::month(Pad::Zero),
+        "-",
+        super::day(Pad::Zero),
+        "T",
+        super::hour(Pad::Zero),
+        ":",
+        super::minute(Pad::Zero),
+        ":",
+        super::second(Pad::Zero),
+        "Z"
+    ];
+
+    const ISO8601_C: &[Item<'static>] = &[
+        super::year(Pad::Zero),
+        super::lit("-"),
+        super::month(Pad::Zero),
+        super::lit("-"),
+        super::day(Pad::Zero),
+        super::lit("T"),
+        super::hour(Pad::Zero),
+        super::lit(":"),
+        super::minute(Pad::Zero),
+        super::lit(":"),
+        super::second(Pad::Zero),
+        super::lit("Z"),
+    ];
+
+    const ISO8601_D: &[Item<'static>] = &[
+        Item::Numeric(Numeric::Year, Pad::Zero),
+        Item::Literal("-"),
+        Item::Numeric(Numeric::Month, Pad::Zero),
+        Item::Literal("-"),
+        Item::Numeric(Numeric::Day, Pad::Zero),
+        Item::Literal("T"),
+        Item::Numeric(Numeric::Hour, Pad::Zero),
+        Item::Literal(":"),
+        Item::Numeric(Numeric::Minute, Pad::Zero),
+        Item::Literal(":"),
+        Item::Numeric(Numeric::Second, Pad::Zero),
+        Item::Literal("Z"),
+    ];
+
+    #[test]
+    fn test_items_strftime_equivalent() {
+        assert_eq!(
+            ISO8601_A.to_vec(),
+            StrftimeItems::new("%Y-%m-%dT%H:%M:%SZ").collect::<Vec<_>>(),
+        );
+        assert_eq!(
+            ISO8601_B.to_vec(),
+            StrftimeItems::new("%Y-%m-%dT%H:%M:%SZ").collect::<Vec<_>>(),
+        );
+        assert_eq!(
+            ISO8601_C.to_vec(),
+            StrftimeItems::new("%Y-%m-%dT%H:%M:%SZ").collect::<Vec<_>>(),
+        );
+        assert_eq!(
+            ISO8601_D.to_vec(),
+            StrftimeItems::new("%Y-%m-%dT%H:%M:%SZ").collect::<Vec<_>>(),
+        );
+    }
+}
+
+/// Produces the `Item` for ...
+pub const fn lit(s: &'static str) -> Item<'static> {
+    Item::Literal(s)
+}
+
+/// Produces the `Item` for ...
+pub const fn space(s: &'static str) -> Item<'static> {
+    Item::Space(s)
+}
+
+/// Produces the `Item` for ...
+pub const fn year(pad: Pad) -> Item<'static> {
+    Item::Numeric(Numeric::Year, pad)
+}
+
+/// Produces the `Item` for ...
+pub const fn year00(pad: Pad) -> Item<'static> {
+    Item::Numeric(Numeric::YearMod100, pad)
+}
+
+/// Produces the `Item` for ...
+pub const fn month(pad: Pad) -> Item<'static> {
+    Item::Numeric(Numeric::Month, pad)
+}
+
+/// Produces the `Item` for ...
+pub const fn short_month() -> Item<'static> {
+    Item::Fixed(Fixed::ShortMonthName)
+}
+
+/// Produces the `Item` for ...
+pub const fn long_month() -> Item<'static> {
+    Item::Fixed(Fixed::LongMonthName)
+}
+
+/// Produces the `Item` for ...
+pub const fn day(pad: Pad) -> Item<'static> {
+    Item::Numeric(Numeric::Day, pad)
+}
+
+/// Produces the `Item` for ...
+pub const fn short_day() -> Item<'static> {
+    Item::Fixed(Fixed::ShortWeekdayName)
+}
+
+/// Produces the `Item` for ...
+pub const fn long_day() -> Item<'static> {
+    Item::Fixed(Fixed::LongWeekdayName)
+}
+
+/// Produces the `Item` for ...
+pub const fn hour(pad: Pad) -> Item<'static> {
+    Item::Numeric(Numeric::Hour, pad)
+}
+
+/// Produces the `Item` for ...
+pub const fn hour12(pad: Pad) -> Item<'static> {
+    Item::Numeric(Numeric::Hour12, pad)
+}
+
+/// Produces the `Item` for ...
+pub const fn minute(pad: Pad) -> Item<'static> {
+    Item::Numeric(Numeric::Minute, pad)
+}
+
+/// Produces the `Item` for ...
+pub const fn second(pad: Pad) -> Item<'static> {
+    Item::Numeric(Numeric::Second, pad)
+}
+
+// remainig from Numeric
+//     YearDiv100,
+//     IsoYear,
+//     IsoYearDiv100,
+//     IsoYearMod100,
+//     WeekFromSun,
+//     WeekFromMon,
+//     IsoWeek,
+//     NumDaysFromSun,
+//     WeekdayFromMon,
+//     Ordinal,
+//     Hour,
+//     Hour12,
+//     Minute,
+//     Second,
+//     Nanosecond,
+//     Timestamp,
+
+// remainin from Fixed
+// LowerAmPm,
+// UpperAmPm,
+// Nanosecond,
+// Nanosecond3,
+// Nanosecond6,
+// Nanosecond9,
+// TimezoneName,
+// TimezoneOffsetColon,
+//  TimezoneOffsetColonZ,
+// TimezoneOffset,
+//  TimezoneOffsetZ,
+//     RFC2822,
+//     RFC3339,

--- a/src/format/literal.rs
+++ b/src/format/literal.rs
@@ -4,36 +4,42 @@ use super::{Fixed, Item, Numeric, Pad};
 #[macro_export]
 macro_rules! items {
 
-    ( $pad:expr;   $( $i:tt ),+  ) => {
-        &[
-            $(
-                __item_with_pad!($pad, $i),
-            )*
-        ]
+    ( $pad:expr;   $( $i:tt ),+  $(,)?) => {
+        {
+            #[allow(unused_imports)]
+            use $crate::format::Item::{*, Numeric as N, Fixed as F};
+            #[allow(unused_imports)]
+            use $crate::format::Fixed::*;
+            #[allow(unused_imports)]
+            use $crate::format::Numeric::*;
+            #[allow(unused_imports)]
+            use $crate::format::Pad::{Zero, Space, None as NoPadding};
+            &[
+                $(
+                    __item_with_pad!($pad, $i),
+                )*
+            ]
+        }
     };
 
-    ( $pad:expr;   $( $i:tt ),+  ,) => {
-        &[
-            $(
-                item_with_pad!($pad, $i),
-            )*
-        ]
+    ( $( $i:expr ),+ $(,)?) => {
+        {
+            #[allow(unused_imports)]
+            use $crate::format::Item::{*, Numeric as N, Fixed as F};
+            #[allow(unused_imports)]
+            use $crate::format::Fixed::*;
+            #[allow(unused_imports)]
+            use $crate::format::Numeric::*;
+            #[allow(unused_imports)]
+            use $crate::format::Pad::{Zero, Space, None as NoPadding};
+            &[
+                $(
+                    __item!($i),
+                )*
+            ]
+        }
     };
 
-    ( $( $i:expr ),+ ) => {
-        &[
-            $(
-                __item!($i),
-            )*
-        ]
-    };
-    ( $( $i:expr ),+ ,) => {
-        &[
-            $(
-                __item!($i),
-            )*
-        ]
-    };
 }
 
 #[doc(hidden)]
@@ -73,21 +79,21 @@ mod tests {
     use crate::format::{Item, Numeric, Pad, StrftimeItems};
 
     const ISO8601_A: &[Item<'static>] = items![
-        Pad::Zero; year, "-", month, "-", day, "T", hour, ":", minute, ":", second, "Z"
+        Zero; year, "-", month, "-", day, "T", hour, ":", minute, ":", second, "Z"
     ];
 
     const ISO8601_B: &[Item<'static>] = items![
-        super::year(Pad::Zero),
+        super::year(Zero),
         "-",
-        super::month(Pad::Zero),
+        super::month(Zero),
         "-",
-        super::day(Pad::Zero),
+        super::day(Zero),
         "T",
-        super::hour(Pad::Zero),
+        super::hour(Zero),
         ":",
-        super::minute(Pad::Zero),
+        super::minute(Zero),
         ":",
-        super::second(Pad::Zero),
+        super::second(Zero),
         "Z"
     ];
 
@@ -106,7 +112,37 @@ mod tests {
         super::lit("Z"),
     ];
 
-    const ISO8601_D: &[Item<'static>] = &[
+    const ISO8601_D: &[Item<'static>] = items![
+        Numeric(Year, Zero),
+        "-",
+        Numeric(Month, Zero),
+        "-",
+        Numeric(Day, Zero),
+        "T",
+        Numeric(Hour, Zero),
+        ":",
+        Numeric(Minute, Zero),
+        ":",
+        Numeric(Second, Zero),
+        "Z",
+    ];
+
+    const ISO8601_E: &[Item<'static>] = items![
+        N(Year, Zero),
+        "-",
+        N(Month, Zero),
+        "-",
+        N(Day, Zero),
+        "T",
+        N(Hour, Zero),
+        ":",
+        N(Minute, Zero),
+        ":",
+        N(Second, Zero),
+        "Z",
+    ];
+
+    const ISO8601_F: &[Item<'static>] = &[
         Item::Numeric(Numeric::Year, Pad::Zero),
         Item::Literal("-"),
         Item::Numeric(Numeric::Month, Pad::Zero),
@@ -137,6 +173,14 @@ mod tests {
         );
         assert_eq!(
             ISO8601_D.to_vec(),
+            StrftimeItems::new("%Y-%m-%dT%H:%M:%SZ").collect::<Vec<_>>(),
+        );
+        assert_eq!(
+            ISO8601_E.to_vec(),
+            StrftimeItems::new("%Y-%m-%dT%H:%M:%SZ").collect::<Vec<_>>(),
+        );
+        assert_eq!(
+            ISO8601_F.to_vec(),
             StrftimeItems::new("%Y-%m-%dT%H:%M:%SZ").collect::<Vec<_>>(),
         );
     }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -300,6 +300,24 @@ pub enum Item<'a> {
     Error,
 }
 
+impl<'a> From<(Numeric, Pad)> for Item<'a> {
+    fn from((n, p): (Numeric, Pad)) -> Self {
+        Item::Numeric(n, p)
+    }
+}
+
+impl<'a> From<Fixed> for Item<'a> {
+    fn from(f: Fixed) -> Self {
+        Item::Fixed(f)
+    }
+}
+
+impl<'a> From<&'a str> for Item<'a> {
+    fn from(s: &'a str) -> Self {
+        Item::Literal(s)
+    }
+}
+
 macro_rules! lit {
     ($x:expr) => {
         Item::Literal($x)

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -55,6 +55,10 @@ use crate::{Month, ParseMonthError, ParseWeekdayError, Weekday};
 #[cfg(feature = "unstable-locales")]
 pub(crate) mod locales;
 
+/// Convenience functions and macros to make it easy to
+/// create valid formatting items at compile time
+pub mod literal;
+
 pub use parse::parse;
 pub use parsed::Parsed;
 /// L10n locales.

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -219,6 +219,11 @@ impl<'a> StrftimeItems<'a> {
         Self::with_remainer(s)
     }
 
+    /// Check if a given strftime string is valid
+    pub fn valid(s: &'a str) -> bool {
+        StrftimeItems::new(s).all(|i| i != Item::Error)
+    }
+
     /// Creates a new parsing iterator from the `strftime`-like format string.
     #[cfg(feature = "unstable-locales")]
     pub fn new_with_locale(s: &'a str, locale: Locale) -> StrftimeItems<'a> {


### PR DESCRIPTION
This can be done now using the `format::Item` `enum`, however it can be quite verbose.

These are some experiments using a macro_rules and some helper functions to make it a bit more convenient.