### PR TITLE
Revise Months API

### DIFF
--- a/src/month.rs
+++ b/src/month.rs
@@ -190,8 +190,15 @@ impl num_traits::FromPrimitive for Month {
 }
 
 /// A duration in calendar months
-#[derive(Clone, Debug, PartialEq)]
-pub struct Months(pub usize);
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd)]
+pub struct Months(pub(crate) u32);
+
+impl Months {
+    /// Construct a new `Months` from a number of months
+    pub fn new(num: u32) -> Self {
+        Self(num)
+    }
+}
 
 /// An error resulting from reading `<Month>` value with `FromStr`.
 #[derive(Clone, PartialEq)]


### PR DESCRIPTION
* Provide `checked_add_months()` and `checked_sub_months()` for
  callers that would like to avoid panics
* Document panic potential in `Add` and `Sub` implementations
* Implement additional traits for `Months` per API guidelines
* Hide inner type for `Months` and add constructor
* Use lower-level APIs to clamp day

Since I didn't get another chance to review #731 before it was merged (and the suggestion to make panicking explicit doesn't seem to have been followed up), here are some proposed improvements.

cc @avantgardnerio 