### PR TITLE
Update iana-time-zone to 0.1.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ breakage if you use `no-default-features`.
 There were/are numerous minor versions before 1.0 due to the language changes.
 Versions with only mechanical changes will be omitted from the following list.
 
+## 0.4.22 (unreleased)
+
+* Fix circular dependency problems between iana-time-zone, core-foundation, and chrono
+
 ## 0.4.20 (unreleased)
 
 * Add more formatting documentation and examples.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.5.2", optional = true }
 criterion = { version = "0.3", optional = true }
 rkyv = {version = "0.7", optional = true}
-iana-time-zone = { version = "0.1.41", optional = true, features = ["fallback"] }
+iana-time-zone = { version = "0.1.44", optional = true, features = ["fallback"] }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 wasm-bindgen = { version = "0.2", optional = true }


### PR DESCRIPTION
The circular dependency problems mentioned in <https://github.com/chronotope/chrono/issues/770#issuecomment-1211570887> where fixed in `iana-time-zone` 0.1.44. `iana-time-zone` now depends on `core-foundation-sys` instead of `core-foundation`.

### Thanks for contributing to chrono!

- [x] Have you added yourself and the change to the [changelog]? (Don't worry about adding the PR number)
- [ ] If this pull request fixes a bug, does it add a test that verifies that we can't reintroduce it?

[changelog]: ../CHANGELOG.md
