### PR TITLE
 Add feature documentation for docs.rs 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -273,5 +273,5 @@ jobs:
           override: true
       - name: Check docs build without warnings
         env:
-          RUSTDOCFLAGS: "-D warnings"
-        run: cargo +nightly doc
+          RUSTDOCFLAGS: "-D warnings --cfg docsrs"
+        run: cargo +nightly doc --all-features --no-deps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versions with only mechanical changes will be omitted from the following list.
 ## 0.4.23
 * Impl Add<Month> + Sub<Month> for NaiveDateTime
 * Export `oldtime::OutOfRangeError` to the public API
+* Add feature documentation for docs.rs [(#779)](https://github.com/chronotope/chrono/pull/779)
 
 ## 0.4.22
 
@@ -53,7 +54,6 @@ Versions with only mechanical changes will be omitted from the following list.
 * Add compatibility with rfc2822 comments (#733)
 * Make `js-sys` and `wasm-bindgen` enabled by default when target is `wasm32-unknown-unknown` for ease of API discovery
 * Add the `Months` struct and associated `Add` and `Sub` impls
-* Add `GNU` `coreutils` `date`-like time zone formatting
 
 ## 0.4.19
 
@@ -779,3 +779,4 @@ and replaced by 0.2.25 very shortly. Duh.)
 ## 0.1.0 (2014-11-20)
 
 The initial version that was available to `crates.io`.
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ wasm-bindgen-test = "0.3"
 
 [package.metadata.docs.rs]
 features = ["serde"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
 features = ["serde"]

--- a/src/date.rs
+++ b/src/date.rs
@@ -313,6 +313,7 @@ where
 {
     /// Formats the date with the specified formatting items.
     #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
     where
@@ -335,6 +336,7 @@ where
     /// assert_eq!(formatted, "02/04/2017");
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
         self.format_with_items(StrftimeItems::new(fmt))
@@ -342,6 +344,7 @@ where
 
     /// Formats the date with the specified formatting items and locale.
     #[cfg(feature = "unstable-locales")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
     #[inline]
     pub fn format_localized_with_items<'a, I, B>(
         &self,
@@ -365,6 +368,7 @@ where
     /// See the [`crate::format::strftime`] module
     /// on the supported escape sequences.
     #[cfg(feature = "unstable-locales")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
     #[inline]
     pub fn format_localized<'a>(
         &self,

--- a/src/date.rs
+++ b/src/date.rs
@@ -362,7 +362,7 @@ where
     }
 
     /// Formats the date with the specified format string and locale.
-    /// See the [`::format::strftime`] module
+    /// See the [`crate::format::strftime`] module
     /// on the supported escape sequences.
     #[cfg(feature = "unstable-locales")]
     #[inline]

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -415,6 +415,7 @@ impl Default for DateTime<Utc> {
 }
 
 #[cfg(feature = "clock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
 impl Default for DateTime<Local> {
     fn default() -> Self {
         Local.from_utc_datetime(&NaiveDateTime::default())
@@ -440,6 +441,7 @@ impl From<DateTime<Utc>> for DateTime<FixedOffset> {
 
 /// Convert a `DateTime<Utc>` instance into a `DateTime<Local>` instance.
 #[cfg(feature = "clock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
 impl From<DateTime<Utc>> for DateTime<Local> {
     /// Convert this `DateTime<Utc>` instance into a `DateTime<Local>` instance.
     ///
@@ -462,6 +464,7 @@ impl From<DateTime<FixedOffset>> for DateTime<Utc> {
 
 /// Convert a `DateTime<FixedOffset>` instance into a `DateTime<Local>` instance.
 #[cfg(feature = "clock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
 impl From<DateTime<FixedOffset>> for DateTime<Local> {
     /// Convert this `DateTime<FixedOffset>` instance into a `DateTime<Local>` instance.
     ///
@@ -474,6 +477,7 @@ impl From<DateTime<FixedOffset>> for DateTime<Local> {
 
 /// Convert a `DateTime<Local>` instance into a `DateTime<Utc>` instance.
 #[cfg(feature = "clock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
 impl From<DateTime<Local>> for DateTime<Utc> {
     /// Convert this `DateTime<Local>` instance into a `DateTime<Utc>` instance.
     ///
@@ -486,6 +490,7 @@ impl From<DateTime<Local>> for DateTime<Utc> {
 
 /// Convert a `DateTime<Local>` instance into a `DateTime<FixedOffset>` instance.
 #[cfg(feature = "clock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
 impl From<DateTime<Local>> for DateTime<FixedOffset> {
     /// Convert this `DateTime<Local>` instance into a `DateTime<FixedOffset>` instance.
     ///
@@ -572,6 +577,7 @@ where
 {
     /// Returns an RFC 2822 date and time string such as `Tue, 1 Jul 2003 10:52:37 +0200`.
     #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     pub fn to_rfc2822(&self) -> String {
         const ITEMS: &[Item<'static>] = &[Item::Fixed(Fixed::RFC2822)];
         self.format_with_items(ITEMS.iter()).to_string()
@@ -579,6 +585,7 @@ where
 
     /// Returns an RFC 3339 and ISO 8601 date and time string such as `1996-12-19T16:39:57-08:00`.
     #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     pub fn to_rfc3339(&self) -> String {
         const ITEMS: &[Item<'static>] = &[Item::Fixed(Fixed::RFC3339)];
         self.format_with_items(ITEMS.iter()).to_string()
@@ -609,6 +616,7 @@ where
     ///            "2018-01-26T10:30:09+08:00");
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     pub fn to_rfc3339_opts(&self, secform: SecondsFormat, use_z: bool) -> String {
         use crate::format::Numeric::*;
         use crate::format::Pad::Zero;
@@ -653,6 +661,7 @@ where
 
     /// Formats the combined date and time with the specified formatting items.
     #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
     where
@@ -676,6 +685,7 @@ where
     /// assert_eq!(formatted, "02/04/2017 12:50");
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
         self.format_with_items(StrftimeItems::new(fmt))
@@ -683,6 +693,7 @@ where
 
     /// Formats the combined date and time with the specified formatting items and locale.
     #[cfg(feature = "unstable-locales")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
     #[inline]
     pub fn format_localized_with_items<'a, I, B>(
         &self,
@@ -709,6 +720,7 @@ where
     /// See the [`crate::format::strftime`] module on the supported escape
     /// sequences.
     #[cfg(feature = "unstable-locales")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
     #[inline]
     pub fn format_localized<'a>(
         &self,
@@ -986,6 +998,7 @@ impl str::FromStr for DateTime<Utc> {
 /// "2012-  12-12T12:  12:12Z".parse::<DateTime<Local>>();
 /// ```
 #[cfg(feature = "clock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
 impl str::FromStr for DateTime<Local> {
     type Err = ParseError;
 
@@ -995,6 +1008,7 @@ impl str::FromStr for DateTime<Local> {
 }
 
 #[cfg(any(feature = "std", test))]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<SystemTime> for DateTime<Utc> {
     fn from(t: SystemTime) -> DateTime<Utc> {
         let (sec, nsec) = match t.duration_since(UNIX_EPOCH) {
@@ -1015,6 +1029,7 @@ impl From<SystemTime> for DateTime<Utc> {
 }
 
 #[cfg(feature = "clock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
 impl From<SystemTime> for DateTime<Local> {
     fn from(t: SystemTime) -> DateTime<Local> {
         DateTime::<Utc>::from(t).with_timezone(&Local)
@@ -1022,6 +1037,7 @@ impl From<SystemTime> for DateTime<Local> {
 }
 
 #[cfg(any(feature = "std", test))]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<Tz: TimeZone> From<DateTime<Tz>> for SystemTime {
     fn from(dt: DateTime<Tz>) -> SystemTime {
         use std::time::Duration;
@@ -1042,6 +1058,14 @@ impl<Tz: TimeZone> From<DateTime<Tz>> for SystemTime {
     feature = "wasmbind",
     not(any(target_os = "emscripten", target_os = "wasi"))
 ))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(
+        target_arch = "wasm32",
+        feature = "wasmbind",
+        not(any(target_os = "emscripten", target_os = "wasi"))
+    )))
+)]
 impl From<js_sys::Date> for DateTime<Utc> {
     fn from(date: js_sys::Date) -> DateTime<Utc> {
         DateTime::<Utc>::from(&date)
@@ -1053,6 +1077,14 @@ impl From<js_sys::Date> for DateTime<Utc> {
     feature = "wasmbind",
     not(any(target_os = "emscripten", target_os = "wasi"))
 ))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(
+        target_arch = "wasm32",
+        feature = "wasmbind",
+        not(any(target_os = "emscripten", target_os = "wasi"))
+    )))
+)]
 impl From<&js_sys::Date> for DateTime<Utc> {
     fn from(date: &js_sys::Date) -> DateTime<Utc> {
         Utc.timestamp_millis(date.get_time() as i64)
@@ -1064,6 +1096,14 @@ impl From<&js_sys::Date> for DateTime<Utc> {
     feature = "wasmbind",
     not(any(target_os = "emscripten", target_os = "wasi"))
 ))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(all(
+        target_arch = "wasm32",
+        feature = "wasmbind",
+        not(any(target_os = "emscripten", target_os = "wasi"))
+    )))
+)]
 impl From<DateTime<Utc>> for js_sys::Date {
     /// Converts a `DateTime<Utc>` to a JS `Date`. The resulting value may be lossy,
     /// any values that have a millisecond timestamp value greater/less than ±8,640,000,000,000,000

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -706,7 +706,7 @@ where
     /// Formats the combined date and time with the specified format string and
     /// locale.
     ///
-    /// See the [`::format::strftime`] module on the supported escape
+    /// See the [`crate::format::strftime`] module on the supported escape
     /// sequences.
     #[cfg(feature = "unstable-locales")]
     #[inline]

--- a/src/datetime/rustc_serialize.rs
+++ b/src/datetime/rustc_serialize.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, doc(cfg(feature = "rustc-serialize")))]
+
 use super::DateTime;
 #[cfg(feature = "clock")]
 use crate::offset::Local;
@@ -80,6 +82,7 @@ impl Decodable for TsSeconds<Utc> {
 }
 
 #[cfg(feature = "clock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
 impl Decodable for DateTime<Local> {
     fn decode<D: Decoder>(d: &mut D) -> Result<DateTime<Local>, D::Error> {
         match d.read_str()?.parse::<DateTime<FixedOffset>>() {
@@ -90,6 +93,7 @@ impl Decodable for DateTime<Local> {
 }
 
 #[cfg(feature = "clock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
 #[allow(deprecated)]
 impl Decodable for TsSeconds<Local> {
     #[allow(deprecated)]

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+
 use core::fmt;
 use serde::{de, ser};
 
@@ -103,6 +105,7 @@ impl<'de> de::Deserialize<'de> for DateTime<Utc> {
 /// See [the `serde` module](./serde/index.html) for alternate
 /// serialization formats.
 #[cfg(feature = "clock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
 impl<'de> de::Deserialize<'de> for DateTime<Local> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -302,11 +302,13 @@ pub enum Item<'a> {
     Literal(&'a str),
     /// Same as `Literal` but with the string owned by the item.
     #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     OwnedLiteral(Box<str>),
     /// Whitespace. Prints literally but reads zero or more whitespace.
     Space(&'a str),
     /// Same as `Space` but with the string owned by the item.
     #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     OwnedSpace(Box<str>),
     /// Numeric item. Can be optionally padded to the maximal length (if any) when formatting;
     /// the parser simply ignores any padded whitespace and zeroes.
@@ -419,6 +421,7 @@ impl fmt::Display for ParseError {
 }
 
 #[cfg(any(feature = "std", test))]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl Error for ParseError {
     #[allow(deprecated)]
     fn description(&self) -> &str {
@@ -437,6 +440,7 @@ const BAD_FORMAT: ParseError = ParseError(ParseErrorKind::BadFormat);
 
 /// Formats single formatting item
 #[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
 pub fn format_item<'a>(
     w: &mut fmt::Formatter,
     date: Option<&NaiveDate>,
@@ -754,6 +758,7 @@ fn format_inner<'a>(
 /// Tries to format given arguments with given formatting items.
 /// Internally used by `DelayedFormat`.
 #[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
 pub fn format<'a, I, B>(
     w: &mut fmt::Formatter,
     date: Option<&NaiveDate>,
@@ -783,6 +788,7 @@ pub mod strftime;
 /// A *temporary* object which can be used as an argument to `format!` or others.
 /// This is normally constructed via `format` methods of each date and time type.
 #[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
 #[derive(Debug)]
 pub struct DelayedFormat<I> {
     /// The date view, if any.
@@ -837,6 +843,7 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
 
     /// Makes a new `DelayedFormat` value out of local date and time and locale.
     #[cfg(feature = "unstable-locales")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
     pub fn new_with_locale(
         date: Option<NaiveDate>,
         time: Option<NaiveTime>,
@@ -848,6 +855,7 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
 
     /// Makes a new `DelayedFormat` value out of local date and time, UTC offset and locale.
     #[cfg(feature = "unstable-locales")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
     pub fn new_with_offset_and_locale<Off>(
         date: Option<NaiveDate>,
         time: Option<NaiveTime>,
@@ -924,6 +932,7 @@ impl FromStr for Weekday {
 
 /// Formats single formatting item
 #[cfg(feature = "unstable-locales")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
 pub fn format_item_localized<'a>(
     w: &mut fmt::Formatter,
     date: Option<&NaiveDate>,
@@ -940,6 +949,7 @@ pub fn format_item_localized<'a>(
 /// Tries to format given arguments with given formatting items.
 /// Internally used by `DelayedFormat`.
 #[cfg(feature = "unstable-locales")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
 pub fn format_localized<'a, I, B>(
     w: &mut fmt::Formatter,
     date: Option<&NaiveDate>,

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -227,6 +227,7 @@ impl<'a> StrftimeItems<'a> {
 
     /// Creates a new parsing iterator from the `strftime`-like format string.
     #[cfg(feature = "unstable-locales")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
     pub fn new_with_locale(s: &'a str, locale: Locale) -> StrftimeItems<'a> {
         let d_fmt = StrftimeItems::new(locales::d_fmt(locale)).collect();
         let d_t_fmt = StrftimeItems::new(locales::d_t_fmt(locale)).collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,8 +423,10 @@
 // can remove this if/when rustc-serialize support is removed
 // keeps clippy happy in the meantime
 #![cfg_attr(feature = "rustc-serialize", allow(deprecated))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[cfg(feature = "oldtime")]
+#[cfg_attr(docsrs, doc(cfg(feature = "oldtime")))]
 extern crate time as oldtime;
 #[cfg(not(feature = "oldtime"))]
 mod oldtime;
@@ -444,9 +446,11 @@ pub mod prelude {
     #[doc(no_inline)]
     pub use crate::Date;
     #[cfg(feature = "clock")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
     #[doc(no_inline)]
     pub use crate::Local;
     #[cfg(feature = "unstable-locales")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
     #[doc(no_inline)]
     pub use crate::Locale;
     #[doc(no_inline)]
@@ -469,6 +473,7 @@ pub use date::{Date, MAX_DATE, MIN_DATE};
 
 mod datetime;
 #[cfg(feature = "rustc-serialize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rustc-serialize")))]
 pub use datetime::rustc_serialize::TsSeconds;
 #[allow(deprecated)]
 pub use datetime::{DateTime, SecondsFormat, MAX_DATETIME, MIN_DATETIME};
@@ -476,6 +481,7 @@ pub use datetime::{DateTime, SecondsFormat, MAX_DATETIME, MIN_DATETIME};
 pub mod format;
 /// L10n locales.
 #[cfg(feature = "unstable-locales")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
 pub use format::Locale;
 pub use format::{ParseError, ParseResult};
 
@@ -485,6 +491,7 @@ pub use naive::{IsoWeek, NaiveDate, NaiveDateTime, NaiveTime, NaiveWeek};
 
 pub mod offset;
 #[cfg(feature = "clock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
 #[doc(no_inline)]
 pub use offset::Local;
 #[doc(no_inline)]
@@ -516,6 +523,7 @@ pub use naive::__BenchYearFlags;
 /// [1]: https://tools.ietf.org/html/rfc3339
 /// [2]: https://serde.rs/attributes.html#field-attributes
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub mod serde {
     pub use super::datetime::serde::*;
 }

--- a/src/month.rs
+++ b/src/month.rs
@@ -213,6 +213,7 @@ impl fmt::Debug for ParseMonthError {
 }
 
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 mod month_serde {
     use super::Month;
     use serde::{de, ser};

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1161,6 +1161,7 @@ impl NaiveDate {
     /// assert_eq!(format!("{}", d.format_with_items(fmt)), "2015-09-05");
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
     where
@@ -1203,6 +1204,7 @@ impl NaiveDate {
     /// assert_eq!(format!("{}", d.format("%A, %-d %B, %C%y")), "Saturday, 5 September, 2015");
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
         self.format_with_items(StrftimeItems::new(fmt))
@@ -2034,6 +2036,7 @@ where
 }
 
 #[cfg(feature = "rustc-serialize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rustc-serialize")))]
 mod rustc_serialize {
     use super::NaiveDate;
     use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
@@ -2065,6 +2068,7 @@ mod rustc_serialize {
 }
 
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 mod serde {
     use super::NaiveDate;
     use core::fmt;

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -732,6 +732,7 @@ impl NaiveDateTime {
     /// assert_eq!(format!("{}", dt.format_with_items(fmt)), "2015-09-05 23:56:04");
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
     where
@@ -774,6 +775,7 @@ impl NaiveDateTime {
     /// assert_eq!(format!("{}", dt.format("around %l %p on %b %-d")), "around 11 PM on Sep 5");
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
         self.format_with_items(StrftimeItems::new(fmt))

--- a/src/naive/datetime/rustc_serialize.rs
+++ b/src/naive/datetime/rustc_serialize.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, doc(cfg(feature = "rustc-serialize")))]
+
 use super::NaiveDateTime;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 use std::ops::Deref;

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -1097,19 +1097,16 @@ where
     }
 }
 
-#[cfg(feature = "serde")]
 enum SerdeError<V: fmt::Display, D: fmt::Display> {
     NonExistent { timestamp: V },
     Ambiguous { timestamp: V, min: D, max: D },
 }
 
 /// Construct a [`SerdeError::NonExistent`]
-#[cfg(feature = "serde")]
 fn ne_timestamp<T: fmt::Display>(ts: T) -> SerdeError<T, u8> {
     SerdeError::NonExistent::<T, u8> { timestamp: ts }
 }
 
-#[cfg(feature = "serde")]
 impl<V: fmt::Display, D: fmt::Display> fmt::Debug for SerdeError<V, D> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ChronoSerdeError({})", self)
@@ -1117,7 +1114,6 @@ impl<V: fmt::Display, D: fmt::Display> fmt::Debug for SerdeError<V, D> {
 }
 
 // impl<V: fmt::Display, D: fmt::Debug> core::error::Error for SerdeError<V, D> {}
-#[cfg(feature = "serde")]
 impl<V: fmt::Display, D: fmt::Display> fmt::Display for SerdeError<V, D> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+
 use core::fmt;
 use serde::{de, ser};
 

--- a/src/naive/mod.rs
+++ b/src/naive/mod.rs
@@ -33,6 +33,7 @@ pub use self::internals::YearFlags as __BenchYearFlags;
 /// [1]: https://serde.rs/attributes.html#field-attributes
 /// [2]: https://tools.ietf.org/html/rfc3339
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 pub mod serde {
     pub use super::datetime::serde::*;
 }

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -744,6 +744,7 @@ impl NaiveTime {
     /// assert_eq!(format!("{}", t.format_with_items(fmt)), "23:56:04");
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
     where
@@ -788,6 +789,7 @@ impl NaiveTime {
     /// assert_eq!(format!("{}", t.format("%-I:%M %p")), "11:56 PM");
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
         self.format_with_items(StrftimeItems::new(fmt))

--- a/src/naive/time/rustc_serialize.rs
+++ b/src/naive/time/rustc_serialize.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, doc(cfg(feature = "rustc-serialize")))]
+
 use super::NaiveTime;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 

--- a/src/naive/time/serde.rs
+++ b/src/naive/time/serde.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, doc(cfg(feature = "serde")))]
+
 use super::NaiveTime;
 use core::fmt;
 use serde::{de, ser};

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -44,6 +44,7 @@ use crate::{Date, DateTime};
 pub struct Utc;
 
 #[cfg(feature = "clock")]
+#[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
 impl Utc {
     /// Returns a `Date` which corresponds to the current date.
     pub fn today() -> Date<Utc> {

--- a/src/oldtime.rs
+++ b/src/oldtime.rs
@@ -382,6 +382,7 @@ impl Div<i32> for Duration {
 }
 
 #[cfg(any(feature = "std", test))]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<'a> std::iter::Sum<&'a Duration> for Duration {
     fn sum<I: Iterator<Item = &'a Duration>>(iter: I) -> Duration {
         iter.fold(Duration::zero(), |acc, x| acc + *x)
@@ -389,6 +390,7 @@ impl<'a> std::iter::Sum<&'a Duration> for Duration {
 }
 
 #[cfg(any(feature = "std", test))]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::iter::Sum<Duration> for Duration {
     fn sum<I: Iterator<Item = Duration>>(iter: I) -> Duration {
         iter.fold(Duration::zero(), |acc, x| acc + x)
@@ -445,6 +447,7 @@ impl fmt::Display for OutOfRangeError {
 }
 
 #[cfg(any(feature = "std", test))]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl Error for OutOfRangeError {
     #[allow(deprecated)]
     fn description(&self) -> &str {

--- a/src/round.rs
+++ b/src/round.rs
@@ -294,6 +294,7 @@ impl fmt::Display for RoundingError {
 }
 
 #[cfg(any(feature = "std", test))]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for RoundingError {
     #[allow(deprecated)]
     fn description(&self) -> &str {

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -192,6 +192,7 @@ pub struct ParseWeekdayError {
 }
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for ParseWeekdayError {}
 
 impl fmt::Display for ParseWeekdayError {
@@ -209,6 +210,7 @@ impl fmt::Debug for ParseWeekdayError {
 // the actual `FromStr` implementation is in the `format` module to leverage the existing code
 
 #[cfg(feature = "serde")]
+#[cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 mod weekday_serde {
     use super::Weekday;
     use core::fmt;


### PR DESCRIPTION
This way the documentation will tell user which feature(s) are needed to use a function, trait, etc. docs.rs displays the information like

> Available on crate feature `serde` only.

Use this command to preview the changes:

```sh
RUSTDOCFLAGS="-D warnings --cfg docsrs" cargo +nightly doc --features=serde
```

### Thanks for contributing to chrono!

- [x] Have you added yourself and the change to the [changelog]? (Don't worry about adding the PR number)
- [x] If this pull request fixes a bug, does it add a test that verifies that we can't reintroduce it?

[changelog]: ../CHANGELOG.md
