### PR TITLE
Prepare 0.4.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,19 @@ breakage if you use `no-default-features`.
 There were/are numerous minor versions before 1.0 due to the language changes.
 Versions with only mechanical changes will be omitted from the following list.
 
-## 0.4.20 (unreleased)
+## 0.4.22
+
+* Allow wasmbindgen to be optional on `wasm32-unknown-unknown` target [(#771)](https://github.com/chronotope/chrono/pull/771)
+* Fix compile error for `x86_64-fortanix-unknown-sgx` [(#767)](https://github.com/chronotope/chrono/pull/767)
+* Update `iana-time-zone` version to 1.44 [(#773)](https://github.com/chronotope/chrono/pull/773)
+
+## 0.4.21
+
+* Fall back to UTC timezone in cases where no timezone is found [(#756)](https://github.com/chronotope/chrono/pull/756)
+* Correctly detect timezone on Android [(#756)](https://github.com/chronotope/chrono/pull/756)
+* Improve documentation for strftime `%Y` specifier [(#760)](https://github.com/chronotope/chrono/pull/760)
+
+## 0.4.20
 
 * Add more formatting documentation and examples.
 * Add support for microseconds timestamps serde serialization/deserialization (#304)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono"
-version = "0.4.21"
+version = "0.4.22"
 description = "Date and time library for Rust"
 homepage = "https://github.com/chronotope/chrono"
 documentation = "https://docs.rs/chrono/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.5.2", optional = true }
 criterion = { version = "0.3", optional = true }
 rkyv = {version = "0.7", optional = true}
-iana-time-zone = { version = "0.1.41", optional = true, features = ["fallback"] }
+iana-time-zone = { version = "0.1.44", optional = true, features = ["fallback"] }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 wasm-bindgen = { version = "0.2", optional = true }

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -22,7 +22,7 @@ use crate::{Datelike, Timelike};
 ///
 /// - `to_*` methods try to make a concrete date and time value out of set fields.
 ///   It fully checks any remaining out-of-range conditions and inconsistent/impossible fields.
-#[derive(Clone, PartialEq, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
 pub struct Parsed {
     /// Year.
     ///

--- a/src/month.rs
+++ b/src/month.rs
@@ -201,7 +201,7 @@ impl Months {
 }
 
 /// An error resulting from reading `<Month>` value with `FromStr`.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ParseMonthError {
     pub(crate) _dummy: (),
 }

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -207,7 +207,7 @@ fn test_date_bounds() {
 impl NaiveDate {
     /// Makes a new `NaiveDate` from year and packed ordinal-flags, with a verification.
     fn from_of(year: i32, of: Of) -> Option<NaiveDate> {
-        if year >= MIN_YEAR && year <= MAX_YEAR && of.valid() {
+        if (MIN_YEAR..=MAX_YEAR).contains(&year) && of.valid() {
             let Of(of) = of;
             Some(NaiveDate { ymdf: (year << 13) | (of as DateImpl) })
         } else {

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -536,7 +536,6 @@ impl NaiveTime {
     /// assert_eq!(from_hms(3, 4, 5).overflowing_add_signed(Duration::hours(-7)),
     ///            (from_hms(20, 4, 5), -86_400));
     /// ```
-    #[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
     pub fn overflowing_add_signed(&self, mut rhs: OldDuration) -> (NaiveTime, i64) {
         let mut secs = self.secs;
         let mut frac = self.frac;
@@ -585,7 +584,7 @@ impl NaiveTime {
             frac -= 1_000_000_000;
             secs += 1;
         }
-        debug_assert!(-86_400 <= secs && secs < 2 * 86_400);
+        debug_assert!((-86_400..2 * 86_400).contains(&secs));
         debug_assert!((0..1_000_000_000).contains(&frac));
 
         if secs < 0 {

--- a/src/offset/local/tz_info/parser.rs
+++ b/src/offset/local/tz_info/parser.rs
@@ -229,7 +229,7 @@ impl<'a> Cursor<'a> {
     }
 
     pub(crate) fn peek(&self) -> Option<&u8> {
-        self.remaining().get(0)
+        self.remaining().first()
     }
 
     /// Returns remaining data

--- a/src/offset/local/tz_info/rule.rs
+++ b/src/offset/local/tz_info/rule.rs
@@ -399,7 +399,7 @@ fn parse_rule_time(cursor: &mut Cursor) -> Result<i32, Error> {
 fn parse_rule_time_extended(cursor: &mut Cursor) -> Result<i32, Error> {
     let (sign, hour, minute, second) = parse_signed_hhmmss(cursor)?;
 
-    if hour < -167 || hour > 167 {
+    if !(-167..=167).contains(&hour) {
         return Err(Error::InvalidTzString("invalid day time hour"));
     }
     if !(0..=59).contains(&minute) {

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -186,7 +186,7 @@ impl num_traits::FromPrimitive for Weekday {
 }
 
 /// An error resulting from reading `Weekday` value with `FromStr`.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ParseWeekdayError {
     pub(crate) _dummy: (),
 }


### PR DESCRIPTION
Bump the iana-time-zone dependency to 0.1.44, which breaks the dependency cycle on iOS/macOS and fixes some issues on RedHat-based Linux distributions.