### PR TITLE
Implement std::error::Error for ParseWeekdayError

### DIFF
--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -191,6 +191,15 @@ pub struct ParseWeekdayError {
     pub(crate) _dummy: (),
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for ParseWeekdayError {}
+
+impl fmt::Display for ParseWeekdayError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_fmt(format_args!("{:?}", self))
+    }
+}
+
 impl fmt::Debug for ParseWeekdayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ParseWeekdayError {{ .. }}")


### PR DESCRIPTION
Fixes #743. @EvanCarroll any thoughts?