### PR TITLE
Clarify serde module contains defaults too in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -506,14 +506,13 @@ pub use traits::{Datelike, Timelike};
 #[doc(hidden)]
 pub use naive::__BenchYearFlags;
 
-/// Serialization/Deserialization in alternate formats
+/// Serialization/Deserialization with serde.
 ///
-/// The various modules in here are intended to be used with serde's [`with`
-/// annotation][1] to serialize as something other than the default [RFC
-/// 3339][2] format.
+/// This module provides default implementations for `DateTime` using the [RFC 3339][1] format and various
+/// alternatives for use with serde's [`with` annotation][1].
 ///
-/// [1]: https://serde.rs/attributes.html#field-attributes
-/// [2]: https://tools.ietf.org/html/rfc3339
+/// [1]: https://tools.ietf.org/html/rfc3339
+/// [2]: https://serde.rs/attributes.html#field-attributes
 #[cfg(feature = "serde")]
 pub mod serde {
     pub use super::datetime::serde::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -511,6 +511,8 @@ pub use naive::__BenchYearFlags;
 /// This module provides default implementations for `DateTime` using the [RFC 3339][1] format and various
 /// alternatives for use with serde's [`with` annotation][1].
 ///
+/// *Available on crate feature 'serde' only.*
+///
 /// [1]: https://tools.ietf.org/html/rfc3339
 /// [2]: https://serde.rs/attributes.html#field-attributes
 #[cfg(feature = "serde")]


### PR DESCRIPTION
Makes it more clear the serde module isn't *only* for alternatives it
is also required for the default implementations.

Adds a small hint in italic that the serde flag needs to be enabled to consume mentioned defaults.

Did not feel the change was notable so left it out of the changelog.

Closes #776 

### Thanks for contributing to chrono!

- [x] Have you added yourself and the change to the [changelog]? (Don't worry
      about adding the PR number)
- [x] If this pull request fixes a bug, does it add a test that verifies that
      we can't reintroduce it?

[changelog]: ../CHANGELOG.md