### PR TITLE
Additional rkyv support by trying to derive the Archived type as Self where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ breakage if you use `no-default-features`.
 There were/are numerous minor versions before 1.0 due to the language changes.
 Versions with only mechanical changes will be omitted from the following list.
 
+## 0.4.21 (unreleased)
+
+* Tweak optional `rkyv` support to use `Self` for `Archive::Archived` when possible.
+
 ## 0.4.20 (unreleased)
 
 * Add more formatting documentation and examples.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ clock = ["std", "winapi"]
 oldtime = ["time"]
 wasmbind = [] # TODO: empty feature to avoid breaking change in 0.4.20, can be removed later
 unstable-locales = ["pure-rust-locales", "alloc"]
+archive_le = ["rkyv", "rkyv/archive_le"]
+archive_be = ["rkyv", "rkyv/archive_be"]
 __internal_bench = ["criterion"]
 __doctest = []
 

--- a/src/month.rs
+++ b/src/month.rs
@@ -29,7 +29,11 @@ use rkyv::{Archive, Deserialize, Serialize};
 // Actual implementation is zero-indexed, API intended as 1-indexed for more intuitive behavior.
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(Archive, Deserialize, Serialize),
+    cfg_attr(not(any(feature = "archive_le", feature = "archive_be")), archive(as = "Self"))
+)]
 pub enum Month {
     /// January
     January = 0,

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -164,7 +164,11 @@ impl NaiveWeek {
 ///
 /// This is currently the internal format of Chrono's date types.
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(Archive, Deserialize, Serialize),
+    cfg_attr(not(any(feature = "archive_le", feature = "archive_be")), archive(as = "Self"))
+)]
 pub struct NaiveDate {
     ymdf: DateImpl, // (year << 13) | of
 }

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -72,7 +72,11 @@ pub const MAX_DATETIME: NaiveDateTime = NaiveDateTime::MAX;
 /// assert_eq!(dt.num_seconds_from_midnight(), 33011);
 /// ```
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(Archive, Deserialize, Serialize),
+    cfg_attr(not(any(feature = "archive_le", feature = "archive_be")), archive(as = "Self"))
+)]
 pub struct NaiveDateTime {
     date: NaiveDate,
     time: NaiveTime,

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -17,7 +17,11 @@ use rkyv::{Archive, Deserialize, Serialize};
 /// One can retrieve this type from the existing [`Datelike`](../trait.Datelike.html) types
 /// via the [`Datelike::iso_week`](../trait.Datelike.html#tymethod.iso_week) method.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(Archive, Deserialize, Serialize),
+    cfg_attr(not(any(feature = "archive_le", feature = "archive_be")), archive(as = "Self"))
+)]
 pub struct IsoWeek {
     // note that this allows for larger year range than `NaiveDate`.
     // this is crucial because we have an edge case for the first and last week supported,

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -188,7 +188,11 @@ mod tests;
 /// Since Chrono alone cannot determine any existence of leap seconds,
 /// **there is absolutely no guarantee that the leap second read has actually happened**.
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(Archive, Deserialize, Serialize),
+    cfg_attr(not(any(feature = "archive_le", feature = "archive_be")), archive(as = "Self"))
+)]
 pub struct NaiveTime {
     secs: u32,
     frac: u32,

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -23,7 +23,11 @@ use crate::Timelike;
 /// `DateTime<FixedOffset>` instances. See the [`east`](#method.east) and
 /// [`west`](#method.west) methods for examples.
 #[derive(PartialEq, Eq, Hash, Copy, Clone)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(Archive, Deserialize, Serialize),
+    cfg_attr(not(any(feature = "archive_le", feature = "archive_be")), archive(as = "Self"))
+)]
 pub struct FixedOffset {
     local_minus_utc: i32,
 }

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -47,7 +47,11 @@ mod tz_info;
 /// let dt: DateTime<Local> = Local.timestamp(0, 0);
 /// ```
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(Archive, Deserialize, Serialize),
+    cfg_attr(not(any(feature = "archive_le", feature = "archive_be")), archive(as = "Self"))
+)]
 pub struct Local;
 
 impl Local {

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -36,7 +36,11 @@ use crate::{Date, DateTime};
 /// assert_eq!(Utc.ymd(1970, 1, 1).and_hms(0, 1, 1), dt);
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(Archive, Deserialize, Serialize),
+    cfg_attr(not(any(feature = "archive_le", feature = "archive_be")), archive(as = "Self"))
+)]
 pub struct Utc;
 
 #[cfg(feature = "clock")]

--- a/src/oldtime.rs
+++ b/src/oldtime.rs
@@ -51,7 +51,11 @@ macro_rules! try_opt {
 ///
 /// This also allows for the negative duration; see individual methods for details.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(Archive, Deserialize, Serialize),
+    cfg_attr(not(any(feature = "archive_le", feature = "archive_be")), archive(as = "Self"))
+)]
 pub struct Duration {
     secs: i64,
     nanos: i32, // Always 0 <= nanos < NANOS_PER_SEC

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -10,7 +10,11 @@ use rkyv::{Archive, Deserialize, Serialize};
 /// One should prefer `*_from_monday` or `*_from_sunday` methods to get the correct result.
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(
+    feature = "rkyv",
+    derive(Archive, Deserialize, Serialize),
+    cfg_attr(not(any(feature = "archive_le", feature = "archive_be")), archive(as = "Self"))
+)]
 pub enum Weekday {
     /// Monday.
     Mon = 0,


### PR DESCRIPTION
The current support for `rkyv` in `chrono` isn't very useful, because `rkyv` generates a new type on each invocation of `derive(Archive)`. This new type won't have any traits or methods implemented on it except `Deserialize`, so it can't be easily used in a zero-copy manner.

However, most `chrono` types are `Copy`, which means that `rkyv` can be configured to use `Self` for `derive(Archive)` instead of generating a new one. One downside is that this doesn't work if `rkyv` is configured to use a specific endianness.

Code can be generic to which specific type `rkyv` generated for the `Archive` impl through the use of `rkyv::Archived<_>`, so `chrono` can opportunistically generate a different type without breaking code that wants to support different endianness, which is also what rkyv currently does for primitives: https://docs.rs/rkyv/0.7.39/src/rkyv/impls/core/primitive.rs.html#107