### PR TITLE
Start work on 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ __doctest = []
 
 [dependencies]
 num-integer = { version = "0.1.36", default-features = false }
-num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.5.2", optional = true }
 criterion = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,19 +20,17 @@ appveyor = { repository = "chronotope/chrono" }
 name = "chrono"
 
 [features]
-default = ["clock", "std", "oldtime", "wasmbind"]
+default = ["clock", "std", "wasmbind"]
 alloc = []
 libc = []
 std = []
 clock = ["std", "winapi", "iana-time-zone"]
-oldtime = ["time"]
 wasmbind = ["wasm-bindgen", "js-sys"]
 unstable-locales = ["pure-rust-locales", "alloc"]
 __internal_bench = ["criterion"]
 __doctest = []
 
 [dependencies]
-time = { version = "0.1.43", optional = true }
 num-integer = { version = "0.1.36", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ __doctest = []
 [dependencies]
 num-integer = { version = "0.1.36", default-features = false }
 num-traits = { version = "0.2", default-features = false }
-rustc-serialize = { version = "0.3.20", optional = true }
 serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.5.2", optional = true }
 criterion = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono"
-version = "0.4.22"
+version = "0.5.0-alpha.1"
 description = "Date and time library for Rust"
 homepage = "https://github.com/chronotope/chrono"
 documentation = "https://docs.rs/chrono/"

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The following illustrates most supported operations to the date and time:
 
 ```rust
 use chrono::prelude::*;
-use chrono::Duration;
+use chrono::TimeDelta;
 
 // assume this returned `2014-11-28T21:45:59.324310806+09:00`:
 let dt = FixedOffset::east(9*3600).ymd(2014, 11, 28).and_hms_nano(21, 45, 59, 324310806);
@@ -211,11 +211,11 @@ assert_eq!(dt.with_year(-300).unwrap().num_days_from_ce(), -109606); // November
 // arithmetic operations
 let dt1 = Utc.ymd(2014, 11, 14).and_hms(8, 9, 10);
 let dt2 = Utc.ymd(2014, 11, 14).and_hms(10, 9, 8);
-assert_eq!(dt1.signed_duration_since(dt2), Duration::seconds(-2 * 3600 + 2));
-assert_eq!(dt2.signed_duration_since(dt1), Duration::seconds(2 * 3600 - 2));
-assert_eq!(Utc.ymd(1970, 1, 1).and_hms(0, 0, 0) + Duration::seconds(1_000_000_000),
+assert_eq!(dt1.signed_duration_since(dt2), TimeDelta::seconds(-2 * 3600 + 2));
+assert_eq!(dt2.signed_duration_since(dt1), TimeDelta::seconds(2 * 3600 - 2));
+assert_eq!(Utc.ymd(1970, 1, 1).and_hms(0, 0, 0) + TimeDelta::seconds(1_000_000_000),
            Utc.ymd(2001, 9, 9).and_hms(1, 46, 40));
-assert_eq!(Utc.ymd(1970, 1, 1).and_hms(0, 0, 0) - Duration::seconds(1_000_000_000),
+assert_eq!(Utc.ymd(1970, 1, 1).and_hms(0, 0, 0) - TimeDelta::seconds(1_000_000_000),
            Utc.ymd(1938, 4, 24).and_hms(22, 13, 20));
 ```
 
@@ -414,4 +414,3 @@ crate ([sources](https://github.com/bcourtine/chrono-ext/)).
 
 Advanced time zone handling is not yet supported.
 For now you can try the [Chrono-tz](https://github.com/chronotope/chrono-tz/) crate instead.
-

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -18,6 +18,9 @@ use std::string::ToString;
 #[cfg(any(feature = "std", test))]
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[cfg(feature = "rkyv")]
+use rkyv::{Archive, Deserialize, Serialize};
+
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use crate::format::DelayedFormat;
 #[cfg(feature = "unstable-locales")]
@@ -28,13 +31,7 @@ use crate::naive::{IsoWeek, NaiveDate, NaiveDateTime, NaiveTime};
 #[cfg(feature = "clock")]
 use crate::offset::Local;
 use crate::offset::{FixedOffset, Offset, TimeZone, Utc};
-use crate::oldtime::Duration as OldDuration;
-use crate::Date;
-use crate::Months;
-use crate::{Datelike, Timelike, Weekday};
-
-#[cfg(feature = "rkyv")]
-use rkyv::{Archive, Deserialize, Serialize};
+use crate::{Date, Datelike, Months, TimeDelta, Timelike, Weekday};
 
 /// documented at re-export site
 #[cfg(feature = "serde")]
@@ -321,7 +318,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// Returns `None` when it will result in overflow.
     #[inline]
-    pub fn checked_add_signed(self, rhs: OldDuration) -> Option<DateTime<Tz>> {
+    pub fn checked_add_signed(self, rhs: TimeDelta) -> Option<DateTime<Tz>> {
         let datetime = self.datetime.checked_add_signed(rhs)?;
         let tz = self.timezone();
         Some(tz.from_utc_datetime(&datetime))
@@ -344,7 +341,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// Returns `None` when it will result in overflow.
     #[inline]
-    pub fn checked_sub_signed(self, rhs: OldDuration) -> Option<DateTime<Tz>> {
+    pub fn checked_sub_signed(self, rhs: TimeDelta) -> Option<DateTime<Tz>> {
         let datetime = self.datetime.checked_sub_signed(rhs)?;
         let tz = self.timezone();
         Some(tz.from_utc_datetime(&datetime))
@@ -366,7 +363,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// Subtracts another `DateTime` from the current date and time.
     /// This does not overflow or underflow at all.
     #[inline]
-    pub fn signed_duration_since<Tz2: TimeZone>(self, rhs: DateTime<Tz2>) -> OldDuration {
+    pub fn signed_duration_since<Tz2: TimeZone>(self, rhs: DateTime<Tz2>) -> TimeDelta {
         self.datetime.signed_duration_since(rhs.datetime)
     }
 
@@ -886,18 +883,18 @@ impl<Tz: TimeZone> hash::Hash for DateTime<Tz> {
     }
 }
 
-impl<Tz: TimeZone> Add<OldDuration> for DateTime<Tz> {
+impl<Tz: TimeZone> Add<TimeDelta> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
     #[inline]
-    fn add(self, rhs: OldDuration) -> DateTime<Tz> {
+    fn add(self, rhs: TimeDelta) -> DateTime<Tz> {
         self.checked_add_signed(rhs).expect("`DateTime + Duration` overflowed")
     }
 }
 
-impl<Tz: TimeZone> AddAssign<OldDuration> for DateTime<Tz> {
+impl<Tz: TimeZone> AddAssign<TimeDelta> for DateTime<Tz> {
     #[inline]
-    fn add_assign(&mut self, rhs: OldDuration) {
+    fn add_assign(&mut self, rhs: TimeDelta) {
         let datetime =
             self.datetime.checked_add_signed(rhs).expect("`DateTime + Duration` overflowed");
         let tz = self.timezone();
@@ -913,18 +910,18 @@ impl<Tz: TimeZone> Add<Months> for DateTime<Tz> {
     }
 }
 
-impl<Tz: TimeZone> Sub<OldDuration> for DateTime<Tz> {
+impl<Tz: TimeZone> Sub<TimeDelta> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
     #[inline]
-    fn sub(self, rhs: OldDuration) -> DateTime<Tz> {
+    fn sub(self, rhs: TimeDelta) -> DateTime<Tz> {
         self.checked_sub_signed(rhs).expect("`DateTime - Duration` overflowed")
     }
 }
 
-impl<Tz: TimeZone> SubAssign<OldDuration> for DateTime<Tz> {
+impl<Tz: TimeZone> SubAssign<TimeDelta> for DateTime<Tz> {
     #[inline]
-    fn sub_assign(&mut self, rhs: OldDuration) {
+    fn sub_assign(&mut self, rhs: TimeDelta) {
         let datetime =
             self.datetime.checked_sub_signed(rhs).expect("`DateTime - Duration` overflowed");
         let tz = self.timezone();
@@ -941,10 +938,10 @@ impl<Tz: TimeZone> Sub<Months> for DateTime<Tz> {
 }
 
 impl<Tz: TimeZone> Sub<DateTime<Tz>> for DateTime<Tz> {
-    type Output = OldDuration;
+    type Output = TimeDelta;
 
     #[inline]
-    fn sub(self, rhs: DateTime<Tz>) -> OldDuration {
+    fn sub(self, rhs: DateTime<Tz>) -> TimeDelta {
         self.signed_duration_since(rhs)
     }
 }

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -36,9 +36,6 @@ use crate::{Datelike, Timelike, Weekday};
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(feature = "rustc-serialize")]
-pub(super) mod rustc_serialize;
-
 /// documented at re-export site
 #[cfg(feature = "serde")]
 pub(super) mod serde;
@@ -1139,7 +1136,7 @@ fn test_auto_conversion() {
     assert_eq!(utc_dt, utc_dt2);
 }
 
-#[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
+#[cfg(all(test, feature = "serde"))]
 fn test_encodable_json<FUtc, FFixed, E>(to_string_utc: FUtc, to_string_fixed: FFixed)
 where
     FUtc: Fn(&DateTime<Utc>) -> Result<String, E>,
@@ -1161,7 +1158,7 @@ where
     );
 }
 
-#[cfg(all(test, feature = "clock", any(feature = "rustc-serialize", feature = "serde")))]
+#[cfg(all(test, feature = "clock", feature = "serde"))]
 fn test_decodable_json<FUtc, FFixed, FLocal, E>(
     utc_from_str: FUtc,
     fixed_from_str: FFixed,
@@ -1208,47 +1205,4 @@ fn test_decodable_json<FUtc, FFixed, FLocal, E>(
 
     assert!(utc_from_str(r#""2014-07-32T12:34:06Z""#).is_err());
     assert!(fixed_from_str(r#""2014-07-32T12:34:06Z""#).is_err());
-}
-
-#[cfg(all(test, feature = "clock", feature = "rustc-serialize"))]
-fn test_decodable_json_timestamps<FUtc, FFixed, FLocal, E>(
-    utc_from_str: FUtc,
-    fixed_from_str: FFixed,
-    local_from_str: FLocal,
-) where
-    FUtc: Fn(&str) -> Result<rustc_serialize::TsSeconds<Utc>, E>,
-    FFixed: Fn(&str) -> Result<rustc_serialize::TsSeconds<FixedOffset>, E>,
-    FLocal: Fn(&str) -> Result<rustc_serialize::TsSeconds<Local>, E>,
-    E: ::core::fmt::Debug,
-{
-    fn norm<Tz: TimeZone>(dt: &Option<DateTime<Tz>>) -> Option<(&DateTime<Tz>, &Tz::Offset)> {
-        dt.as_ref().map(|dt| (dt, dt.offset()))
-    }
-
-    assert_eq!(
-        norm(&utc_from_str("0").ok().map(DateTime::from)),
-        norm(&Some(Utc.ymd(1970, 1, 1).and_hms(0, 0, 0)))
-    );
-    assert_eq!(
-        norm(&utc_from_str("-1").ok().map(DateTime::from)),
-        norm(&Some(Utc.ymd(1969, 12, 31).and_hms(23, 59, 59)))
-    );
-
-    assert_eq!(
-        norm(&fixed_from_str("0").ok().map(DateTime::from)),
-        norm(&Some(FixedOffset::east(0).ymd(1970, 1, 1).and_hms(0, 0, 0)))
-    );
-    assert_eq!(
-        norm(&fixed_from_str("-1").ok().map(DateTime::from)),
-        norm(&Some(FixedOffset::east(0).ymd(1969, 12, 31).and_hms(23, 59, 59)))
-    );
-
-    assert_eq!(
-        *fixed_from_str("0").expect("0 timestamp should parse"),
-        Utc.ymd(1970, 1, 1).and_hms(0, 0, 0)
-    );
-    assert_eq!(
-        *local_from_str("-1").expect("-1 timestamp should parse"),
-        Utc.ymd(1969, 12, 31).and_hms(23, 59, 59)
-    );
 }

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -5,9 +5,9 @@ use crate::naive::{NaiveDate, NaiveTime};
 #[cfg(feature = "clock")]
 use crate::offset::Local;
 use crate::offset::{FixedOffset, TimeZone, Utc};
-use crate::oldtime::Duration;
 #[cfg(feature = "clock")]
 use crate::Datelike;
+use crate::TimeDelta;
 
 #[test]
 fn test_datetime_offset() {
@@ -38,10 +38,10 @@ fn test_datetime_offset() {
 
     let dt = Utc.ymd(2014, 5, 6).and_hms(7, 8, 9);
     assert_eq!(dt, edt.ymd(2014, 5, 6).and_hms(3, 8, 9));
-    assert_eq!(dt + Duration::seconds(3600 + 60 + 1), Utc.ymd(2014, 5, 6).and_hms(8, 9, 10));
+    assert_eq!(dt + TimeDelta::seconds(3600 + 60 + 1), Utc.ymd(2014, 5, 6).and_hms(8, 9, 10));
     assert_eq!(
         dt.signed_duration_since(edt.ymd(2014, 5, 6).and_hms(10, 11, 12)),
-        Duration::seconds(-7 * 3600 - 3 * 60 - 3)
+        TimeDelta::seconds(-7 * 3600 - 3 * 60 - 3)
     );
 
     assert_eq!(*Utc.ymd(2014, 5, 6).and_hms(7, 8, 9).offset(), Utc);
@@ -331,11 +331,11 @@ fn test_from_system_time() {
     // SystemTime -> DateTime<Utc>
     assert_eq!(DateTime::<Utc>::from(UNIX_EPOCH), epoch);
     assert_eq!(
-        DateTime::<Utc>::from(UNIX_EPOCH + Duration::new(999_999_999, nanos)),
+        DateTime::<Utc>::from(UNIX_EPOCH + TimeDelta::new(999_999_999, nanos)),
         Utc.ymd(2001, 9, 9).and_hms_nano(1, 46, 39, nanos)
     );
     assert_eq!(
-        DateTime::<Utc>::from(UNIX_EPOCH - Duration::new(999_999_999, nanos)),
+        DateTime::<Utc>::from(UNIX_EPOCH - TimeDelta::new(999_999_999, nanos)),
         Utc.ymd(1938, 4, 24).and_hms_nano(22, 13, 20, 1_000)
     );
 
@@ -343,11 +343,11 @@ fn test_from_system_time() {
     assert_eq!(SystemTime::from(epoch), UNIX_EPOCH);
     assert_eq!(
         SystemTime::from(Utc.ymd(2001, 9, 9).and_hms_nano(1, 46, 39, nanos)),
-        UNIX_EPOCH + Duration::new(999_999_999, nanos)
+        UNIX_EPOCH + TimeDelta::new(999_999_999, nanos)
     );
     assert_eq!(
         SystemTime::from(Utc.ymd(1938, 4, 24).and_hms_nano(22, 13, 20, 1_000)),
-        UNIX_EPOCH - Duration::new(999_999_999, nanos)
+        UNIX_EPOCH - TimeDelta::new(999_999_999, nanos)
     );
 
     // DateTime<any tz> -> SystemTime (via `with_timezone`)
@@ -415,15 +415,15 @@ fn test_years_elapsed() {
     const WEEKS_PER_YEAR: f32 = 52.1775;
 
     // This is always at least one year because 1 year = 52.1775 weeks.
-    let one_year_ago = Utc::today() - Duration::weeks((WEEKS_PER_YEAR * 1.5).ceil() as i64);
+    let one_year_ago = Utc::today() - TimeDelta::weeks((WEEKS_PER_YEAR * 1.5).ceil() as i64);
     // A bit more than 2 years.
-    let two_year_ago = Utc::today() - Duration::weeks((WEEKS_PER_YEAR * 2.5).ceil() as i64);
+    let two_year_ago = Utc::today() - TimeDelta::weeks((WEEKS_PER_YEAR * 2.5).ceil() as i64);
 
     assert_eq!(Utc::today().years_since(one_year_ago), Some(1));
     assert_eq!(Utc::today().years_since(two_year_ago), Some(2));
 
     // If the given DateTime is later than now, the function will always return 0.
-    let future = Utc::today() + Duration::weeks(12);
+    let future = Utc::today() + TimeDelta::weeks(12);
     assert_eq!(Utc::today().years_since(future), None);
 }
 
@@ -433,20 +433,20 @@ fn test_datetime_add_assign() {
     let datetime = DateTime::<Utc>::from_utc(naivedatetime, Utc);
     let mut datetime_add = datetime;
 
-    datetime_add += Duration::seconds(60);
-    assert_eq!(datetime_add, datetime + Duration::seconds(60));
+    datetime_add += TimeDelta::seconds(60);
+    assert_eq!(datetime_add, datetime + TimeDelta::seconds(60));
 
     let timezone = FixedOffset::east(60 * 60);
     let datetime = datetime.with_timezone(&timezone);
     let datetime_add = datetime_add.with_timezone(&timezone);
 
-    assert_eq!(datetime_add, datetime + Duration::seconds(60));
+    assert_eq!(datetime_add, datetime + TimeDelta::seconds(60));
 
     let timezone = FixedOffset::west(2 * 60 * 60);
     let datetime = datetime.with_timezone(&timezone);
     let datetime_add = datetime_add.with_timezone(&timezone);
 
-    assert_eq!(datetime_add, datetime + Duration::seconds(60));
+    assert_eq!(datetime_add, datetime + TimeDelta::seconds(60));
 }
 
 #[test]
@@ -459,8 +459,8 @@ fn test_datetime_add_assign_local() {
 
     // ensure we cross a DST transition
     for i in 1..=365 {
-        datetime_add += Duration::days(1);
-        assert_eq!(datetime_add, datetime + Duration::days(i))
+        datetime_add += TimeDelta::days(1);
+        assert_eq!(datetime_add, datetime + TimeDelta::days(i))
     }
 }
 
@@ -470,20 +470,20 @@ fn test_datetime_sub_assign() {
     let datetime = DateTime::<Utc>::from_utc(naivedatetime, Utc);
     let mut datetime_sub = datetime;
 
-    datetime_sub -= Duration::minutes(90);
-    assert_eq!(datetime_sub, datetime - Duration::minutes(90));
+    datetime_sub -= TimeDelta::minutes(90);
+    assert_eq!(datetime_sub, datetime - TimeDelta::minutes(90));
 
     let timezone = FixedOffset::east(60 * 60);
     let datetime = datetime.with_timezone(&timezone);
     let datetime_sub = datetime_sub.with_timezone(&timezone);
 
-    assert_eq!(datetime_sub, datetime - Duration::minutes(90));
+    assert_eq!(datetime_sub, datetime - TimeDelta::minutes(90));
 
     let timezone = FixedOffset::west(2 * 60 * 60);
     let datetime = datetime.with_timezone(&timezone);
     let datetime_sub = datetime_sub.with_timezone(&timezone);
 
-    assert_eq!(datetime_sub, datetime - Duration::minutes(90));
+    assert_eq!(datetime_sub, datetime - TimeDelta::minutes(90));
 }
 
 #[test]
@@ -496,7 +496,7 @@ fn test_datetime_sub_assign_local() {
 
     // ensure we cross a DST transition
     for i in 1..=365 {
-        datetime_sub -= Duration::days(1);
-        assert_eq!(datetime_sub, datetime - Duration::days(i))
+        datetime_sub -= TimeDelta::days(1);
+        assert_eq!(datetime_sub, datetime - TimeDelta::days(i))
     }
 }

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -4,8 +4,9 @@
 //! A collection of parsed date and time items.
 //! They can be constructed incrementally while being checked for consistency.
 
+use core::convert::TryFrom;
+
 use num_integer::div_rem;
-use num_traits::ToPrimitive;
 
 use super::{ParseResult, IMPOSSIBLE, NOT_ENOUGH, OUT_OF_RANGE};
 use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
@@ -131,7 +132,7 @@ impl Parsed {
     /// Tries to set the [`year`](#structfield.year) field from given value.
     #[inline]
     pub fn set_year(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.year, value.to_i32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.year, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Tries to set the [`year_div_100`](#structfield.year_div_100) field from given value.
@@ -140,7 +141,7 @@ impl Parsed {
         if value < 0 {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.year_div_100, value.to_i32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.year_div_100, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Tries to set the [`year_mod_100`](#structfield.year_mod_100) field from given value.
@@ -149,13 +150,13 @@ impl Parsed {
         if value < 0 {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.year_mod_100, value.to_i32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.year_mod_100, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Tries to set the [`isoyear`](#structfield.isoyear) field from given value.
     #[inline]
     pub fn set_isoyear(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.isoyear, value.to_i32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.isoyear, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Tries to set the [`isoyear_div_100`](#structfield.isoyear_div_100) field from given value.
@@ -164,7 +165,7 @@ impl Parsed {
         if value < 0 {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.isoyear_div_100, value.to_i32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.isoyear_div_100, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Tries to set the [`isoyear_mod_100`](#structfield.isoyear_mod_100) field from given value.
@@ -173,31 +174,31 @@ impl Parsed {
         if value < 0 {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.isoyear_mod_100, value.to_i32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.isoyear_mod_100, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Tries to set the [`month`](#structfield.month) field from given value.
     #[inline]
     pub fn set_month(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.month, value.to_u32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.month, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Tries to set the [`week_from_sun`](#structfield.week_from_sun) field from given value.
     #[inline]
     pub fn set_week_from_sun(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.week_from_sun, value.to_u32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.week_from_sun, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Tries to set the [`week_from_mon`](#structfield.week_from_mon) field from given value.
     #[inline]
     pub fn set_week_from_mon(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.week_from_mon, value.to_u32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.week_from_mon, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Tries to set the [`isoweek`](#structfield.isoweek) field from given value.
     #[inline]
     pub fn set_isoweek(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.isoweek, value.to_u32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.isoweek, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Tries to set the [`weekday`](#structfield.weekday) field from given value.
@@ -209,13 +210,13 @@ impl Parsed {
     /// Tries to set the [`ordinal`](#structfield.ordinal) field from given value.
     #[inline]
     pub fn set_ordinal(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.ordinal, value.to_u32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.ordinal, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Tries to set the [`day`](#structfield.day) field from given value.
     #[inline]
     pub fn set_day(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.day, value.to_u32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.day, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Tries to set the [`hour_div_12`](#structfield.hour_div_12) field from given value.
@@ -239,7 +240,7 @@ impl Parsed {
     /// [`hour_mod_12`](#structfield.hour_mod_12) fields from given value.
     #[inline]
     pub fn set_hour(&mut self, value: i64) -> ParseResult<()> {
-        let v = value.to_u32().ok_or(OUT_OF_RANGE)?;
+        let v = u32::try_from(value).map_err(|_| OUT_OF_RANGE)?;
         set_if_consistent(&mut self.hour_div_12, v / 12)?;
         set_if_consistent(&mut self.hour_mod_12, v % 12)?;
         Ok(())
@@ -248,19 +249,19 @@ impl Parsed {
     /// Tries to set the [`minute`](#structfield.minute) field from given value.
     #[inline]
     pub fn set_minute(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.minute, value.to_u32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.minute, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Tries to set the [`second`](#structfield.second) field from given value.
     #[inline]
     pub fn set_second(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.second, value.to_u32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.second, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Tries to set the [`nanosecond`](#structfield.nanosecond) field from given value.
     #[inline]
     pub fn set_nanosecond(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.nanosecond, value.to_u32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.nanosecond, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Tries to set the [`timestamp`](#structfield.timestamp) field from given value.
@@ -272,7 +273,7 @@ impl Parsed {
     /// Tries to set the [`offset`](#structfield.offset) field from given value.
     #[inline]
     pub fn set_offset(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.offset, value.to_i32().ok_or(OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.offset, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
     /// Returns a parsed naive date out of given fields.

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -10,10 +10,7 @@ use num_traits::ToPrimitive;
 use super::{ParseResult, IMPOSSIBLE, NOT_ENOUGH, OUT_OF_RANGE};
 use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
 use crate::offset::{FixedOffset, LocalResult, Offset, TimeZone};
-use crate::oldtime::Duration as OldDuration;
-use crate::DateTime;
-use crate::Weekday;
-use crate::{Datelike, Timelike};
+use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 
 /// Parsed parts of date and time. There are two classes of methods:
 ///
@@ -428,7 +425,7 @@ impl Parsed {
                     + (week_from_sun as i32 - 1) * 7
                     + weekday.num_days_from_sunday() as i32;
                 let date = newyear
-                    .checked_add_signed(OldDuration::days(i64::from(ndays)))
+                    .checked_add_signed(TimeDelta::days(i64::from(ndays)))
                     .ok_or(OUT_OF_RANGE)?;
                 if date.year() != year {
                     return Err(OUT_OF_RANGE);
@@ -462,7 +459,7 @@ impl Parsed {
                     + (week_from_mon as i32 - 1) * 7
                     + weekday.num_days_from_monday() as i32;
                 let date = newyear
-                    .checked_add_signed(OldDuration::days(i64::from(ndays)))
+                    .checked_add_signed(TimeDelta::days(i64::from(ndays)))
                     .ok_or(OUT_OF_RANGE)?;
                 if date.year() != year {
                     return Err(OUT_OF_RANGE);
@@ -585,7 +582,7 @@ impl Parsed {
                     59 => {}
                     // `datetime` is known to be off by one second.
                     0 => {
-                        datetime -= OldDuration::seconds(1);
+                        datetime -= TimeDelta::seconds(1);
                     }
                     // otherwise it is impossible.
                     _ => return Err(IMPOSSIBLE),
@@ -629,7 +626,7 @@ impl Parsed {
 
         // this is used to prevent an overflow when calling FixedOffset::from_local_datetime
         datetime
-            .checked_sub_signed(OldDuration::seconds(i64::from(offset.local_minus_utc())))
+            .checked_sub_signed(TimeDelta::seconds(i64::from(offset.local_minus_utc())))
             .ok_or(OUT_OF_RANGE)?;
 
         match offset.from_local_datetime(&datetime) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,10 +425,6 @@
 #![cfg_attr(feature = "rustc-serialize", allow(deprecated))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-#[cfg(feature = "oldtime")]
-#[cfg_attr(docsrs, doc(cfg(feature = "oldtime")))]
-extern crate time as oldtime;
-#[cfg(not(feature = "oldtime"))]
 mod oldtime;
 // this reexport is to aid the transition and should not be in the prelude!
 pub use oldtime::{Duration, OutOfRangeError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,9 +420,6 @@
 #![warn(unreachable_pub)]
 #![deny(dead_code)]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
-// can remove this if/when rustc-serialize support is removed
-// keeps clippy happy in the meantime
-#![cfg_attr(feature = "rustc-serialize", allow(deprecated))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod oldtime;
@@ -468,9 +465,6 @@ mod date;
 pub use date::{Date, MAX_DATE, MIN_DATE};
 
 mod datetime;
-#[cfg(feature = "rustc-serialize")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rustc-serialize")))]
-pub use datetime::rustc_serialize::TsSeconds;
 #[allow(deprecated)]
 pub use datetime::{DateTime, SecondsFormat, MAX_DATETIME, MIN_DATETIME};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,30 +63,16 @@
 //!
 //! ### Duration
 //!
-//! Chrono currently uses its own [`Duration`] type to represent the magnitude
-//! of a time span. Since this has the same name as the newer, standard type for
-//! duration, the reference will refer this type as `OldDuration`.
-//!
-//! Note that this is an "accurate" duration represented as seconds and
+//! Chrono currently uses its own [`TimeDelta`] type to represent the magnitude
+//! of a time span. Note that this is an "accurate" duration represented as seconds and
 //! nanoseconds and does not represent "nominal" components such as days or
 //! months.
-//!
-//! When the `oldtime` feature is enabled, [`Duration`] is an alias for the
-//! [`time::Duration`](https://docs.rs/time/0.1.40/time/struct.Duration.html)
-//! type from v0.1 of the time crate. time v0.1 is deprecated, so new code
-//! should disable the `oldtime` feature and use the `chrono::Duration` type
-//! instead. The `oldtime` feature is enabled by default for backwards
-//! compatibility, but future versions of Chrono are likely to remove the
-//! feature entirely.
 //!
 //! Chrono does not yet natively support
 //! the standard [`Duration`](https://doc.rust-lang.org/std/time/struct.Duration.html) type,
 //! but it will be supported in the future.
 //! Meanwhile you can convert between two types with
-//! [`Duration::from_std`](https://docs.rs/time/0.1.40/time/struct.Duration.html#method.from_std)
-//! and
-//! [`Duration::to_std`](https://docs.rs/time/0.1.40/time/struct.Duration.html#method.to_std)
-//! methods.
+//! [`TimeDelta::from_std`] and [`TimeDelta::to_std`] methods.
 //!
 //! ### Date and Time
 //!
@@ -173,7 +159,7 @@
 //!
 //! ```rust
 //! use chrono::prelude::*;
-//! use chrono::Duration;
+//! use chrono::TimeDelta;
 //!
 //! // assume this returned `2014-11-28T21:45:59.324310806+09:00`:
 //! let dt = FixedOffset::east(9*3600).ymd(2014, 11, 28).and_hms_nano(21, 45, 59, 324310806);
@@ -200,11 +186,11 @@
 //! // arithmetic operations
 //! let dt1 = Utc.ymd(2014, 11, 14).and_hms(8, 9, 10);
 //! let dt2 = Utc.ymd(2014, 11, 14).and_hms(10, 9, 8);
-//! assert_eq!(dt1.signed_duration_since(dt2), Duration::seconds(-2 * 3600 + 2));
-//! assert_eq!(dt2.signed_duration_since(dt1), Duration::seconds(2 * 3600 - 2));
-//! assert_eq!(Utc.ymd(1970, 1, 1).and_hms(0, 0, 0) + Duration::seconds(1_000_000_000),
+//! assert_eq!(dt1.signed_duration_since(dt2), TimeDelta::seconds(-2 * 3600 + 2));
+//! assert_eq!(dt2.signed_duration_since(dt1), TimeDelta::seconds(2 * 3600 - 2));
+//! assert_eq!(Utc.ymd(1970, 1, 1).and_hms(0, 0, 0) + TimeDelta::seconds(1_000_000_000),
 //!            Utc.ymd(2001, 9, 9).and_hms(1, 46, 40));
-//! assert_eq!(Utc.ymd(1970, 1, 1).and_hms(0, 0, 0) - Duration::seconds(1_000_000_000),
+//! assert_eq!(Utc.ymd(1970, 1, 1).and_hms(0, 0, 0) - TimeDelta::seconds(1_000_000_000),
 //!            Utc.ymd(1938, 4, 24).and_hms(22, 13, 20));
 //! ```
 //!
@@ -422,9 +408,9 @@
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-mod oldtime;
+mod time_delta;
 // this reexport is to aid the transition and should not be in the prelude!
-pub use oldtime::{Duration, OutOfRangeError};
+pub use time_delta::TimeDelta;
 
 #[cfg(feature = "__doctest")]
 #[cfg_attr(feature = "__doctest", cfg(doctest))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,6 +409,8 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 mod time_delta;
+use core::fmt;
+
 // this reexport is to aid the transition and should not be in the prelude!
 pub use time_delta::TimeDelta;
 
@@ -503,6 +505,33 @@ pub use naive::__BenchYearFlags;
 pub mod serde {
     pub use super::datetime::serde::*;
 }
+
+/// Out of range error type used in various converting APIs
+#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+pub struct OutOfRange {
+    _private: (),
+}
+
+impl OutOfRange {
+    fn new() -> OutOfRange {
+        OutOfRange { _private: () }
+    }
+}
+
+impl fmt::Display for OutOfRange {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "out of range")
+    }
+}
+
+impl fmt::Debug for OutOfRange {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "out of range")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for OutOfRange {}
 
 /// MSRV 1.42
 #[cfg(test)]

--- a/src/month.rs
+++ b/src/month.rs
@@ -1,7 +1,9 @@
-use core::fmt;
+use core::{convert::TryFrom, fmt};
 
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
+
+use crate::OutOfRange;
 
 /// The month of the year.
 ///
@@ -151,39 +153,24 @@ impl Month {
     }
 }
 
-impl num_traits::FromPrimitive for Month {
-    /// Returns an Option<Month> from a i64, assuming a 1-index, January = 1.
-    ///
-    /// `Month::from_i64(n: i64)`: | `1`                  | `2`                   | ... | `12`
-    /// ---------------------------| -------------------- | --------------------- | ... | -----
-    /// ``:                        | Some(Month::January) | Some(Month::February) | ... | Some(Month::December)
+impl TryFrom<u8> for Month {
+    type Error = OutOfRange;
 
-    #[inline]
-    fn from_u64(n: u64) -> Option<Month> {
-        Self::from_u32(n as u32)
-    }
-
-    #[inline]
-    fn from_i64(n: i64) -> Option<Month> {
-        Self::from_u32(n as u32)
-    }
-
-    #[inline]
-    fn from_u32(n: u32) -> Option<Month> {
-        match n {
-            1 => Some(Month::January),
-            2 => Some(Month::February),
-            3 => Some(Month::March),
-            4 => Some(Month::April),
-            5 => Some(Month::May),
-            6 => Some(Month::June),
-            7 => Some(Month::July),
-            8 => Some(Month::August),
-            9 => Some(Month::September),
-            10 => Some(Month::October),
-            11 => Some(Month::November),
-            12 => Some(Month::December),
-            _ => None,
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Month::January),
+            2 => Ok(Month::February),
+            3 => Ok(Month::March),
+            4 => Ok(Month::April),
+            5 => Ok(Month::May),
+            6 => Ok(Month::June),
+            7 => Ok(Month::July),
+            8 => Ok(Month::August),
+            9 => Ok(Month::September),
+            10 => Ok(Month::October),
+            11 => Ok(Month::November),
+            12 => Ok(Month::December),
+            _ => Err(OutOfRange::new()),
         }
     }
 }
@@ -318,24 +305,20 @@ mod month_serde {
 
 #[cfg(test)]
 mod tests {
+    use core::convert::TryFrom;
+
     use super::Month;
-    use crate::{Datelike, TimeZone, Utc};
+    use crate::{Datelike, OutOfRange, TimeZone, Utc};
 
     #[test]
-    fn test_month_enum_primitive_parse() {
-        use num_traits::FromPrimitive;
-
-        let jan_opt = Month::from_u32(1);
-        let feb_opt = Month::from_u64(2);
-        let dec_opt = Month::from_i64(12);
-        let no_month = Month::from_u32(13);
-        assert_eq!(jan_opt, Some(Month::January));
-        assert_eq!(feb_opt, Some(Month::February));
-        assert_eq!(dec_opt, Some(Month::December));
-        assert_eq!(no_month, None);
+    fn test_month_enum_try_from() {
+        assert_eq!(Month::try_from(1), Ok(Month::January));
+        assert_eq!(Month::try_from(2), Ok(Month::February));
+        assert_eq!(Month::try_from(12), Ok(Month::December));
+        assert_eq!(Month::try_from(13), Err(OutOfRange::new()));
 
         let date = Utc.ymd(2019, 10, 28).and_hms(9, 10, 11);
-        assert_eq!(Month::from_u32(date.month()), Some(Month::October));
+        assert_eq!(Month::try_from(date.month() as u8), Ok(Month::October));
 
         let month = Month::January;
         let dt = Utc.ymd(2019, month.number_from_month(), 28).and_hms(9, 10, 11);

--- a/src/month.rs
+++ b/src/month.rs
@@ -28,7 +28,6 @@ use rkyv::{Archive, Deserialize, Serialize};
 /// Can be Serialized/Deserialized with serde
 // Actual implementation is zero-indexed, API intended as 1-indexed for more intuitive behavior.
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
-#[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
 pub enum Month {
     /// January

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1985,7 +1985,7 @@ impl Default for NaiveDate {
     }
 }
 
-#[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
+#[cfg(all(test, feature = "serde"))]
 fn test_encodable_json<F, E>(to_string: F)
 where
     F: Fn(&NaiveDate) -> Result<String, E>,
@@ -1998,7 +1998,7 @@ where
     assert_eq!(to_string(&NaiveDate::MAX).ok(), Some(r#""+262143-12-31""#.into()));
 }
 
-#[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
+#[cfg(all(test, feature = "serde"))]
 fn test_decodable_json<F, E>(from_str: F)
 where
     F: Fn(&str) -> Result<NaiveDate, E>,
@@ -2030,41 +2030,8 @@ where
     assert!(from_str(&i64::MIN.to_string()).is_err());
     assert!(from_str(&i64::MAX.to_string()).is_err());
     assert!(from_str(r#"{}"#).is_err());
-    // pre-0.3.0 rustc-serialize format is now invalid
     assert!(from_str(r#"{"ymdf":20}"#).is_err());
     assert!(from_str(r#"null"#).is_err());
-}
-
-#[cfg(feature = "rustc-serialize")]
-#[cfg_attr(docsrs, doc(cfg(feature = "rustc-serialize")))]
-mod rustc_serialize {
-    use super::NaiveDate;
-    use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
-
-    impl Encodable for NaiveDate {
-        fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-            format!("{:?}", self).encode(s)
-        }
-    }
-
-    impl Decodable for NaiveDate {
-        fn decode<D: Decoder>(d: &mut D) -> Result<NaiveDate, D::Error> {
-            d.read_str()?.parse().map_err(|_| d.error("invalid date"))
-        }
-    }
-
-    #[cfg(test)]
-    use rustc_serialize::json;
-
-    #[test]
-    fn test_encodable() {
-        super::test_encodable_json(json::encode);
-    }
-
-    #[test]
-    fn test_decodable() {
-        super::test_decodable_json(json::decode);
-    }
 }
 
 #[cfg(feature = "serde")]

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -5,11 +5,11 @@
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
+use core::convert::TryFrom;
 use core::ops::{Add, AddAssign, RangeInclusive, Sub, SubAssign};
 use core::{fmt, str};
 
 use num_integer::div_mod_floor;
-use num_traits::ToPrimitive;
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -1058,7 +1058,7 @@ impl NaiveDate {
         let year = self.year();
         let (mut year_div_400, year_mod_400) = div_mod_floor(year, 400);
         let cycle = internals::yo_to_cycle(year_mod_400 as u32, self.of().ordinal());
-        let cycle = (cycle as i32).checked_add(rhs.num_days().to_i32()?)?;
+        let cycle = (cycle as i32).checked_add(i32::try_from(rhs.num_days()).ok()?)?;
         let (cycle_div_400y, cycle) = div_mod_floor(cycle, 146_097);
         year_div_400 += cycle_div_400y;
 
@@ -1089,7 +1089,7 @@ impl NaiveDate {
         let year = self.year();
         let (mut year_div_400, year_mod_400) = div_mod_floor(year, 400);
         let cycle = internals::yo_to_cycle(year_mod_400 as u32, self.of().ordinal());
-        let cycle = (cycle as i32).checked_sub(rhs.num_days().to_i32()?)?;
+        let cycle = (cycle as i32).checked_sub(i32::try_from(rhs.num_days()).ok()?)?;
         let (cycle_div_400y, cycle) = div_mod_floor(cycle, 146_097);
         year_div_400 += cycle_div_400y;
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -19,8 +19,7 @@ use crate::format::{parse, ParseError, ParseResult, Parsed, StrftimeItems};
 use crate::format::{Item, Numeric, Pad};
 use crate::month::Months;
 use crate::naive::{IsoWeek, NaiveDateTime, NaiveTime};
-use crate::oldtime::Duration as OldDuration;
-use crate::{Datelike, Duration, Weekday};
+use crate::{Datelike, TimeDelta, Weekday};
 
 use super::internals::{self, DateImpl, Mdf, Of, YearFlags};
 use super::isoweek;
@@ -76,7 +75,7 @@ impl NaiveWeek {
         let start = self.start.num_days_from_monday();
         let end = self.date.weekday().num_days_from_monday();
         let days = if start > end { 7 - start + end } else { end - start };
-        self.date - Duration::days(days.into())
+        self.date - TimeDelta::days(days.into())
     }
 
     /// Returns a date representing the last day of the week.
@@ -92,7 +91,7 @@ impl NaiveWeek {
     /// ```
     #[inline]
     pub fn last_day(&self) -> NaiveDate {
-        self.first_day() + Duration::days(6)
+        self.first_day() + TimeDelta::days(6)
     }
 
     /// Returns a [`RangeInclusive<T>`] representing the whole week bounded by
@@ -194,7 +193,7 @@ fn test_date_bounds() {
     );
 
     // let's also check that the entire range do not exceed 2^44 seconds
-    // (sometimes used for bounding `Duration` against overflow)
+    // (sometimes used for bounding `TimeDelta` against overflow)
     let maxsecs = NaiveDate::MAX.signed_duration_since(NaiveDate::MIN).num_seconds();
     let maxsecs = maxsecs + 86401; // also take care of DateTime
     assert!(
@@ -1044,18 +1043,18 @@ impl NaiveDate {
     /// # Example
     ///
     /// ```
-    /// use chrono::{Duration, NaiveDate};
+    /// use chrono::{TimeDelta, NaiveDate};
     ///
     /// let d = NaiveDate::from_ymd(2015, 9, 5);
-    /// assert_eq!(d.checked_add_signed(Duration::days(40)),
+    /// assert_eq!(d.checked_add_signed(TimeDelta::days(40)),
     ///            Some(NaiveDate::from_ymd(2015, 10, 15)));
-    /// assert_eq!(d.checked_add_signed(Duration::days(-40)),
+    /// assert_eq!(d.checked_add_signed(TimeDelta::days(-40)),
     ///            Some(NaiveDate::from_ymd(2015, 7, 27)));
-    /// assert_eq!(d.checked_add_signed(Duration::days(1_000_000_000)), None);
-    /// assert_eq!(d.checked_add_signed(Duration::days(-1_000_000_000)), None);
-    /// assert_eq!(NaiveDate::MAX.checked_add_signed(Duration::days(1)), None);
+    /// assert_eq!(d.checked_add_signed(TimeDelta::days(1_000_000_000)), None);
+    /// assert_eq!(d.checked_add_signed(TimeDelta::days(-1_000_000_000)), None);
+    /// assert_eq!(NaiveDate::MAX.checked_add_signed(TimeDelta::days(1)), None);
     /// ```
-    pub fn checked_add_signed(self, rhs: OldDuration) -> Option<NaiveDate> {
+    pub fn checked_add_signed(self, rhs: TimeDelta) -> Option<NaiveDate> {
         let year = self.year();
         let (mut year_div_400, year_mod_400) = div_mod_floor(year, 400);
         let cycle = internals::yo_to_cycle(year_mod_400 as u32, self.of().ordinal());
@@ -1068,25 +1067,25 @@ impl NaiveDate {
         NaiveDate::from_of(year_div_400 * 400 + year_mod_400 as i32, Of::new(ordinal, flags))
     }
 
-    /// Subtracts the `days` part of given `Duration` from the current date.
+    /// Subtracts the `days` part of given `TimeDelta` from the current date.
     ///
     /// Returns `None` when it will result in overflow.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::{Duration, NaiveDate};
+    /// use chrono::{TimeDelta, NaiveDate};
     ///
     /// let d = NaiveDate::from_ymd(2015, 9, 5);
-    /// assert_eq!(d.checked_sub_signed(Duration::days(40)),
+    /// assert_eq!(d.checked_sub_signed(TimeDelta::days(40)),
     ///            Some(NaiveDate::from_ymd(2015, 7, 27)));
-    /// assert_eq!(d.checked_sub_signed(Duration::days(-40)),
+    /// assert_eq!(d.checked_sub_signed(TimeDelta::days(-40)),
     ///            Some(NaiveDate::from_ymd(2015, 10, 15)));
-    /// assert_eq!(d.checked_sub_signed(Duration::days(1_000_000_000)), None);
-    /// assert_eq!(d.checked_sub_signed(Duration::days(-1_000_000_000)), None);
-    /// assert_eq!(NaiveDate::MIN.checked_sub_signed(Duration::days(1)), None);
+    /// assert_eq!(d.checked_sub_signed(TimeDelta::days(1_000_000_000)), None);
+    /// assert_eq!(d.checked_sub_signed(TimeDelta::days(-1_000_000_000)), None);
+    /// assert_eq!(NaiveDate::MIN.checked_sub_signed(TimeDelta::days(1)), None);
     /// ```
-    pub fn checked_sub_signed(self, rhs: OldDuration) -> Option<NaiveDate> {
+    pub fn checked_sub_signed(self, rhs: TimeDelta) -> Option<NaiveDate> {
         let year = self.year();
         let (mut year_div_400, year_mod_400) = div_mod_floor(year, 400);
         let cycle = internals::yo_to_cycle(year_mod_400 as u32, self.of().ordinal());
@@ -1100,35 +1099,35 @@ impl NaiveDate {
     }
 
     /// Subtracts another `NaiveDate` from the current date.
-    /// Returns a `Duration` of integral numbers.
+    /// Returns a `TimeDelta` of integral numbers.
     ///
     /// This does not overflow or underflow at all,
-    /// as all possible output fits in the range of `Duration`.
+    /// as all possible output fits in the range of `TimeDelta`.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::{Duration, NaiveDate};
+    /// use chrono::{TimeDelta, NaiveDate};
     ///
     /// let from_ymd = NaiveDate::from_ymd;
     /// let since = NaiveDate::signed_duration_since;
     ///
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2014, 1, 1)), Duration::zero());
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2013, 12, 31)), Duration::days(1));
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2014, 1, 2)), Duration::days(-1));
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2013, 9, 23)), Duration::days(100));
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2013, 1, 1)), Duration::days(365));
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2010, 1, 1)), Duration::days(365*4 + 1));
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(1614, 1, 1)), Duration::days(365*400 + 97));
+    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2014, 1, 1)), TimeDelta::zero());
+    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2013, 12, 31)), TimeDelta::days(1));
+    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2014, 1, 2)), TimeDelta::days(-1));
+    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2013, 9, 23)), TimeDelta::days(100));
+    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2013, 1, 1)), TimeDelta::days(365));
+    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2010, 1, 1)), TimeDelta::days(365*4 + 1));
+    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(1614, 1, 1)), TimeDelta::days(365*400 + 97));
     /// ```
-    pub fn signed_duration_since(self, rhs: NaiveDate) -> OldDuration {
+    pub fn signed_duration_since(self, rhs: NaiveDate) -> TimeDelta {
         let year1 = self.year();
         let year2 = rhs.year();
         let (year1_div_400, year1_mod_400) = div_mod_floor(year1, 400);
         let (year2_div_400, year2_mod_400) = div_mod_floor(year2, 400);
         let cycle1 = i64::from(internals::yo_to_cycle(year1_mod_400 as u32, self.of().ordinal()));
         let cycle2 = i64::from(internals::yo_to_cycle(year2_mod_400 as u32, rhs.of().ordinal()));
-        OldDuration::days(
+        TimeDelta::days(
             (i64::from(year1_div_400) - i64::from(year2_div_400)) * 146_097 + (cycle1 - cycle2),
         )
     }
@@ -1636,31 +1635,31 @@ impl Datelike for NaiveDate {
 /// # Example
 ///
 /// ```
-/// use chrono::{Duration, NaiveDate};
+/// use chrono::{TimeDelta, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
-/// assert_eq!(from_ymd(2014, 1, 1) + Duration::zero(),             from_ymd(2014, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) + Duration::seconds(86399),     from_ymd(2014, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) + Duration::seconds(-86399),    from_ymd(2014, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) + Duration::days(1),            from_ymd(2014, 1, 2));
-/// assert_eq!(from_ymd(2014, 1, 1) + Duration::days(-1),           from_ymd(2013, 12, 31));
-/// assert_eq!(from_ymd(2014, 1, 1) + Duration::days(364),          from_ymd(2014, 12, 31));
-/// assert_eq!(from_ymd(2014, 1, 1) + Duration::days(365*4 + 1),    from_ymd(2018, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) + Duration::days(365*400 + 97), from_ymd(2414, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::zero(),             from_ymd(2014, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::seconds(86399),     from_ymd(2014, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::seconds(-86399),    from_ymd(2014, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(1),            from_ymd(2014, 1, 2));
+/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(-1),           from_ymd(2013, 12, 31));
+/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(364),          from_ymd(2014, 12, 31));
+/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(365*4 + 1),    from_ymd(2018, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(365*400 + 97), from_ymd(2414, 1, 1));
 /// ```
-impl Add<OldDuration> for NaiveDate {
+impl Add<TimeDelta> for NaiveDate {
     type Output = NaiveDate;
 
     #[inline]
-    fn add(self, rhs: OldDuration) -> NaiveDate {
-        self.checked_add_signed(rhs).expect("`NaiveDate + Duration` overflowed")
+    fn add(self, rhs: TimeDelta) -> NaiveDate {
+        self.checked_add_signed(rhs).expect("`NaiveDate + TimeDelta` overflowed")
     }
 }
 
-impl AddAssign<OldDuration> for NaiveDate {
+impl AddAssign<TimeDelta> for NaiveDate {
     #[inline]
-    fn add_assign(&mut self, rhs: OldDuration) {
+    fn add_assign(&mut self, rhs: TimeDelta) {
         *self = self.add(rhs);
     }
 }
@@ -1677,7 +1676,7 @@ impl Add<Months> for NaiveDate {
     /// # Example
     ///
     /// ```
-    /// use chrono::{Duration, NaiveDate, Months};
+    /// use chrono::{TimeDelta, NaiveDate, Months};
     ///
     /// let from_ymd = NaiveDate::from_ymd;
     ///
@@ -1705,7 +1704,7 @@ impl Sub<Months> for NaiveDate {
     /// # Example
     ///
     /// ```
-    /// use chrono::{Duration, NaiveDate, Months};
+    /// use chrono::{TimeDelta, NaiveDate, Months};
     ///
     /// let from_ymd = NaiveDate::from_ymd;
     ///
@@ -1718,9 +1717,9 @@ impl Sub<Months> for NaiveDate {
     }
 }
 
-/// A subtraction of `Duration` from `NaiveDate` discards the fractional days,
-/// rounding to the closest integral number of days towards `Duration::zero()`.
-/// It is the same as the addition with a negated `Duration`.
+/// A subtraction of `TimeDelta` from `NaiveDate` discards the fractional days,
+/// rounding to the closest integral number of days towards `TimeDelta::zero()`.
+/// It is the same as the addition with a negated `TimeDelta`.
 ///
 /// Panics on underflow or overflow.
 /// Use [`NaiveDate::checked_sub_signed`](#method.checked_sub_signed) to detect that.
@@ -1728,40 +1727,40 @@ impl Sub<Months> for NaiveDate {
 /// # Example
 ///
 /// ```
-/// use chrono::{Duration, NaiveDate};
+/// use chrono::{TimeDelta, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
-/// assert_eq!(from_ymd(2014, 1, 1) - Duration::zero(),             from_ymd(2014, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) - Duration::seconds(86399),     from_ymd(2014, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) - Duration::seconds(-86399),    from_ymd(2014, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) - Duration::days(1),            from_ymd(2013, 12, 31));
-/// assert_eq!(from_ymd(2014, 1, 1) - Duration::days(-1),           from_ymd(2014, 1, 2));
-/// assert_eq!(from_ymd(2014, 1, 1) - Duration::days(364),          from_ymd(2013, 1, 2));
-/// assert_eq!(from_ymd(2014, 1, 1) - Duration::days(365*4 + 1),    from_ymd(2010, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) - Duration::days(365*400 + 97), from_ymd(1614, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::zero(),             from_ymd(2014, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::seconds(86399),     from_ymd(2014, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::seconds(-86399),    from_ymd(2014, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(1),            from_ymd(2013, 12, 31));
+/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(-1),           from_ymd(2014, 1, 2));
+/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(364),          from_ymd(2013, 1, 2));
+/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(365*4 + 1),    from_ymd(2010, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(365*400 + 97), from_ymd(1614, 1, 1));
 /// ```
-impl Sub<OldDuration> for NaiveDate {
+impl Sub<TimeDelta> for NaiveDate {
     type Output = NaiveDate;
 
     #[inline]
-    fn sub(self, rhs: OldDuration) -> NaiveDate {
-        self.checked_sub_signed(rhs).expect("`NaiveDate - Duration` overflowed")
+    fn sub(self, rhs: TimeDelta) -> NaiveDate {
+        self.checked_sub_signed(rhs).expect("`NaiveDate - TimeDelta` overflowed")
     }
 }
 
-impl SubAssign<OldDuration> for NaiveDate {
+impl SubAssign<TimeDelta> for NaiveDate {
     #[inline]
-    fn sub_assign(&mut self, rhs: OldDuration) {
+    fn sub_assign(&mut self, rhs: TimeDelta) {
         *self = self.sub(rhs);
     }
 }
 
 /// Subtracts another `NaiveDate` from the current date.
-/// Returns a `Duration` of integral numbers.
+/// Returns a `TimeDelta` of integral numbers.
 ///
 /// This does not overflow or underflow at all,
-/// as all possible output fits in the range of `Duration`.
+/// as all possible output fits in the range of `TimeDelta`.
 ///
 /// The implementation is a wrapper around
 /// [`NaiveDate::signed_duration_since`](#method.signed_duration_since).
@@ -1769,23 +1768,23 @@ impl SubAssign<OldDuration> for NaiveDate {
 /// # Example
 ///
 /// ```
-/// use chrono::{Duration, NaiveDate};
+/// use chrono::{TimeDelta, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2014, 1, 1), Duration::zero());
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 12, 31), Duration::days(1));
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2014, 1, 2), Duration::days(-1));
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 9, 23), Duration::days(100));
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 1, 1), Duration::days(365));
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2010, 1, 1), Duration::days(365*4 + 1));
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(1614, 1, 1), Duration::days(365*400 + 97));
+/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2014, 1, 1), TimeDelta::zero());
+/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 12, 31), TimeDelta::days(1));
+/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2014, 1, 2), TimeDelta::days(-1));
+/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 9, 23), TimeDelta::days(100));
+/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 1, 1), TimeDelta::days(365));
+/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2010, 1, 1), TimeDelta::days(365*4 + 1));
+/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(1614, 1, 1), TimeDelta::days(365*400 + 97));
 /// ```
 impl Sub<NaiveDate> for NaiveDate {
-    type Output = OldDuration;
+    type Output = TimeDelta;
 
     #[inline]
-    fn sub(self, rhs: NaiveDate) -> OldDuration {
+    fn sub(self, rhs: NaiveDate) -> TimeDelta {
         self.signed_duration_since(rhs)
     }
 }
@@ -1838,11 +1837,11 @@ impl Iterator for NaiveDateWeeksIterator {
     type Item = NaiveDate;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if NaiveDate::MAX - self.value < OldDuration::weeks(1) {
+        if NaiveDate::MAX - self.value < TimeDelta::weeks(1) {
             return None;
         }
         let current = self.value;
-        self.value = current + OldDuration::weeks(1);
+        self.value = current + TimeDelta::weeks(1);
         Some(current)
     }
 
@@ -1856,11 +1855,11 @@ impl ExactSizeIterator for NaiveDateWeeksIterator {}
 
 impl DoubleEndedIterator for NaiveDateWeeksIterator {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if self.value - NaiveDate::MIN < OldDuration::weeks(1) {
+        if self.value - NaiveDate::MIN < TimeDelta::weeks(1) {
             return None;
         }
         let current = self.value;
-        self.value = current - OldDuration::weeks(1);
+        self.value = current - TimeDelta::weeks(1);
         Some(current)
     }
 }
@@ -2125,7 +2124,7 @@ mod tests {
     use super::{
         Months, NaiveDate, MAX_DAYS_FROM_YEAR_0, MAX_YEAR, MIN_DAYS_FROM_YEAR_0, MIN_YEAR,
     };
-    use crate::oldtime::Duration;
+    use crate::time_delta::TimeDelta;
     use crate::{Datelike, Weekday};
     use std::{i32, u32};
 
@@ -2522,61 +2521,61 @@ mod tests {
 
     #[test]
     fn test_date_add() {
-        fn check((y1, m1, d1): (i32, u32, u32), rhs: Duration, ymd: Option<(i32, u32, u32)>) {
+        fn check((y1, m1, d1): (i32, u32, u32), rhs: TimeDelta, ymd: Option<(i32, u32, u32)>) {
             let lhs = NaiveDate::from_ymd(y1, m1, d1);
             let sum = ymd.map(|(y, m, d)| NaiveDate::from_ymd(y, m, d));
             assert_eq!(lhs.checked_add_signed(rhs), sum);
             assert_eq!(lhs.checked_sub_signed(-rhs), sum);
         }
 
-        check((2014, 1, 1), Duration::zero(), Some((2014, 1, 1)));
-        check((2014, 1, 1), Duration::seconds(86399), Some((2014, 1, 1)));
+        check((2014, 1, 1), TimeDelta::zero(), Some((2014, 1, 1)));
+        check((2014, 1, 1), TimeDelta::seconds(86399), Some((2014, 1, 1)));
         // always round towards zero
-        check((2014, 1, 1), Duration::seconds(-86399), Some((2014, 1, 1)));
-        check((2014, 1, 1), Duration::days(1), Some((2014, 1, 2)));
-        check((2014, 1, 1), Duration::days(-1), Some((2013, 12, 31)));
-        check((2014, 1, 1), Duration::days(364), Some((2014, 12, 31)));
-        check((2014, 1, 1), Duration::days(365 * 4 + 1), Some((2018, 1, 1)));
-        check((2014, 1, 1), Duration::days(365 * 400 + 97), Some((2414, 1, 1)));
+        check((2014, 1, 1), TimeDelta::seconds(-86399), Some((2014, 1, 1)));
+        check((2014, 1, 1), TimeDelta::days(1), Some((2014, 1, 2)));
+        check((2014, 1, 1), TimeDelta::days(-1), Some((2013, 12, 31)));
+        check((2014, 1, 1), TimeDelta::days(364), Some((2014, 12, 31)));
+        check((2014, 1, 1), TimeDelta::days(365 * 4 + 1), Some((2018, 1, 1)));
+        check((2014, 1, 1), TimeDelta::days(365 * 400 + 97), Some((2414, 1, 1)));
 
-        check((-7, 1, 1), Duration::days(365 * 12 + 3), Some((5, 1, 1)));
+        check((-7, 1, 1), TimeDelta::days(365 * 12 + 3), Some((5, 1, 1)));
 
         // overflow check
-        check((0, 1, 1), Duration::days(MAX_DAYS_FROM_YEAR_0 as i64), Some((MAX_YEAR, 12, 31)));
-        check((0, 1, 1), Duration::days(MAX_DAYS_FROM_YEAR_0 as i64 + 1), None);
-        check((0, 1, 1), Duration::max_value(), None);
-        check((0, 1, 1), Duration::days(MIN_DAYS_FROM_YEAR_0 as i64), Some((MIN_YEAR, 1, 1)));
-        check((0, 1, 1), Duration::days(MIN_DAYS_FROM_YEAR_0 as i64 - 1), None);
-        check((0, 1, 1), Duration::min_value(), None);
+        check((0, 1, 1), TimeDelta::days(MAX_DAYS_FROM_YEAR_0 as i64), Some((MAX_YEAR, 12, 31)));
+        check((0, 1, 1), TimeDelta::days(MAX_DAYS_FROM_YEAR_0 as i64 + 1), None);
+        check((0, 1, 1), TimeDelta::max_value(), None);
+        check((0, 1, 1), TimeDelta::days(MIN_DAYS_FROM_YEAR_0 as i64), Some((MIN_YEAR, 1, 1)));
+        check((0, 1, 1), TimeDelta::days(MIN_DAYS_FROM_YEAR_0 as i64 - 1), None);
+        check((0, 1, 1), TimeDelta::min_value(), None);
     }
 
     #[test]
     fn test_date_sub() {
-        fn check((y1, m1, d1): (i32, u32, u32), (y2, m2, d2): (i32, u32, u32), diff: Duration) {
+        fn check((y1, m1, d1): (i32, u32, u32), (y2, m2, d2): (i32, u32, u32), diff: TimeDelta) {
             let lhs = NaiveDate::from_ymd(y1, m1, d1);
             let rhs = NaiveDate::from_ymd(y2, m2, d2);
             assert_eq!(lhs.signed_duration_since(rhs), diff);
             assert_eq!(rhs.signed_duration_since(lhs), -diff);
         }
 
-        check((2014, 1, 1), (2014, 1, 1), Duration::zero());
-        check((2014, 1, 2), (2014, 1, 1), Duration::days(1));
-        check((2014, 12, 31), (2014, 1, 1), Duration::days(364));
-        check((2015, 1, 3), (2014, 1, 1), Duration::days(365 + 2));
-        check((2018, 1, 1), (2014, 1, 1), Duration::days(365 * 4 + 1));
-        check((2414, 1, 1), (2014, 1, 1), Duration::days(365 * 400 + 97));
+        check((2014, 1, 1), (2014, 1, 1), TimeDelta::zero());
+        check((2014, 1, 2), (2014, 1, 1), TimeDelta::days(1));
+        check((2014, 12, 31), (2014, 1, 1), TimeDelta::days(364));
+        check((2015, 1, 3), (2014, 1, 1), TimeDelta::days(365 + 2));
+        check((2018, 1, 1), (2014, 1, 1), TimeDelta::days(365 * 4 + 1));
+        check((2414, 1, 1), (2014, 1, 1), TimeDelta::days(365 * 400 + 97));
 
-        check((MAX_YEAR, 12, 31), (0, 1, 1), Duration::days(MAX_DAYS_FROM_YEAR_0 as i64));
-        check((MIN_YEAR, 1, 1), (0, 1, 1), Duration::days(MIN_DAYS_FROM_YEAR_0 as i64));
+        check((MAX_YEAR, 12, 31), (0, 1, 1), TimeDelta::days(MAX_DAYS_FROM_YEAR_0 as i64));
+        check((MIN_YEAR, 1, 1), (0, 1, 1), TimeDelta::days(MIN_DAYS_FROM_YEAR_0 as i64));
     }
 
     #[test]
     fn test_date_addassignment() {
         let ymd = NaiveDate::from_ymd;
         let mut date = ymd(2016, 10, 1);
-        date += Duration::days(10);
+        date += TimeDelta::days(10);
         assert_eq!(date, ymd(2016, 10, 11));
-        date += Duration::days(30);
+        date += TimeDelta::days(30);
         assert_eq!(date, ymd(2016, 11, 10));
     }
 
@@ -2584,9 +2583,9 @@ mod tests {
     fn test_date_subassignment() {
         let ymd = NaiveDate::from_ymd;
         let mut date = ymd(2016, 10, 11);
-        date -= Duration::days(10);
+        date -= TimeDelta::days(10);
         assert_eq!(date, ymd(2016, 10, 1));
-        date -= Duration::days(2);
+        date -= TimeDelta::days(2);
         assert_eq!(date, ymd(2016, 9, 29));
     }
 

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -21,9 +21,6 @@ use crate::naive::{IsoWeek, NaiveDate, NaiveTime};
 use crate::oldtime::Duration as OldDuration;
 use crate::{DateTime, Datelike, LocalResult, Months, TimeZone, Timelike, Weekday};
 
-#[cfg(feature = "rustc-serialize")]
-pub(super) mod rustc_serialize;
-
 /// Tools to help serializing/deserializing `NaiveDateTime`s
 #[cfg(feature = "serde")]
 pub(crate) mod serde;
@@ -1665,7 +1662,7 @@ impl Default for NaiveDateTime {
     }
 }
 
-#[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
+#[cfg(all(test, feature = "serde"))]
 fn test_encodable_json<F, E>(to_string: F)
 where
     F: Fn(&NaiveDateTime) -> Result<String, E>,
@@ -1697,7 +1694,7 @@ where
     );
 }
 
-#[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
+#[cfg(all(test, feature = "serde"))]
 fn test_decodable_json<F, E>(from_str: F)
 where
     F: Fn(&str) -> Result<NaiveDateTime, E>,
@@ -1757,22 +1754,4 @@ where
     // pre-0.3.0 rustc-serialize format is now invalid
     assert!(from_str(r#"{"date":{"ymdf":20},"time":{"secs":0,"frac":0}}"#).is_err());
     assert!(from_str(r#"null"#).is_err());
-}
-
-#[cfg(all(test, feature = "rustc-serialize"))]
-fn test_decodable_json_timestamp<F, E>(from_str: F)
-where
-    F: Fn(&str) -> Result<rustc_serialize::TsSeconds, E>,
-    E: ::std::fmt::Debug,
-{
-    assert_eq!(
-        *from_str("0").unwrap(),
-        NaiveDate::from_ymd(1970, 1, 1).and_hms(0, 0, 0),
-        "should parse integers as timestamps"
-    );
-    assert_eq!(
-        *from_str("-1").unwrap(),
-        NaiveDate::from_ymd(1969, 12, 31).and_hms(23, 59, 59),
-        "should parse integers as timestamps"
-    );
 }

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -5,11 +5,11 @@
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
+use core::convert::TryFrom;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::{fmt, str};
 
 use num_integer::div_mod_floor;
-use num_traits::ToPrimitive;
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -155,8 +155,8 @@ impl NaiveDateTime {
     #[inline]
     pub fn from_timestamp_opt(secs: i64, nsecs: u32) -> Option<NaiveDateTime> {
         let (days, secs) = div_mod_floor(secs, 86_400);
-        let date = days
-            .to_i32()
+        let date = i32::try_from(days)
+            .ok()
             .and_then(|days| days.checked_add(719_163))
             .and_then(NaiveDate::from_num_days_from_ce_opt);
         let time = NaiveTime::from_num_seconds_from_midnight_opt(secs as u32, nsecs);

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -18,8 +18,7 @@ use crate::format::DelayedFormat;
 use crate::format::{parse, ParseError, ParseResult, Parsed, StrftimeItems};
 use crate::format::{Fixed, Item, Numeric, Pad};
 use crate::naive::{IsoWeek, NaiveDate, NaiveTime};
-use crate::oldtime::Duration as OldDuration;
-use crate::{DateTime, Datelike, LocalResult, Months, TimeZone, Timelike, Weekday};
+use crate::{DateTime, Datelike, LocalResult, Months, TimeDelta, TimeZone, Timelike, Weekday};
 
 /// Tools to help serializing/deserializing `NaiveDateTime`s
 #[cfg(feature = "serde")]
@@ -28,10 +27,10 @@ pub(crate) mod serde;
 #[cfg(test)]
 mod tests;
 
-/// The tight upper bound guarantees that a duration with `|Duration| >= 2^MAX_SECS_BITS`
+/// The tight upper bound guarantees that a duration with `|TimeDelta| >= 2^MAX_SECS_BITS`
 /// will always overflow the addition with any date and time type.
 ///
-/// So why is this needed? `Duration::seconds(rhs)` may overflow, and we don't have
+/// So why is this needed? `TimeDelta::seconds(rhs)` may overflow, and we don't have
 /// an alternative returning `Option` or `Result`. Thus we need some early bound to avoid
 /// touching that call when we are already sure that it WILL overflow...
 const MAX_SECS_BITS: usize = 44;
@@ -453,7 +452,7 @@ impl NaiveDateTime {
         self.time.nanosecond()
     }
 
-    /// Adds given `Duration` to the current date and time.
+    /// Adds given `TimeDelta` to the current date and time.
     ///
     /// As a part of Chrono's [leap second handling](./struct.NaiveTime.html#leap-second-handling),
     /// the addition assumes that **there is no leap second ever**,
@@ -465,68 +464,68 @@ impl NaiveDateTime {
     /// # Example
     ///
     /// ```
-    /// use chrono::{Duration, NaiveDate};
+    /// use chrono::{TimeDelta, NaiveDate};
     ///
     /// let from_ymd = NaiveDate::from_ymd;
     ///
     /// let d = from_ymd(2016, 7, 8);
     /// let hms = |h, m, s| d.and_hms(h, m, s);
-    /// assert_eq!(hms(3, 5, 7).checked_add_signed(Duration::zero()),
+    /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::zero()),
     ///            Some(hms(3, 5, 7)));
-    /// assert_eq!(hms(3, 5, 7).checked_add_signed(Duration::seconds(1)),
+    /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::seconds(1)),
     ///            Some(hms(3, 5, 8)));
-    /// assert_eq!(hms(3, 5, 7).checked_add_signed(Duration::seconds(-1)),
+    /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::seconds(-1)),
     ///            Some(hms(3, 5, 6)));
-    /// assert_eq!(hms(3, 5, 7).checked_add_signed(Duration::seconds(3600 + 60)),
+    /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::seconds(3600 + 60)),
     ///            Some(hms(4, 6, 7)));
-    /// assert_eq!(hms(3, 5, 7).checked_add_signed(Duration::seconds(86_400)),
+    /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::seconds(86_400)),
     ///            Some(from_ymd(2016, 7, 9).and_hms(3, 5, 7)));
     ///
     /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli);
-    /// assert_eq!(hmsm(3, 5, 7, 980).checked_add_signed(Duration::milliseconds(450)),
+    /// assert_eq!(hmsm(3, 5, 7, 980).checked_add_signed(TimeDelta::milliseconds(450)),
     ///            Some(hmsm(3, 5, 8, 430)));
     /// ```
     ///
     /// Overflow returns `None`.
     ///
     /// ```
-    /// # use chrono::{Duration, NaiveDate};
+    /// # use chrono::{TimeDelta, NaiveDate};
     /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).and_hms(h, m, s);
-    /// assert_eq!(hms(3, 5, 7).checked_add_signed(Duration::days(1_000_000_000)), None);
+    /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::days(1_000_000_000)), None);
     /// ```
     ///
     /// Leap seconds are handled,
     /// but the addition assumes that it is the only leap second happened.
     ///
     /// ```
-    /// # use chrono::{Duration, NaiveDate};
+    /// # use chrono::{TimeDelta, NaiveDate};
     /// # let from_ymd = NaiveDate::from_ymd;
     /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
     /// let leap = hmsm(3, 5, 59, 1_300);
-    /// assert_eq!(leap.checked_add_signed(Duration::zero()),
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::zero()),
     ///            Some(hmsm(3, 5, 59, 1_300)));
-    /// assert_eq!(leap.checked_add_signed(Duration::milliseconds(-500)),
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::milliseconds(-500)),
     ///            Some(hmsm(3, 5, 59, 800)));
-    /// assert_eq!(leap.checked_add_signed(Duration::milliseconds(500)),
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::milliseconds(500)),
     ///            Some(hmsm(3, 5, 59, 1_800)));
-    /// assert_eq!(leap.checked_add_signed(Duration::milliseconds(800)),
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::milliseconds(800)),
     ///            Some(hmsm(3, 6, 0, 100)));
-    /// assert_eq!(leap.checked_add_signed(Duration::seconds(10)),
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::seconds(10)),
     ///            Some(hmsm(3, 6, 9, 300)));
-    /// assert_eq!(leap.checked_add_signed(Duration::seconds(-10)),
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::seconds(-10)),
     ///            Some(hmsm(3, 5, 50, 300)));
-    /// assert_eq!(leap.checked_add_signed(Duration::days(1)),
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::days(1)),
     ///            Some(from_ymd(2016, 7, 9).and_hms_milli(3, 5, 59, 300)));
     /// ```
-    pub fn checked_add_signed(self, rhs: OldDuration) -> Option<NaiveDateTime> {
+    pub fn checked_add_signed(self, rhs: TimeDelta) -> Option<NaiveDateTime> {
         let (time, rhs) = self.time.overflowing_add_signed(rhs);
 
-        // early checking to avoid overflow in OldDuration::seconds
+        // early checking to avoid overflow in OldTimeDelta::seconds
         if rhs <= (-1 << MAX_SECS_BITS) || rhs >= (1 << MAX_SECS_BITS) {
             return None;
         }
 
-        let date = self.date.checked_add_signed(OldDuration::seconds(rhs))?;
+        let date = self.date.checked_add_signed(TimeDelta::seconds(rhs))?;
         Some(NaiveDateTime { date, time })
     }
 
@@ -558,7 +557,7 @@ impl NaiveDateTime {
         Some(Self { date: self.date.checked_add_months(rhs)?, time: self.time })
     }
 
-    /// Subtracts given `Duration` from the current date and time.
+    /// Subtracts given `TimeDelta` from the current date and time.
     ///
     /// As a part of Chrono's [leap second handling](./struct.NaiveTime.html#leap-second-handling),
     /// the subtraction assumes that **there is no leap second ever**,
@@ -570,64 +569,64 @@ impl NaiveDateTime {
     /// # Example
     ///
     /// ```
-    /// use chrono::{Duration, NaiveDate};
+    /// use chrono::{TimeDelta, NaiveDate};
     ///
     /// let from_ymd = NaiveDate::from_ymd;
     ///
     /// let d = from_ymd(2016, 7, 8);
     /// let hms = |h, m, s| d.and_hms(h, m, s);
-    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(Duration::zero()),
+    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::zero()),
     ///            Some(hms(3, 5, 7)));
-    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(Duration::seconds(1)),
+    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::seconds(1)),
     ///            Some(hms(3, 5, 6)));
-    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(Duration::seconds(-1)),
+    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::seconds(-1)),
     ///            Some(hms(3, 5, 8)));
-    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(Duration::seconds(3600 + 60)),
+    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::seconds(3600 + 60)),
     ///            Some(hms(2, 4, 7)));
-    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(Duration::seconds(86_400)),
+    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::seconds(86_400)),
     ///            Some(from_ymd(2016, 7, 7).and_hms(3, 5, 7)));
     ///
     /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli);
-    /// assert_eq!(hmsm(3, 5, 7, 450).checked_sub_signed(Duration::milliseconds(670)),
+    /// assert_eq!(hmsm(3, 5, 7, 450).checked_sub_signed(TimeDelta::milliseconds(670)),
     ///            Some(hmsm(3, 5, 6, 780)));
     /// ```
     ///
     /// Overflow returns `None`.
     ///
     /// ```
-    /// # use chrono::{Duration, NaiveDate};
+    /// # use chrono::{TimeDelta, NaiveDate};
     /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).and_hms(h, m, s);
-    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(Duration::days(1_000_000_000)), None);
+    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::days(1_000_000_000)), None);
     /// ```
     ///
     /// Leap seconds are handled,
     /// but the subtraction assumes that it is the only leap second happened.
     ///
     /// ```
-    /// # use chrono::{Duration, NaiveDate};
+    /// # use chrono::{TimeDelta, NaiveDate};
     /// # let from_ymd = NaiveDate::from_ymd;
     /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
     /// let leap = hmsm(3, 5, 59, 1_300);
-    /// assert_eq!(leap.checked_sub_signed(Duration::zero()),
+    /// assert_eq!(leap.checked_sub_signed(TimeDelta::zero()),
     ///            Some(hmsm(3, 5, 59, 1_300)));
-    /// assert_eq!(leap.checked_sub_signed(Duration::milliseconds(200)),
+    /// assert_eq!(leap.checked_sub_signed(TimeDelta::milliseconds(200)),
     ///            Some(hmsm(3, 5, 59, 1_100)));
-    /// assert_eq!(leap.checked_sub_signed(Duration::milliseconds(500)),
+    /// assert_eq!(leap.checked_sub_signed(TimeDelta::milliseconds(500)),
     ///            Some(hmsm(3, 5, 59, 800)));
-    /// assert_eq!(leap.checked_sub_signed(Duration::seconds(60)),
+    /// assert_eq!(leap.checked_sub_signed(TimeDelta::seconds(60)),
     ///            Some(hmsm(3, 5, 0, 300)));
-    /// assert_eq!(leap.checked_sub_signed(Duration::days(1)),
+    /// assert_eq!(leap.checked_sub_signed(TimeDelta::days(1)),
     ///            Some(from_ymd(2016, 7, 7).and_hms_milli(3, 6, 0, 300)));
     /// ```
-    pub fn checked_sub_signed(self, rhs: OldDuration) -> Option<NaiveDateTime> {
+    pub fn checked_sub_signed(self, rhs: TimeDelta) -> Option<NaiveDateTime> {
         let (time, rhs) = self.time.overflowing_sub_signed(rhs);
 
-        // early checking to avoid overflow in OldDuration::seconds
+        // early checking to avoid overflow in OldTimeDelta::seconds
         if rhs <= (-1 << MAX_SECS_BITS) || rhs >= (1 << MAX_SECS_BITS) {
             return None;
         }
 
-        let date = self.date.checked_sub_signed(OldDuration::seconds(rhs))?;
+        let date = self.date.checked_sub_signed(TimeDelta::seconds(rhs))?;
         Some(NaiveDateTime { date, time })
     }
 
@@ -671,33 +670,33 @@ impl NaiveDateTime {
     /// # Example
     ///
     /// ```
-    /// use chrono::{Duration, NaiveDate};
+    /// use chrono::{TimeDelta, NaiveDate};
     ///
     /// let from_ymd = NaiveDate::from_ymd;
     ///
     /// let d = from_ymd(2016, 7, 8);
     /// assert_eq!(d.and_hms(3, 5, 7).signed_duration_since(d.and_hms(2, 4, 6)),
-    ///            Duration::seconds(3600 + 60 + 1));
+    ///            TimeDelta::seconds(3600 + 60 + 1));
     ///
     /// // July 8 is 190th day in the year 2016
     /// let d0 = from_ymd(2016, 1, 1);
     /// assert_eq!(d.and_hms_milli(0, 7, 6, 500).signed_duration_since(d0.and_hms(0, 0, 0)),
-    ///            Duration::seconds(189 * 86_400 + 7 * 60 + 6) + Duration::milliseconds(500));
+    ///            TimeDelta::seconds(189 * 86_400 + 7 * 60 + 6) + TimeDelta::milliseconds(500));
     /// ```
     ///
     /// Leap seconds are handled, but the subtraction assumes that
     /// there were no other leap seconds happened.
     ///
     /// ```
-    /// # use chrono::{Duration, NaiveDate};
+    /// # use chrono::{TimeDelta, NaiveDate};
     /// # let from_ymd = NaiveDate::from_ymd;
     /// let leap = from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500);
     /// assert_eq!(leap.signed_duration_since(from_ymd(2015, 6, 30).and_hms(23, 0, 0)),
-    ///            Duration::seconds(3600) + Duration::milliseconds(500));
+    ///            TimeDelta::seconds(3600) + TimeDelta::milliseconds(500));
     /// assert_eq!(from_ymd(2015, 7, 1).and_hms(1, 0, 0).signed_duration_since(leap),
-    ///            Duration::seconds(3600) - Duration::milliseconds(500));
+    ///            TimeDelta::seconds(3600) - TimeDelta::milliseconds(500));
     /// ```
-    pub fn signed_duration_since(self, rhs: NaiveDateTime) -> OldDuration {
+    pub fn signed_duration_since(self, rhs: NaiveDateTime) -> TimeDelta {
         self.date.signed_duration_since(rhs.date) + self.time.signed_duration_since(rhs.time)
     }
 
@@ -1279,7 +1278,7 @@ impl Timelike for NaiveDateTime {
     }
 }
 
-/// An addition of `Duration` to `NaiveDateTime` yields another `NaiveDateTime`.
+/// An addition of `TimeDelta` to `NaiveDateTime` yields another `NaiveDateTime`.
 ///
 /// As a part of Chrono's [leap second handling](./struct.NaiveTime.html#leap-second-handling),
 /// the addition assumes that **there is no leap second ever**,
@@ -1292,54 +1291,54 @@ impl Timelike for NaiveDateTime {
 /// # Example
 ///
 /// ```
-/// use chrono::{Duration, NaiveDate};
+/// use chrono::{TimeDelta, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
 /// let d = from_ymd(2016, 7, 8);
 /// let hms = |h, m, s| d.and_hms(h, m, s);
-/// assert_eq!(hms(3, 5, 7) + Duration::zero(),             hms(3, 5, 7));
-/// assert_eq!(hms(3, 5, 7) + Duration::seconds(1),         hms(3, 5, 8));
-/// assert_eq!(hms(3, 5, 7) + Duration::seconds(-1),        hms(3, 5, 6));
-/// assert_eq!(hms(3, 5, 7) + Duration::seconds(3600 + 60), hms(4, 6, 7));
-/// assert_eq!(hms(3, 5, 7) + Duration::seconds(86_400),
+/// assert_eq!(hms(3, 5, 7) + TimeDelta::zero(),             hms(3, 5, 7));
+/// assert_eq!(hms(3, 5, 7) + TimeDelta::seconds(1),         hms(3, 5, 8));
+/// assert_eq!(hms(3, 5, 7) + TimeDelta::seconds(-1),        hms(3, 5, 6));
+/// assert_eq!(hms(3, 5, 7) + TimeDelta::seconds(3600 + 60), hms(4, 6, 7));
+/// assert_eq!(hms(3, 5, 7) + TimeDelta::seconds(86_400),
 ///            from_ymd(2016, 7, 9).and_hms(3, 5, 7));
-/// assert_eq!(hms(3, 5, 7) + Duration::days(365),
+/// assert_eq!(hms(3, 5, 7) + TimeDelta::days(365),
 ///            from_ymd(2017, 7, 8).and_hms(3, 5, 7));
 ///
 /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli);
-/// assert_eq!(hmsm(3, 5, 7, 980) + Duration::milliseconds(450), hmsm(3, 5, 8, 430));
+/// assert_eq!(hmsm(3, 5, 7, 980) + TimeDelta::milliseconds(450), hmsm(3, 5, 8, 430));
 /// ```
 ///
 /// Leap seconds are handled,
 /// but the addition assumes that it is the only leap second happened.
 ///
 /// ```
-/// # use chrono::{Duration, NaiveDate};
+/// # use chrono::{TimeDelta, NaiveDate};
 /// # let from_ymd = NaiveDate::from_ymd;
 /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
 /// let leap = hmsm(3, 5, 59, 1_300);
-/// assert_eq!(leap + Duration::zero(),             hmsm(3, 5, 59, 1_300));
-/// assert_eq!(leap + Duration::milliseconds(-500), hmsm(3, 5, 59, 800));
-/// assert_eq!(leap + Duration::milliseconds(500),  hmsm(3, 5, 59, 1_800));
-/// assert_eq!(leap + Duration::milliseconds(800),  hmsm(3, 6, 0, 100));
-/// assert_eq!(leap + Duration::seconds(10),        hmsm(3, 6, 9, 300));
-/// assert_eq!(leap + Duration::seconds(-10),       hmsm(3, 5, 50, 300));
-/// assert_eq!(leap + Duration::days(1),
+/// assert_eq!(leap + TimeDelta::zero(),             hmsm(3, 5, 59, 1_300));
+/// assert_eq!(leap + TimeDelta::milliseconds(-500), hmsm(3, 5, 59, 800));
+/// assert_eq!(leap + TimeDelta::milliseconds(500),  hmsm(3, 5, 59, 1_800));
+/// assert_eq!(leap + TimeDelta::milliseconds(800),  hmsm(3, 6, 0, 100));
+/// assert_eq!(leap + TimeDelta::seconds(10),        hmsm(3, 6, 9, 300));
+/// assert_eq!(leap + TimeDelta::seconds(-10),       hmsm(3, 5, 50, 300));
+/// assert_eq!(leap + TimeDelta::days(1),
 ///            from_ymd(2016, 7, 9).and_hms_milli(3, 5, 59, 300));
 /// ```
-impl Add<OldDuration> for NaiveDateTime {
+impl Add<TimeDelta> for NaiveDateTime {
     type Output = NaiveDateTime;
 
     #[inline]
-    fn add(self, rhs: OldDuration) -> NaiveDateTime {
-        self.checked_add_signed(rhs).expect("`NaiveDateTime + Duration` overflowed")
+    fn add(self, rhs: TimeDelta) -> NaiveDateTime {
+        self.checked_add_signed(rhs).expect("`NaiveDateTime + TimeDelta` overflowed")
     }
 }
 
-impl AddAssign<OldDuration> for NaiveDateTime {
+impl AddAssign<TimeDelta> for NaiveDateTime {
     #[inline]
-    fn add_assign(&mut self, rhs: OldDuration) {
+    fn add_assign(&mut self, rhs: TimeDelta) {
         *self = self.add(rhs);
     }
 }
@@ -1356,7 +1355,7 @@ impl Add<Months> for NaiveDateTime {
     /// # Example
     ///
     /// ```
-    /// use chrono::{Duration, NaiveDateTime, Months, NaiveDate};
+    /// use chrono::{TimeDelta, NaiveDateTime, Months, NaiveDate};
     /// use std::str::FromStr;
     ///
     /// assert_eq!(
@@ -1389,8 +1388,8 @@ impl Add<Months> for NaiveDateTime {
     }
 }
 
-/// A subtraction of `Duration` from `NaiveDateTime` yields another `NaiveDateTime`.
-/// It is the same as the addition with a negated `Duration`.
+/// A subtraction of `TimeDelta` from `NaiveDateTime` yields another `NaiveDateTime`.
+/// It is the same as the addition with a negated `TimeDelta`.
 ///
 /// As a part of Chrono's [leap second handling](./struct.NaiveTime.html#leap-second-handling),
 /// the addition assumes that **there is no leap second ever**,
@@ -1403,52 +1402,52 @@ impl Add<Months> for NaiveDateTime {
 /// # Example
 ///
 /// ```
-/// use chrono::{Duration, NaiveDate};
+/// use chrono::{TimeDelta, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
 /// let d = from_ymd(2016, 7, 8);
 /// let hms = |h, m, s| d.and_hms(h, m, s);
-/// assert_eq!(hms(3, 5, 7) - Duration::zero(),             hms(3, 5, 7));
-/// assert_eq!(hms(3, 5, 7) - Duration::seconds(1),         hms(3, 5, 6));
-/// assert_eq!(hms(3, 5, 7) - Duration::seconds(-1),        hms(3, 5, 8));
-/// assert_eq!(hms(3, 5, 7) - Duration::seconds(3600 + 60), hms(2, 4, 7));
-/// assert_eq!(hms(3, 5, 7) - Duration::seconds(86_400),
+/// assert_eq!(hms(3, 5, 7) - TimeDelta::zero(),             hms(3, 5, 7));
+/// assert_eq!(hms(3, 5, 7) - TimeDelta::seconds(1),         hms(3, 5, 6));
+/// assert_eq!(hms(3, 5, 7) - TimeDelta::seconds(-1),        hms(3, 5, 8));
+/// assert_eq!(hms(3, 5, 7) - TimeDelta::seconds(3600 + 60), hms(2, 4, 7));
+/// assert_eq!(hms(3, 5, 7) - TimeDelta::seconds(86_400),
 ///            from_ymd(2016, 7, 7).and_hms(3, 5, 7));
-/// assert_eq!(hms(3, 5, 7) - Duration::days(365),
+/// assert_eq!(hms(3, 5, 7) - TimeDelta::days(365),
 ///            from_ymd(2015, 7, 9).and_hms(3, 5, 7));
 ///
 /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli);
-/// assert_eq!(hmsm(3, 5, 7, 450) - Duration::milliseconds(670), hmsm(3, 5, 6, 780));
+/// assert_eq!(hmsm(3, 5, 7, 450) - TimeDelta::milliseconds(670), hmsm(3, 5, 6, 780));
 /// ```
 ///
 /// Leap seconds are handled,
 /// but the subtraction assumes that it is the only leap second happened.
 ///
 /// ```
-/// # use chrono::{Duration, NaiveDate};
+/// # use chrono::{TimeDelta, NaiveDate};
 /// # let from_ymd = NaiveDate::from_ymd;
 /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli);
 /// let leap = hmsm(3, 5, 59, 1_300);
-/// assert_eq!(leap - Duration::zero(),            hmsm(3, 5, 59, 1_300));
-/// assert_eq!(leap - Duration::milliseconds(200), hmsm(3, 5, 59, 1_100));
-/// assert_eq!(leap - Duration::milliseconds(500), hmsm(3, 5, 59, 800));
-/// assert_eq!(leap - Duration::seconds(60),       hmsm(3, 5, 0, 300));
-/// assert_eq!(leap - Duration::days(1),
+/// assert_eq!(leap - TimeDelta::zero(),            hmsm(3, 5, 59, 1_300));
+/// assert_eq!(leap - TimeDelta::milliseconds(200), hmsm(3, 5, 59, 1_100));
+/// assert_eq!(leap - TimeDelta::milliseconds(500), hmsm(3, 5, 59, 800));
+/// assert_eq!(leap - TimeDelta::seconds(60),       hmsm(3, 5, 0, 300));
+/// assert_eq!(leap - TimeDelta::days(1),
 ///            from_ymd(2016, 7, 7).and_hms_milli(3, 6, 0, 300));
 /// ```
-impl Sub<OldDuration> for NaiveDateTime {
+impl Sub<TimeDelta> for NaiveDateTime {
     type Output = NaiveDateTime;
 
     #[inline]
-    fn sub(self, rhs: OldDuration) -> NaiveDateTime {
-        self.checked_sub_signed(rhs).expect("`NaiveDateTime - Duration` overflowed")
+    fn sub(self, rhs: TimeDelta) -> NaiveDateTime {
+        self.checked_sub_signed(rhs).expect("`NaiveDateTime - TimeDelta` overflowed")
     }
 }
 
-impl SubAssign<OldDuration> for NaiveDateTime {
+impl SubAssign<TimeDelta> for NaiveDateTime {
     #[inline]
-    fn sub_assign(&mut self, rhs: OldDuration) {
+    fn sub_assign(&mut self, rhs: TimeDelta) {
         *self = self.sub(rhs);
     }
 }
@@ -1462,7 +1461,7 @@ impl SubAssign<OldDuration> for NaiveDateTime {
 /// # Example
 ///
 /// ```
-/// use chrono::{Duration, NaiveDateTime, Months, NaiveDate};
+/// use chrono::{TimeDelta, NaiveDateTime, Months, NaiveDate};
 /// use std::str::FromStr;
 ///
 /// assert_eq!(
@@ -1500,36 +1499,36 @@ impl Sub<Months> for NaiveDateTime {
 /// # Example
 ///
 /// ```
-/// use chrono::{Duration, NaiveDate};
+/// use chrono::{TimeDelta, NaiveDate};
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
 /// let d = from_ymd(2016, 7, 8);
-/// assert_eq!(d.and_hms(3, 5, 7) - d.and_hms(2, 4, 6), Duration::seconds(3600 + 60 + 1));
+/// assert_eq!(d.and_hms(3, 5, 7) - d.and_hms(2, 4, 6), TimeDelta::seconds(3600 + 60 + 1));
 ///
 /// // July 8 is 190th day in the year 2016
 /// let d0 = from_ymd(2016, 1, 1);
 /// assert_eq!(d.and_hms_milli(0, 7, 6, 500) - d0.and_hms(0, 0, 0),
-///            Duration::seconds(189 * 86_400 + 7 * 60 + 6) + Duration::milliseconds(500));
+///            TimeDelta::seconds(189 * 86_400 + 7 * 60 + 6) + TimeDelta::milliseconds(500));
 /// ```
 ///
 /// Leap seconds are handled, but the subtraction assumes that no other leap
 /// seconds happened.
 ///
 /// ```
-/// # use chrono::{Duration, NaiveDate};
+/// # use chrono::{TimeDelta, NaiveDate};
 /// # let from_ymd = NaiveDate::from_ymd;
 /// let leap = from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500);
 /// assert_eq!(leap - from_ymd(2015, 6, 30).and_hms(23, 0, 0),
-///            Duration::seconds(3600) + Duration::milliseconds(500));
+///            TimeDelta::seconds(3600) + TimeDelta::milliseconds(500));
 /// assert_eq!(from_ymd(2015, 7, 1).and_hms(1, 0, 0) - leap,
-///            Duration::seconds(3600) - Duration::milliseconds(500));
+///            TimeDelta::seconds(3600) - TimeDelta::milliseconds(500));
 /// ```
 impl Sub<NaiveDateTime> for NaiveDateTime {
-    type Output = OldDuration;
+    type Output = TimeDelta;
 
     #[inline]
-    fn sub(self, rhs: NaiveDateTime) -> OldDuration {
+    fn sub(self, rhs: NaiveDateTime) -> TimeDelta {
         self.signed_duration_since(rhs)
     }
 }

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -1,6 +1,6 @@
 use super::NaiveDateTime;
 use crate::naive::NaiveDate;
-use crate::oldtime::Duration;
+use crate::time_delta::TimeDelta;
 use crate::{Datelike, FixedOffset, Utc};
 use std::i64;
 
@@ -21,7 +21,7 @@ fn test_datetime_from_timestamp() {
 fn test_datetime_add() {
     fn check(
         (y, m, d, h, n, s): (i32, u32, u32, u32, u32, u32),
-        rhs: Duration,
+        rhs: TimeDelta,
         result: Option<(i32, u32, u32, u32, u32, u32)>,
     ) {
         let lhs = NaiveDate::from_ymd(y, m, d).and_hms(h, n, s);
@@ -30,12 +30,12 @@ fn test_datetime_add() {
         assert_eq!(lhs.checked_sub_signed(-rhs), sum);
     }
 
-    check((2014, 5, 6, 7, 8, 9), Duration::seconds(3600 + 60 + 1), Some((2014, 5, 6, 8, 9, 10)));
-    check((2014, 5, 6, 7, 8, 9), Duration::seconds(-(3600 + 60 + 1)), Some((2014, 5, 6, 6, 7, 8)));
-    check((2014, 5, 6, 7, 8, 9), Duration::seconds(86399), Some((2014, 5, 7, 7, 8, 8)));
-    check((2014, 5, 6, 7, 8, 9), Duration::seconds(86_400 * 10), Some((2014, 5, 16, 7, 8, 9)));
-    check((2014, 5, 6, 7, 8, 9), Duration::seconds(-86_400 * 10), Some((2014, 4, 26, 7, 8, 9)));
-    check((2014, 5, 6, 7, 8, 9), Duration::seconds(86_400 * 10), Some((2014, 5, 16, 7, 8, 9)));
+    check((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(3600 + 60 + 1), Some((2014, 5, 6, 8, 9, 10)));
+    check((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(-(3600 + 60 + 1)), Some((2014, 5, 6, 6, 7, 8)));
+    check((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(86399), Some((2014, 5, 7, 7, 8, 8)));
+    check((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(86_400 * 10), Some((2014, 5, 16, 7, 8, 9)));
+    check((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(-86_400 * 10), Some((2014, 4, 26, 7, 8, 9)));
+    check((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(86_400 * 10), Some((2014, 5, 16, 7, 8, 9)));
 
     // overflow check
     // assumes that we have correct values for MAX/MIN_DAYS_FROM_YEAR_0 from `naive::date`.
@@ -44,38 +44,38 @@ fn test_datetime_add() {
     check((0, 1, 1, 0, 0, 0), max_days_from_year_0, Some((NaiveDate::MAX.year(), 12, 31, 0, 0, 0)));
     check(
         (0, 1, 1, 0, 0, 0),
-        max_days_from_year_0 + Duration::seconds(86399),
+        max_days_from_year_0 + TimeDelta::seconds(86399),
         Some((NaiveDate::MAX.year(), 12, 31, 23, 59, 59)),
     );
-    check((0, 1, 1, 0, 0, 0), max_days_from_year_0 + Duration::seconds(86_400), None);
-    check((0, 1, 1, 0, 0, 0), Duration::max_value(), None);
+    check((0, 1, 1, 0, 0, 0), max_days_from_year_0 + TimeDelta::seconds(86_400), None);
+    check((0, 1, 1, 0, 0, 0), TimeDelta::max_value(), None);
 
     let min_days_from_year_0 = NaiveDate::MIN.signed_duration_since(NaiveDate::from_ymd(0, 1, 1));
     check((0, 1, 1, 0, 0, 0), min_days_from_year_0, Some((NaiveDate::MIN.year(), 1, 1, 0, 0, 0)));
-    check((0, 1, 1, 0, 0, 0), min_days_from_year_0 - Duration::seconds(1), None);
-    check((0, 1, 1, 0, 0, 0), Duration::min_value(), None);
+    check((0, 1, 1, 0, 0, 0), min_days_from_year_0 - TimeDelta::seconds(1), None);
+    check((0, 1, 1, 0, 0, 0), TimeDelta::min_value(), None);
 }
 
 #[test]
 fn test_datetime_sub() {
     let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).and_hms(h, n, s);
     let since = NaiveDateTime::signed_duration_since;
-    assert_eq!(since(ymdhms(2014, 5, 6, 7, 8, 9), ymdhms(2014, 5, 6, 7, 8, 9)), Duration::zero());
+    assert_eq!(since(ymdhms(2014, 5, 6, 7, 8, 9), ymdhms(2014, 5, 6, 7, 8, 9)), TimeDelta::zero());
     assert_eq!(
         since(ymdhms(2014, 5, 6, 7, 8, 10), ymdhms(2014, 5, 6, 7, 8, 9)),
-        Duration::seconds(1)
+        TimeDelta::seconds(1)
     );
     assert_eq!(
         since(ymdhms(2014, 5, 6, 7, 8, 9), ymdhms(2014, 5, 6, 7, 8, 10)),
-        Duration::seconds(-1)
+        TimeDelta::seconds(-1)
     );
     assert_eq!(
         since(ymdhms(2014, 5, 7, 7, 8, 9), ymdhms(2014, 5, 6, 7, 8, 10)),
-        Duration::seconds(86399)
+        TimeDelta::seconds(86399)
     );
     assert_eq!(
         since(ymdhms(2001, 9, 9, 1, 46, 39), ymdhms(1970, 1, 1, 0, 0, 0)),
-        Duration::seconds(999_999_999)
+        TimeDelta::seconds(999_999_999)
     );
 }
 
@@ -83,9 +83,9 @@ fn test_datetime_sub() {
 fn test_datetime_addassignment() {
     let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).and_hms(h, n, s);
     let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
-    date += Duration::minutes(10_000_000);
+    date += TimeDelta::minutes(10_000_000);
     assert_eq!(date, ymdhms(2035, 10, 6, 20, 50, 10));
-    date += Duration::days(10);
+    date += TimeDelta::days(10);
     assert_eq!(date, ymdhms(2035, 10, 16, 20, 50, 10));
 }
 
@@ -93,9 +93,9 @@ fn test_datetime_addassignment() {
 fn test_datetime_subassignment() {
     let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).and_hms(h, n, s);
     let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
-    date -= Duration::minutes(10_000_000);
+    date -= TimeDelta::minutes(10_000_000);
     assert_eq!(date, ymdhms(1997, 9, 26, 23, 30, 10));
-    date -= Duration::days(10);
+    date -= TimeDelta::days(10);
     assert_eq!(date, ymdhms(1997, 9, 16, 23, 30, 10));
 }
 
@@ -217,7 +217,7 @@ fn test_datetime_add_sub_invariant() {
     // issue #37
     let base = NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0);
     let t = -946684799990000;
-    let time = base + Duration::microseconds(t);
+    let time = base + TimeDelta::microseconds(t);
     assert_eq!(t, time.signed_duration_since(base).num_microseconds().unwrap());
 }
 

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -15,10 +15,12 @@
 
 #![cfg_attr(feature = "__internal_bench", allow(missing_docs))]
 
-use crate::Weekday;
+use core::convert::TryFrom;
 use core::{fmt, i32};
+
 use num_integer::{div_rem, mod_floor};
-use num_traits::FromPrimitive;
+
+use crate::Weekday;
 
 /// The internal date representation. This also includes the packed `Mdf` value.
 pub(super) type DateImpl = i32;
@@ -322,7 +324,7 @@ impl Of {
     #[inline]
     pub(super) fn weekday(&self) -> Weekday {
         let Of(of) = *self;
-        Weekday::from_u32(((of >> 4) + (of & 0b111)) % 7).unwrap()
+        Weekday::try_from((((of >> 4) + (of & 0b111)) % 7) as u8).unwrap()
     }
 
     #[inline]
@@ -330,7 +332,7 @@ impl Of {
         // week ordinal = ordinal + delta
         let Of(of) = *self;
         let weekord = (of >> 4).wrapping_add(self.flags().isoweek_delta());
-        (weekord / 7, Weekday::from_u32(weekord % 7).unwrap())
+        (weekord / 7, Weekday::try_from((weekord % 7) as u8).unwrap())
     }
 
     #[cfg_attr(feature = "cargo-clippy", allow(clippy::wrong_self_convention))]

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -19,9 +19,6 @@ use crate::format::{Fixed, Item, Numeric, Pad};
 use crate::oldtime::Duration as OldDuration;
 use crate::Timelike;
 
-#[cfg(feature = "rustc-serialize")]
-mod rustc_serialize;
-
 #[cfg(feature = "serde")]
 mod serde;
 
@@ -1336,7 +1333,7 @@ impl Default for NaiveTime {
     }
 }
 
-#[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
+#[cfg(all(test, feature = "serde"))]
 fn test_encodable_json<F, E>(to_string: F)
 where
     F: Fn(&NaiveTime) -> Result<String, E>,
@@ -1367,7 +1364,7 @@ where
     );
 }
 
-#[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
+#[cfg(all(test, feature = "serde"))]
 fn test_decodable_json<F, E>(from_str: F)
 where
     F: Fn(&str) -> Result<NaiveTime, E>,

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -16,8 +16,7 @@ use rkyv::{Archive, Deserialize, Serialize};
 use crate::format::DelayedFormat;
 use crate::format::{parse, ParseError, ParseResult, Parsed, StrftimeItems};
 use crate::format::{Fixed, Item, Numeric, Pad};
-use crate::oldtime::Duration as OldDuration;
-use crate::Timelike;
+use crate::{TimeDelta, Timelike};
 
 #[cfg(feature = "serde")]
 mod serde;
@@ -92,7 +91,7 @@ mod tests;
 /// In reality, of course, leap seconds are separated by at least 6 months.
 /// We will also use some intuitive concise notations for the explanation.
 ///
-/// `Time + Duration`
+/// `Time + TimeDelta`
 /// (short for [`NaiveTime::overflowing_add_signed`](#method.overflowing_add_signed)):
 ///
 /// - `03:00:00 + 1s = 03:00:01`.
@@ -104,7 +103,7 @@ mod tests;
 /// - `03:00:60 + 61s = 03:02:00`.
 /// - `03:00:60.1 + 0.8s = 03:00:60.9`.
 ///
-/// `Time - Duration`
+/// `Time - TimeDelta`
 /// (short for [`NaiveTime::overflowing_sub_signed`](#method.overflowing_sub_signed)):
 ///
 /// - `03:00:00 - 1s = 02:59:59`.
@@ -133,21 +132,21 @@ mod tests;
 ///
 /// In general,
 ///
-/// - `Time + Duration` unconditionally equals to `Duration + Time`.
+/// - `Time + TimeDelta` unconditionally equals to `TimeDelta + Time`.
 ///
-/// - `Time - Duration` unconditionally equals to `Time + (-Duration)`.
+/// - `Time - TimeDelta` unconditionally equals to `Time + (-TimeDelta)`.
 ///
 /// - `Time1 - Time2` unconditionally equals to `-(Time2 - Time1)`.
 ///
 /// - Associativity does not generally hold, because
-///   `(Time + Duration1) - Duration2` no longer equals to `Time + (Duration1 - Duration2)`
+///   `(Time + TimeDelta1) - TimeDelta2` no longer equals to `Time + (TimeDelta1 - TimeDelta2)`
 ///   for two positive durations.
 ///
-///     - As a special case, `(Time + Duration) - Duration` also does not equal to `Time`.
+///     - As a special case, `(Time + TimeDelta) - TimeDelta` also does not equal to `Time`.
 ///
 ///     - If you can assume that all durations have the same sign, however,
 ///       then the associativity holds:
-///       `(Time + Duration1) + Duration2` equals to `Time + (Duration1 + Duration2)`
+///       `(Time + TimeDelta1) + TimeDelta2` equals to `Time + (TimeDelta1 + TimeDelta2)`
 ///       for two positive durations.
 ///
 /// ## Reading And Writing Leap Seconds
@@ -514,26 +513,26 @@ impl NaiveTime {
         parsed.to_naive_time()
     }
 
-    /// Adds given `Duration` to the current time,
+    /// Adds given `TimeDelta` to the current time,
     /// and also returns the number of *seconds*
     /// in the integral number of days ignored from the addition.
-    /// (We cannot return `Duration` because it is subject to overflow or underflow.)
+    /// (We cannot return `TimeDelta` because it is subject to overflow or underflow.)
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::{Duration, NaiveTime};
+    /// use chrono::{TimeDelta, NaiveTime};
     ///
     /// let from_hms = NaiveTime::from_hms;
     ///
-    /// assert_eq!(from_hms(3, 4, 5).overflowing_add_signed(Duration::hours(11)),
+    /// assert_eq!(from_hms(3, 4, 5).overflowing_add_signed(TimeDelta::hours(11)),
     ///            (from_hms(14, 4, 5), 0));
-    /// assert_eq!(from_hms(3, 4, 5).overflowing_add_signed(Duration::hours(23)),
+    /// assert_eq!(from_hms(3, 4, 5).overflowing_add_signed(TimeDelta::hours(23)),
     ///            (from_hms(2, 4, 5), 86_400));
-    /// assert_eq!(from_hms(3, 4, 5).overflowing_add_signed(Duration::hours(-7)),
+    /// assert_eq!(from_hms(3, 4, 5).overflowing_add_signed(TimeDelta::hours(-7)),
     ///            (from_hms(20, 4, 5), -86_400));
     /// ```
-    pub fn overflowing_add_signed(&self, mut rhs: OldDuration) -> (NaiveTime, i64) {
+    pub fn overflowing_add_signed(&self, mut rhs: TimeDelta) -> (NaiveTime, i64) {
         let mut secs = self.secs;
         let mut frac = self.frac;
 
@@ -542,12 +541,12 @@ impl NaiveTime {
         // otherwise the addition immediately finishes.
         if frac >= 1_000_000_000 {
             let rfrac = 2_000_000_000 - frac;
-            if rhs >= OldDuration::nanoseconds(i64::from(rfrac)) {
-                rhs = rhs - OldDuration::nanoseconds(i64::from(rfrac));
+            if rhs >= TimeDelta::nanoseconds(i64::from(rfrac)) {
+                rhs = rhs - TimeDelta::nanoseconds(i64::from(rfrac));
                 secs += 1;
                 frac = 0;
-            } else if rhs < OldDuration::nanoseconds(-i64::from(frac)) {
-                rhs = rhs + OldDuration::nanoseconds(i64::from(frac));
+            } else if rhs < TimeDelta::nanoseconds(-i64::from(frac)) {
+                rhs = rhs + TimeDelta::nanoseconds(i64::from(frac));
                 frac = 0;
             } else {
                 frac = (i64::from(frac) + rhs.num_nanoseconds().unwrap()) as u32;
@@ -559,8 +558,8 @@ impl NaiveTime {
         debug_assert!(frac < 1_000_000_000);
 
         let rhssecs = rhs.num_seconds();
-        let rhsfrac = (rhs - OldDuration::seconds(rhssecs)).num_nanoseconds().unwrap();
-        debug_assert_eq!(OldDuration::seconds(rhssecs) + OldDuration::nanoseconds(rhsfrac), rhs);
+        let rhsfrac = (rhs - TimeDelta::seconds(rhssecs)).num_nanoseconds().unwrap();
+        debug_assert_eq!(TimeDelta::seconds(rhssecs) + TimeDelta::nanoseconds(rhsfrac), rhs);
         let rhssecsinday = rhssecs % 86_400;
         let mut morerhssecs = rhssecs - rhssecsinday;
         let rhssecs = rhssecsinday as i32;
@@ -596,33 +595,33 @@ impl NaiveTime {
         (NaiveTime { secs: secs as u32, frac: frac as u32 }, morerhssecs)
     }
 
-    /// Subtracts given `Duration` from the current time,
+    /// Subtracts given `TimeDelta` from the current time,
     /// and also returns the number of *seconds*
     /// in the integral number of days ignored from the subtraction.
-    /// (We cannot return `Duration` because it is subject to overflow or underflow.)
+    /// (We cannot return `TimeDelta` because it is subject to overflow or underflow.)
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::{Duration, NaiveTime};
+    /// use chrono::{TimeDelta, NaiveTime};
     ///
     /// let from_hms = NaiveTime::from_hms;
     ///
-    /// assert_eq!(from_hms(3, 4, 5).overflowing_sub_signed(Duration::hours(2)),
+    /// assert_eq!(from_hms(3, 4, 5).overflowing_sub_signed(TimeDelta::hours(2)),
     ///            (from_hms(1, 4, 5), 0));
-    /// assert_eq!(from_hms(3, 4, 5).overflowing_sub_signed(Duration::hours(17)),
+    /// assert_eq!(from_hms(3, 4, 5).overflowing_sub_signed(TimeDelta::hours(17)),
     ///            (from_hms(10, 4, 5), 86_400));
-    /// assert_eq!(from_hms(3, 4, 5).overflowing_sub_signed(Duration::hours(-22)),
+    /// assert_eq!(from_hms(3, 4, 5).overflowing_sub_signed(TimeDelta::hours(-22)),
     ///            (from_hms(1, 4, 5), -86_400));
     /// ```
     #[inline]
-    pub fn overflowing_sub_signed(&self, rhs: OldDuration) -> (NaiveTime, i64) {
+    pub fn overflowing_sub_signed(&self, rhs: TimeDelta) -> (NaiveTime, i64) {
         let (time, rhs) = self.overflowing_add_signed(-rhs);
         (time, -rhs) // safe to negate, rhs is within +/- (2^63 / 1000)
     }
 
     /// Subtracts another `NaiveTime` from the current time.
-    /// Returns a `Duration` within +/- 1 day.
+    /// Returns a `TimeDelta` within +/- 1 day.
     /// This does not overflow or underflow at all.
     ///
     /// As a part of Chrono's [leap second handling](#leap-second-handling),
@@ -634,48 +633,48 @@ impl NaiveTime {
     /// # Example
     ///
     /// ```
-    /// use chrono::{Duration, NaiveTime};
+    /// use chrono::{TimeDelta, NaiveTime};
     ///
     /// let from_hmsm = NaiveTime::from_hms_milli;
     /// let since = NaiveTime::signed_duration_since;
     ///
     /// assert_eq!(since(from_hmsm(3, 5, 7, 900), from_hmsm(3, 5, 7, 900)),
-    ///            Duration::zero());
+    ///            TimeDelta::zero());
     /// assert_eq!(since(from_hmsm(3, 5, 7, 900), from_hmsm(3, 5, 7, 875)),
-    ///            Duration::milliseconds(25));
+    ///            TimeDelta::milliseconds(25));
     /// assert_eq!(since(from_hmsm(3, 5, 7, 900), from_hmsm(3, 5, 6, 925)),
-    ///            Duration::milliseconds(975));
+    ///            TimeDelta::milliseconds(975));
     /// assert_eq!(since(from_hmsm(3, 5, 7, 900), from_hmsm(3, 5, 0, 900)),
-    ///            Duration::seconds(7));
+    ///            TimeDelta::seconds(7));
     /// assert_eq!(since(from_hmsm(3, 5, 7, 900), from_hmsm(3, 0, 7, 900)),
-    ///            Duration::seconds(5 * 60));
+    ///            TimeDelta::seconds(5 * 60));
     /// assert_eq!(since(from_hmsm(3, 5, 7, 900), from_hmsm(0, 5, 7, 900)),
-    ///            Duration::seconds(3 * 3600));
+    ///            TimeDelta::seconds(3 * 3600));
     /// assert_eq!(since(from_hmsm(3, 5, 7, 900), from_hmsm(4, 5, 7, 900)),
-    ///            Duration::seconds(-3600));
+    ///            TimeDelta::seconds(-3600));
     /// assert_eq!(since(from_hmsm(3, 5, 7, 900), from_hmsm(2, 4, 6, 800)),
-    ///            Duration::seconds(3600 + 60 + 1) + Duration::milliseconds(100));
+    ///            TimeDelta::seconds(3600 + 60 + 1) + TimeDelta::milliseconds(100));
     /// ```
     ///
     /// Leap seconds are handled, but the subtraction assumes that
     /// there were no other leap seconds happened.
     ///
     /// ```
-    /// # use chrono::{Duration, NaiveTime};
+    /// # use chrono::{TimeDelta, NaiveTime};
     /// # let from_hmsm = NaiveTime::from_hms_milli;
     /// # let since = NaiveTime::signed_duration_since;
     /// assert_eq!(since(from_hmsm(3, 0, 59, 1_000), from_hmsm(3, 0, 59, 0)),
-    ///            Duration::seconds(1));
+    ///            TimeDelta::seconds(1));
     /// assert_eq!(since(from_hmsm(3, 0, 59, 1_500), from_hmsm(3, 0, 59, 0)),
-    ///            Duration::milliseconds(1500));
+    ///            TimeDelta::milliseconds(1500));
     /// assert_eq!(since(from_hmsm(3, 0, 59, 1_000), from_hmsm(3, 0, 0, 0)),
-    ///            Duration::seconds(60));
+    ///            TimeDelta::seconds(60));
     /// assert_eq!(since(from_hmsm(3, 0, 0, 0), from_hmsm(2, 59, 59, 1_000)),
-    ///            Duration::seconds(1));
+    ///            TimeDelta::seconds(1));
     /// assert_eq!(since(from_hmsm(3, 0, 59, 1_000), from_hmsm(2, 59, 59, 1_000)),
-    ///            Duration::seconds(61));
+    ///            TimeDelta::seconds(61));
     /// ```
-    pub fn signed_duration_since(self, rhs: NaiveTime) -> OldDuration {
+    pub fn signed_duration_since(self, rhs: NaiveTime) -> TimeDelta {
         //     |    |    :leap|    |    |    |    |    |    |    :leap|    |
         //     |    |    :    |    |    |    |    |    |    |    :    |    |
         // ----+----+-----*---+----+----+----+----+----+----+-------*-+----+----
@@ -710,7 +709,7 @@ impl NaiveTime {
             }
         };
 
-        OldDuration::seconds(secs + adjust) + OldDuration::nanoseconds(frac)
+        TimeDelta::seconds(secs + adjust) + TimeDelta::nanoseconds(frac)
     }
 
     /// Formats the time with the specified formatting items.
@@ -1012,7 +1011,7 @@ impl Timelike for NaiveTime {
     }
 }
 
-/// An addition of `Duration` to `NaiveTime` wraps around and never overflows or underflows.
+/// An addition of `TimeDelta` to `NaiveTime` wraps around and never overflows or underflows.
 /// In particular the addition ignores integral number of days.
 ///
 /// As a part of Chrono's [leap second handling](#leap-second-handling),
@@ -1023,63 +1022,63 @@ impl Timelike for NaiveTime {
 /// # Example
 ///
 /// ```
-/// use chrono::{Duration, NaiveTime};
+/// use chrono::{TimeDelta, NaiveTime};
 ///
 /// let from_hmsm = NaiveTime::from_hms_milli;
 ///
-/// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::zero(),                  from_hmsm(3, 5, 7, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::seconds(1),              from_hmsm(3, 5, 8, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::seconds(-1),             from_hmsm(3, 5, 6, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::seconds(60 + 4),         from_hmsm(3, 6, 11, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::seconds(7*60*60 - 6*60), from_hmsm(9, 59, 7, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::milliseconds(80),        from_hmsm(3, 5, 7, 80));
-/// assert_eq!(from_hmsm(3, 5, 7, 950) + Duration::milliseconds(280),     from_hmsm(3, 5, 8, 230));
-/// assert_eq!(from_hmsm(3, 5, 7, 950) + Duration::milliseconds(-980),    from_hmsm(3, 5, 6, 970));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::zero(),                  from_hmsm(3, 5, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::seconds(1),              from_hmsm(3, 5, 8, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::seconds(-1),             from_hmsm(3, 5, 6, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::seconds(60 + 4),         from_hmsm(3, 6, 11, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::seconds(7*60*60 - 6*60), from_hmsm(9, 59, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::milliseconds(80),        from_hmsm(3, 5, 7, 80));
+/// assert_eq!(from_hmsm(3, 5, 7, 950) + TimeDelta::milliseconds(280),     from_hmsm(3, 5, 8, 230));
+/// assert_eq!(from_hmsm(3, 5, 7, 950) + TimeDelta::milliseconds(-980),    from_hmsm(3, 5, 6, 970));
 /// ```
 ///
 /// The addition wraps around.
 ///
 /// ```
-/// # use chrono::{Duration, NaiveTime};
+/// # use chrono::{TimeDelta, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
-/// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::seconds(22*60*60), from_hmsm(1, 5, 7, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::seconds(-8*60*60), from_hmsm(19, 5, 7, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) + Duration::days(800),         from_hmsm(3, 5, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::seconds(22*60*60), from_hmsm(1, 5, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::seconds(-8*60*60), from_hmsm(19, 5, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::days(800),         from_hmsm(3, 5, 7, 0));
 /// ```
 ///
 /// Leap seconds are handled, but the addition assumes that it is the only leap second happened.
 ///
 /// ```
-/// # use chrono::{Duration, NaiveTime};
+/// # use chrono::{TimeDelta, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
 /// let leap = from_hmsm(3, 5, 59, 1_300);
-/// assert_eq!(leap + Duration::zero(),             from_hmsm(3, 5, 59, 1_300));
-/// assert_eq!(leap + Duration::milliseconds(-500), from_hmsm(3, 5, 59, 800));
-/// assert_eq!(leap + Duration::milliseconds(500),  from_hmsm(3, 5, 59, 1_800));
-/// assert_eq!(leap + Duration::milliseconds(800),  from_hmsm(3, 6, 0, 100));
-/// assert_eq!(leap + Duration::seconds(10),        from_hmsm(3, 6, 9, 300));
-/// assert_eq!(leap + Duration::seconds(-10),       from_hmsm(3, 5, 50, 300));
-/// assert_eq!(leap + Duration::days(1),            from_hmsm(3, 5, 59, 300));
+/// assert_eq!(leap + TimeDelta::zero(),             from_hmsm(3, 5, 59, 1_300));
+/// assert_eq!(leap + TimeDelta::milliseconds(-500), from_hmsm(3, 5, 59, 800));
+/// assert_eq!(leap + TimeDelta::milliseconds(500),  from_hmsm(3, 5, 59, 1_800));
+/// assert_eq!(leap + TimeDelta::milliseconds(800),  from_hmsm(3, 6, 0, 100));
+/// assert_eq!(leap + TimeDelta::seconds(10),        from_hmsm(3, 6, 9, 300));
+/// assert_eq!(leap + TimeDelta::seconds(-10),       from_hmsm(3, 5, 50, 300));
+/// assert_eq!(leap + TimeDelta::days(1),            from_hmsm(3, 5, 59, 300));
 /// ```
-impl Add<OldDuration> for NaiveTime {
+impl Add<TimeDelta> for NaiveTime {
     type Output = NaiveTime;
 
     #[inline]
-    fn add(self, rhs: OldDuration) -> NaiveTime {
+    fn add(self, rhs: TimeDelta) -> NaiveTime {
         self.overflowing_add_signed(rhs).0
     }
 }
 
-impl AddAssign<OldDuration> for NaiveTime {
+impl AddAssign<TimeDelta> for NaiveTime {
     #[inline]
-    fn add_assign(&mut self, rhs: OldDuration) {
+    fn add_assign(&mut self, rhs: TimeDelta) {
         *self = self.add(rhs);
     }
 }
 
-/// A subtraction of `Duration` from `NaiveTime` wraps around and never overflows or underflows.
+/// A subtraction of `TimeDelta` from `NaiveTime` wraps around and never overflows or underflows.
 /// In particular the addition ignores integral number of days.
-/// It is the same as the addition with a negated `Duration`.
+/// It is the same as the addition with a negated `TimeDelta`.
 ///
 /// As a part of Chrono's [leap second handling](#leap-second-handling),
 /// the addition assumes that **there is no leap second ever**,
@@ -1089,57 +1088,57 @@ impl AddAssign<OldDuration> for NaiveTime {
 /// # Example
 ///
 /// ```
-/// use chrono::{Duration, NaiveTime};
+/// use chrono::{TimeDelta, NaiveTime};
 ///
 /// let from_hmsm = NaiveTime::from_hms_milli;
 ///
-/// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::zero(),                  from_hmsm(3, 5, 7, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::seconds(1),              from_hmsm(3, 5, 6, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::seconds(60 + 5),         from_hmsm(3, 4, 2, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::seconds(2*60*60 + 6*60), from_hmsm(0, 59, 7, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::milliseconds(80),        from_hmsm(3, 5, 6, 920));
-/// assert_eq!(from_hmsm(3, 5, 7, 950) - Duration::milliseconds(280),     from_hmsm(3, 5, 7, 670));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::zero(),                  from_hmsm(3, 5, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::seconds(1),              from_hmsm(3, 5, 6, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::seconds(60 + 5),         from_hmsm(3, 4, 2, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::seconds(2*60*60 + 6*60), from_hmsm(0, 59, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::milliseconds(80),        from_hmsm(3, 5, 6, 920));
+/// assert_eq!(from_hmsm(3, 5, 7, 950) - TimeDelta::milliseconds(280),     from_hmsm(3, 5, 7, 670));
 /// ```
 ///
 /// The subtraction wraps around.
 ///
 /// ```
-/// # use chrono::{Duration, NaiveTime};
+/// # use chrono::{TimeDelta, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
-/// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::seconds(8*60*60), from_hmsm(19, 5, 7, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) - Duration::days(800),        from_hmsm(3, 5, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::seconds(8*60*60), from_hmsm(19, 5, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::days(800),        from_hmsm(3, 5, 7, 0));
 /// ```
 ///
 /// Leap seconds are handled, but the subtraction assumes that it is the only leap second happened.
 ///
 /// ```
-/// # use chrono::{Duration, NaiveTime};
+/// # use chrono::{TimeDelta, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
 /// let leap = from_hmsm(3, 5, 59, 1_300);
-/// assert_eq!(leap - Duration::zero(),            from_hmsm(3, 5, 59, 1_300));
-/// assert_eq!(leap - Duration::milliseconds(200), from_hmsm(3, 5, 59, 1_100));
-/// assert_eq!(leap - Duration::milliseconds(500), from_hmsm(3, 5, 59, 800));
-/// assert_eq!(leap - Duration::seconds(60),       from_hmsm(3, 5, 0, 300));
-/// assert_eq!(leap - Duration::days(1),           from_hmsm(3, 6, 0, 300));
+/// assert_eq!(leap - TimeDelta::zero(),            from_hmsm(3, 5, 59, 1_300));
+/// assert_eq!(leap - TimeDelta::milliseconds(200), from_hmsm(3, 5, 59, 1_100));
+/// assert_eq!(leap - TimeDelta::milliseconds(500), from_hmsm(3, 5, 59, 800));
+/// assert_eq!(leap - TimeDelta::seconds(60),       from_hmsm(3, 5, 0, 300));
+/// assert_eq!(leap - TimeDelta::days(1),           from_hmsm(3, 6, 0, 300));
 /// ```
-impl Sub<OldDuration> for NaiveTime {
+impl Sub<TimeDelta> for NaiveTime {
     type Output = NaiveTime;
 
     #[inline]
-    fn sub(self, rhs: OldDuration) -> NaiveTime {
+    fn sub(self, rhs: TimeDelta) -> NaiveTime {
         self.overflowing_sub_signed(rhs).0
     }
 }
 
-impl SubAssign<OldDuration> for NaiveTime {
+impl SubAssign<TimeDelta> for NaiveTime {
     #[inline]
-    fn sub_assign(&mut self, rhs: OldDuration) {
+    fn sub_assign(&mut self, rhs: TimeDelta) {
         *self = self.sub(rhs);
     }
 }
 
 /// Subtracts another `NaiveTime` from the current time.
-/// Returns a `Duration` within +/- 1 day.
+/// Returns a `TimeDelta` within +/- 1 day.
 /// This does not overflow or underflow at all.
 ///
 /// As a part of Chrono's [leap second handling](#leap-second-handling),
@@ -1154,40 +1153,40 @@ impl SubAssign<OldDuration> for NaiveTime {
 /// # Example
 ///
 /// ```
-/// use chrono::{Duration, NaiveTime};
+/// use chrono::{TimeDelta, NaiveTime};
 ///
 /// let from_hmsm = NaiveTime::from_hms_milli;
 ///
-/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 7, 900), Duration::zero());
-/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 7, 875), Duration::milliseconds(25));
-/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 6, 925), Duration::milliseconds(975));
-/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 0, 900), Duration::seconds(7));
-/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 0, 7, 900), Duration::seconds(5 * 60));
-/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(0, 5, 7, 900), Duration::seconds(3 * 3600));
-/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(4, 5, 7, 900), Duration::seconds(-3600));
+/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 7, 900), TimeDelta::zero());
+/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 7, 875), TimeDelta::milliseconds(25));
+/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 6, 925), TimeDelta::milliseconds(975));
+/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 0, 900), TimeDelta::seconds(7));
+/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 0, 7, 900), TimeDelta::seconds(5 * 60));
+/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(0, 5, 7, 900), TimeDelta::seconds(3 * 3600));
+/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(4, 5, 7, 900), TimeDelta::seconds(-3600));
 /// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(2, 4, 6, 800),
-///            Duration::seconds(3600 + 60 + 1) + Duration::milliseconds(100));
+///            TimeDelta::seconds(3600 + 60 + 1) + TimeDelta::milliseconds(100));
 /// ```
 ///
 /// Leap seconds are handled, but the subtraction assumes that
 /// there were no other leap seconds happened.
 ///
 /// ```
-/// # use chrono::{Duration, NaiveTime};
+/// # use chrono::{TimeDelta, NaiveTime};
 /// # let from_hmsm = NaiveTime::from_hms_milli;
-/// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(3, 0, 59, 0), Duration::seconds(1));
+/// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(3, 0, 59, 0), TimeDelta::seconds(1));
 /// assert_eq!(from_hmsm(3, 0, 59, 1_500) - from_hmsm(3, 0, 59, 0),
-///            Duration::milliseconds(1500));
-/// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(3, 0, 0, 0), Duration::seconds(60));
-/// assert_eq!(from_hmsm(3, 0, 0, 0) - from_hmsm(2, 59, 59, 1_000), Duration::seconds(1));
+///            TimeDelta::milliseconds(1500));
+/// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(3, 0, 0, 0), TimeDelta::seconds(60));
+/// assert_eq!(from_hmsm(3, 0, 0, 0) - from_hmsm(2, 59, 59, 1_000), TimeDelta::seconds(1));
 /// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(2, 59, 59, 1_000),
-///            Duration::seconds(61));
+///            TimeDelta::seconds(61));
 /// ```
 impl Sub<NaiveTime> for NaiveTime {
-    type Output = OldDuration;
+    type Output = TimeDelta;
 
     #[inline]
-    fn sub(self, rhs: NaiveTime) -> OldDuration {
+    fn sub(self, rhs: NaiveTime) -> TimeDelta {
         self.signed_duration_since(rhs)
     }
 }

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -1,7 +1,7 @@
-use super::NaiveTime;
-use crate::oldtime::Duration;
-use crate::Timelike;
 use std::u32;
+
+use super::NaiveTime;
+use crate::{TimeDelta, Timelike};
 
 #[test]
 fn test_time_from_hms_milli() {
@@ -77,23 +77,23 @@ fn test_time_add() {
 
     let hmsm = NaiveTime::from_hms_milli;
 
-    check!(hmsm(3, 5, 7, 900), Duration::zero(), hmsm(3, 5, 7, 900));
-    check!(hmsm(3, 5, 7, 900), Duration::milliseconds(100), hmsm(3, 5, 8, 0));
-    check!(hmsm(3, 5, 7, 1_300), Duration::milliseconds(-1800), hmsm(3, 5, 6, 500));
-    check!(hmsm(3, 5, 7, 1_300), Duration::milliseconds(-800), hmsm(3, 5, 7, 500));
-    check!(hmsm(3, 5, 7, 1_300), Duration::milliseconds(-100), hmsm(3, 5, 7, 1_200));
-    check!(hmsm(3, 5, 7, 1_300), Duration::milliseconds(100), hmsm(3, 5, 7, 1_400));
-    check!(hmsm(3, 5, 7, 1_300), Duration::milliseconds(800), hmsm(3, 5, 8, 100));
-    check!(hmsm(3, 5, 7, 1_300), Duration::milliseconds(1800), hmsm(3, 5, 9, 100));
-    check!(hmsm(3, 5, 7, 900), Duration::seconds(86399), hmsm(3, 5, 6, 900)); // overwrap
-    check!(hmsm(3, 5, 7, 900), Duration::seconds(-86399), hmsm(3, 5, 8, 900));
-    check!(hmsm(3, 5, 7, 900), Duration::days(12345), hmsm(3, 5, 7, 900));
-    check!(hmsm(3, 5, 7, 1_300), Duration::days(1), hmsm(3, 5, 7, 300));
-    check!(hmsm(3, 5, 7, 1_300), Duration::days(-1), hmsm(3, 5, 8, 300));
+    check!(hmsm(3, 5, 7, 900), TimeDelta::zero(), hmsm(3, 5, 7, 900));
+    check!(hmsm(3, 5, 7, 900), TimeDelta::milliseconds(100), hmsm(3, 5, 8, 0));
+    check!(hmsm(3, 5, 7, 1_300), TimeDelta::milliseconds(-1800), hmsm(3, 5, 6, 500));
+    check!(hmsm(3, 5, 7, 1_300), TimeDelta::milliseconds(-800), hmsm(3, 5, 7, 500));
+    check!(hmsm(3, 5, 7, 1_300), TimeDelta::milliseconds(-100), hmsm(3, 5, 7, 1_200));
+    check!(hmsm(3, 5, 7, 1_300), TimeDelta::milliseconds(100), hmsm(3, 5, 7, 1_400));
+    check!(hmsm(3, 5, 7, 1_300), TimeDelta::milliseconds(800), hmsm(3, 5, 8, 100));
+    check!(hmsm(3, 5, 7, 1_300), TimeDelta::milliseconds(1800), hmsm(3, 5, 9, 100));
+    check!(hmsm(3, 5, 7, 900), TimeDelta::seconds(86399), hmsm(3, 5, 6, 900)); // overwrap
+    check!(hmsm(3, 5, 7, 900), TimeDelta::seconds(-86399), hmsm(3, 5, 8, 900));
+    check!(hmsm(3, 5, 7, 900), TimeDelta::days(12345), hmsm(3, 5, 7, 900));
+    check!(hmsm(3, 5, 7, 1_300), TimeDelta::days(1), hmsm(3, 5, 7, 300));
+    check!(hmsm(3, 5, 7, 1_300), TimeDelta::days(-1), hmsm(3, 5, 8, 300));
 
     // regression tests for #37
-    check!(hmsm(0, 0, 0, 0), Duration::milliseconds(-990), hmsm(23, 59, 59, 10));
-    check!(hmsm(0, 0, 0, 0), Duration::milliseconds(-9990), hmsm(23, 59, 50, 10));
+    check!(hmsm(0, 0, 0, 0), TimeDelta::milliseconds(-990), hmsm(23, 59, 59, 10));
+    check!(hmsm(0, 0, 0, 0), TimeDelta::milliseconds(-9990), hmsm(23, 59, 50, 10));
 }
 
 #[test]
@@ -101,25 +101,25 @@ fn test_time_overflowing_add() {
     let hmsm = NaiveTime::from_hms_milli;
 
     assert_eq!(
-        hmsm(3, 4, 5, 678).overflowing_add_signed(Duration::hours(11)),
+        hmsm(3, 4, 5, 678).overflowing_add_signed(TimeDelta::hours(11)),
         (hmsm(14, 4, 5, 678), 0)
     );
     assert_eq!(
-        hmsm(3, 4, 5, 678).overflowing_add_signed(Duration::hours(23)),
+        hmsm(3, 4, 5, 678).overflowing_add_signed(TimeDelta::hours(23)),
         (hmsm(2, 4, 5, 678), 86_400)
     );
     assert_eq!(
-        hmsm(3, 4, 5, 678).overflowing_add_signed(Duration::hours(-7)),
+        hmsm(3, 4, 5, 678).overflowing_add_signed(TimeDelta::hours(-7)),
         (hmsm(20, 4, 5, 678), -86_400)
     );
 
     // overflowing_add_signed with leap seconds may be counter-intuitive
     assert_eq!(
-        hmsm(3, 4, 5, 1_678).overflowing_add_signed(Duration::days(1)),
+        hmsm(3, 4, 5, 1_678).overflowing_add_signed(TimeDelta::days(1)),
         (hmsm(3, 4, 5, 678), 86_400)
     );
     assert_eq!(
-        hmsm(3, 4, 5, 1_678).overflowing_add_signed(Duration::days(-1)),
+        hmsm(3, 4, 5, 1_678).overflowing_add_signed(TimeDelta::days(-1)),
         (hmsm(3, 4, 6, 678), -86_400)
     );
 }
@@ -128,9 +128,9 @@ fn test_time_overflowing_add() {
 fn test_time_addassignment() {
     let hms = NaiveTime::from_hms;
     let mut time = hms(12, 12, 12);
-    time += Duration::hours(10);
+    time += TimeDelta::hours(10);
     assert_eq!(time, hms(22, 12, 12));
-    time += Duration::hours(10);
+    time += TimeDelta::hours(10);
     assert_eq!(time, hms(8, 12, 12));
 }
 
@@ -138,9 +138,9 @@ fn test_time_addassignment() {
 fn test_time_subassignment() {
     let hms = NaiveTime::from_hms;
     let mut time = hms(12, 12, 12);
-    time -= Duration::hours(10);
+    time -= TimeDelta::hours(10);
     assert_eq!(time, hms(2, 12, 12));
-    time -= Duration::hours(10);
+    time -= TimeDelta::hours(10);
     assert_eq!(time, hms(16, 12, 12));
 }
 
@@ -156,25 +156,25 @@ fn test_time_sub() {
 
     let hmsm = NaiveTime::from_hms_milli;
 
-    check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 900), Duration::zero());
-    check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 600), Duration::milliseconds(300));
-    check!(hmsm(3, 5, 7, 200), hmsm(2, 4, 6, 200), Duration::seconds(3600 + 60 + 1));
+    check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 900), TimeDelta::zero());
+    check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 600), TimeDelta::milliseconds(300));
+    check!(hmsm(3, 5, 7, 200), hmsm(2, 4, 6, 200), TimeDelta::seconds(3600 + 60 + 1));
     check!(
         hmsm(3, 5, 7, 200),
         hmsm(2, 4, 6, 300),
-        Duration::seconds(3600 + 60) + Duration::milliseconds(900)
+        TimeDelta::seconds(3600 + 60) + TimeDelta::milliseconds(900)
     );
 
     // treats the leap second as if it coincides with the prior non-leap second,
     // as required by `time1 - time2 = duration` and `time2 - time1 = -duration` equivalence.
-    check!(hmsm(3, 5, 7, 200), hmsm(3, 5, 6, 1_800), Duration::milliseconds(400));
-    check!(hmsm(3, 5, 7, 1_200), hmsm(3, 5, 6, 1_800), Duration::milliseconds(1400));
-    check!(hmsm(3, 5, 7, 1_200), hmsm(3, 5, 6, 800), Duration::milliseconds(1400));
+    check!(hmsm(3, 5, 7, 200), hmsm(3, 5, 6, 1_800), TimeDelta::milliseconds(400));
+    check!(hmsm(3, 5, 7, 1_200), hmsm(3, 5, 6, 1_800), TimeDelta::milliseconds(1400));
+    check!(hmsm(3, 5, 7, 1_200), hmsm(3, 5, 6, 800), TimeDelta::milliseconds(1400));
 
     // additional equality: `time1 + duration = time2` is equivalent to
     // `time2 - time1 = duration` IF AND ONLY IF `time2` represents a non-leap second.
-    assert_eq!(hmsm(3, 5, 6, 800) + Duration::milliseconds(400), hmsm(3, 5, 7, 200));
-    assert_eq!(hmsm(3, 5, 6, 1_800) + Duration::milliseconds(400), hmsm(3, 5, 7, 200));
+    assert_eq!(hmsm(3, 5, 6, 800) + TimeDelta::milliseconds(400), hmsm(3, 5, 7, 200));
+    assert_eq!(hmsm(3, 5, 6, 1_800) + TimeDelta::milliseconds(400), hmsm(3, 5, 7, 200));
 }
 
 #[test]

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -12,7 +12,7 @@ use rkyv::{Archive, Deserialize, Serialize};
 
 use super::{LocalResult, Offset, TimeZone};
 use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
-use crate::oldtime::Duration as OldDuration;
+use crate::time_delta::TimeDelta;
 use crate::DateTime;
 use crate::Timelike;
 
@@ -157,12 +157,12 @@ impl fmt::Display for FixedOffset {
 
 fn add_with_leapsecond<T>(lhs: &T, rhs: i32) -> T
 where
-    T: Timelike + Add<OldDuration, Output = T>,
+    T: Timelike + Add<TimeDelta, Output = T>,
 {
     // extract and temporarily remove the fractional part and later recover it
     let nanos = lhs.nanosecond();
     let lhs = lhs.with_nanosecond(0).unwrap();
-    (lhs + OldDuration::seconds(i64::from(rhs))).with_nanosecond(nanos).unwrap()
+    (lhs + TimeDelta::seconds(i64::from(rhs))).with_nanosecond(nanos).unwrap()
 }
 
 impl Add<FixedOffset> for NaiveTime {

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -128,7 +128,7 @@ impl TimeZone for Local {
         let mut local = local.clone();
         // Get the offset from the js runtime
         let offset = FixedOffset::west((js_sys::Date::new_0().get_timezone_offset() as i32) * 60);
-        local -= crate::Duration::seconds(offset.local_minus_utc() as i64);
+        local -= crate::TimeDelta::seconds(offset.local_minus_utc() as i64);
         LocalResult::Single(DateTime::from_utc(local, offset))
     }
 
@@ -173,7 +173,7 @@ impl TimeZone for Local {
 mod tests {
     use super::Local;
     use crate::offset::TimeZone;
-    use crate::{Datelike, Duration, NaiveDate, NaiveDateTime, Timelike};
+    use crate::{Datelike, NaiveDate, NaiveDateTime, TimeDelta, Timelike};
 
     use std::{path, process};
 
@@ -247,7 +247,7 @@ mod tests {
                 verify_against_date_command_local(date_path, date);
             }
 
-            date += crate::Duration::hours(1);
+            date += crate::TimeDelta::hours(1);
         }
     }
 
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn verify_correct_offsets_distant_past() {
         // let distant_past = Local::now() - Duration::days(365 * 100);
-        let distant_past = Local::now() - Duration::days(250 * 31);
+        let distant_past = Local::now() - TimeDelta::days(250 * 31);
         let from_local = Local.from_local_datetime(&distant_past.naive_local()).unwrap();
         let from_utc = Local.from_utc_datetime(&distant_past.naive_utc());
 
@@ -280,7 +280,7 @@ mod tests {
 
     #[test]
     fn verify_correct_offsets_distant_future() {
-        let distant_future = Local::now() + Duration::days(250 * 31);
+        let distant_future = Local::now() + TimeDelta::days(250 * 31);
         let from_local = Local.from_local_datetime(&distant_future.naive_local()).unwrap();
         let from_utc = Local.from_utc_datetime(&distant_future.naive_utc());
 

--- a/src/round.rs
+++ b/src/round.rs
@@ -3,7 +3,7 @@
 
 use crate::datetime::DateTime;
 use crate::naive::NaiveDateTime;
-use crate::oldtime::Duration;
+use crate::time_delta::TimeDelta;
 use crate::TimeZone;
 use crate::Timelike;
 use core::cmp::Ordering;
@@ -46,7 +46,7 @@ pub trait SubsecRound {
 
 impl<T> SubsecRound for T
 where
-    T: Timelike + Add<Duration, Output = T> + Sub<Duration, Output = T>,
+    T: Timelike + Add<TimeDelta, Output = T> + Sub<TimeDelta, Output = T>,
 {
     fn round_subsecs(self, digits: u16) -> T {
         let span = span_for_digits(digits);
@@ -54,9 +54,9 @@ where
         if delta_down > 0 {
             let delta_up = span - delta_down;
             if delta_up <= delta_down {
-                self + Duration::nanoseconds(delta_up.into())
+                self + TimeDelta::nanoseconds(delta_up.into())
             } else {
-                self - Duration::nanoseconds(delta_down.into())
+                self - TimeDelta::nanoseconds(delta_down.into())
             }
         } else {
             self // unchanged
@@ -67,7 +67,7 @@ where
         let span = span_for_digits(digits);
         let delta_down = self.nanosecond() % span;
         if delta_down > 0 {
-            self - Duration::nanoseconds(delta_down.into())
+            self - TimeDelta::nanoseconds(delta_down.into())
         } else {
             self // unchanged
         }
@@ -91,13 +91,13 @@ fn span_for_digits(digits: u16) -> u32 {
     }
 }
 
-/// Extension trait for rounding or truncating a DateTime by a Duration.
+/// Extension trait for rounding or truncating a DateTime by a TimeDelta.
 ///
 /// # Limitations
-/// Both rounding and truncating are done via [`Duration::num_nanoseconds`] and
+/// Both rounding and truncating are done via [`TimeDelta::num_nanoseconds`] and
 /// [`DateTime::timestamp_nanos`]. This means that they will fail if either the
-/// `Duration` or the `DateTime` are too big to represented as nanoseconds. They
-/// will also fail if the `Duration` is bigger than the timestamp.
+/// `TimeDelta` or the `DateTime` are too big to represented as nanoseconds. They
+/// will also fail if the `TimeDelta` is bigger than the timestamp.
 pub trait DurationRound: Sized {
     /// Error that can occur in rounding or truncating
     #[cfg(any(feature = "std", test))]
@@ -107,39 +107,39 @@ pub trait DurationRound: Sized {
     #[cfg(not(any(feature = "std", test)))]
     type Err: fmt::Debug + fmt::Display;
 
-    /// Return a copy rounded by Duration.
+    /// Return a copy rounded by TimeDelta.
     ///
     /// # Example
     /// ``` rust
-    /// # use chrono::{DateTime, DurationRound, Duration, TimeZone, Utc};
+    /// # use chrono::{DateTime, DurationRound, TimeDelta, TimeZone, Utc};
     /// let dt = Utc.ymd(2018, 1, 11).and_hms_milli(12, 0, 0, 154);
     /// assert_eq!(
-    ///     dt.duration_round(Duration::milliseconds(10)).unwrap().to_string(),
+    ///     dt.duration_round(TimeDelta::milliseconds(10)).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
     /// );
     /// assert_eq!(
-    ///     dt.duration_round(Duration::days(1)).unwrap().to_string(),
+    ///     dt.duration_round(TimeDelta::days(1)).unwrap().to_string(),
     ///     "2018-01-12 00:00:00 UTC"
     /// );
     /// ```
-    fn duration_round(self, duration: Duration) -> Result<Self, Self::Err>;
+    fn duration_round(self, duration: TimeDelta) -> Result<Self, Self::Err>;
 
-    /// Return a copy truncated by Duration.
+    /// Return a copy truncated by TimeDelta.
     ///
     /// # Example
     /// ``` rust
-    /// # use chrono::{DateTime, DurationRound, Duration, TimeZone, Utc};
+    /// # use chrono::{DateTime, DurationRound, TimeDelta, TimeZone, Utc};
     /// let dt = Utc.ymd(2018, 1, 11).and_hms_milli(12, 0, 0, 154);
     /// assert_eq!(
-    ///     dt.duration_trunc(Duration::milliseconds(10)).unwrap().to_string(),
+    ///     dt.duration_trunc(TimeDelta::milliseconds(10)).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
     /// );
     /// assert_eq!(
-    ///     dt.duration_trunc(Duration::days(1)).unwrap().to_string(),
+    ///     dt.duration_trunc(TimeDelta::days(1)).unwrap().to_string(),
     ///     "2018-01-11 00:00:00 UTC"
     /// );
     /// ```
-    fn duration_trunc(self, duration: Duration) -> Result<Self, Self::Err>;
+    fn duration_trunc(self, duration: TimeDelta) -> Result<Self, Self::Err>;
 }
 
 /// The maximum number of seconds a DateTime can be to be represented as nanoseconds
@@ -148,11 +148,11 @@ const MAX_SECONDS_TIMESTAMP_FOR_NANOS: i64 = 9_223_372_036;
 impl<Tz: TimeZone> DurationRound for DateTime<Tz> {
     type Err = RoundingError;
 
-    fn duration_round(self, duration: Duration) -> Result<Self, Self::Err> {
+    fn duration_round(self, duration: TimeDelta) -> Result<Self, Self::Err> {
         duration_round(self.naive_local(), self, duration)
     }
 
-    fn duration_trunc(self, duration: Duration) -> Result<Self, Self::Err> {
+    fn duration_trunc(self, duration: TimeDelta) -> Result<Self, Self::Err> {
         duration_trunc(self.naive_local(), self, duration)
     }
 }
@@ -160,11 +160,11 @@ impl<Tz: TimeZone> DurationRound for DateTime<Tz> {
 impl DurationRound for NaiveDateTime {
     type Err = RoundingError;
 
-    fn duration_round(self, duration: Duration) -> Result<Self, Self::Err> {
+    fn duration_round(self, duration: TimeDelta) -> Result<Self, Self::Err> {
         duration_round(self, self, duration)
     }
 
-    fn duration_trunc(self, duration: Duration) -> Result<Self, Self::Err> {
+    fn duration_trunc(self, duration: TimeDelta) -> Result<Self, Self::Err> {
         duration_trunc(self, self, duration)
     }
 }
@@ -172,10 +172,10 @@ impl DurationRound for NaiveDateTime {
 fn duration_round<T>(
     naive: NaiveDateTime,
     original: T,
-    duration: Duration,
+    duration: TimeDelta,
 ) -> Result<T, RoundingError>
 where
-    T: Timelike + Add<Duration, Output = T> + Sub<Duration, Output = T>,
+    T: Timelike + Add<TimeDelta, Output = T> + Sub<TimeDelta, Output = T>,
 {
     if let Some(span) = duration.num_nanoseconds() {
         if naive.timestamp().abs() > MAX_SECONDS_TIMESTAMP_FOR_NANOS {
@@ -198,9 +198,9 @@ where
                 (span - delta_down, delta_down)
             };
             if delta_up <= delta_down {
-                Ok(original + Duration::nanoseconds(delta_up))
+                Ok(original + TimeDelta::nanoseconds(delta_up))
             } else {
-                Ok(original - Duration::nanoseconds(delta_down))
+                Ok(original - TimeDelta::nanoseconds(delta_down))
             }
         }
     } else {
@@ -211,10 +211,10 @@ where
 fn duration_trunc<T>(
     naive: NaiveDateTime,
     original: T,
-    duration: Duration,
+    duration: TimeDelta,
 ) -> Result<T, RoundingError>
 where
-    T: Timelike + Add<Duration, Output = T> + Sub<Duration, Output = T>,
+    T: Timelike + Add<TimeDelta, Output = T> + Sub<TimeDelta, Output = T>,
 {
     if let Some(span) = duration.num_nanoseconds() {
         if naive.timestamp().abs() > MAX_SECONDS_TIMESTAMP_FOR_NANOS {
@@ -227,40 +227,40 @@ where
         let delta_down = stamp % span;
         match delta_down.cmp(&0) {
             Ordering::Equal => Ok(original),
-            Ordering::Greater => Ok(original - Duration::nanoseconds(delta_down)),
-            Ordering::Less => Ok(original - Duration::nanoseconds(span - delta_down.abs())),
+            Ordering::Greater => Ok(original - TimeDelta::nanoseconds(delta_down)),
+            Ordering::Less => Ok(original - TimeDelta::nanoseconds(span - delta_down.abs())),
         }
     } else {
         Err(RoundingError::DurationExceedsLimit)
     }
 }
 
-/// An error from rounding by `Duration`
+/// An error from rounding by `TimeDelta`
 ///
 /// See: [`DurationRound`]
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub enum RoundingError {
-    /// Error when the Duration exceeds the Duration from or until the Unix epoch.
+    /// Error when the TimeDelta exceeds the TimeDelta from or until the Unix epoch.
     ///
     /// ``` rust
-    /// # use chrono::{DateTime, DurationRound, Duration, RoundingError, TimeZone, Utc};
+    /// # use chrono::{DateTime, DurationRound, TimeDelta, RoundingError, TimeZone, Utc};
     /// let dt = Utc.ymd(1970, 12, 12).and_hms(0, 0, 0);
     ///
     /// assert_eq!(
-    ///     dt.duration_round(Duration::days(365)),
+    ///     dt.duration_round(TimeDelta::days(365)),
     ///     Err(RoundingError::DurationExceedsTimestamp),
     /// );
     /// ```
     DurationExceedsTimestamp,
 
-    /// Error when `Duration.num_nanoseconds` exceeds the limit.
+    /// Error when `TimeDelta.num_nanoseconds` exceeds the limit.
     ///
     /// ``` rust
-    /// # use chrono::{DateTime, DurationRound, Duration, RoundingError, TimeZone, Utc};
+    /// # use chrono::{DateTime, DurationRound, TimeDelta, RoundingError, TimeZone, Utc};
     /// let dt = Utc.ymd(2260, 12, 31).and_hms_nano(23, 59, 59, 1_75_500_000);
     ///
     /// assert_eq!(
-    ///     dt.duration_round(Duration::days(300 * 365)),
+    ///     dt.duration_round(TimeDelta::days(300 * 365)),
     ///     Err(RoundingError::DurationExceedsLimit)
     /// );
     /// ```
@@ -269,10 +269,10 @@ pub enum RoundingError {
     /// Error when `DateTime.timestamp_nanos` exceeds the limit.
     ///
     /// ``` rust
-    /// # use chrono::{DateTime, DurationRound, Duration, RoundingError, TimeZone, Utc};
+    /// # use chrono::{DateTime, DurationRound, TimeDelta, RoundingError, TimeZone, Utc};
     /// let dt = Utc.ymd(2300, 12, 12).and_hms(0, 0, 0);
     ///
-    /// assert_eq!(dt.duration_round(Duration::days(1)), Err(RoundingError::TimestampExceedsLimit),);
+    /// assert_eq!(dt.duration_round(TimeDelta::days(1)), Err(RoundingError::TimestampExceedsLimit),);
     /// ```
     TimestampExceedsLimit,
 }
@@ -304,7 +304,7 @@ impl std::error::Error for RoundingError {
 
 #[cfg(test)]
 mod tests {
-    use super::{Duration, DurationRound, SubsecRound};
+    use super::{DurationRound, SubsecRound, TimeDelta};
     use crate::offset::{FixedOffset, TimeZone, Utc};
     use crate::Timelike;
 
@@ -399,64 +399,64 @@ mod tests {
         let dt = Utc.ymd(2016, 12, 31).and_hms_nano(23, 59, 59, 175_500_000);
 
         assert_eq!(
-            dt.duration_round(Duration::zero()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::zero()).unwrap().to_string(),
             "2016-12-31 23:59:59.175500 UTC"
         );
 
         assert_eq!(
-            dt.duration_round(Duration::milliseconds(10)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::milliseconds(10)).unwrap().to_string(),
             "2016-12-31 23:59:59.180 UTC"
         );
 
         // round up
         let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 30, 0);
         assert_eq!(
-            dt.duration_round(Duration::minutes(5)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:25:00 UTC"
         );
         // round down
         let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 29, 999);
         assert_eq!(
-            dt.duration_round(Duration::minutes(5)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:20:00 UTC"
         );
 
         assert_eq!(
-            dt.duration_round(Duration::minutes(10)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(10)).unwrap().to_string(),
             "2012-12-12 18:20:00 UTC"
         );
         assert_eq!(
-            dt.duration_round(Duration::minutes(30)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(30)).unwrap().to_string(),
             "2012-12-12 18:30:00 UTC"
         );
         assert_eq!(
-            dt.duration_round(Duration::hours(1)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::hours(1)).unwrap().to_string(),
             "2012-12-12 18:00:00 UTC"
         );
         assert_eq!(
-            dt.duration_round(Duration::days(1)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::days(1)).unwrap().to_string(),
             "2012-12-13 00:00:00 UTC"
         );
 
         // timezone east
         let dt = FixedOffset::east(3600).ymd(2020, 10, 27).and_hms(15, 0, 0);
         assert_eq!(
-            dt.duration_round(Duration::days(1)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-28 00:00:00 +01:00"
         );
         assert_eq!(
-            dt.duration_round(Duration::weeks(1)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::weeks(1)).unwrap().to_string(),
             "2020-10-29 00:00:00 +01:00"
         );
 
         // timezone west
         let dt = FixedOffset::west(3600).ymd(2020, 10, 27).and_hms(15, 0, 0);
         assert_eq!(
-            dt.duration_round(Duration::days(1)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-28 00:00:00 -01:00"
         );
         assert_eq!(
-            dt.duration_round(Duration::weeks(1)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::weeks(1)).unwrap().to_string(),
             "2020-10-29 00:00:00 -01:00"
         );
     }
@@ -466,42 +466,42 @@ mod tests {
         let dt = Utc.ymd(2016, 12, 31).and_hms_nano(23, 59, 59, 175_500_000).naive_utc();
 
         assert_eq!(
-            dt.duration_round(Duration::zero()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::zero()).unwrap().to_string(),
             "2016-12-31 23:59:59.175500"
         );
 
         assert_eq!(
-            dt.duration_round(Duration::milliseconds(10)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::milliseconds(10)).unwrap().to_string(),
             "2016-12-31 23:59:59.180"
         );
 
         // round up
         let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 30, 0).naive_utc();
         assert_eq!(
-            dt.duration_round(Duration::minutes(5)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:25:00"
         );
         // round down
         let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 29, 999).naive_utc();
         assert_eq!(
-            dt.duration_round(Duration::minutes(5)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:20:00"
         );
 
         assert_eq!(
-            dt.duration_round(Duration::minutes(10)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(10)).unwrap().to_string(),
             "2012-12-12 18:20:00"
         );
         assert_eq!(
-            dt.duration_round(Duration::minutes(30)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(30)).unwrap().to_string(),
             "2012-12-12 18:30:00"
         );
         assert_eq!(
-            dt.duration_round(Duration::hours(1)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::hours(1)).unwrap().to_string(),
             "2012-12-12 18:00:00"
         );
         assert_eq!(
-            dt.duration_round(Duration::days(1)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::days(1)).unwrap().to_string(),
             "2012-12-13 00:00:00"
         );
     }
@@ -510,7 +510,7 @@ mod tests {
     fn test_duration_round_pre_epoch() {
         let dt = Utc.ymd(1969, 12, 12).and_hms(12, 12, 12);
         assert_eq!(
-            dt.duration_round(Duration::minutes(10)).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(10)).unwrap().to_string(),
             "1969-12-12 12:10:00 UTC"
         );
     }
@@ -520,58 +520,58 @@ mod tests {
         let dt = Utc.ymd(2016, 12, 31).and_hms_nano(23, 59, 59, 175_500_000);
 
         assert_eq!(
-            dt.duration_trunc(Duration::milliseconds(10)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::milliseconds(10)).unwrap().to_string(),
             "2016-12-31 23:59:59.170 UTC"
         );
 
         // would round up
         let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 30, 0);
         assert_eq!(
-            dt.duration_trunc(Duration::minutes(5)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:20:00 UTC"
         );
         // would round down
         let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 29, 999);
         assert_eq!(
-            dt.duration_trunc(Duration::minutes(5)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:20:00 UTC"
         );
         assert_eq!(
-            dt.duration_trunc(Duration::minutes(10)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(10)).unwrap().to_string(),
             "2012-12-12 18:20:00 UTC"
         );
         assert_eq!(
-            dt.duration_trunc(Duration::minutes(30)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(30)).unwrap().to_string(),
             "2012-12-12 18:00:00 UTC"
         );
         assert_eq!(
-            dt.duration_trunc(Duration::hours(1)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::hours(1)).unwrap().to_string(),
             "2012-12-12 18:00:00 UTC"
         );
         assert_eq!(
-            dt.duration_trunc(Duration::days(1)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::days(1)).unwrap().to_string(),
             "2012-12-12 00:00:00 UTC"
         );
 
         // timezone east
         let dt = FixedOffset::east(3600).ymd(2020, 10, 27).and_hms(15, 0, 0);
         assert_eq!(
-            dt.duration_trunc(Duration::days(1)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-27 00:00:00 +01:00"
         );
         assert_eq!(
-            dt.duration_trunc(Duration::weeks(1)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::weeks(1)).unwrap().to_string(),
             "2020-10-22 00:00:00 +01:00"
         );
 
         // timezone west
         let dt = FixedOffset::west(3600).ymd(2020, 10, 27).and_hms(15, 0, 0);
         assert_eq!(
-            dt.duration_trunc(Duration::days(1)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-27 00:00:00 -01:00"
         );
         assert_eq!(
-            dt.duration_trunc(Duration::weeks(1)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::weeks(1)).unwrap().to_string(),
             "2020-10-22 00:00:00 -01:00"
         );
     }
@@ -581,36 +581,36 @@ mod tests {
         let dt = Utc.ymd(2016, 12, 31).and_hms_nano(23, 59, 59, 175_500_000).naive_utc();
 
         assert_eq!(
-            dt.duration_trunc(Duration::milliseconds(10)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::milliseconds(10)).unwrap().to_string(),
             "2016-12-31 23:59:59.170"
         );
 
         // would round up
         let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 30, 0).naive_utc();
         assert_eq!(
-            dt.duration_trunc(Duration::minutes(5)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:20:00"
         );
         // would round down
         let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 29, 999).naive_utc();
         assert_eq!(
-            dt.duration_trunc(Duration::minutes(5)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:20:00"
         );
         assert_eq!(
-            dt.duration_trunc(Duration::minutes(10)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(10)).unwrap().to_string(),
             "2012-12-12 18:20:00"
         );
         assert_eq!(
-            dt.duration_trunc(Duration::minutes(30)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(30)).unwrap().to_string(),
             "2012-12-12 18:00:00"
         );
         assert_eq!(
-            dt.duration_trunc(Duration::hours(1)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::hours(1)).unwrap().to_string(),
             "2012-12-12 18:00:00"
         );
         assert_eq!(
-            dt.duration_trunc(Duration::days(1)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::days(1)).unwrap().to_string(),
             "2012-12-12 00:00:00"
         );
     }
@@ -619,7 +619,7 @@ mod tests {
     fn test_duration_trunc_pre_epoch() {
         let dt = Utc.ymd(1969, 12, 12).and_hms(12, 12, 12);
         assert_eq!(
-            dt.duration_trunc(Duration::minutes(10)).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(10)).unwrap().to_string(),
             "1969-12-12 12:10:00 UTC"
         );
     }

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -52,66 +52,66 @@ macro_rules! try_opt {
 /// This also allows for the negative duration; see individual methods for details.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 #[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
-pub struct Duration {
+pub struct TimeDelta {
     secs: i64,
     nanos: i32, // Always 0 <= nanos < NANOS_PER_SEC
 }
 
 /// The minimum possible `Duration`: `i64::MIN` milliseconds.
-pub(crate) const MIN: Duration = Duration {
+pub(crate) const MIN: TimeDelta = TimeDelta {
     secs: i64::MIN / MILLIS_PER_SEC - 1,
     nanos: NANOS_PER_SEC + (i64::MIN % MILLIS_PER_SEC) as i32 * NANOS_PER_MILLI,
 };
 
 /// The maximum possible `Duration`: `i64::MAX` milliseconds.
-pub(crate) const MAX: Duration = Duration {
+pub(crate) const MAX: TimeDelta = TimeDelta {
     secs: i64::MAX / MILLIS_PER_SEC,
     nanos: (i64::MAX % MILLIS_PER_SEC) as i32 * NANOS_PER_MILLI,
 };
 
-impl Duration {
+impl TimeDelta {
     /// Makes a new `Duration` with given number of weeks.
     /// Equivalent to `Duration::seconds(weeks * 7 * 24 * 60 * 60)` with overflow checks.
     /// Panics when the duration is out of bounds.
     #[inline]
-    pub fn weeks(weeks: i64) -> Duration {
+    pub fn weeks(weeks: i64) -> TimeDelta {
         let secs = weeks.checked_mul(SECS_PER_WEEK).expect("Duration::weeks out of bounds");
-        Duration::seconds(secs)
+        TimeDelta::seconds(secs)
     }
 
     /// Makes a new `Duration` with given number of days.
     /// Equivalent to `Duration::seconds(days * 24 * 60 * 60)` with overflow checks.
     /// Panics when the duration is out of bounds.
     #[inline]
-    pub fn days(days: i64) -> Duration {
+    pub fn days(days: i64) -> TimeDelta {
         let secs = days.checked_mul(SECS_PER_DAY).expect("Duration::days out of bounds");
-        Duration::seconds(secs)
+        TimeDelta::seconds(secs)
     }
 
     /// Makes a new `Duration` with given number of hours.
     /// Equivalent to `Duration::seconds(hours * 60 * 60)` with overflow checks.
     /// Panics when the duration is out of bounds.
     #[inline]
-    pub fn hours(hours: i64) -> Duration {
+    pub fn hours(hours: i64) -> TimeDelta {
         let secs = hours.checked_mul(SECS_PER_HOUR).expect("Duration::hours ouf of bounds");
-        Duration::seconds(secs)
+        TimeDelta::seconds(secs)
     }
 
     /// Makes a new `Duration` with given number of minutes.
     /// Equivalent to `Duration::seconds(minutes * 60)` with overflow checks.
     /// Panics when the duration is out of bounds.
     #[inline]
-    pub fn minutes(minutes: i64) -> Duration {
+    pub fn minutes(minutes: i64) -> TimeDelta {
         let secs = minutes.checked_mul(SECS_PER_MINUTE).expect("Duration::minutes out of bounds");
-        Duration::seconds(secs)
+        TimeDelta::seconds(secs)
     }
 
     /// Makes a new `Duration` with given number of seconds.
     /// Panics when the duration is more than `i64::MAX` seconds
     /// or less than `i64::MIN` seconds.
     #[inline]
-    pub fn seconds(seconds: i64) -> Duration {
-        let d = Duration { secs: seconds, nanos: 0 };
+    pub fn seconds(seconds: i64) -> TimeDelta {
+        let d = TimeDelta { secs: seconds, nanos: 0 };
         if d < MIN || d > MAX {
             panic!("Duration::seconds out of bounds");
         }
@@ -120,25 +120,25 @@ impl Duration {
 
     /// Makes a new `Duration` with given number of milliseconds.
     #[inline]
-    pub fn milliseconds(milliseconds: i64) -> Duration {
+    pub fn milliseconds(milliseconds: i64) -> TimeDelta {
         let (secs, millis) = div_mod_floor_64(milliseconds, MILLIS_PER_SEC);
         let nanos = millis as i32 * NANOS_PER_MILLI;
-        Duration { secs: secs, nanos: nanos }
+        TimeDelta { secs: secs, nanos: nanos }
     }
 
     /// Makes a new `Duration` with given number of microseconds.
     #[inline]
-    pub fn microseconds(microseconds: i64) -> Duration {
+    pub fn microseconds(microseconds: i64) -> TimeDelta {
         let (secs, micros) = div_mod_floor_64(microseconds, MICROS_PER_SEC);
         let nanos = micros as i32 * NANOS_PER_MICRO;
-        Duration { secs: secs, nanos: nanos }
+        TimeDelta { secs: secs, nanos: nanos }
     }
 
     /// Makes a new `Duration` with given number of nanoseconds.
     #[inline]
-    pub fn nanoseconds(nanos: i64) -> Duration {
+    pub fn nanoseconds(nanos: i64) -> TimeDelta {
         let (secs, nanos) = div_mod_floor_64(nanos, NANOS_PER_SEC as i64);
-        Duration { secs: secs, nanos: nanos as i32 }
+        TimeDelta { secs: secs, nanos: nanos as i32 }
     }
 
     /// Returns the total number of whole weeks in the duration.
@@ -211,14 +211,14 @@ impl Duration {
     }
 
     /// Add two durations, returning `None` if overflow occurred.
-    pub fn checked_add(&self, rhs: &Duration) -> Option<Duration> {
+    pub fn checked_add(&self, rhs: &TimeDelta) -> Option<TimeDelta> {
         let mut secs = try_opt!(self.secs.checked_add(rhs.secs));
         let mut nanos = self.nanos + rhs.nanos;
         if nanos >= NANOS_PER_SEC {
             nanos -= NANOS_PER_SEC;
             secs = try_opt!(secs.checked_add(1));
         }
-        let d = Duration { secs: secs, nanos: nanos };
+        let d = TimeDelta { secs: secs, nanos: nanos };
         // Even if d is within the bounds of i64 seconds,
         // it might still overflow i64 milliseconds.
         if d < MIN || d > MAX {
@@ -229,14 +229,14 @@ impl Duration {
     }
 
     /// Subtract two durations, returning `None` if overflow occurred.
-    pub fn checked_sub(&self, rhs: &Duration) -> Option<Duration> {
+    pub fn checked_sub(&self, rhs: &TimeDelta) -> Option<TimeDelta> {
         let mut secs = try_opt!(self.secs.checked_sub(rhs.secs));
         let mut nanos = self.nanos - rhs.nanos;
         if nanos < 0 {
             nanos += NANOS_PER_SEC;
             secs = try_opt!(secs.checked_sub(1));
         }
-        let d = Duration { secs: secs, nanos: nanos };
+        let d = TimeDelta { secs: secs, nanos: nanos };
         // Even if d is within the bounds of i64 seconds,
         // it might still overflow i64 milliseconds.
         if d < MIN || d > MAX {
@@ -248,30 +248,30 @@ impl Duration {
 
     /// Returns the duration as an absolute (non-negative) value.
     #[inline]
-    pub fn abs(&self) -> Duration {
+    pub fn abs(&self) -> TimeDelta {
         if self.secs < 0 && self.nanos != 0 {
-            Duration { secs: (self.secs + 1).abs(), nanos: NANOS_PER_SEC - self.nanos }
+            TimeDelta { secs: (self.secs + 1).abs(), nanos: NANOS_PER_SEC - self.nanos }
         } else {
-            Duration { secs: self.secs.abs(), nanos: self.nanos }
+            TimeDelta { secs: self.secs.abs(), nanos: self.nanos }
         }
     }
 
     /// The minimum possible `Duration`: `i64::MIN` milliseconds.
     #[inline]
-    pub fn min_value() -> Duration {
+    pub fn min_value() -> TimeDelta {
         MIN
     }
 
     /// The maximum possible `Duration`: `i64::MAX` milliseconds.
     #[inline]
-    pub fn max_value() -> Duration {
+    pub fn max_value() -> TimeDelta {
         MAX
     }
 
     /// A duration where the stored seconds and nanoseconds are equal to zero.
     #[inline]
-    pub fn zero() -> Duration {
-        Duration { secs: 0, nanos: 0 }
+    pub fn zero() -> TimeDelta {
+        TimeDelta { secs: 0, nanos: 0 }
     }
 
     /// Returns `true` if the duration equals `Duration::zero()`.
@@ -284,12 +284,13 @@ impl Duration {
     ///
     /// This function errors when original duration is larger than the maximum
     /// value supported for this type.
-    pub fn from_std(duration: StdDuration) -> Result<Duration, OutOfRangeError> {
+    pub fn from_std(duration: StdDuration) -> Result<TimeDelta, OutOfRangeError> {
         // We need to check secs as u64 before coercing to i64
         if duration.as_secs() > MAX.secs as u64 {
             return Err(OutOfRangeError(()));
         }
-        let d = Duration { secs: duration.as_secs() as i64, nanos: duration.subsec_nanos() as i32 };
+        let d =
+            TimeDelta { secs: duration.as_secs() as i64, nanos: duration.subsec_nanos() as i32 };
         if d > MAX {
             return Err(OutOfRangeError(()));
         }
@@ -308,63 +309,63 @@ impl Duration {
     }
 }
 
-impl Neg for Duration {
-    type Output = Duration;
+impl Neg for TimeDelta {
+    type Output = TimeDelta;
 
     #[inline]
-    fn neg(self) -> Duration {
+    fn neg(self) -> TimeDelta {
         if self.nanos == 0 {
-            Duration { secs: -self.secs, nanos: 0 }
+            TimeDelta { secs: -self.secs, nanos: 0 }
         } else {
-            Duration { secs: -self.secs - 1, nanos: NANOS_PER_SEC - self.nanos }
+            TimeDelta { secs: -self.secs - 1, nanos: NANOS_PER_SEC - self.nanos }
         }
     }
 }
 
-impl Add for Duration {
-    type Output = Duration;
+impl Add for TimeDelta {
+    type Output = TimeDelta;
 
-    fn add(self, rhs: Duration) -> Duration {
+    fn add(self, rhs: TimeDelta) -> TimeDelta {
         let mut secs = self.secs + rhs.secs;
         let mut nanos = self.nanos + rhs.nanos;
         if nanos >= NANOS_PER_SEC {
             nanos -= NANOS_PER_SEC;
             secs += 1;
         }
-        Duration { secs: secs, nanos: nanos }
+        TimeDelta { secs: secs, nanos: nanos }
     }
 }
 
-impl Sub for Duration {
-    type Output = Duration;
+impl Sub for TimeDelta {
+    type Output = TimeDelta;
 
-    fn sub(self, rhs: Duration) -> Duration {
+    fn sub(self, rhs: TimeDelta) -> TimeDelta {
         let mut secs = self.secs - rhs.secs;
         let mut nanos = self.nanos - rhs.nanos;
         if nanos < 0 {
             nanos += NANOS_PER_SEC;
             secs -= 1;
         }
-        Duration { secs: secs, nanos: nanos }
+        TimeDelta { secs: secs, nanos: nanos }
     }
 }
 
-impl Mul<i32> for Duration {
-    type Output = Duration;
+impl Mul<i32> for TimeDelta {
+    type Output = TimeDelta;
 
-    fn mul(self, rhs: i32) -> Duration {
+    fn mul(self, rhs: i32) -> TimeDelta {
         // Multiply nanoseconds as i64, because it cannot overflow that way.
         let total_nanos = self.nanos as i64 * rhs as i64;
         let (extra_secs, nanos) = div_mod_floor_64(total_nanos, NANOS_PER_SEC as i64);
         let secs = self.secs * rhs as i64 + extra_secs;
-        Duration { secs: secs, nanos: nanos as i32 }
+        TimeDelta { secs: secs, nanos: nanos as i32 }
     }
 }
 
-impl Div<i32> for Duration {
-    type Output = Duration;
+impl Div<i32> for TimeDelta {
+    type Output = TimeDelta;
 
-    fn div(self, rhs: i32) -> Duration {
+    fn div(self, rhs: i32) -> TimeDelta {
         let mut secs = self.secs / rhs as i64;
         let carry = self.secs - secs * rhs as i64;
         let extra_nanos = carry * NANOS_PER_SEC as i64 / rhs as i64;
@@ -377,27 +378,27 @@ impl Div<i32> for Duration {
             nanos += NANOS_PER_SEC;
             secs -= 1;
         }
-        Duration { secs: secs, nanos: nanos }
+        TimeDelta { secs: secs, nanos: nanos }
     }
 }
 
 #[cfg(any(feature = "std", test))]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl<'a> std::iter::Sum<&'a Duration> for Duration {
-    fn sum<I: Iterator<Item = &'a Duration>>(iter: I) -> Duration {
-        iter.fold(Duration::zero(), |acc, x| acc + *x)
+impl<'a> std::iter::Sum<&'a TimeDelta> for TimeDelta {
+    fn sum<I: Iterator<Item = &'a TimeDelta>>(iter: I) -> TimeDelta {
+        iter.fold(TimeDelta::zero(), |acc, x| acc + *x)
     }
 }
 
 #[cfg(any(feature = "std", test))]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl std::iter::Sum<Duration> for Duration {
-    fn sum<I: Iterator<Item = Duration>>(iter: I) -> Duration {
-        iter.fold(Duration::zero(), |acc, x| acc + x)
+impl std::iter::Sum<TimeDelta> for TimeDelta {
+    fn sum<I: Iterator<Item = TimeDelta>>(iter: I) -> TimeDelta {
+        iter.fold(TimeDelta::zero(), |acc, x| acc + x)
     }
 }
 
-impl fmt::Display for Duration {
+impl fmt::Display for TimeDelta {
     /// Format a duration using the [ISO 8601] format
     ///
     /// [ISO 8601]: https://en.wikipedia.org/wiki/ISO_8601#Durations
@@ -484,263 +485,269 @@ fn div_rem_64(this: i64, other: i64) -> (i64, i64) {
 
 #[cfg(test)]
 mod tests {
-    use super::{Duration, OutOfRangeError, MAX, MIN};
+    use super::{OutOfRangeError, TimeDelta, MAX, MIN};
     use std::time::Duration as StdDuration;
     use std::{i32, i64};
 
     #[test]
     fn test_duration() {
-        assert!(Duration::seconds(1) != Duration::zero());
-        assert_eq!(Duration::seconds(1) + Duration::seconds(2), Duration::seconds(3));
+        assert!(TimeDelta::seconds(1) != TimeDelta::zero());
+        assert_eq!(TimeDelta::seconds(1) + TimeDelta::seconds(2), TimeDelta::seconds(3));
         assert_eq!(
-            Duration::seconds(86399) + Duration::seconds(4),
-            Duration::days(1) + Duration::seconds(3)
+            TimeDelta::seconds(86399) + TimeDelta::seconds(4),
+            TimeDelta::days(1) + TimeDelta::seconds(3)
         );
-        assert_eq!(Duration::days(10) - Duration::seconds(1000), Duration::seconds(863000));
-        assert_eq!(Duration::days(10) - Duration::seconds(1000000), Duration::seconds(-136000));
+        assert_eq!(TimeDelta::days(10) - TimeDelta::seconds(1000), TimeDelta::seconds(863000));
+        assert_eq!(TimeDelta::days(10) - TimeDelta::seconds(1000000), TimeDelta::seconds(-136000));
         assert_eq!(
-            Duration::days(2) + Duration::seconds(86399) + Duration::nanoseconds(1234567890),
-            Duration::days(3) + Duration::nanoseconds(234567890)
+            TimeDelta::days(2) + TimeDelta::seconds(86399) + TimeDelta::nanoseconds(1234567890),
+            TimeDelta::days(3) + TimeDelta::nanoseconds(234567890)
         );
-        assert_eq!(-Duration::days(3), Duration::days(-3));
+        assert_eq!(-TimeDelta::days(3), TimeDelta::days(-3));
         assert_eq!(
-            -(Duration::days(3) + Duration::seconds(70)),
-            Duration::days(-4) + Duration::seconds(86400 - 70)
+            -(TimeDelta::days(3) + TimeDelta::seconds(70)),
+            TimeDelta::days(-4) + TimeDelta::seconds(86400 - 70)
         );
     }
 
     #[test]
     fn test_duration_num_days() {
-        assert_eq!(Duration::zero().num_days(), 0);
-        assert_eq!(Duration::days(1).num_days(), 1);
-        assert_eq!(Duration::days(-1).num_days(), -1);
-        assert_eq!(Duration::seconds(86399).num_days(), 0);
-        assert_eq!(Duration::seconds(86401).num_days(), 1);
-        assert_eq!(Duration::seconds(-86399).num_days(), 0);
-        assert_eq!(Duration::seconds(-86401).num_days(), -1);
-        assert_eq!(Duration::days(i32::MAX as i64).num_days(), i32::MAX as i64);
-        assert_eq!(Duration::days(i32::MIN as i64).num_days(), i32::MIN as i64);
+        assert_eq!(TimeDelta::zero().num_days(), 0);
+        assert_eq!(TimeDelta::days(1).num_days(), 1);
+        assert_eq!(TimeDelta::days(-1).num_days(), -1);
+        assert_eq!(TimeDelta::seconds(86399).num_days(), 0);
+        assert_eq!(TimeDelta::seconds(86401).num_days(), 1);
+        assert_eq!(TimeDelta::seconds(-86399).num_days(), 0);
+        assert_eq!(TimeDelta::seconds(-86401).num_days(), -1);
+        assert_eq!(TimeDelta::days(i32::MAX as i64).num_days(), i32::MAX as i64);
+        assert_eq!(TimeDelta::days(i32::MIN as i64).num_days(), i32::MIN as i64);
     }
 
     #[test]
     fn test_duration_num_seconds() {
-        assert_eq!(Duration::zero().num_seconds(), 0);
-        assert_eq!(Duration::seconds(1).num_seconds(), 1);
-        assert_eq!(Duration::seconds(-1).num_seconds(), -1);
-        assert_eq!(Duration::milliseconds(999).num_seconds(), 0);
-        assert_eq!(Duration::milliseconds(1001).num_seconds(), 1);
-        assert_eq!(Duration::milliseconds(-999).num_seconds(), 0);
-        assert_eq!(Duration::milliseconds(-1001).num_seconds(), -1);
+        assert_eq!(TimeDelta::zero().num_seconds(), 0);
+        assert_eq!(TimeDelta::seconds(1).num_seconds(), 1);
+        assert_eq!(TimeDelta::seconds(-1).num_seconds(), -1);
+        assert_eq!(TimeDelta::milliseconds(999).num_seconds(), 0);
+        assert_eq!(TimeDelta::milliseconds(1001).num_seconds(), 1);
+        assert_eq!(TimeDelta::milliseconds(-999).num_seconds(), 0);
+        assert_eq!(TimeDelta::milliseconds(-1001).num_seconds(), -1);
     }
 
     #[test]
     fn test_duration_num_milliseconds() {
-        assert_eq!(Duration::zero().num_milliseconds(), 0);
-        assert_eq!(Duration::milliseconds(1).num_milliseconds(), 1);
-        assert_eq!(Duration::milliseconds(-1).num_milliseconds(), -1);
-        assert_eq!(Duration::microseconds(999).num_milliseconds(), 0);
-        assert_eq!(Duration::microseconds(1001).num_milliseconds(), 1);
-        assert_eq!(Duration::microseconds(-999).num_milliseconds(), 0);
-        assert_eq!(Duration::microseconds(-1001).num_milliseconds(), -1);
-        assert_eq!(Duration::milliseconds(i64::MAX).num_milliseconds(), i64::MAX);
-        assert_eq!(Duration::milliseconds(i64::MIN).num_milliseconds(), i64::MIN);
+        assert_eq!(TimeDelta::zero().num_milliseconds(), 0);
+        assert_eq!(TimeDelta::milliseconds(1).num_milliseconds(), 1);
+        assert_eq!(TimeDelta::milliseconds(-1).num_milliseconds(), -1);
+        assert_eq!(TimeDelta::microseconds(999).num_milliseconds(), 0);
+        assert_eq!(TimeDelta::microseconds(1001).num_milliseconds(), 1);
+        assert_eq!(TimeDelta::microseconds(-999).num_milliseconds(), 0);
+        assert_eq!(TimeDelta::microseconds(-1001).num_milliseconds(), -1);
+        assert_eq!(TimeDelta::milliseconds(i64::MAX).num_milliseconds(), i64::MAX);
+        assert_eq!(TimeDelta::milliseconds(i64::MIN).num_milliseconds(), i64::MIN);
         assert_eq!(MAX.num_milliseconds(), i64::MAX);
         assert_eq!(MIN.num_milliseconds(), i64::MIN);
     }
 
     #[test]
     fn test_duration_num_microseconds() {
-        assert_eq!(Duration::zero().num_microseconds(), Some(0));
-        assert_eq!(Duration::microseconds(1).num_microseconds(), Some(1));
-        assert_eq!(Duration::microseconds(-1).num_microseconds(), Some(-1));
-        assert_eq!(Duration::nanoseconds(999).num_microseconds(), Some(0));
-        assert_eq!(Duration::nanoseconds(1001).num_microseconds(), Some(1));
-        assert_eq!(Duration::nanoseconds(-999).num_microseconds(), Some(0));
-        assert_eq!(Duration::nanoseconds(-1001).num_microseconds(), Some(-1));
-        assert_eq!(Duration::microseconds(i64::MAX).num_microseconds(), Some(i64::MAX));
-        assert_eq!(Duration::microseconds(i64::MIN).num_microseconds(), Some(i64::MIN));
+        assert_eq!(TimeDelta::zero().num_microseconds(), Some(0));
+        assert_eq!(TimeDelta::microseconds(1).num_microseconds(), Some(1));
+        assert_eq!(TimeDelta::microseconds(-1).num_microseconds(), Some(-1));
+        assert_eq!(TimeDelta::nanoseconds(999).num_microseconds(), Some(0));
+        assert_eq!(TimeDelta::nanoseconds(1001).num_microseconds(), Some(1));
+        assert_eq!(TimeDelta::nanoseconds(-999).num_microseconds(), Some(0));
+        assert_eq!(TimeDelta::nanoseconds(-1001).num_microseconds(), Some(-1));
+        assert_eq!(TimeDelta::microseconds(i64::MAX).num_microseconds(), Some(i64::MAX));
+        assert_eq!(TimeDelta::microseconds(i64::MIN).num_microseconds(), Some(i64::MIN));
         assert_eq!(MAX.num_microseconds(), None);
         assert_eq!(MIN.num_microseconds(), None);
 
         // overflow checks
         const MICROS_PER_DAY: i64 = 86400_000_000;
         assert_eq!(
-            Duration::days(i64::MAX / MICROS_PER_DAY).num_microseconds(),
+            TimeDelta::days(i64::MAX / MICROS_PER_DAY).num_microseconds(),
             Some(i64::MAX / MICROS_PER_DAY * MICROS_PER_DAY)
         );
         assert_eq!(
-            Duration::days(i64::MIN / MICROS_PER_DAY).num_microseconds(),
+            TimeDelta::days(i64::MIN / MICROS_PER_DAY).num_microseconds(),
             Some(i64::MIN / MICROS_PER_DAY * MICROS_PER_DAY)
         );
-        assert_eq!(Duration::days(i64::MAX / MICROS_PER_DAY + 1).num_microseconds(), None);
-        assert_eq!(Duration::days(i64::MIN / MICROS_PER_DAY - 1).num_microseconds(), None);
+        assert_eq!(TimeDelta::days(i64::MAX / MICROS_PER_DAY + 1).num_microseconds(), None);
+        assert_eq!(TimeDelta::days(i64::MIN / MICROS_PER_DAY - 1).num_microseconds(), None);
     }
 
     #[test]
     fn test_duration_num_nanoseconds() {
-        assert_eq!(Duration::zero().num_nanoseconds(), Some(0));
-        assert_eq!(Duration::nanoseconds(1).num_nanoseconds(), Some(1));
-        assert_eq!(Duration::nanoseconds(-1).num_nanoseconds(), Some(-1));
-        assert_eq!(Duration::nanoseconds(i64::MAX).num_nanoseconds(), Some(i64::MAX));
-        assert_eq!(Duration::nanoseconds(i64::MIN).num_nanoseconds(), Some(i64::MIN));
+        assert_eq!(TimeDelta::zero().num_nanoseconds(), Some(0));
+        assert_eq!(TimeDelta::nanoseconds(1).num_nanoseconds(), Some(1));
+        assert_eq!(TimeDelta::nanoseconds(-1).num_nanoseconds(), Some(-1));
+        assert_eq!(TimeDelta::nanoseconds(i64::MAX).num_nanoseconds(), Some(i64::MAX));
+        assert_eq!(TimeDelta::nanoseconds(i64::MIN).num_nanoseconds(), Some(i64::MIN));
         assert_eq!(MAX.num_nanoseconds(), None);
         assert_eq!(MIN.num_nanoseconds(), None);
 
         // overflow checks
         const NANOS_PER_DAY: i64 = 86400_000_000_000;
         assert_eq!(
-            Duration::days(i64::MAX / NANOS_PER_DAY).num_nanoseconds(),
+            TimeDelta::days(i64::MAX / NANOS_PER_DAY).num_nanoseconds(),
             Some(i64::MAX / NANOS_PER_DAY * NANOS_PER_DAY)
         );
         assert_eq!(
-            Duration::days(i64::MIN / NANOS_PER_DAY).num_nanoseconds(),
+            TimeDelta::days(i64::MIN / NANOS_PER_DAY).num_nanoseconds(),
             Some(i64::MIN / NANOS_PER_DAY * NANOS_PER_DAY)
         );
-        assert_eq!(Duration::days(i64::MAX / NANOS_PER_DAY + 1).num_nanoseconds(), None);
-        assert_eq!(Duration::days(i64::MIN / NANOS_PER_DAY - 1).num_nanoseconds(), None);
+        assert_eq!(TimeDelta::days(i64::MAX / NANOS_PER_DAY + 1).num_nanoseconds(), None);
+        assert_eq!(TimeDelta::days(i64::MIN / NANOS_PER_DAY - 1).num_nanoseconds(), None);
     }
 
     #[test]
     fn test_duration_checked_ops() {
         assert_eq!(
-            Duration::milliseconds(i64::MAX - 1).checked_add(&Duration::microseconds(999)),
-            Some(Duration::milliseconds(i64::MAX - 2) + Duration::microseconds(1999))
+            TimeDelta::milliseconds(i64::MAX - 1).checked_add(&TimeDelta::microseconds(999)),
+            Some(TimeDelta::milliseconds(i64::MAX - 2) + TimeDelta::microseconds(1999))
         );
-        assert!(Duration::milliseconds(i64::MAX)
-            .checked_add(&Duration::microseconds(1000))
+        assert!(TimeDelta::milliseconds(i64::MAX)
+            .checked_add(&TimeDelta::microseconds(1000))
             .is_none());
 
         assert_eq!(
-            Duration::milliseconds(i64::MIN).checked_sub(&Duration::milliseconds(0)),
-            Some(Duration::milliseconds(i64::MIN))
+            TimeDelta::milliseconds(i64::MIN).checked_sub(&TimeDelta::milliseconds(0)),
+            Some(TimeDelta::milliseconds(i64::MIN))
         );
-        assert!(Duration::milliseconds(i64::MIN).checked_sub(&Duration::milliseconds(1)).is_none());
+        assert!(TimeDelta::milliseconds(i64::MIN)
+            .checked_sub(&TimeDelta::milliseconds(1))
+            .is_none());
     }
 
     #[test]
     fn test_duration_abs() {
-        assert_eq!(Duration::milliseconds(1300).abs(), Duration::milliseconds(1300));
-        assert_eq!(Duration::milliseconds(1000).abs(), Duration::milliseconds(1000));
-        assert_eq!(Duration::milliseconds(300).abs(), Duration::milliseconds(300));
-        assert_eq!(Duration::milliseconds(0).abs(), Duration::milliseconds(0));
-        assert_eq!(Duration::milliseconds(-300).abs(), Duration::milliseconds(300));
-        assert_eq!(Duration::milliseconds(-700).abs(), Duration::milliseconds(700));
-        assert_eq!(Duration::milliseconds(-1000).abs(), Duration::milliseconds(1000));
-        assert_eq!(Duration::milliseconds(-1300).abs(), Duration::milliseconds(1300));
-        assert_eq!(Duration::milliseconds(-1700).abs(), Duration::milliseconds(1700));
+        assert_eq!(TimeDelta::milliseconds(1300).abs(), TimeDelta::milliseconds(1300));
+        assert_eq!(TimeDelta::milliseconds(1000).abs(), TimeDelta::milliseconds(1000));
+        assert_eq!(TimeDelta::milliseconds(300).abs(), TimeDelta::milliseconds(300));
+        assert_eq!(TimeDelta::milliseconds(0).abs(), TimeDelta::milliseconds(0));
+        assert_eq!(TimeDelta::milliseconds(-300).abs(), TimeDelta::milliseconds(300));
+        assert_eq!(TimeDelta::milliseconds(-700).abs(), TimeDelta::milliseconds(700));
+        assert_eq!(TimeDelta::milliseconds(-1000).abs(), TimeDelta::milliseconds(1000));
+        assert_eq!(TimeDelta::milliseconds(-1300).abs(), TimeDelta::milliseconds(1300));
+        assert_eq!(TimeDelta::milliseconds(-1700).abs(), TimeDelta::milliseconds(1700));
     }
 
     #[test]
     fn test_duration_mul() {
-        assert_eq!(Duration::zero() * i32::MAX, Duration::zero());
-        assert_eq!(Duration::zero() * i32::MIN, Duration::zero());
-        assert_eq!(Duration::nanoseconds(1) * 0, Duration::zero());
-        assert_eq!(Duration::nanoseconds(1) * 1, Duration::nanoseconds(1));
-        assert_eq!(Duration::nanoseconds(1) * 1_000_000_000, Duration::seconds(1));
-        assert_eq!(Duration::nanoseconds(1) * -1_000_000_000, -Duration::seconds(1));
-        assert_eq!(-Duration::nanoseconds(1) * 1_000_000_000, -Duration::seconds(1));
+        assert_eq!(TimeDelta::zero() * i32::MAX, TimeDelta::zero());
+        assert_eq!(TimeDelta::zero() * i32::MIN, TimeDelta::zero());
+        assert_eq!(TimeDelta::nanoseconds(1) * 0, TimeDelta::zero());
+        assert_eq!(TimeDelta::nanoseconds(1) * 1, TimeDelta::nanoseconds(1));
+        assert_eq!(TimeDelta::nanoseconds(1) * 1_000_000_000, TimeDelta::seconds(1));
+        assert_eq!(TimeDelta::nanoseconds(1) * -1_000_000_000, -TimeDelta::seconds(1));
+        assert_eq!(-TimeDelta::nanoseconds(1) * 1_000_000_000, -TimeDelta::seconds(1));
         assert_eq!(
-            Duration::nanoseconds(30) * 333_333_333,
-            Duration::seconds(10) - Duration::nanoseconds(10)
+            TimeDelta::nanoseconds(30) * 333_333_333,
+            TimeDelta::seconds(10) - TimeDelta::nanoseconds(10)
         );
         assert_eq!(
-            (Duration::nanoseconds(1) + Duration::seconds(1) + Duration::days(1)) * 3,
-            Duration::nanoseconds(3) + Duration::seconds(3) + Duration::days(3)
+            (TimeDelta::nanoseconds(1) + TimeDelta::seconds(1) + TimeDelta::days(1)) * 3,
+            TimeDelta::nanoseconds(3) + TimeDelta::seconds(3) + TimeDelta::days(3)
         );
-        assert_eq!(Duration::milliseconds(1500) * -2, Duration::seconds(-3));
-        assert_eq!(Duration::milliseconds(-1500) * 2, Duration::seconds(-3));
+        assert_eq!(TimeDelta::milliseconds(1500) * -2, TimeDelta::seconds(-3));
+        assert_eq!(TimeDelta::milliseconds(-1500) * 2, TimeDelta::seconds(-3));
     }
 
     #[test]
     fn test_duration_div() {
-        assert_eq!(Duration::zero() / i32::MAX, Duration::zero());
-        assert_eq!(Duration::zero() / i32::MIN, Duration::zero());
-        assert_eq!(Duration::nanoseconds(123_456_789) / 1, Duration::nanoseconds(123_456_789));
-        assert_eq!(Duration::nanoseconds(123_456_789) / -1, -Duration::nanoseconds(123_456_789));
-        assert_eq!(-Duration::nanoseconds(123_456_789) / -1, Duration::nanoseconds(123_456_789));
-        assert_eq!(-Duration::nanoseconds(123_456_789) / 1, -Duration::nanoseconds(123_456_789));
-        assert_eq!(Duration::seconds(1) / 3, Duration::nanoseconds(333_333_333));
-        assert_eq!(Duration::seconds(4) / 3, Duration::nanoseconds(1_333_333_333));
-        assert_eq!(Duration::seconds(-1) / 2, Duration::milliseconds(-500));
-        assert_eq!(Duration::seconds(1) / -2, Duration::milliseconds(-500));
-        assert_eq!(Duration::seconds(-1) / -2, Duration::milliseconds(500));
-        assert_eq!(Duration::seconds(-4) / 3, Duration::nanoseconds(-1_333_333_333));
-        assert_eq!(Duration::seconds(-4) / -3, Duration::nanoseconds(1_333_333_333));
+        assert_eq!(TimeDelta::zero() / i32::MAX, TimeDelta::zero());
+        assert_eq!(TimeDelta::zero() / i32::MIN, TimeDelta::zero());
+        assert_eq!(TimeDelta::nanoseconds(123_456_789) / 1, TimeDelta::nanoseconds(123_456_789));
+        assert_eq!(TimeDelta::nanoseconds(123_456_789) / -1, -TimeDelta::nanoseconds(123_456_789));
+        assert_eq!(-TimeDelta::nanoseconds(123_456_789) / -1, TimeDelta::nanoseconds(123_456_789));
+        assert_eq!(-TimeDelta::nanoseconds(123_456_789) / 1, -TimeDelta::nanoseconds(123_456_789));
+        assert_eq!(TimeDelta::seconds(1) / 3, TimeDelta::nanoseconds(333_333_333));
+        assert_eq!(TimeDelta::seconds(4) / 3, TimeDelta::nanoseconds(1_333_333_333));
+        assert_eq!(TimeDelta::seconds(-1) / 2, TimeDelta::milliseconds(-500));
+        assert_eq!(TimeDelta::seconds(1) / -2, TimeDelta::milliseconds(-500));
+        assert_eq!(TimeDelta::seconds(-1) / -2, TimeDelta::milliseconds(500));
+        assert_eq!(TimeDelta::seconds(-4) / 3, TimeDelta::nanoseconds(-1_333_333_333));
+        assert_eq!(TimeDelta::seconds(-4) / -3, TimeDelta::nanoseconds(1_333_333_333));
     }
 
     #[test]
     fn test_duration_sum() {
-        let duration_list_1 = [Duration::zero(), Duration::seconds(1)];
-        let sum_1: Duration = duration_list_1.iter().sum();
-        assert_eq!(sum_1, Duration::seconds(1));
+        let duration_list_1 = [TimeDelta::zero(), TimeDelta::seconds(1)];
+        let sum_1: TimeDelta = duration_list_1.iter().sum();
+        assert_eq!(sum_1, TimeDelta::seconds(1));
 
-        let duration_list_2 =
-            [Duration::zero(), Duration::seconds(1), Duration::seconds(6), Duration::seconds(10)];
-        let sum_2: Duration = duration_list_2.iter().sum();
-        assert_eq!(sum_2, Duration::seconds(17));
+        let duration_list_2 = [
+            TimeDelta::zero(),
+            TimeDelta::seconds(1),
+            TimeDelta::seconds(6),
+            TimeDelta::seconds(10),
+        ];
+        let sum_2: TimeDelta = duration_list_2.iter().sum();
+        assert_eq!(sum_2, TimeDelta::seconds(17));
 
         let duration_vec = vec![
-            Duration::zero(),
-            Duration::seconds(1),
-            Duration::seconds(6),
-            Duration::seconds(10),
+            TimeDelta::zero(),
+            TimeDelta::seconds(1),
+            TimeDelta::seconds(6),
+            TimeDelta::seconds(10),
         ];
-        let sum_3: Duration = duration_vec.into_iter().sum();
-        assert_eq!(sum_3, Duration::seconds(17));
+        let sum_3: TimeDelta = duration_vec.into_iter().sum();
+        assert_eq!(sum_3, TimeDelta::seconds(17));
     }
 
     #[test]
     fn test_duration_fmt() {
-        assert_eq!(Duration::zero().to_string(), "PT0S");
-        assert_eq!(Duration::days(42).to_string(), "P42D");
-        assert_eq!(Duration::days(-42).to_string(), "-P42D");
-        assert_eq!(Duration::seconds(42).to_string(), "PT42S");
-        assert_eq!(Duration::milliseconds(42).to_string(), "PT0.042S");
-        assert_eq!(Duration::microseconds(42).to_string(), "PT0.000042S");
-        assert_eq!(Duration::nanoseconds(42).to_string(), "PT0.000000042S");
-        assert_eq!((Duration::days(7) + Duration::milliseconds(6543)).to_string(), "P7DT6.543S");
-        assert_eq!(Duration::seconds(-86401).to_string(), "-P1DT1S");
-        assert_eq!(Duration::nanoseconds(-1).to_string(), "-PT0.000000001S");
+        assert_eq!(TimeDelta::zero().to_string(), "PT0S");
+        assert_eq!(TimeDelta::days(42).to_string(), "P42D");
+        assert_eq!(TimeDelta::days(-42).to_string(), "-P42D");
+        assert_eq!(TimeDelta::seconds(42).to_string(), "PT42S");
+        assert_eq!(TimeDelta::milliseconds(42).to_string(), "PT0.042S");
+        assert_eq!(TimeDelta::microseconds(42).to_string(), "PT0.000042S");
+        assert_eq!(TimeDelta::nanoseconds(42).to_string(), "PT0.000000042S");
+        assert_eq!((TimeDelta::days(7) + TimeDelta::milliseconds(6543)).to_string(), "P7DT6.543S");
+        assert_eq!(TimeDelta::seconds(-86401).to_string(), "-P1DT1S");
+        assert_eq!(TimeDelta::nanoseconds(-1).to_string(), "-PT0.000000001S");
 
         // the format specifier should have no effect on `Duration`
         assert_eq!(
-            format!("{:30}", Duration::days(1) + Duration::milliseconds(2345)),
+            format!("{:30}", TimeDelta::days(1) + TimeDelta::milliseconds(2345)),
             "P1DT2.345S"
         );
     }
 
     #[test]
     fn test_to_std() {
-        assert_eq!(Duration::seconds(1).to_std(), Ok(StdDuration::new(1, 0)));
-        assert_eq!(Duration::seconds(86401).to_std(), Ok(StdDuration::new(86401, 0)));
-        assert_eq!(Duration::milliseconds(123).to_std(), Ok(StdDuration::new(0, 123000000)));
-        assert_eq!(Duration::milliseconds(123765).to_std(), Ok(StdDuration::new(123, 765000000)));
-        assert_eq!(Duration::nanoseconds(777).to_std(), Ok(StdDuration::new(0, 777)));
+        assert_eq!(TimeDelta::seconds(1).to_std(), Ok(StdDuration::new(1, 0)));
+        assert_eq!(TimeDelta::seconds(86401).to_std(), Ok(StdDuration::new(86401, 0)));
+        assert_eq!(TimeDelta::milliseconds(123).to_std(), Ok(StdDuration::new(0, 123000000)));
+        assert_eq!(TimeDelta::milliseconds(123765).to_std(), Ok(StdDuration::new(123, 765000000)));
+        assert_eq!(TimeDelta::nanoseconds(777).to_std(), Ok(StdDuration::new(0, 777)));
         assert_eq!(MAX.to_std(), Ok(StdDuration::new(9223372036854775, 807000000)));
-        assert_eq!(Duration::seconds(-1).to_std(), Err(OutOfRangeError(())));
-        assert_eq!(Duration::milliseconds(-1).to_std(), Err(OutOfRangeError(())));
+        assert_eq!(TimeDelta::seconds(-1).to_std(), Err(OutOfRangeError(())));
+        assert_eq!(TimeDelta::milliseconds(-1).to_std(), Err(OutOfRangeError(())));
     }
 
     #[test]
     fn test_from_std() {
-        assert_eq!(Ok(Duration::seconds(1)), Duration::from_std(StdDuration::new(1, 0)));
-        assert_eq!(Ok(Duration::seconds(86401)), Duration::from_std(StdDuration::new(86401, 0)));
+        assert_eq!(Ok(TimeDelta::seconds(1)), TimeDelta::from_std(StdDuration::new(1, 0)));
+        assert_eq!(Ok(TimeDelta::seconds(86401)), TimeDelta::from_std(StdDuration::new(86401, 0)));
         assert_eq!(
-            Ok(Duration::milliseconds(123)),
-            Duration::from_std(StdDuration::new(0, 123000000))
+            Ok(TimeDelta::milliseconds(123)),
+            TimeDelta::from_std(StdDuration::new(0, 123000000))
         );
         assert_eq!(
-            Ok(Duration::milliseconds(123765)),
-            Duration::from_std(StdDuration::new(123, 765000000))
+            Ok(TimeDelta::milliseconds(123765)),
+            TimeDelta::from_std(StdDuration::new(123, 765000000))
         );
-        assert_eq!(Ok(Duration::nanoseconds(777)), Duration::from_std(StdDuration::new(0, 777)));
-        assert_eq!(Ok(MAX), Duration::from_std(StdDuration::new(9223372036854775, 807000000)));
+        assert_eq!(Ok(TimeDelta::nanoseconds(777)), TimeDelta::from_std(StdDuration::new(0, 777)));
+        assert_eq!(Ok(MAX), TimeDelta::from_std(StdDuration::new(9223372036854775, 807000000)));
         assert_eq!(
-            Duration::from_std(StdDuration::new(9223372036854776, 0)),
+            TimeDelta::from_std(StdDuration::new(9223372036854776, 0)),
             Err(OutOfRangeError(()))
         );
         assert_eq!(
-            Duration::from_std(StdDuration::new(9223372036854775, 807000001)),
+            TimeDelta::from_std(StdDuration::new(9223372036854775, 807000001)),
             Err(OutOfRangeError(()))
         );
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -180,7 +180,7 @@ pub trait Timelike: Sized {
 #[cfg(test)]
 mod tests {
     use super::Datelike;
-    use crate::{Duration, NaiveDate};
+    use crate::{NaiveDate, TimeDelta};
 
     /// Tests `Datelike::num_days_from_ce` against an alternative implementation.
     ///
@@ -229,7 +229,7 @@ mod tests {
                 "on {:?}",
                 jan1_year
             );
-            let mid_year = jan1_year + Duration::days(133);
+            let mid_year = jan1_year + TimeDelta::days(133);
             assert_eq!(
                 mid_year.num_days_from_ce(),
                 num_days_from_ce(&mid_year),

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -1,7 +1,9 @@
-use core::fmt;
+use core::{fmt, convert::TryFrom};
 
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
+
+use crate::OutOfRange;
 
 /// The day of week.
 ///
@@ -155,32 +157,19 @@ impl fmt::Display for Weekday {
 /// Any weekday can be represented as an integer from 0 to 6, which equals to
 /// [`Weekday::num_days_from_monday`](#method.num_days_from_monday) in this implementation.
 /// Do not heavily depend on this though; use explicit methods whenever possible.
-impl num_traits::FromPrimitive for Weekday {
-    #[inline]
-    fn from_i64(n: i64) -> Option<Weekday> {
-        match n {
-            0 => Some(Weekday::Mon),
-            1 => Some(Weekday::Tue),
-            2 => Some(Weekday::Wed),
-            3 => Some(Weekday::Thu),
-            4 => Some(Weekday::Fri),
-            5 => Some(Weekday::Sat),
-            6 => Some(Weekday::Sun),
-            _ => None,
-        }
-    }
+impl TryFrom<u8> for Weekday {
+    type Error = OutOfRange;
 
-    #[inline]
-    fn from_u64(n: u64) -> Option<Weekday> {
-        match n {
-            0 => Some(Weekday::Mon),
-            1 => Some(Weekday::Tue),
-            2 => Some(Weekday::Wed),
-            3 => Some(Weekday::Thu),
-            4 => Some(Weekday::Fri),
-            5 => Some(Weekday::Sat),
-            6 => Some(Weekday::Sun),
-            _ => None,
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Weekday::Mon),
+            1 => Ok(Weekday::Tue),
+            2 => Ok(Weekday::Wed),
+            3 => Ok(Weekday::Thu),
+            4 => Ok(Weekday::Fri),
+            5 => Ok(Weekday::Sat),
+            6 => Ok(Weekday::Sun),
+            _ => Err(OutOfRange::new()),
         }
     }
 }


### PR DESCRIPTION
This breaks compatibility on the main branch by removing the dependency on time 0.1, rustc-serialize and num-traits. Before we merge this, I propose we create a 0.4.x branch to continue development of compatible features and fixes. In the pull request template, we could suggest targeting the PR at 0.4.x if it makes semver-compatible changes, since it is easier to merge forward than back.

This also renames the internal `oldtime::Duration` to `TimeDelta` (without making other changes to the functionality). That seemed like an interesting small change to get us started on an incremental path toward a better design.
