### PR TITLE
Do not include iana-time-zone for sgx

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,28 @@ jobs:
         run: cargo build --target thumbv6m-none-eabi --color=always
         working-directory: ./ci/core-test
 
+  intel_sgx:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install rust with fortanix sgx toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          target: x86_64-fortanix-unknown-sgx
+          override: true
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Build sgx lib
+        run: cargo build --target x86_64-fortanix-unknown-sgx --color=always
+        working-directory: ./ci/core-test
+
   wasm:
     strategy:
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ rkyv = {version = "0.7", optional = true}
 wasm-bindgen = { version = "0.2" }
 js-sys = { version = "0.3" } # contains FFI bindings for the JS Date API
 
-[target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "solaris")))'.dependencies]
+[target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "solaris", target_env = "sgx")))'.dependencies]
 iana-time-zone = { version = "0.1.41", optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,13 +40,12 @@ serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.5.2", optional = true }
 criterion = { version = "0.3", optional = true }
 rkyv = {version = "0.7", optional = true}
+iana-time-zone = { version = "0.1.41", optional = true, features = ["fallback"] }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 wasm-bindgen = { version = "0.2" }
 js-sys = { version = "0.3" } # contains FFI bindings for the JS Date API
 
-[target.'cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "solaris", target_env = "sgx")))'.dependencies]
-iana-time-zone = { version = "0.1.41", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.0", features = ["std", "minwinbase", "minwindef", "timezoneapi"], optional = true }

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -103,12 +103,6 @@ const TZDB_LOCATION: &str = " /system/usr/share/zoneinfo";
 #[cfg(not(target_os = "android"))]
 const TZDB_LOCATION: &str = "/usr/share/zoneinfo";
 
-#[cfg(any(target_os = "emscripten", target_os = "wasi", target_os = "solaris"))]
-fn fallback_timezone() -> Option<TimeZone> {
-    Some(TimeZone::utc())
-}
-
-#[cfg(not(any(target_os = "emscripten", target_os = "wasi", target_os = "solaris")))]
 fn fallback_timezone() -> Option<TimeZone> {
     let tz_name = iana_time_zone::get_timezone().ok()?;
     let bytes = fs::read(format!("{}/{}", TZDB_LOCATION, tz_name)).ok()?;


### PR DESCRIPTION
In previous versions chrono with default features built successfully on the sgx platform. Since `iana-time-zone` is not implemented for this platform, do not include it when `target_env = "sgx"`.

### Thanks for contributing to chrono!

- [ ] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)
- [ ] If this pull request fixes a bug, does it add a test that verifies that
      we can't reintroduce it?

[changelog]: ../CHANGELOG.md
