### PR TITLE
GNU coreutils `date`-like time zone formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Versions with only mechanical changes will be omitted from the following list.
 * Add compatibility with rfc2822 comments (#733)
 * Make `js-sys` and `wasm-bindgen` enabled by default when target is `wasm32-unknown-unknown` for ease of API discovery
 * Add the `Months` struct and associated `Add` and `Sub` impls
+* Add `GNU` `coreutils` `date`-like time zone formatting
 
 ## 0.4.19
 
@@ -762,4 +763,3 @@ and replaced by 0.2.25 very shortly. Duh.)
 ## 0.1.0 (2014-11-20)
 
 The initial version that was available to `crates.io`.
-

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -224,13 +224,13 @@ pub enum Fixed {
     /// The offset is limited from `-24:00` to `+24:00`,
     /// which is the same as [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.
     TimezoneOffsetColon,
-    /// Offset from the local time to UTC (`+09:00` or `-04:00` or `+00:00`).
+    /// Offset from the local time to UTC with seconds (`+09:00:00` or `-04:00:00` or `+00:00:00`).
     ///
     /// In the parser, the colon can be omitted and/or surrounded with any amount of whitespace.
     /// The offset is limited from `-24:00` to `+24:00`,
     /// which is the same as [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.
     TimezoneOffsetDoubleColon,
-    /// Offset from the local time to UTC with seconds (`+09:00:00` or `-04:00:00` or `+00:00:00`).
+    /// Offset from the local time to UTC without minutes (`+09` or `-04` or `+00`).
     ///
     /// In the parser, the colon can be omitted and/or surrounded with any amount of whitespace.
     /// The offset is limited from `-24:00` to `+24:00`,

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -236,7 +236,7 @@ pub enum Fixed {
     /// The offset is limited from `-24:00` to `+24:00`,
     /// which is the same as [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.
     TimezoneOffsetTripleColon,
-    /// Offset from the local time to UTC without minutes (`+09` or `-04` or `+00`).
+    /// Offset from the local time to UTC (`+09:00` or `-04:00` or `Z`).
     ///
     /// In the parser, the colon can be omitted and/or surrounded with any amount of whitespace,
     /// and `Z` can be either in upper case or in lower case.

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -227,13 +227,13 @@ pub enum Fixed {
     /// Offset from the local time to UTC with seconds (`+09:00:00` or `-04:00:00` or `+00:00:00`).
     ///
     /// In the parser, the colon can be omitted and/or surrounded with any amount of whitespace.
-    /// The offset is limited from `-24:00` to `+24:00`,
+    /// The offset is limited from `-24:00:00` to `+24:00:00`,
     /// which is the same as [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.
     TimezoneOffsetDoubleColon,
     /// Offset from the local time to UTC without minutes (`+09` or `-04` or `+00`).
     ///
     /// In the parser, the colon can be omitted and/or surrounded with any amount of whitespace.
-    /// The offset is limited from `-24:00` to `+24:00`,
+    /// The offset is limited from `-24` to `+24`,
     /// which is the same as [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.
     TimezoneOffsetTripleColon,
     /// Offset from the local time to UTC (`+09:00` or `-04:00` or `Z`).

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -286,6 +286,7 @@ enum InternalInternal {
     Nanosecond9NoDot,
 }
 
+#[cfg(any(feature = "alloc", feature = "std", test))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ColonType {
     None,

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -288,10 +288,10 @@ enum InternalInternal {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ColonType {
-    NoColon,
-    SingleColon,
-    DoubleColon,
-    TripleColon,
+    None,
+    Single,
+    Double,
+    Triple,
 }
 
 /// A single formatting item. This is used for both formatting and parsing.
@@ -583,14 +583,14 @@ fn format_inner<'a>(
                 if !allow_zulu || off != 0 {
                     let (sign, off) = if off < 0 { ('-', -off) } else { ('+', off) };
 
-                    match colon_type.unwrap_or(ColonType::NoColon) {
-                        ColonType::NoColon => {
+                    match colon_type.unwrap_or(ColonType::None) {
+                        ColonType::None => {
                             write!(result, "{}{:02}{:02}", sign, off / 3600, off / 60 % 60)
                         }
-                        ColonType::SingleColon => {
+                        ColonType::Single => {
                             write!(result, "{}{:02}:{:02}", sign, off / 3600, off / 60 % 60)
                         }
-                        ColonType::DoubleColon => {
+                        ColonType::Double => {
                             write!(
                                 result,
                                 "{}{:02}:{:02}:{:02}",
@@ -600,7 +600,7 @@ fn format_inner<'a>(
                                 off % 60
                             )
                         }
-                        ColonType::TripleColon => {
+                        ColonType::Triple => {
                             write!(result, "{}{:02}", sign, off / 3600)
                         }
                     }
@@ -688,16 +688,16 @@ fn format_inner<'a>(
                         Ok(())
                     }),
                     TimezoneOffsetColon => off.map(|&(_, off)| {
-                        write_local_minus_utc(result, off, false, Some(ColonType::SingleColon))
+                        write_local_minus_utc(result, off, false, Some(ColonType::Single))
                     }),
                     TimezoneOffsetDoubleColon => off.map(|&(_, off)| {
-                        write_local_minus_utc(result, off, false, Some(ColonType::DoubleColon))
+                        write_local_minus_utc(result, off, false, Some(ColonType::Double))
                     }),
                     TimezoneOffsetTripleColon => off.map(|&(_, off)| {
-                        write_local_minus_utc(result, off, false, Some(ColonType::TripleColon))
+                        write_local_minus_utc(result, off, false, Some(ColonType::Triple))
                     }),
                     TimezoneOffsetColonZ => off.map(|&(_, off)| {
-                        write_local_minus_utc(result, off, true, Some(ColonType::SingleColon))
+                        write_local_minus_utc(result, off, true, Some(ColonType::Single))
                     }),
                     TimezoneOffset => {
                         off.map(|&(_, off)| write_local_minus_utc(result, off, false, None))
@@ -736,12 +736,7 @@ fn format_inner<'a>(
                             // reuse `Debug` impls which already print ISO 8601 format.
                             // this is faster in this way.
                             write!(result, "{:?}T{:?}", d, t)?;
-                            Some(write_local_minus_utc(
-                                result,
-                                off,
-                                false,
-                                Some(ColonType::SingleColon),
-                            ))
+                            Some(write_local_minus_utc(result, off, false, Some(ColonType::Single)))
                         } else {
                             None
                         }

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -420,7 +420,10 @@ where
                         try_consume!(scan::timezone_name_skip(s));
                     }
 
-                    &TimezoneOffsetColon | &TimezoneOffset => {
+                    &TimezoneOffsetColon
+                    | &TimezoneOffsetDoubleColon
+                    | &TimezoneOffsetTripleColon
+                    | &TimezoneOffset => {
                         let offset = try_consume!(scan::timezone_offset(
                             s.trim_left(),
                             scan::colon_or_space

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -71,8 +71,8 @@ The following specifiers are available both to formatting and parsing.
 | `%Z`  | `ACST`   | Local time zone name. Skips all non-whitespace characters during parsing. [^9] |
 | `%z`  | `+0930`  | Offset from the local time to UTC (with UTC being `+0000`).                |
 | `%:z` | `+09:30` | Same as `%z` but with a colon.                                             |
-| `%::z` | `+09:30:00` | Offset from the local time to UTC with seconds.
-| `%:::z` | `+09` | Offset from the local time to UTC without minutes.
+|`%::z`|`+09:30:00`| Offset from the local time to UTC with seconds.                            |
+|`%:::z`| `+09`    | Offset from the local time to UTC without minutes.                         |
 | `%#z` | `+09`    | *Parsing only:* Same as `%z` but allows minutes to be missing or present.  |
 |       |          |                                                                            |
 |       |          | **DATE & TIME SPECIFIERS:**                                                |


### PR DESCRIPTION
Pull request adds additional string formatting options for time zones using multiple colons as syntax, which are identical to formatting options in GNU coreutils `date` ( https://man7.org/linux/man-pages/man1/date.1.html )

This would fix https://github.com/uutils/coreutils/issues/3780 

The pull request adds additional format specifiers for `chrono::format::strftime`.

In addition to currently implemented `%z` and `%:z` PR adds 2 new time zone formatting identifiers:

1. `%::z` -Offset from the local time to UTC with seconds. 
Example output: `+09:30:00` 
2. `%:::z`  - Offset from the local time to UTC without minutes. 
Example output: `+09`