### PR TITLE
Bump version to 0.4.20-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono"
-version = "0.4.20-beta.1"
+version = "0.4.20-rc.1"
 description = "Date and time library for Rust"
 homepage = "https://github.com/chronotope/chrono"
 documentation = "https://docs.rs/chrono/"


### PR DESCRIPTION
Would like to get recent changes (in particular, #728) out on crates.io so we can do a call for testing and finally get this puppy out the door.