### PR TITLE
Clarify docs for `DateTime::with_timezone`

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -313,7 +313,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     }
 
     /// Changes the associated time zone.
-    /// This does not change the actual `DateTime` (but will change the string representation).
+    /// The returned `DateTime` references the same instant of time from the perspective of the provided time zone.
     #[inline]
     pub fn with_timezone<Tz2: TimeZone>(&self, tz: &Tz2) -> DateTime<Tz2> {
         tz.from_utc_datetime(&self.datetime)


### PR DESCRIPTION
The previous docs don't really make sense, why am I calling a method if it doesn't change the value? The new wording clarifies what is held the same and what changes.

### Thanks for contributing to chrono!

- [ ] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)
- [ ] If this pull request fixes a bug, does it add a test that verifies that
      we can't reintroduce it?

[changelog]: ../CHANGELOG.md
