### PR TITLE
Expose functions needed for pyo3

### DIFF
--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -995,7 +995,8 @@ impl NaiveDate {
 
     /// Returns the packed month-day-flags.
     #[inline]
-    fn mdf(&self) -> Mdf {
+    #[doc(hidden)]
+    pub fn mdf(&self) -> Mdf {
         self.of().to_mdf()
     }
 

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -372,8 +372,9 @@ impl fmt::Debug for Of {
 /// The whole bits except for the least 3 bits are referred as `Mdl`
 /// (month, day of month and leap flag),
 /// which is an index to the `MDL_TO_OL` lookup table.
+#[doc(hidden)]
 #[derive(PartialEq, PartialOrd, Copy, Clone)]
-pub(super) struct Mdf(pub(super) u32);
+pub struct Mdf(pub(super) u32);
 
 impl Mdf {
     #[inline]
@@ -420,8 +421,10 @@ impl Mdf {
         }
     }
 
+    // Exported for pyo3.
+    #[doc(hidden)]
     #[inline]
-    pub(super) fn month(&self) -> u32 {
+    pub fn month(&self) -> u32 {
         let Mdf(mdf) = *self;
         mdf >> 9
     }
@@ -433,8 +436,10 @@ impl Mdf {
         Mdf((mdf & 0b1_1111_1111) | (month << 9))
     }
 
+    // Exported for chrono.
+    #[doc(hidden)]
     #[inline]
-    pub(super) fn day(&self) -> u32 {
+    pub fn day(&self) -> u32 {
         let Mdf(mdf) = *self;
         (mdf >> 4) & 0b1_1111
     }

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -792,7 +792,8 @@ impl NaiveTime {
     }
 
     /// Returns a triple of the hour, minute and second numbers.
-    fn hms(&self) -> (u32, u32, u32) {
+    #[doc(hidden)]
+    pub fn hms(&self) -> (u32, u32, u32) {
         let (mins, sec) = div_mod_floor(self.secs, 60);
         let (hour, min) = div_mod_floor(mins, 60);
         (hour, min, sec)


### PR DESCRIPTION
Companion pull request for https://github.com/PyO3/pyo3/pull/2604

Changes to API
- Make some functions public but doc hidden
  - `Mdf`
  - `TimeDelta` fields (`secs`, `nanos`) - standard library `Duration` already provides something similar as `as_secs` and `as_nanos`
- Move duration min max into `TimeDelta::MIN` and `TimeDelta::MAX` as public function similar to standard library `Duration`

Thanks to @Psykopear for helping out with the pull request and help pushing this forward.

cc @Psykopear @davidhewitt @djc

This is still a draft and can be discussed, @Psykopear made a version that works on stable chrono without exposing any internal details https://github.com/pickfire/pyo3/pull/1