### PR TITLE
Bump optional dependency iana-time-zone for RUSTSEC-2022-0049

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ breakage if you use `no-default-features`.
 There were/are numerous minor versions before 1.0 due to the language changes.
 Versions with only mechanical changes will be omitted from the following list.
 
+## 0.4.23
+
+* Update `iana-time-zone` version to 1.45 for [RUSTSEC-2022-0049](https://rustsec.org/advisories/RUSTSEC-2022-0049.html)
+
 ## 0.4.22
 
 * Allow wasmbindgen to be optional on `wasm32-unknown-unknown` target [(#771)](https://github.com/chronotope/chrono/pull/771)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.5.2", optional = true }
 criterion = { version = "0.3", optional = true }
 rkyv = {version = "0.7", optional = true}
-iana-time-zone = { version = "0.1.44", optional = true, features = ["fallback"] }
+iana-time-zone = { version = "0.1.45", optional = true, features = ["fallback"] }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 wasm-bindgen = { version = "0.2", optional = true }


### PR DESCRIPTION
Per [RUSTSEC-2022-0049](https://rustsec.org/advisories/RUSTSEC-2022-0049.html): `src/offset/local/unix.rs:107` calls vulnerable function `iana_time_zone::get_timezone`. Affects MacOS/iOS targets. This PR bumps to non-vulnerable version of the optional dependency.
