### PR TITLE
Update CI test for wasm32-unknown-unknown to enable wasmbind feature

### DIFF
--- a/ci/github.sh
+++ b/ci/github.sh
@@ -121,7 +121,7 @@ test_wasm_emscripten() {
 }
 
 test_wasm_unknown() {
-    runt cargo build --target wasm32-unknown-unknown
+    runt cargo build --target wasm32-unknown-unknown --features wasmbind
 }
 
 main "$@"


### PR DESCRIPTION
This PR is to fix #740. All that's been committed so far is a change to the CI configuration that will allow discovering compilation errors like this again in the future. Once a CI run has been scheduled and we have observed the failure in the logs, I will commit the fixing change.

- [ ] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)
- [ ] If this pull request fixes a bug, does it add a test that verifies that
      we can't reintroduce it?

[changelog]: ../CHANGELOG.md
