### PR TITLE
Make most constructors fallible (relates #815)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,27 +33,32 @@ which Chrono builds upon and should acknowledge:
 
 ## Limitations
 
-Only proleptic Gregorian calendar (i.e. extended to support older dates) is supported.
-Be very careful if you really have to deal with pre-20C dates, they can be in Julian or others.
+Only proleptic Gregorian calendar (i.e. extended to support older dates) is
+supported. Be very careful if you really have to deal with pre-20C dates, they
+can be in Julian or others.
 
-Date types are limited in about +/- 262,000 years from the common epoch.
-Time types are limited in the nanosecond accuracy.
+Date types are limited in about +/- 262,000 years from the common epoch. Time
+types are limited in the nanosecond accuracy.
 
-[Leap seconds are supported in the representation but
-Chrono doesn't try to make use of them](https://docs.rs/chrono/0.5/chrono/naive/struct.NaiveTime.html#leap-second-handling).
-(The main reason is that leap seconds are not really predictable.)
-Almost *every* operation over the possible leap seconds will ignore them.
-Consider using `NaiveDateTime` with the implicit TAI (International Atomic Time) scale
-if you want.
+[Leap seconds] are supported in the representation but Chrono doesn't try to
+make use of them. (The main reason is that leap seconds are not really
+predictable.) Almost *every* operation over the possible leap seconds will
+ignore them. Consider using `NaiveDateTime` with the implicit TAI (International
+Atomic Time) scale if you want.
 
-Chrono inherently does not support an inaccurate or partial date and time representation.
-Any operation that can be ambiguous will return `None` in such cases.
-For example, "a month later" of 2014-01-30 is not well-defined
-and consequently `Utc.ymd(2014, 1, 30).with_month(2)` returns `None`.
+Chrono inherently does not support an inaccurate or partial date and time
+representation. Any operation that can be ambiguous will return
+`Err(ChronoError)` in such cases. For example, "a month later" of 2014-01-30 is
+not well-defined and consequently `Utc.ymd(2014, 1, 30)?.with_month(2)?` returns
+`Err(ChronoError)`.
 
-Non ISO week handling is not yet supported.
-For now you can use the [chrono_ext](https://crates.io/crates/chrono_ext)
-crate ([sources](https://github.com/bcourtine/chrono-ext/)).
+Non ISO week handling is not yet supported. For now you can use the [chrono_ext]
+crate ([sources]).
 
-Advanced time zone handling is not yet supported.
-For now you can try the [Chrono-tz](https://github.com/chronotope/chrono-tz/) crate instead.
+Advanced time zone handling is not yet supported. For now you can try the
+[Chrono-tz] crate instead.
+
+[chrono_ext]: https://crates.io/crates/chrono_ext
+[Chrono-tz]: https://github.com/chronotope/chrono-tz/
+[Leap seconds]: https://docs.rs/chrono/0.5/chrono/naive/struct.NaiveTime.html#leap-second-handling
+[sources]: https://github.com/bcourtine/chrono-ext/

--- a/README.md
+++ b/README.md
@@ -47,10 +47,9 @@ ignore them. Consider using `NaiveDateTime` with the implicit TAI (International
 Atomic Time) scale if you want.
 
 Chrono inherently does not support an inaccurate or partial date and time
-representation. Any operation that can be ambiguous will return
-`Err(ChronoError)` in such cases. For example, "a month later" of 2014-01-30 is
-not well-defined and consequently `Utc.ymd(2014, 1, 30)?.with_month(2)?` returns
-`Err(ChronoError)`.
+representation. Any operation that can be ambiguous will return `Err(Error)` in
+such cases. For example, "a month later" of 2014-01-30 is not well-defined and
+consequently `Utc.ymd(2014, 1, 30)?.with_month(2)?` returns `Err(Error)`.
 
 Non ISO week handling is not yet supported. For now you can use the [chrono_ext]
 crate ([sources]).

--- a/README.md
+++ b/README.md
@@ -33,31 +33,27 @@ which Chrono builds upon and should acknowledge:
 
 ## Limitations
 
-Only proleptic Gregorian calendar (i.e. extended to support older dates) is
-supported. Be very careful if you really have to deal with pre-20C dates, they
-can be in Julian or others.
+Only proleptic Gregorian calendar (i.e. extended to support older dates) is supported.
+Be very careful if you really have to deal with pre-20C dates, they can be in Julian or others.
 
-Date types are limited in about +/- 262,000 years from the common epoch. Time
-types are limited in the nanosecond accuracy.
+Date types are limited in about +/- 262,000 years from the common epoch.
+Time types are limited in the nanosecond accuracy.
 
-[Leap seconds] are supported in the representation but Chrono doesn't try to
-make use of them. (The main reason is that leap seconds are not really
-predictable.) Almost *every* operation over the possible leap seconds will
-ignore them. Consider using `NaiveDateTime` with the implicit TAI (International
-Atomic Time) scale if you want.
+[Leap seconds are supported in the representation but
+Chrono doesn't try to make use of them](https://docs.rs/chrono/0.5/chrono/naive/struct.NaiveTime.html#leap-second-handling).
+(The main reason is that leap seconds are not really predictable.)
+Almost *every* operation over the possible leap seconds will ignore them.
+Consider using `NaiveDateTime` with the implicit TAI (International Atomic Time) scale
+if you want.
 
-Chrono inherently does not support an inaccurate or partial date and time
-representation. Any operation that can be ambiguous will return `Err(Error)` in
-such cases. For example, "a month later" of 2014-01-30 is not well-defined and
-consequently `Utc.ymd(2014, 1, 30)?.with_month(2)?` returns `Err(Error)`.
+Chrono inherently does not support an inaccurate or partial date and time representation.
+Any operation that can be ambiguous will return `Err(chrono::Error)` in such cases.
+For example, "a month later" of 2014-01-30 is not well-defined
+and consequently `Utc.ymd(2014, 1, 30)?.with_month(2)?` returns `Err(chrono::Error)`.
 
-Non ISO week handling is not yet supported. For now you can use the [chrono_ext]
-crate ([sources]).
+Non ISO week handling is not yet supported.
+For now you can use the [chrono_ext](https://crates.io/crates/chrono_ext)
+crate ([sources](https://github.com/bcourtine/chrono-ext/)).
 
-Advanced time zone handling is not yet supported. For now you can try the
-[Chrono-tz] crate instead.
-
-[chrono_ext]: https://crates.io/crates/chrono_ext
-[Chrono-tz]: https://github.com/chronotope/chrono-tz/
-[Leap seconds]: https://docs.rs/chrono/0.5/chrono/naive/struct.NaiveTime.html#leap-second-handling
-[sources]: https://github.com/bcourtine/chrono-ext/
+Advanced time zone handling is not yet supported.
+For now you can try the [Chrono-tz](https://github.com/chronotope/chrono-tz/) crate instead.

--- a/benches/chrono.rs
+++ b/benches/chrono.rs
@@ -35,14 +35,14 @@ fn bench_datetime_from_str(c: &mut Criterion) {
 }
 
 fn bench_datetime_to_rfc2822(c: &mut Criterion) {
-    let pst = FixedOffset::east(8 * 60 * 60);
-    let dt = pst.ymd(2018, 1, 11).and_hms_nano(10, 5, 13, 84_660_000);
+    let pst = FixedOffset::east(8 * 60 * 60).unwrap();
+    let dt = pst.ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap();
     c.bench_function("bench_datetime_to_rfc2822", |b| b.iter(|| black_box(dt).to_rfc2822()));
 }
 
 fn bench_datetime_to_rfc3339(c: &mut Criterion) {
-    let pst = FixedOffset::east(8 * 60 * 60);
-    let dt = pst.ymd(2018, 1, 11).and_hms_nano(10, 5, 13, 84_660_000);
+    let pst = FixedOffset::east(8 * 60 * 60).unwrap();
+    let dt = pst.ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap();
     c.bench_function("bench_datetime_to_rfc3339", |b| b.iter(|| black_box(dt).to_rfc3339()));
 }
 
@@ -90,7 +90,7 @@ fn num_days_from_ce_alt<Date: Datelike>(date: &Date) -> i32 {
 fn bench_num_days_from_ce(c: &mut Criterion) {
     let mut group = c.benchmark_group("num_days_from_ce");
     for year in &[1, 500, 2000, 2019] {
-        let d = NaiveDate::from_ymd(*year, 1, 1);
+        let d = NaiveDate::from_ymd(*year, 1, 1).unwrap();
         group.bench_with_input(BenchmarkId::new("new", year), &d, |b, y| {
             b.iter(|| num_days_from_ce_alt(y))
         });

--- a/ci/core-test/src/lib.rs
+++ b/ci/core-test/src/lib.rs
@@ -3,5 +3,5 @@
 use chrono::{TimeZone, Utc};
 
 pub fn create_time() {
-    let _ = Utc.ymd(2019, 1, 1).and_hms(0, 0, 0);
+    let _ = Utc.ymd(2019, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
 }

--- a/src/date.rs
+++ b/src/date.rs
@@ -17,7 +17,7 @@ use crate::format::Locale;
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use crate::format::{DelayedFormat, Item, StrftimeItems};
 use crate::naive::{IsoWeek, NaiveDate, NaiveTime};
-use crate::offset::{FixedTimeZone, TimeZone, Utc};
+use crate::offset::{TimeZone, Utc};
 use crate::time_delta::TimeDelta;
 use crate::{DateTime, Datelike, Error, Weekday};
 
@@ -207,13 +207,6 @@ impl<Tz: TimeZone> Date<Tz> {
     #[inline]
     pub fn with_timezone<Tz2: TimeZone>(&self, tz: &Tz2) -> Result<Date<Tz2>, Error> {
         tz.from_utc_date(&self.date)
-    }
-
-    /// Changes the associated time zone.
-    /// This does not change the actual `Date` (but will change the string representation).
-    #[inline]
-    pub fn with_fixed_timezone<Tz2: FixedTimeZone>(&self, tz: &Tz2) -> Date<Tz2> {
-        tz.from_utc_date_fixed(&self.date)
     }
 
     /// Adds given `Duration` to the current date.
@@ -556,14 +549,14 @@ mod tests {
         assert_eq!(date_add, date + TimeDelta::days(5));
 
         let timezone = FixedOffset::east(60 * 60).unwrap();
-        let date = date.with_fixed_timezone(&timezone);
-        let date_add = date_add.with_fixed_timezone(&timezone);
+        let date = date.with_timezone(&timezone).unwrap();
+        let date_add = date_add.with_timezone(&timezone).unwrap();
 
         assert_eq!(date_add, date + TimeDelta::days(5));
 
         let timezone = FixedOffset::west(2 * 60 * 60).unwrap();
-        let date = date.with_fixed_timezone(&timezone);
-        let date_add = date_add.with_fixed_timezone(&timezone);
+        let date = date.with_timezone(&timezone).unwrap();
+        let date_add = date_add.with_timezone(&timezone).unwrap();
 
         assert_eq!(date_add, date + TimeDelta::days(5));
     }
@@ -590,14 +583,14 @@ mod tests {
         assert_eq!(date_sub, date - TimeDelta::days(5));
 
         let timezone = FixedOffset::east(60 * 60).unwrap();
-        let date = date.with_fixed_timezone(&timezone);
-        let date_sub = date_sub.with_fixed_timezone(&timezone);
+        let date = date.with_timezone(&timezone).unwrap();
+        let date_sub = date_sub.with_timezone(&timezone).unwrap();
 
         assert_eq!(date_sub, date - TimeDelta::days(5));
 
         let timezone = FixedOffset::west(2 * 60 * 60).unwrap();
-        let date = date.with_fixed_timezone(&timezone);
-        let date_sub = date_sub.with_fixed_timezone(&timezone);
+        let date = date.with_timezone(&timezone).unwrap();
+        let date_sub = date_sub.with_timezone(&timezone).unwrap();
 
         assert_eq!(date_sub, date - TimeDelta::days(5));
     }

--- a/src/date.rs
+++ b/src/date.rs
@@ -19,7 +19,7 @@ use crate::format::{DelayedFormat, Item, StrftimeItems};
 use crate::naive::{IsoWeek, NaiveDate, NaiveTime};
 use crate::offset::{FixedTimeZone, TimeZone, Utc};
 use crate::time_delta::TimeDelta;
-use crate::{ChronoError, DateTime, Datelike, Weekday};
+use crate::{DateTime, Datelike, Error, Weekday};
 
 /// ISO 8601 calendar date with time zone.
 ///
@@ -88,7 +88,7 @@ impl<Tz: TimeZone> Date<Tz> {
     ///
     /// Panics on invalid datetime.
     #[inline]
-    pub fn and_time(&self, time: NaiveTime) -> Result<DateTime<Tz>, ChronoError> {
+    pub fn and_time(&self, time: NaiveTime) -> Result<DateTime<Tz>, Error> {
         let dt = self.naive_local().and_time(time);
         self.timezone().from_local_datetime(&dt)?.single()
     }
@@ -96,9 +96,9 @@ impl<Tz: TimeZone> Date<Tz> {
     /// Makes a new `DateTime` from the current date, hour, minute and second.
     /// The offset in the current date is preserved.
     ///
-    /// Returns `Err(ChronoError)` on invalid hour, minute and/or second.
+    /// Returns `Err(Error)` on invalid hour, minute and/or second.
     #[inline]
-    pub fn and_hms(&self, hour: u32, min: u32, sec: u32) -> Result<DateTime<Tz>, ChronoError> {
+    pub fn and_hms(&self, hour: u32, min: u32, sec: u32) -> Result<DateTime<Tz>, Error> {
         let time = NaiveTime::from_hms(hour, min, sec)?;
         self.and_time(time)
     }
@@ -107,7 +107,7 @@ impl<Tz: TimeZone> Date<Tz> {
     /// The millisecond part can exceed 1,000 in order to represent the leap second.
     /// The offset in the current date is preserved.
     ///
-    /// Returns `Err(ChronoError)` on invalid hour, minute, second and/or millisecond.
+    /// Returns `Err(Error)` on invalid hour, minute, second and/or millisecond.
     #[inline]
     pub fn and_hms_milli(
         &self,
@@ -115,7 +115,7 @@ impl<Tz: TimeZone> Date<Tz> {
         min: u32,
         sec: u32,
         milli: u32,
-    ) -> Result<DateTime<Tz>, ChronoError> {
+    ) -> Result<DateTime<Tz>, Error> {
         let time = NaiveTime::from_hms_milli(hour, min, sec, milli)?;
         self.and_time(time)
     }
@@ -124,7 +124,7 @@ impl<Tz: TimeZone> Date<Tz> {
     /// The microsecond part can exceed 1,000,000 in order to represent the leap second.
     /// The offset in the current date is preserved.
     ///
-    /// Returns `Err(ChronoError)` on invalid hour, minute, second and/or microsecond.
+    /// Returns `Err(Error)` on invalid hour, minute, second and/or microsecond.
     #[inline]
     pub fn and_hms_micro(
         &self,
@@ -132,7 +132,7 @@ impl<Tz: TimeZone> Date<Tz> {
         min: u32,
         sec: u32,
         micro: u32,
-    ) -> Result<DateTime<Tz>, ChronoError> {
+    ) -> Result<DateTime<Tz>, Error> {
         let time = NaiveTime::from_hms_micro(hour, min, sec, micro)?;
         self.and_time(time)
     }
@@ -141,7 +141,7 @@ impl<Tz: TimeZone> Date<Tz> {
     /// The nanosecond part can exceed 1,000,000,000 in order to represent the leap second.
     /// The offset in the current date is preserved.
     ///
-    /// Returns `Err(ChronoError)` on invalid hour, minute, second and/or nanosecond.
+    /// Returns `Err(Error)` on invalid hour, minute, second and/or nanosecond.
     #[inline]
     pub fn and_hms_nano(
         &self,
@@ -149,14 +149,14 @@ impl<Tz: TimeZone> Date<Tz> {
         min: u32,
         sec: u32,
         nano: u32,
-    ) -> Result<DateTime<Tz>, ChronoError> {
+    ) -> Result<DateTime<Tz>, Error> {
         let time = NaiveTime::from_hms_nano(hour, min, sec, nano)?;
         self.and_time(time)
     }
 
     /// Makes a new `Date` for the next date.
     ///
-    /// Returns `Err(ChronoError)` when `self` is the last representable date.
+    /// Returns `Err(Error)` when `self` is the last representable date.
     ///
     /// ```
     /// use chrono::prelude::*;
@@ -164,17 +164,17 @@ impl<Tz: TimeZone> Date<Tz> {
     /// assert_eq!(Utc.ymd(2022, 09, 12)?.single()?.succ()?, Utc.ymd(2022, 09, 13)?.single()?);
     ///
     /// assert!(Date::<Utc>::MAX_UTC.succ().is_err());
-    /// Ok::<_, ChronoError>(())
+    /// Ok::<_, Error>(())
     /// ```
     #[inline]
-    pub fn succ(&self) -> Result<Date<Tz>, ChronoError> {
+    pub fn succ(&self) -> Result<Date<Tz>, Error> {
         let date = self.date.succ()?;
         Ok(Date::from_utc(date, self.offset.clone()))
     }
 
     /// Makes a new `Date` for the prior date.
     ///
-    /// Returns `Err(ChronoError)` when `self` is the first representable date.
+    /// Returns `Err(Error)` when `self` is the first representable date.
     ///
     /// ```
     /// use chrono::prelude::*;
@@ -182,10 +182,10 @@ impl<Tz: TimeZone> Date<Tz> {
     /// assert_eq!(Utc.ymd(2022, 09, 12)?.single()?.succ()?, Utc.ymd(2022, 09, 13)?.single()?);
     ///
     /// assert!(Date::<Utc>::MIN_UTC.pred().is_err());
-    /// Ok::<_, ChronoError>(())
+    /// Ok::<_, Error>(())
     /// ```
     #[inline]
-    pub fn pred(&self) -> Result<Date<Tz>, ChronoError> {
+    pub fn pred(&self) -> Result<Date<Tz>, Error> {
         let date = self.date.pred()?;
         Ok(Date::from_utc(date, self.offset.clone()))
     }
@@ -205,7 +205,7 @@ impl<Tz: TimeZone> Date<Tz> {
     /// Changes the associated time zone.
     /// This does not change the actual `Date` (but will change the string representation).
     #[inline]
-    pub fn with_timezone<Tz2: TimeZone>(&self, tz: &Tz2) -> Result<Date<Tz2>, ChronoError> {
+    pub fn with_timezone<Tz2: TimeZone>(&self, tz: &Tz2) -> Result<Date<Tz2>, Error> {
         tz.from_utc_date(&self.date)
     }
 
@@ -218,7 +218,7 @@ impl<Tz: TimeZone> Date<Tz> {
 
     /// Adds given `Duration` to the current date.
     ///
-    /// Returns `Err(ChronoError)` when it will result in overflow.
+    /// Returns `Err(Error)` when it will result in overflow.
     #[inline]
     pub fn checked_add_signed(self, rhs: TimeDelta) -> Option<Self> {
         let date = self.date.checked_add_signed(rhs)?;
@@ -227,7 +227,7 @@ impl<Tz: TimeZone> Date<Tz> {
 
     /// Subtracts given `Duration` from the current date.
     ///
-    /// Returns `Err(ChronoError)` when it will result in overflow.
+    /// Returns `Err(Error)` when it will result in overflow.
     #[inline]
     pub fn checked_sub_signed(self, rhs: TimeDelta) -> Option<Self> {
         let date = self.date.checked_sub_signed(rhs)?;
@@ -275,9 +275,9 @@ impl<Tz: TimeZone> Date<Tz> {
 }
 
 /// Maps the local date to other date with given conversion function.
-fn map_local<Tz: TimeZone, F>(d: &Date<Tz>, mut f: F) -> Result<Date<Tz>, ChronoError>
+fn map_local<Tz: TimeZone, F>(d: &Date<Tz>, mut f: F) -> Result<Date<Tz>, Error>
 where
-    F: FnMut(NaiveDate) -> Result<NaiveDate, ChronoError>,
+    F: FnMut(NaiveDate) -> Result<NaiveDate, Error>,
 {
     let date = f(d.naive_local())?;
     d.timezone().from_local_date(&date)?.single()
@@ -310,7 +310,7 @@ where
     /// let date_time: Date<Utc> = Utc.ymd(2017, 04, 02)?.single()?;
     /// let formatted = format!("{}", date_time.format("%d/%m/%Y"));
     /// assert_eq!(formatted, "02/04/2017");
-    /// Ok::<_, chrono::ChronoError>(())
+    /// Ok::<_, chrono::Error>(())
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
@@ -395,37 +395,37 @@ impl<Tz: TimeZone> Datelike for Date<Tz> {
     }
 
     #[inline]
-    fn with_year(&self, year: i32) -> Result<Date<Tz>, ChronoError> {
+    fn with_year(&self, year: i32) -> Result<Date<Tz>, Error> {
         map_local(self, |date| date.with_year(year))
     }
 
     #[inline]
-    fn with_month(&self, month: u32) -> Result<Date<Tz>, ChronoError> {
+    fn with_month(&self, month: u32) -> Result<Date<Tz>, Error> {
         map_local(self, |date| date.with_month(month))
     }
 
     #[inline]
-    fn with_month0(&self, month0: u32) -> Result<Date<Tz>, ChronoError> {
+    fn with_month0(&self, month0: u32) -> Result<Date<Tz>, Error> {
         map_local(self, |date| date.with_month0(month0))
     }
 
     #[inline]
-    fn with_day(&self, day: u32) -> Result<Date<Tz>, ChronoError> {
+    fn with_day(&self, day: u32) -> Result<Date<Tz>, Error> {
         map_local(self, |date| date.with_day(day))
     }
 
     #[inline]
-    fn with_day0(&self, day0: u32) -> Result<Date<Tz>, ChronoError> {
+    fn with_day0(&self, day0: u32) -> Result<Date<Tz>, Error> {
         map_local(self, |date| date.with_day0(day0))
     }
 
     #[inline]
-    fn with_ordinal(&self, ordinal: u32) -> Result<Date<Tz>, ChronoError> {
+    fn with_ordinal(&self, ordinal: u32) -> Result<Date<Tz>, Error> {
         map_local(self, |date| date.with_ordinal(ordinal))
     }
 
     #[inline]
-    fn with_ordinal0(&self, ordinal0: u32) -> Result<Date<Tz>, ChronoError> {
+    fn with_ordinal0(&self, ordinal0: u32) -> Result<Date<Tz>, Error> {
         map_local(self, |date| date.with_ordinal0(ordinal0))
     }
 }

--- a/src/date.rs
+++ b/src/date.rs
@@ -17,10 +17,9 @@ use crate::format::Locale;
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use crate::format::{DelayedFormat, Item, StrftimeItems};
 use crate::naive::{IsoWeek, NaiveDate, NaiveTime};
-use crate::offset::{TimeZone, Utc};
+use crate::offset::{FixedTimeZone, TimeZone, Utc};
 use crate::time_delta::TimeDelta;
-use crate::DateTime;
-use crate::{Datelike, Weekday};
+use crate::{ChronoError, DateTime, Datelike, Weekday};
 
 /// ISO 8601 calendar date with time zone.
 ///
@@ -84,137 +83,88 @@ impl<Tz: TimeZone> Date<Tz> {
     ///
     /// Panics on invalid datetime.
     #[inline]
-    pub fn and_time(&self, time: NaiveTime) -> Option<DateTime<Tz>> {
-        let localdt = self.naive_local().and_time(time);
-        self.timezone().from_local_datetime(&localdt).single()
+    pub fn and_time(&self, time: NaiveTime) -> Result<DateTime<Tz>, ChronoError> {
+        let dt = self.naive_local().and_time(time);
+        self.timezone().from_local_datetime(&dt)?.single()
     }
 
     /// Makes a new `DateTime` from the current date, hour, minute and second.
     /// The offset in the current date is preserved.
     ///
-    /// Panics on invalid hour, minute and/or second.
+    /// Returns `Err(ChronoError)` on invalid hour, minute and/or second.
     #[inline]
-    pub fn and_hms(&self, hour: u32, min: u32, sec: u32) -> DateTime<Tz> {
-        self.and_hms_opt(hour, min, sec).expect("invalid time")
-    }
-
-    /// Makes a new `DateTime` from the current date, hour, minute and second.
-    /// The offset in the current date is preserved.
-    ///
-    /// Returns `None` on invalid hour, minute and/or second.
-    #[inline]
-    pub fn and_hms_opt(&self, hour: u32, min: u32, sec: u32) -> Option<DateTime<Tz>> {
-        NaiveTime::from_hms_opt(hour, min, sec).and_then(|time| self.and_time(time))
+    pub fn and_hms(&self, hour: u32, min: u32, sec: u32) -> Result<DateTime<Tz>, ChronoError> {
+        let time = NaiveTime::from_hms(hour, min, sec)?;
+        self.and_time(time)
     }
 
     /// Makes a new `DateTime` from the current date, hour, minute, second and millisecond.
     /// The millisecond part can exceed 1,000 in order to represent the leap second.
     /// The offset in the current date is preserved.
     ///
-    /// Panics on invalid hour, minute, second and/or millisecond.
+    /// Returns `Err(ChronoError)` on invalid hour, minute, second and/or millisecond.
     #[inline]
-    pub fn and_hms_milli(&self, hour: u32, min: u32, sec: u32, milli: u32) -> DateTime<Tz> {
-        self.and_hms_milli_opt(hour, min, sec, milli).expect("invalid time")
-    }
-
-    /// Makes a new `DateTime` from the current date, hour, minute, second and millisecond.
-    /// The millisecond part can exceed 1,000 in order to represent the leap second.
-    /// The offset in the current date is preserved.
-    ///
-    /// Returns `None` on invalid hour, minute, second and/or millisecond.
-    #[inline]
-    pub fn and_hms_milli_opt(
+    pub fn and_hms_milli(
         &self,
         hour: u32,
         min: u32,
         sec: u32,
         milli: u32,
-    ) -> Option<DateTime<Tz>> {
-        NaiveTime::from_hms_milli_opt(hour, min, sec, milli).and_then(|time| self.and_time(time))
+    ) -> Result<DateTime<Tz>, ChronoError> {
+        let time = NaiveTime::from_hms_milli(hour, min, sec, milli)?;
+        self.and_time(time)
     }
 
     /// Makes a new `DateTime` from the current date, hour, minute, second and microsecond.
     /// The microsecond part can exceed 1,000,000 in order to represent the leap second.
     /// The offset in the current date is preserved.
     ///
-    /// Panics on invalid hour, minute, second and/or microsecond.
+    /// Returns `Err(ChronoError)` on invalid hour, minute, second and/or microsecond.
     #[inline]
-    pub fn and_hms_micro(&self, hour: u32, min: u32, sec: u32, micro: u32) -> DateTime<Tz> {
-        self.and_hms_micro_opt(hour, min, sec, micro).expect("invalid time")
-    }
-
-    /// Makes a new `DateTime` from the current date, hour, minute, second and microsecond.
-    /// The microsecond part can exceed 1,000,000 in order to represent the leap second.
-    /// The offset in the current date is preserved.
-    ///
-    /// Returns `None` on invalid hour, minute, second and/or microsecond.
-    #[inline]
-    pub fn and_hms_micro_opt(
+    pub fn and_hms_micro(
         &self,
         hour: u32,
         min: u32,
         sec: u32,
         micro: u32,
-    ) -> Option<DateTime<Tz>> {
-        NaiveTime::from_hms_micro_opt(hour, min, sec, micro).and_then(|time| self.and_time(time))
+    ) -> Result<DateTime<Tz>, ChronoError> {
+        let time = NaiveTime::from_hms_micro(hour, min, sec, micro)?;
+        self.and_time(time)
     }
 
     /// Makes a new `DateTime` from the current date, hour, minute, second and nanosecond.
     /// The nanosecond part can exceed 1,000,000,000 in order to represent the leap second.
     /// The offset in the current date is preserved.
     ///
-    /// Panics on invalid hour, minute, second and/or nanosecond.
+    /// Returns `Err(ChronoError)` on invalid hour, minute, second and/or nanosecond.
     #[inline]
-    pub fn and_hms_nano(&self, hour: u32, min: u32, sec: u32, nano: u32) -> DateTime<Tz> {
-        self.and_hms_nano_opt(hour, min, sec, nano).expect("invalid time")
-    }
-
-    /// Makes a new `DateTime` from the current date, hour, minute, second and nanosecond.
-    /// The nanosecond part can exceed 1,000,000,000 in order to represent the leap second.
-    /// The offset in the current date is preserved.
-    ///
-    /// Returns `None` on invalid hour, minute, second and/or nanosecond.
-    #[inline]
-    pub fn and_hms_nano_opt(
+    pub fn and_hms_nano(
         &self,
         hour: u32,
         min: u32,
         sec: u32,
         nano: u32,
-    ) -> Option<DateTime<Tz>> {
-        NaiveTime::from_hms_nano_opt(hour, min, sec, nano).and_then(|time| self.and_time(time))
+    ) -> Result<DateTime<Tz>, ChronoError> {
+        let time = NaiveTime::from_hms_nano(hour, min, sec, nano)?;
+        self.and_time(time)
     }
 
     /// Makes a new `Date` for the next date.
     ///
-    /// Panics when `self` is the last representable date.
+    /// Returns `Err(ChronoError)` when `self` is the last representable date.
     #[inline]
-    pub fn succ(&self) -> Date<Tz> {
-        self.succ_opt().expect("out of bound")
-    }
-
-    /// Makes a new `Date` for the next date.
-    ///
-    /// Returns `None` when `self` is the last representable date.
-    #[inline]
-    pub fn succ_opt(&self) -> Option<Date<Tz>> {
-        self.date.succ_opt().map(|date| Date::from_utc(date, self.offset.clone()))
+    pub fn succ(&self) -> Result<Date<Tz>, ChronoError> {
+        let date = self.date.succ()?;
+        Ok(Date::from_utc(date, self.offset.clone()))
     }
 
     /// Makes a new `Date` for the prior date.
     ///
-    /// Panics when `self` is the first representable date.
+    /// Returns `Err(ChronoError)` when `self` is the first representable date.
     #[inline]
-    pub fn pred(&self) -> Date<Tz> {
-        self.pred_opt().expect("out of bound")
-    }
-
-    /// Makes a new `Date` for the prior date.
-    ///
-    /// Returns `None` when `self` is the first representable date.
-    #[inline]
-    pub fn pred_opt(&self) -> Option<Date<Tz>> {
-        self.date.pred_opt().map(|date| Date::from_utc(date, self.offset.clone()))
+    pub fn pred_opt(&self) -> Result<Date<Tz>, ChronoError> {
+        let date = self.date.pred()?;
+        Ok(Date::from_utc(date, self.offset.clone()))
     }
 
     /// Retrieves an associated offset from UTC.
@@ -232,26 +182,33 @@ impl<Tz: TimeZone> Date<Tz> {
     /// Changes the associated time zone.
     /// This does not change the actual `Date` (but will change the string representation).
     #[inline]
-    pub fn with_timezone<Tz2: TimeZone>(&self, tz: &Tz2) -> Date<Tz2> {
+    pub fn with_timezone<Tz2: TimeZone>(&self, tz: &Tz2) -> Result<Date<Tz2>, ChronoError> {
         tz.from_utc_date(&self.date)
+    }
+
+    /// Changes the associated time zone.
+    /// This does not change the actual `Date` (but will change the string representation).
+    #[inline]
+    pub fn with_fixed_timezone<Tz2: FixedTimeZone>(&self, tz: &Tz2) -> Date<Tz2> {
+        tz.from_utc_date_fixed(&self.date)
     }
 
     /// Adds given `Duration` to the current date.
     ///
     /// Returns `None` when it will result in overflow.
     #[inline]
-    pub fn checked_add_signed(self, rhs: TimeDelta) -> Option<Date<Tz>> {
+    pub fn checked_add_signed(self, rhs: TimeDelta) -> Result<Date<Tz>, ChronoError> {
         let date = self.date.checked_add_signed(rhs)?;
-        Some(Date { date, offset: self.offset })
+        Ok(Date { date, offset: self.offset })
     }
 
     /// Subtracts given `Duration` from the current date.
     ///
     /// Returns `None` when it will result in overflow.
     #[inline]
-    pub fn checked_sub_signed(self, rhs: TimeDelta) -> Option<Date<Tz>> {
+    pub fn checked_sub_signed(self, rhs: TimeDelta) -> Result<Date<Tz>, ChronoError> {
         let date = self.date.checked_sub_signed(rhs)?;
-        Some(Date { date, offset: self.offset })
+        Ok(Date { date, offset: self.offset })
     }
 
     /// Subtracts another `Date` from the current date.
@@ -300,11 +257,12 @@ impl<Tz: TimeZone> Date<Tz> {
 }
 
 /// Maps the local date to other date with given conversion function.
-fn map_local<Tz: TimeZone, F>(d: &Date<Tz>, mut f: F) -> Option<Date<Tz>>
+fn map_local<Tz: TimeZone, F>(d: &Date<Tz>, mut f: F) -> Result<Date<Tz>, ChronoError>
 where
-    F: FnMut(NaiveDate) -> Option<NaiveDate>,
+    F: FnMut(NaiveDate) -> Result<NaiveDate, ChronoError>,
 {
-    f(d.naive_local()).and_then(|date| d.timezone().from_local_date(&date).single())
+    let date = f(d.naive_local())?;
+    d.timezone().from_local_date(&date)?.single()
 }
 
 impl<Tz: TimeZone> Date<Tz>
@@ -331,9 +289,10 @@ where
     /// ```rust
     /// use chrono::prelude::*;
     ///
-    /// let date_time: Date<Utc> = Utc.ymd(2017, 04, 02);
+    /// let date_time: Date<Utc> = Utc.ymd(2017, 04, 02)?.single()?;
     /// let formatted = format!("{}", date_time.format("%d/%m/%Y"));
     /// assert_eq!(formatted, "02/04/2017");
+    /// Ok::<_, chrono::ChronoError>(())
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
@@ -418,37 +377,37 @@ impl<Tz: TimeZone> Datelike for Date<Tz> {
     }
 
     #[inline]
-    fn with_year(&self, year: i32) -> Option<Date<Tz>> {
+    fn with_year(&self, year: i32) -> Result<Date<Tz>, ChronoError> {
         map_local(self, |date| date.with_year(year))
     }
 
     #[inline]
-    fn with_month(&self, month: u32) -> Option<Date<Tz>> {
+    fn with_month(&self, month: u32) -> Result<Date<Tz>, ChronoError> {
         map_local(self, |date| date.with_month(month))
     }
 
     #[inline]
-    fn with_month0(&self, month0: u32) -> Option<Date<Tz>> {
+    fn with_month0(&self, month0: u32) -> Result<Date<Tz>, ChronoError> {
         map_local(self, |date| date.with_month0(month0))
     }
 
     #[inline]
-    fn with_day(&self, day: u32) -> Option<Date<Tz>> {
+    fn with_day(&self, day: u32) -> Result<Date<Tz>, ChronoError> {
         map_local(self, |date| date.with_day(day))
     }
 
     #[inline]
-    fn with_day0(&self, day0: u32) -> Option<Date<Tz>> {
+    fn with_day0(&self, day0: u32) -> Result<Date<Tz>, ChronoError> {
         map_local(self, |date| date.with_day0(day0))
     }
 
     #[inline]
-    fn with_ordinal(&self, ordinal: u32) -> Option<Date<Tz>> {
+    fn with_ordinal(&self, ordinal: u32) -> Result<Date<Tz>, ChronoError> {
         map_local(self, |date| date.with_ordinal(ordinal))
     }
 
     #[inline]
-    fn with_ordinal0(&self, ordinal0: u32) -> Option<Date<Tz>> {
+    fn with_ordinal0(&self, ordinal0: u32) -> Result<Date<Tz>, ChronoError> {
         map_local(self, |date| date.with_ordinal0(ordinal0))
     }
 }
@@ -555,36 +514,38 @@ mod tests {
         const WEEKS_PER_YEAR: f32 = 52.1775;
 
         // This is always at least one year because 1 year = 52.1775 weeks.
-        let one_year_ago = Utc::today() - TimeDelta::weeks((WEEKS_PER_YEAR * 1.5).ceil() as i64);
+        let one_year_ago =
+            Utc::today().unwrap() - TimeDelta::weeks((WEEKS_PER_YEAR * 1.5).ceil() as i64);
         // A bit more than 2 years.
-        let two_year_ago = Utc::today() - TimeDelta::weeks((WEEKS_PER_YEAR * 2.5).ceil() as i64);
+        let two_year_ago =
+            Utc::today().unwrap() - TimeDelta::weeks((WEEKS_PER_YEAR * 2.5).ceil() as i64);
 
-        assert_eq!(Utc::today().years_since(one_year_ago), Some(1));
-        assert_eq!(Utc::today().years_since(two_year_ago), Some(2));
+        assert_eq!(Utc::today().unwrap().years_since(one_year_ago), Some(1));
+        assert_eq!(Utc::today().unwrap().years_since(two_year_ago), Some(2));
 
         // If the given DateTime is later than now, the function will always return 0.
-        let future = Utc::today() + TimeDelta::weeks(12);
-        assert_eq!(Utc::today().years_since(future), None);
+        let future = Utc::today().unwrap() + TimeDelta::weeks(12);
+        assert_eq!(Utc::today().unwrap().years_since(future), None);
     }
 
     #[test]
     fn test_date_add_assign() {
-        let naivedate = NaiveDate::from_ymd(2000, 1, 1);
+        let naivedate = NaiveDate::from_ymd(2000, 1, 1).unwrap();
         let date = Date::<Utc>::from_utc(naivedate, Utc);
         let mut date_add = date;
 
         date_add += TimeDelta::days(5);
         assert_eq!(date_add, date + TimeDelta::days(5));
 
-        let timezone = FixedOffset::east(60 * 60);
-        let date = date.with_timezone(&timezone);
-        let date_add = date_add.with_timezone(&timezone);
+        let timezone = FixedOffset::east(60 * 60).unwrap();
+        let date = date.with_fixed_timezone(&timezone);
+        let date_add = date_add.with_fixed_timezone(&timezone);
 
         assert_eq!(date_add, date + TimeDelta::days(5));
 
-        let timezone = FixedOffset::west(2 * 60 * 60);
-        let date = date.with_timezone(&timezone);
-        let date_add = date_add.with_timezone(&timezone);
+        let timezone = FixedOffset::west(2 * 60 * 60).unwrap();
+        let date = date.with_fixed_timezone(&timezone);
+        let date_add = date_add.with_fixed_timezone(&timezone);
 
         assert_eq!(date_add, date + TimeDelta::days(5));
     }
@@ -592,9 +553,9 @@ mod tests {
     #[test]
     #[cfg(feature = "clock")]
     fn test_date_add_assign_local() {
-        let naivedate = NaiveDate::from_ymd(2000, 1, 1);
+        let naivedate = NaiveDate::from_ymd(2000, 1, 1).unwrap();
 
-        let date = Local.from_utc_date(&naivedate);
+        let date = Local.from_utc_date(&naivedate).unwrap();
         let mut date_add = date;
 
         date_add += TimeDelta::days(5);
@@ -603,22 +564,22 @@ mod tests {
 
     #[test]
     fn test_date_sub_assign() {
-        let naivedate = NaiveDate::from_ymd(2000, 1, 1);
+        let naivedate = NaiveDate::from_ymd(2000, 1, 1).unwrap();
         let date = Date::<Utc>::from_utc(naivedate, Utc);
         let mut date_sub = date;
 
         date_sub -= TimeDelta::days(5);
         assert_eq!(date_sub, date - TimeDelta::days(5));
 
-        let timezone = FixedOffset::east(60 * 60);
-        let date = date.with_timezone(&timezone);
-        let date_sub = date_sub.with_timezone(&timezone);
+        let timezone = FixedOffset::east(60 * 60).unwrap();
+        let date = date.with_fixed_timezone(&timezone);
+        let date_sub = date_sub.with_fixed_timezone(&timezone);
 
         assert_eq!(date_sub, date - TimeDelta::days(5));
 
-        let timezone = FixedOffset::west(2 * 60 * 60);
-        let date = date.with_timezone(&timezone);
-        let date_sub = date_sub.with_timezone(&timezone);
+        let timezone = FixedOffset::west(2 * 60 * 60).unwrap();
+        let date = date.with_fixed_timezone(&timezone);
+        let date_sub = date_sub.with_fixed_timezone(&timezone);
 
         assert_eq!(date_sub, date - TimeDelta::days(5));
     }
@@ -626,9 +587,9 @@ mod tests {
     #[test]
     #[cfg(feature = "clock")]
     fn test_date_sub_assign_local() {
-        let naivedate = NaiveDate::from_ymd(2000, 1, 1);
+        let naivedate = NaiveDate::from_ymd(2000, 1, 1).unwrap();
 
-        let date = Local.from_utc_date(&naivedate);
+        let date = Local.from_utc_date(&naivedate).unwrap();
         let mut date_sub = date;
 
         date_sub -= TimeDelta::days(5);

--- a/src/date.rs
+++ b/src/date.rs
@@ -69,6 +69,11 @@ pub const MIN_DATE: Date<Utc> = Date::<Utc>::MIN_UTC;
 pub const MAX_DATE: Date<Utc> = Date::<Utc>::MAX_UTC;
 
 impl<Tz: TimeZone> Date<Tz> {
+    /// The minimum possible `Date`.
+    pub const MIN_UTC: Date<Utc> = Date { date: NaiveDate::MIN, offset: Utc };
+    /// The maximum possible `Date`.
+    pub const MAX_UTC: Date<Utc> = Date { date: NaiveDate::MAX, offset: Utc };
+
     /// Makes a new `Date` with given *UTC* date and offset.
     /// The local date should be constructed via the `TimeZone` trait.
     //
@@ -152,6 +157,15 @@ impl<Tz: TimeZone> Date<Tz> {
     /// Makes a new `Date` for the next date.
     ///
     /// Returns `Err(ChronoError)` when `self` is the last representable date.
+    ///
+    /// ```
+    /// use chrono::prelude::*;
+    ///
+    /// assert_eq!(Utc.ymd(2022, 09, 12)?.single()?.succ()?, Utc.ymd(2022, 09, 13)?.single()?);
+    ///
+    /// assert!(Date::<Utc>::MAX_UTC.succ().is_err());
+    /// Ok::<_, ChronoError>(())
+    /// ```
     #[inline]
     pub fn succ(&self) -> Result<Date<Tz>, ChronoError> {
         let date = self.date.succ()?;
@@ -161,8 +175,17 @@ impl<Tz: TimeZone> Date<Tz> {
     /// Makes a new `Date` for the prior date.
     ///
     /// Returns `Err(ChronoError)` when `self` is the first representable date.
+    ///
+    /// ```
+    /// use chrono::prelude::*;
+    ///
+    /// assert_eq!(Utc.ymd(2022, 09, 12)?.single()?.succ()?, Utc.ymd(2022, 09, 13)?.single()?);
+    ///
+    /// assert!(Date::<Utc>::MIN_UTC.pred().is_err());
+    /// Ok::<_, ChronoError>(())
+    /// ```
     #[inline]
-    pub fn pred_opt(&self) -> Result<Date<Tz>, ChronoError> {
+    pub fn pred(&self) -> Result<Date<Tz>, ChronoError> {
         let date = self.date.pred()?;
         Ok(Date::from_utc(date, self.offset.clone()))
     }
@@ -249,11 +272,6 @@ impl<Tz: TimeZone> Date<Tz> {
             false => None,
         }
     }
-
-    /// The minimum possible `Date`.
-    pub const MIN_UTC: Date<Utc> = Date { date: NaiveDate::MIN, offset: Utc };
-    /// The maximum possible `Date`.
-    pub const MAX_UTC: Date<Utc> = Date { date: NaiveDate::MAX, offset: Utc };
 }
 
 /// Maps the local date to other date with given conversion function.

--- a/src/date.rs
+++ b/src/date.rs
@@ -195,7 +195,7 @@ impl<Tz: TimeZone> Date<Tz> {
 
     /// Adds given `Duration` to the current date.
     ///
-    /// Returns `None` when it will result in overflow.
+    /// Returns `Err(ChronoError)` when it will result in overflow.
     #[inline]
     pub fn checked_add_signed(self, rhs: TimeDelta) -> Result<Date<Tz>, ChronoError> {
         let date = self.date.checked_add_signed(rhs)?;
@@ -204,7 +204,7 @@ impl<Tz: TimeZone> Date<Tz> {
 
     /// Subtracts given `Duration` from the current date.
     ///
-    /// Returns `None` when it will result in overflow.
+    /// Returns `Err(ChronoError)` when it will result in overflow.
     #[inline]
     pub fn checked_sub_signed(self, rhs: TimeDelta) -> Result<Date<Tz>, ChronoError> {
         let date = self.date.checked_sub_signed(rhs)?;

--- a/src/date.rs
+++ b/src/date.rs
@@ -220,18 +220,18 @@ impl<Tz: TimeZone> Date<Tz> {
     ///
     /// Returns `Err(ChronoError)` when it will result in overflow.
     #[inline]
-    pub fn checked_add_signed(self, rhs: TimeDelta) -> Result<Date<Tz>, ChronoError> {
+    pub fn checked_add_signed(self, rhs: TimeDelta) -> Option<Self> {
         let date = self.date.checked_add_signed(rhs)?;
-        Ok(Date { date, offset: self.offset })
+        Some(Self { date, offset: self.offset })
     }
 
     /// Subtracts given `Duration` from the current date.
     ///
     /// Returns `Err(ChronoError)` when it will result in overflow.
     #[inline]
-    pub fn checked_sub_signed(self, rhs: TimeDelta) -> Result<Date<Tz>, ChronoError> {
+    pub fn checked_sub_signed(self, rhs: TimeDelta) -> Option<Self> {
         let date = self.date.checked_sub_signed(rhs)?;
-        Ok(Date { date, offset: self.offset })
+        Some(Self { date, offset: self.offset })
     }
 
     /// Subtracts another `Date` from the current date.

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -325,7 +325,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// Changes the associated time zone.
     /// The returned `DateTime` references the same instant of time from the perspective of the provided time zone.
     #[inline]
-    pub fn with_fixed_timezone<Tz2: FixedTimeZone>(&self, tz: &Tz2) -> DateTime<Tz2> {
+    pub(crate) fn with_fixed_timezone<Tz2: FixedTimeZone>(&self, tz: &Tz2) -> DateTime<Tz2> {
         tz.from_utc_datetime_fixed(&self.datetime)
     }
 

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -11,6 +11,7 @@ use alloc::string::{String, ToString};
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::cmp::Ordering;
+#[cfg(feature = "clock")]
 use core::convert::TryFrom;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::{fmt, hash, str};

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -33,7 +33,7 @@ use crate::naive::{Days, IsoWeek, NaiveDate, NaiveDateTime, NaiveTime};
 #[cfg(feature = "clock")]
 use crate::offset::Local;
 use crate::offset::{FixedOffset, FixedTimeZone, Offset, TimeZone, Utc};
-use crate::{ChronoError, Date, Datelike, Months, TimeDelta, Timelike, Weekday};
+use crate::{Date, Datelike, Error, Months, TimeDelta, Timelike, Weekday};
 
 /// documented at re-export site
 #[cfg(feature = "serde")]
@@ -103,7 +103,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// let dt = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(61, 0)?, Utc);
     /// assert_eq!(Utc.timestamp(61, 0)?, dt);
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     //
     // note: this constructor is purposely not named to `new` to discourage the direct usage.
@@ -135,7 +135,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// assert_eq!(datetime_east, datetime_utc.with_timezone(&timezone_east)?);
     /// assert_eq!(datetime_west, datetime_utc.with_timezone(&timezone_west)?);
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     #[inline]
     pub fn from_local(datetime: NaiveDateTime, offset: Tz::Offset) -> DateTime<Tz> {
@@ -159,7 +159,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// assert_eq!(dt.date(), date);
     ///
     /// assert_eq!(dt.date().and_hms(1, 1, 1)?, date.and_hms(1, 1, 1)?);
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     #[inline]
     pub fn date(&self) -> Date<Tz> {
@@ -177,7 +177,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// let date: DateTime<Utc> = Utc.ymd(2020, 1, 1)?.and_hms(0, 0, 0)?;
     /// let other: DateTime<FixedOffset> = FixedOffset::east(23)?.ymd(2020, 1, 1)?.and_hms(0, 0, 0)?;
     /// assert_eq!(date.date_naive(), other.date_naive());
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     #[inline]
     pub fn date_naive(&self) -> NaiveDate {
@@ -216,7 +216,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// let dt = Utc.ymd(2001, 9, 9)?.and_hms_milli(1, 46, 40, 555)?;
     /// assert_eq!(dt.timestamp_millis(), 1_000_000_000_555);
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     #[inline]
     pub fn timestamp_millis(&self) -> i64 {
@@ -241,7 +241,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// let dt = Utc.ymd(2001, 9, 9)?.and_hms_micro(1, 46, 40, 555)?;
     /// assert_eq!(dt.timestamp_micros(), 1_000_000_000_000_555);
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     #[inline]
     pub fn timestamp_micros(&self) -> i64 {
@@ -266,7 +266,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// let dt = Utc.ymd(2001, 9, 9)?.and_hms_nano(1, 46, 40, 555)?;
     /// assert_eq!(dt.timestamp_nanos(), 1_000_000_000_000_000_555);
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     #[inline]
     pub fn timestamp_nanos(&self) -> i64 {
@@ -318,7 +318,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// Changes the associated time zone.
     /// The returned `DateTime` references the same instant of time from the perspective of the provided time zone.
     #[inline]
-    pub fn with_timezone<Tz2: TimeZone>(&self, tz: &Tz2) -> Result<DateTime<Tz2>, ChronoError> {
+    pub fn with_timezone<Tz2: TimeZone>(&self, tz: &Tz2) -> Result<DateTime<Tz2>, Error> {
         tz.from_utc_datetime(&self.datetime)
     }
 
@@ -331,7 +331,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
 
     /// Adds given `Duration` to the current date and time.
     ///
-    /// Returns `Err(ChronoError)` when it will result in overflow.
+    /// Returns `Err(Error)` when it will result in overflow.
     #[inline]
     pub fn checked_add_signed(self, rhs: TimeDelta) -> Option<Self> {
         let datetime = self.datetime.checked_add_signed(rhs)?;
@@ -341,7 +341,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
 
     /// Adds given `Months` to the current date and time.
     ///
-    /// Returns `Err(ChronoError)` when it will result in overflow, or if the
+    /// Returns `Err(Error)` when it will result in overflow, or if the
     /// local time is not valid on the newly calculated date.
     ///
     /// See [`NaiveDate::checked_add_months`] for more details on behavior
@@ -352,7 +352,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
 
     /// Subtracts given `Duration` from the current date and time.
     ///
-    /// Returns `Err(ChronoError)` when it will result in overflow.
+    /// Returns `Err(Error)` when it will result in overflow.
     #[inline]
     pub fn checked_sub_signed(self, rhs: TimeDelta) -> Option<Self> {
         let datetime = self.datetime.checked_sub_signed(rhs)?;
@@ -362,7 +362,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
 
     /// Subtracts given `Months` from the current date and time.
     ///
-    /// Returns `Err(ChronoError)` when it will result in overflow, or if the
+    /// Returns `Err(Error)` when it will result in overflow, or if the
     /// local time is not valid on the newly calculated date.
     ///
     /// See [`NaiveDate::checked_sub_months`] for more details on behavior
@@ -373,7 +373,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
 
     /// Add a duration in [`Days`] to the date part of the `DateTime`
     ///
-    /// Returns `Err(ChronoError)` if the resulting date would be out of range.
+    /// Returns `Err(Error)` if the resulting date would be out of range.
     pub fn checked_add_days(self, days: Days) -> Option<Self> {
         let dt = self.datetime.checked_add_days(days)?;
         dt.and_local_timezone(TimeZone::from_offset(&self.offset)).ok()
@@ -381,7 +381,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
 
     /// Subtract a duration in [`Days`] from the date part of the `DateTime`
     ///
-    /// Returns `Err(ChronoError)` if the resulting date would be out of range.
+    /// Returns `Err(Error)` if the resulting date would be out of range.
     pub fn checked_sub_days(self, days: Days) -> Option<Self> {
         let dt = self.datetime.checked_sub_days(days)?;
         dt.and_local_timezone(TimeZone::from_offset(&self.offset)).ok()
@@ -465,7 +465,7 @@ impl From<DateTime<Utc>> for DateTime<FixedOffset> {
 #[cfg(feature = "clock")]
 #[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
 impl TryFrom<DateTime<Utc>> for DateTime<Local> {
-    type Error = ChronoError;
+    type Error = Error;
 
     /// Convert this `DateTime<Utc>` instance into a `DateTime<Local>` instance.
     ///
@@ -490,7 +490,7 @@ impl From<DateTime<FixedOffset>> for DateTime<Utc> {
 #[cfg(feature = "clock")]
 #[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
 impl TryFrom<DateTime<FixedOffset>> for DateTime<Local> {
-    type Error = ChronoError;
+    type Error = Error;
 
     /// Convert this `DateTime<FixedOffset>` instance into a `DateTime<Local>` instance.
     ///
@@ -528,9 +528,9 @@ impl From<DateTime<Local>> for DateTime<FixedOffset> {
 }
 
 /// Maps the local datetime to other datetime with given conversion function.
-fn map_local<Tz: TimeZone, F>(dt: &DateTime<Tz>, mut f: F) -> Result<DateTime<Tz>, ChronoError>
+fn map_local<Tz: TimeZone, F>(dt: &DateTime<Tz>, mut f: F) -> Result<DateTime<Tz>, Error>
 where
-    F: FnMut(NaiveDateTime) -> Result<NaiveDateTime, ChronoError>,
+    F: FnMut(NaiveDateTime) -> Result<NaiveDateTime, Error>,
 {
     let datetime = f(dt.naive_local())?;
     dt.timezone().from_local_datetime(&datetime)?.single()
@@ -707,7 +707,7 @@ where
     /// let dt = pst.ymd(2018, 1, 26)?.and_hms_micro(10, 30, 9, 453_829)?;
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Secs, true),
     ///            "2018-01-26T10:30:09+08:00");
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
@@ -777,7 +777,7 @@ where
     /// let date_time: DateTime<Utc> = Utc.ymd(2017, 04, 02)?.and_hms(12, 50, 32)?;
     /// let formatted = format!("{}", date_time.format("%d/%m/%Y %H:%M"));
     /// assert_eq!(formatted, "02/04/2017 12:50");
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
@@ -865,37 +865,37 @@ impl<Tz: TimeZone> Datelike for DateTime<Tz> {
     }
 
     #[inline]
-    fn with_year(&self, year: i32) -> Result<DateTime<Tz>, ChronoError> {
+    fn with_year(&self, year: i32) -> Result<DateTime<Tz>, Error> {
         map_local(self, |datetime| datetime.with_year(year))
     }
 
     #[inline]
-    fn with_month(&self, month: u32) -> Result<DateTime<Tz>, ChronoError> {
+    fn with_month(&self, month: u32) -> Result<DateTime<Tz>, Error> {
         map_local(self, |datetime| datetime.with_month(month))
     }
 
     #[inline]
-    fn with_month0(&self, month0: u32) -> Result<DateTime<Tz>, ChronoError> {
+    fn with_month0(&self, month0: u32) -> Result<DateTime<Tz>, Error> {
         map_local(self, |datetime| datetime.with_month0(month0))
     }
 
     #[inline]
-    fn with_day(&self, day: u32) -> Result<DateTime<Tz>, ChronoError> {
+    fn with_day(&self, day: u32) -> Result<DateTime<Tz>, Error> {
         map_local(self, |datetime| datetime.with_day(day))
     }
 
     #[inline]
-    fn with_day0(&self, day0: u32) -> Result<DateTime<Tz>, ChronoError> {
+    fn with_day0(&self, day0: u32) -> Result<DateTime<Tz>, Error> {
         map_local(self, |datetime| datetime.with_day0(day0))
     }
 
     #[inline]
-    fn with_ordinal(&self, ordinal: u32) -> Result<DateTime<Tz>, ChronoError> {
+    fn with_ordinal(&self, ordinal: u32) -> Result<DateTime<Tz>, Error> {
         map_local(self, |datetime| datetime.with_ordinal(ordinal))
     }
 
     #[inline]
-    fn with_ordinal0(&self, ordinal0: u32) -> Result<DateTime<Tz>, ChronoError> {
+    fn with_ordinal0(&self, ordinal0: u32) -> Result<DateTime<Tz>, Error> {
         map_local(self, |datetime| datetime.with_ordinal0(ordinal0))
     }
 }
@@ -919,22 +919,22 @@ impl<Tz: TimeZone> Timelike for DateTime<Tz> {
     }
 
     #[inline]
-    fn with_hour(&self, hour: u32) -> Result<DateTime<Tz>, ChronoError> {
+    fn with_hour(&self, hour: u32) -> Result<DateTime<Tz>, Error> {
         map_local(self, |datetime| datetime.with_hour(hour))
     }
 
     #[inline]
-    fn with_minute(&self, min: u32) -> Result<DateTime<Tz>, ChronoError> {
+    fn with_minute(&self, min: u32) -> Result<DateTime<Tz>, Error> {
         map_local(self, |datetime| datetime.with_minute(min))
     }
 
     #[inline]
-    fn with_second(&self, sec: u32) -> Result<DateTime<Tz>, ChronoError> {
+    fn with_second(&self, sec: u32) -> Result<DateTime<Tz>, Error> {
         map_local(self, |datetime| datetime.with_second(sec))
     }
 
     #[inline]
-    fn with_nanosecond(&self, nano: u32) -> Result<DateTime<Tz>, ChronoError> {
+    fn with_nanosecond(&self, nano: u32) -> Result<DateTime<Tz>, Error> {
         map_local(self, |datetime| datetime.with_nanosecond(nano))
     }
 }
@@ -966,7 +966,7 @@ impl<Tz: TimeZone, Tz2: TimeZone> PartialOrd<DateTime<Tz2>> for DateTime<Tz> {
     /// assert_eq!(later.to_string(), "2015-05-14 22:00:00 -05:00");
     ///
     /// assert!(later > earlier);
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     fn partial_cmp(&self, other: &DateTime<Tz2>) -> Option<Ordering> {
         self.datetime.partial_cmp(&other.datetime)
@@ -1184,7 +1184,7 @@ impl<Tz: TimeZone> From<DateTime<Tz>> for SystemTime {
     )))
 )]
 impl std::convert::TryFrom<js_sys::Date> for DateTime<Utc> {
-    type Error = ChronoError;
+    type Error = Error;
 
     fn try_from(date: js_sys::Date) -> Result<Self, Self::Error> {
         DateTime::<Utc>::try_from(&date)
@@ -1205,7 +1205,7 @@ impl std::convert::TryFrom<js_sys::Date> for DateTime<Utc> {
     )))
 )]
 impl std::convert::TryFrom<&js_sys::Date> for DateTime<Utc> {
-    type Error = ChronoError;
+    type Error = Error;
 
     fn try_from(date: &js_sys::Date) -> Result<Self, Self::Error> {
         Utc.timestamp_millis(date.get_time() as i64)

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -331,7 +331,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
 
     /// Adds given `Duration` to the current date and time.
     ///
-    /// Returns `None` when it will result in overflow.
+    /// Returns `Err(ChronoError)` when it will result in overflow.
     #[inline]
     pub fn checked_add_signed(self, rhs: TimeDelta) -> Result<DateTime<Tz>, ChronoError> {
         let datetime = self.datetime.checked_add_signed(rhs)?;
@@ -341,7 +341,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
 
     /// Adds given `Months` to the current date and time.
     ///
-    /// Returns `None` when it will result in overflow, or if the
+    /// Returns `Err(ChronoError)` when it will result in overflow, or if the
     /// local time is not valid on the newly calculated date.
     ///
     /// See [`NaiveDate::checked_add_months`] for more details on behavior
@@ -352,7 +352,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
 
     /// Subtracts given `Duration` from the current date and time.
     ///
-    /// Returns `None` when it will result in overflow.
+    /// Returns `Err(ChronoError)` when it will result in overflow.
     #[inline]
     pub fn checked_sub_signed(self, rhs: TimeDelta) -> Result<DateTime<Tz>, ChronoError> {
         let datetime = self.datetime.checked_sub_signed(rhs)?;
@@ -362,7 +362,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
 
     /// Subtracts given `Months` from the current date and time.
     ///
-    /// Returns `None` when it will result in overflow, or if the
+    /// Returns `Err(ChronoError)` when it will result in overflow, or if the
     /// local time is not valid on the newly calculated date.
     ///
     /// See [`NaiveDate::checked_sub_months`] for more details on behavior
@@ -373,7 +373,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
 
     /// Add a duration in [`Days`] to the date part of the `DateTime`
     ///
-    /// Returns `None` if the resulting date would be out of range.
+    /// Returns `Err(ChronoError)` if the resulting date would be out of range.
     pub fn checked_add_days(self, days: Days) -> Result<Self, ChronoError> {
         let dt = self.datetime.checked_add_days(days)?;
         dt.and_local_timezone(TimeZone::from_offset(&self.offset))
@@ -381,7 +381,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
 
     /// Subtract a duration in [`Days`] from the date part of the `DateTime`
     ///
-    /// Returns `None` if the resulting date would be out of range.
+    /// Returns `Err(ChronoError)` if the resulting date would be out of range.
     pub fn checked_sub_days(self, days: Days) -> Result<Self, ChronoError> {
         let dt = self.datetime.checked_sub_days(days)?;
         dt.and_local_timezone(TimeZone::from_offset(&self.offset))

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -333,10 +333,10 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// Returns `Err(ChronoError)` when it will result in overflow.
     #[inline]
-    pub fn checked_add_signed(self, rhs: TimeDelta) -> Result<DateTime<Tz>, ChronoError> {
+    pub fn checked_add_signed(self, rhs: TimeDelta) -> Option<Self> {
         let datetime = self.datetime.checked_add_signed(rhs)?;
         let tz = self.timezone();
-        tz.from_utc_datetime(&datetime)
+        tz.from_utc_datetime(&datetime).ok()
     }
 
     /// Adds given `Months` to the current date and time.
@@ -345,19 +345,19 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// local time is not valid on the newly calculated date.
     ///
     /// See [`NaiveDate::checked_add_months`] for more details on behavior
-    pub fn checked_add_months(self, rhs: Months) -> Result<DateTime<Tz>, ChronoError> {
+    pub fn checked_add_months(self, rhs: Months) -> Option<Self> {
         let datetime = self.naive_local().checked_add_months(rhs)?;
-        datetime.and_local_timezone(Tz::from_offset(&self.offset))
+        datetime.and_local_timezone(Tz::from_offset(&self.offset)).ok()
     }
 
     /// Subtracts given `Duration` from the current date and time.
     ///
     /// Returns `Err(ChronoError)` when it will result in overflow.
     #[inline]
-    pub fn checked_sub_signed(self, rhs: TimeDelta) -> Result<DateTime<Tz>, ChronoError> {
+    pub fn checked_sub_signed(self, rhs: TimeDelta) -> Option<Self> {
         let datetime = self.datetime.checked_sub_signed(rhs)?;
         let tz = self.timezone();
-        tz.from_utc_datetime(&datetime)
+        tz.from_utc_datetime(&datetime).ok()
     }
 
     /// Subtracts given `Months` from the current date and time.
@@ -366,25 +366,25 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// local time is not valid on the newly calculated date.
     ///
     /// See [`NaiveDate::checked_sub_months`] for more details on behavior
-    pub fn checked_sub_months(self, rhs: Months) -> Result<DateTime<Tz>, ChronoError> {
+    pub fn checked_sub_months(self, rhs: Months) -> Option<Self> {
         let dt = self.naive_local().checked_sub_months(rhs)?;
-        dt.and_local_timezone(Tz::from_offset(&self.offset))
+        dt.and_local_timezone(Tz::from_offset(&self.offset)).ok()
     }
 
     /// Add a duration in [`Days`] to the date part of the `DateTime`
     ///
     /// Returns `Err(ChronoError)` if the resulting date would be out of range.
-    pub fn checked_add_days(self, days: Days) -> Result<Self, ChronoError> {
+    pub fn checked_add_days(self, days: Days) -> Option<Self> {
         let dt = self.datetime.checked_add_days(days)?;
-        dt.and_local_timezone(TimeZone::from_offset(&self.offset))
+        dt.and_local_timezone(TimeZone::from_offset(&self.offset)).ok()
     }
 
     /// Subtract a duration in [`Days`] from the date part of the `DateTime`
     ///
     /// Returns `Err(ChronoError)` if the resulting date would be out of range.
-    pub fn checked_sub_days(self, days: Days) -> Result<Self, ChronoError> {
+    pub fn checked_sub_days(self, days: Days) -> Option<Self> {
         let dt = self.datetime.checked_sub_days(days)?;
-        dt.and_local_timezone(TimeZone::from_offset(&self.offset))
+        dt.and_local_timezone(TimeZone::from_offset(&self.offset)).ok()
     }
 
     /// Subtracts another `DateTime` from the current date and time.

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1118,9 +1118,11 @@ impl<Tz: TimeZone> From<DateTime<Tz>> for SystemTime {
         not(any(target_os = "emscripten", target_os = "wasi"))
     )))
 )]
-impl From<js_sys::Date> for DateTime<Utc> {
-    fn from(date: js_sys::Date) -> DateTime<Utc> {
-        DateTime::<Utc>::from(&date)
+impl std::convert::TryFrom<js_sys::Date> for DateTime<Utc> {
+    type Error = ChronoError;
+
+    fn try_from(date: js_sys::Date) -> Result<Self, Self::Error> {
+        DateTime::<Utc>::try_from(&date)
     }
 }
 
@@ -1137,8 +1139,10 @@ impl From<js_sys::Date> for DateTime<Utc> {
         not(any(target_os = "emscripten", target_os = "wasi"))
     )))
 )]
-impl From<&js_sys::Date> for DateTime<Utc> {
-    fn from(date: &js_sys::Date) -> DateTime<Utc> {
+impl std::convert::TryFrom<&js_sys::Date> for DateTime<Utc> {
+    type Error = ChronoError;
+
+    fn try_from(date: &js_sys::Date) -> Result<Self, Self::Error> {
         Utc.timestamp_millis(date.get_time() as i64)
     }
 }

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -1,10 +1,10 @@
 #![cfg_attr(docsrs, doc(cfg(feature = "serde")))]
 
 use core::fmt;
+use serde::de::Error;
 use serde::{de, ser};
 
 use super::DateTime;
-use crate::naive::datetime::serde::serde_from;
 #[cfg(feature = "clock")]
 use crate::offset::Local;
 use crate::offset::{FixedOffset, TimeZone, Utc};
@@ -77,7 +77,7 @@ impl<'de> de::Deserialize<'de> for DateTime<Utc> {
     where
         D: de::Deserializer<'de>,
     {
-        deserializer.deserialize_str(DateTimeVisitor).map(|dt| dt.with_timezone(&Utc))
+        deserializer.deserialize_str(DateTimeVisitor)?.with_timezone(&Utc).map_err(D::Error::custom)
     }
 }
 
@@ -95,7 +95,10 @@ impl<'de> de::Deserialize<'de> for DateTime<Local> {
     where
         D: de::Deserializer<'de>,
     {
-        deserializer.deserialize_str(DateTimeVisitor).map(|dt| dt.with_timezone(&Local))
+        deserializer
+            .deserialize_str(DateTimeVisitor)?
+            .with_timezone(&Local)
+            .map_err(D::Error::custom)
     }
 }
 
@@ -115,7 +118,7 @@ impl<'de> de::Deserialize<'de> for DateTime<Local> {
 ///     time: DateTime<Utc>
 /// }
 ///
-/// let time = Utc.ymd(2018, 5, 17).and_hms_nano(02, 04, 59, 918355733);
+/// let time = Utc.ymd(2018, 5, 17)?.and_hms_nano(02, 04, 59, 918355733)?;
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -124,7 +127,7 @@ impl<'de> de::Deserialize<'de> for DateTime<Local> {
 /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok::<(), serde_json::Error>(())
+/// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 pub mod ts_nanoseconds {
     use core::fmt;
@@ -132,8 +135,6 @@ pub mod ts_nanoseconds {
 
     use crate::offset::TimeZone;
     use crate::{DateTime, Utc};
-
-    use super::serde_from;
 
     /// Serialize a UTC datetime into an integer number of nanoseconds since the epoch
     ///
@@ -152,11 +153,11 @@ pub mod ts_nanoseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Utc.ymd(2018, 5, 17).and_hms_nano(02, 04, 59, 918355733),
+    ///     time: Utc.ymd(2018, 5, 17)?.and_hms_nano(02, 04, 59, 918355733)?,
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -182,7 +183,7 @@ pub mod ts_nanoseconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
@@ -205,10 +206,7 @@ pub mod ts_nanoseconds {
         where
             E: de::Error,
         {
-            serde_from(
-                Utc.timestamp_opt(value / 1_000_000_000, (value % 1_000_000_000) as u32),
-                &value,
-            )
+            Utc.timestamp(value / 1_000_000_000, (value % 1_000_000_000) as u32).map_err(E::custom)
         }
 
         /// Deserialize a timestamp in nanoseconds since the epoch
@@ -216,10 +214,8 @@ pub mod ts_nanoseconds {
         where
             E: de::Error,
         {
-            serde_from(
-                Utc.timestamp_opt((value / 1_000_000_000) as i64, (value % 1_000_000_000) as u32),
-                &value,
-            )
+            Utc.timestamp((value / 1_000_000_000) as i64, (value % 1_000_000_000) as u32)
+                .map_err(E::custom)
         }
     }
 }
@@ -240,7 +236,7 @@ pub mod ts_nanoseconds {
 ///     time: Option<DateTime<Utc>>
 /// }
 ///
-/// let time = Some(Utc.ymd(2018, 5, 17).and_hms_nano(02, 04, 59, 918355733));
+/// let time = Some(Utc.ymd(2018, 5, 17)?.and_hms_nano(02, 04, 59, 918355733)?);
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -249,7 +245,7 @@ pub mod ts_nanoseconds {
 /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok::<(), serde_json::Error>(())
+/// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 pub mod ts_nanoseconds_option {
     use core::fmt;
@@ -276,11 +272,11 @@ pub mod ts_nanoseconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(Utc.ymd(2018, 5, 17).and_hms_nano(02, 04, 59, 918355733)),
+    ///     time: Some(Utc.ymd(2018, 5, 17)?.and_hms_nano(02, 04, 59, 918355733)?),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -309,7 +305,7 @@ pub mod ts_nanoseconds_option {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where
@@ -369,7 +365,7 @@ pub mod ts_nanoseconds_option {
 ///     time: DateTime<Utc>
 /// }
 ///
-/// let time = Utc.ymd(2018, 5, 17).and_hms_micro(02, 04, 59, 918355);
+/// let time = Utc.ymd(2018, 5, 17)?.and_hms_micro(02, 04, 59, 918355)?;
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -378,13 +374,12 @@ pub mod ts_nanoseconds_option {
 /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok::<(), serde_json::Error>(())
+/// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 pub mod ts_microseconds {
     use core::fmt;
     use serde::{de, ser};
 
-    use super::serde_from;
     use crate::offset::TimeZone;
     use crate::{DateTime, Utc};
 
@@ -405,11 +400,11 @@ pub mod ts_microseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Utc.ymd(2018, 5, 17).and_hms_micro(02, 04, 59, 918355),
+    ///     time: Utc.ymd(2018, 5, 17)?.and_hms_micro(02, 04, 59, 918355)?,
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -435,7 +430,7 @@ pub mod ts_microseconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
@@ -458,10 +453,8 @@ pub mod ts_microseconds {
         where
             E: de::Error,
         {
-            serde_from(
-                Utc.timestamp_opt(value / 1_000_000, ((value % 1_000_000) * 1_000) as u32),
-                &value,
-            )
+            Utc.timestamp(value / 1_000_000, ((value % 1_000_000) * 1_000) as u32)
+                .map_err(E::custom)
         }
 
         /// Deserialize a timestamp in milliseconds since the epoch
@@ -469,10 +462,8 @@ pub mod ts_microseconds {
         where
             E: de::Error,
         {
-            serde_from(
-                Utc.timestamp_opt((value / 1_000_000) as i64, ((value % 1_000_000) * 1_000) as u32),
-                &value,
-            )
+            Utc.timestamp((value / 1_000_000) as i64, ((value % 1_000_000) * 1_000) as u32)
+                .map_err(E::custom)
         }
     }
 }
@@ -493,7 +484,7 @@ pub mod ts_microseconds {
 ///     time: Option<DateTime<Utc>>
 /// }
 ///
-/// let time = Some(Utc.ymd(2018, 5, 17).and_hms_micro(02, 04, 59, 918355));
+/// let time = Some(Utc.ymd(2018, 5, 17)?.and_hms_micro(02, 04, 59, 918355)?);
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -502,7 +493,7 @@ pub mod ts_microseconds {
 /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok::<(), serde_json::Error>(())
+/// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 pub mod ts_microseconds_option {
     use core::fmt;
@@ -528,11 +519,11 @@ pub mod ts_microseconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(Utc.ymd(2018, 5, 17).and_hms_micro(02, 04, 59, 918355)),
+    ///     time: Some(Utc.ymd(2018, 5, 17)?.and_hms_micro(02, 04, 59, 918355)?),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -561,7 +552,7 @@ pub mod ts_microseconds_option {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where
@@ -621,7 +612,7 @@ pub mod ts_microseconds_option {
 ///     time: DateTime<Utc>
 /// }
 ///
-/// let time = Utc.ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918);
+/// let time = Utc.ymd(2018, 5, 17)?.and_hms_milli(02, 04, 59, 918)?;
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -630,13 +621,12 @@ pub mod ts_microseconds_option {
 /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok::<(), serde_json::Error>(())
+/// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 pub mod ts_milliseconds {
     use core::fmt;
     use serde::{de, ser};
 
-    use super::serde_from;
     use crate::offset::TimeZone;
     use crate::{DateTime, Utc};
 
@@ -657,11 +647,11 @@ pub mod ts_milliseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Utc.ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918),
+    ///     time: Utc.ymd(2018, 5, 17)?.and_hms_milli(02, 04, 59, 918)?,
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -687,13 +677,13 @@ pub mod ts_milliseconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
         D: de::Deserializer<'de>,
     {
-        d.deserialize_i64(MilliSecondsTimestampVisitor).map(|dt| dt.with_timezone(&Utc))
+        Ok(d.deserialize_i64(MilliSecondsTimestampVisitor)?.with_fixed_timezone(&Utc))
     }
 
     pub(super) struct MilliSecondsTimestampVisitor;
@@ -710,7 +700,7 @@ pub mod ts_milliseconds {
         where
             E: de::Error,
         {
-            serde_from(Utc.timestamp_opt(value / 1000, ((value % 1000) * 1_000_000) as u32), &value)
+            Utc.timestamp(value / 1000, ((value % 1000) * 1_000_000) as u32).map_err(E::custom)
         }
 
         /// Deserialize a timestamp in milliseconds since the epoch
@@ -718,10 +708,8 @@ pub mod ts_milliseconds {
         where
             E: de::Error,
         {
-            serde_from(
-                Utc.timestamp_opt((value / 1000) as i64, ((value % 1000) * 1_000_000) as u32),
-                &value,
-            )
+            Utc.timestamp((value / 1000) as i64, ((value % 1000) * 1_000_000) as u32)
+                .map_err(E::custom)
         }
     }
 }
@@ -742,7 +730,7 @@ pub mod ts_milliseconds {
 ///     time: Option<DateTime<Utc>>
 /// }
 ///
-/// let time = Some(Utc.ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918));
+/// let time = Some(Utc.ymd(2018, 5, 17)?.and_hms_milli(02, 04, 59, 918)?);
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -751,7 +739,7 @@ pub mod ts_milliseconds {
 /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok::<(), serde_json::Error>(())
+/// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 pub mod ts_milliseconds_option {
     use core::fmt;
@@ -777,11 +765,11 @@ pub mod ts_milliseconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(Utc.ymd(2018, 5, 17).and_hms_milli(02, 04, 59, 918)),
+    ///     time: Some(Utc.ymd(2018, 5, 17)?.and_hms_milli(02, 04, 59, 918)?),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -817,19 +805,19 @@ pub mod ts_milliseconds_option {
     /// }
     ///
     /// let my_s: E<S> = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
-    /// assert_eq!(my_s, E::V(S { time: Some(Utc.timestamp(1526522699, 918000000)) }));
+    /// assert_eq!(my_s, E::V(S { time: Some(Utc.timestamp(1526522699, 918000000)?) }));
     /// let s: E<S> = serde_json::from_str(r#"{ "time": null }"#)?;
     /// assert_eq!(s, E::V(S { time: None }));
     /// let t: E<S> = serde_json::from_str(r#"{}"#)?;
     /// assert_eq!(t, E::V(S { time: None }));
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where
         D: de::Deserializer<'de>,
     {
-        d.deserialize_option(OptionMilliSecondsTimestampVisitor)
-            .map(|opt| opt.map(|dt| dt.with_timezone(&Utc)))
+        Ok(d.deserialize_option(OptionMilliSecondsTimestampVisitor)?
+            .map(|dt| dt.with_fixed_timezone(&Utc)))
     }
 
     struct OptionMilliSecondsTimestampVisitor;
@@ -883,7 +871,7 @@ pub mod ts_milliseconds_option {
 ///     time: DateTime<Utc>
 /// }
 ///
-/// let time = Utc.ymd(2015, 5, 15).and_hms(10, 0, 0);
+/// let time = Utc.ymd(2015, 5, 15)?.and_hms(10, 0, 0)?;
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -892,13 +880,12 @@ pub mod ts_milliseconds_option {
 /// assert_eq!(as_string, r#"{"time":1431684000}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok::<(), serde_json::Error>(())
+/// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 pub mod ts_seconds {
     use core::fmt;
     use serde::{de, ser};
 
-    use super::serde_from;
     use crate::offset::TimeZone;
     use crate::{DateTime, Utc};
 
@@ -919,11 +906,11 @@ pub mod ts_seconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Utc.ymd(2015, 5, 15).and_hms(10, 0, 0),
+    ///     time: Utc.ymd(2015, 5, 15)?.and_hms(10, 0, 0)?,
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -949,7 +936,7 @@ pub mod ts_seconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
@@ -972,7 +959,7 @@ pub mod ts_seconds {
         where
             E: de::Error,
         {
-            serde_from(Utc.timestamp_opt(value, 0), &value)
+            Utc.timestamp(value, 0).map_err(E::custom)
         }
 
         /// Deserialize a timestamp in seconds since the epoch
@@ -980,7 +967,7 @@ pub mod ts_seconds {
         where
             E: de::Error,
         {
-            serde_from(Utc.timestamp_opt(value as i64, 0), &value)
+            Utc.timestamp(value as i64, 0).map_err(E::custom)
         }
     }
 }
@@ -1001,7 +988,7 @@ pub mod ts_seconds {
 ///     time: Option<DateTime<Utc>>
 /// }
 ///
-/// let time = Some(Utc.ymd(2015, 5, 15).and_hms(10, 0, 0));
+/// let time = Some(Utc.ymd(2015, 5, 15)?.and_hms(10, 0, 0)?);
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -1010,7 +997,7 @@ pub mod ts_seconds {
 /// assert_eq!(as_string, r#"{"time":1431684000}"#);
 /// let my_s: S = serde_json::from_str(&as_string)?;
 /// assert_eq!(my_s.time, time);
-/// # Ok::<(), serde_json::Error>(())
+/// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 pub mod ts_seconds_option {
     use core::fmt;
@@ -1036,11 +1023,11 @@ pub mod ts_seconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(Utc.ymd(2015, 5, 15).and_hms(10, 0, 0)),
+    ///     time: Some(Utc.ymd(2015, 5, 15)?.and_hms(10, 0, 0)?),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -1069,7 +1056,7 @@ pub mod ts_seconds_option {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
-    /// # Ok::<(), serde_json::Error>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where
@@ -1134,7 +1121,7 @@ fn test_serde_bincode() {
     // it is not self-describing.
     use bincode::{deserialize, serialize};
 
-    let dt = Utc.ymd(2014, 7, 24).and_hms(12, 34, 6);
+    let dt = Utc.ymd(2014, 7, 24).unwrap().and_hms(12, 34, 6).unwrap();
     let encoded = serialize(&dt).unwrap();
     let decoded: DateTime<Utc> = deserialize(&encoded).unwrap();
     assert_eq!(dt, decoded);

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -9,135 +9,177 @@ use crate::offset::{FixedOffset, TimeZone, Utc};
 use crate::Datelike;
 use crate::TimeDelta;
 
+macro_rules! ymd {
+    ($year:expr, $month:expr, $day:expr) => {
+        NaiveDate::from_ymd($year, $month, $day).unwrap()
+    };
+}
+
 #[test]
 fn test_datetime_offset() {
-    let est = FixedOffset::west(5 * 60 * 60);
-    let edt = FixedOffset::west(4 * 60 * 60);
-    let kst = FixedOffset::east(9 * 60 * 60);
+    let est = FixedOffset::west(5 * 60 * 60).unwrap();
+    let edt = FixedOffset::west(4 * 60 * 60).unwrap();
+    let kst = FixedOffset::east(9 * 60 * 60).unwrap();
 
-    assert_eq!(format!("{}", Utc.ymd(2014, 5, 6).and_hms(7, 8, 9)), "2014-05-06 07:08:09 UTC");
-    assert_eq!(format!("{}", edt.ymd(2014, 5, 6).and_hms(7, 8, 9)), "2014-05-06 07:08:09 -04:00");
-    assert_eq!(format!("{}", kst.ymd(2014, 5, 6).and_hms(7, 8, 9)), "2014-05-06 07:08:09 +09:00");
-    assert_eq!(format!("{:?}", Utc.ymd(2014, 5, 6).and_hms(7, 8, 9)), "2014-05-06T07:08:09Z");
-    assert_eq!(format!("{:?}", edt.ymd(2014, 5, 6).and_hms(7, 8, 9)), "2014-05-06T07:08:09-04:00");
-    assert_eq!(format!("{:?}", kst.ymd(2014, 5, 6).and_hms(7, 8, 9)), "2014-05-06T07:08:09+09:00");
+    assert_eq!(
+        format!("{}", Utc.ymd(2014, 5, 6).unwrap().and_hms(7, 8, 9).unwrap()),
+        "2014-05-06 07:08:09 UTC"
+    );
+    assert_eq!(
+        format!("{}", edt.ymd(2014, 5, 6).unwrap().and_hms(7, 8, 9).unwrap()),
+        "2014-05-06 07:08:09 -04:00"
+    );
+    assert_eq!(
+        format!("{}", kst.ymd(2014, 5, 6).unwrap().and_hms(7, 8, 9).unwrap()),
+        "2014-05-06 07:08:09 +09:00"
+    );
+    assert_eq!(
+        format!("{:?}", Utc.ymd(2014, 5, 6).unwrap().and_hms(7, 8, 9).unwrap()),
+        "2014-05-06T07:08:09Z"
+    );
+    assert_eq!(
+        format!("{:?}", edt.ymd(2014, 5, 6).unwrap().and_hms(7, 8, 9).unwrap()),
+        "2014-05-06T07:08:09-04:00"
+    );
+    assert_eq!(
+        format!("{:?}", kst.ymd(2014, 5, 6).unwrap().and_hms(7, 8, 9).unwrap()),
+        "2014-05-06T07:08:09+09:00"
+    );
 
     // edge cases
-    assert_eq!(format!("{:?}", Utc.ymd(2014, 5, 6).and_hms(0, 0, 0)), "2014-05-06T00:00:00Z");
-    assert_eq!(format!("{:?}", edt.ymd(2014, 5, 6).and_hms(0, 0, 0)), "2014-05-06T00:00:00-04:00");
-    assert_eq!(format!("{:?}", kst.ymd(2014, 5, 6).and_hms(0, 0, 0)), "2014-05-06T00:00:00+09:00");
-    assert_eq!(format!("{:?}", Utc.ymd(2014, 5, 6).and_hms(23, 59, 59)), "2014-05-06T23:59:59Z");
     assert_eq!(
-        format!("{:?}", edt.ymd(2014, 5, 6).and_hms(23, 59, 59)),
+        format!("{:?}", Utc.ymd(2014, 5, 6).unwrap().and_hms(0, 0, 0).unwrap()),
+        "2014-05-06T00:00:00Z"
+    );
+    assert_eq!(
+        format!("{:?}", edt.ymd(2014, 5, 6).unwrap().and_hms(0, 0, 0).unwrap()),
+        "2014-05-06T00:00:00-04:00"
+    );
+    assert_eq!(
+        format!("{:?}", kst.ymd(2014, 5, 6).unwrap().and_hms(0, 0, 0).unwrap()),
+        "2014-05-06T00:00:00+09:00"
+    );
+    assert_eq!(
+        format!("{:?}", Utc.ymd(2014, 5, 6).unwrap().and_hms(23, 59, 59).unwrap()),
+        "2014-05-06T23:59:59Z"
+    );
+    assert_eq!(
+        format!("{:?}", edt.ymd(2014, 5, 6).unwrap().and_hms(23, 59, 59).unwrap()),
         "2014-05-06T23:59:59-04:00"
     );
     assert_eq!(
-        format!("{:?}", kst.ymd(2014, 5, 6).and_hms(23, 59, 59)),
+        format!("{:?}", kst.ymd(2014, 5, 6).unwrap().and_hms(23, 59, 59).unwrap()),
         "2014-05-06T23:59:59+09:00"
     );
 
-    let dt = Utc.ymd(2014, 5, 6).and_hms(7, 8, 9);
-    assert_eq!(dt, edt.ymd(2014, 5, 6).and_hms(3, 8, 9));
-    assert_eq!(dt + TimeDelta::seconds(3600 + 60 + 1), Utc.ymd(2014, 5, 6).and_hms(8, 9, 10));
+    let dt = Utc.ymd(2014, 5, 6).unwrap().and_hms(7, 8, 9).unwrap();
+    assert_eq!(dt, edt.ymd(2014, 5, 6).unwrap().and_hms(3, 8, 9).unwrap());
     assert_eq!(
-        dt.signed_duration_since(edt.ymd(2014, 5, 6).and_hms(10, 11, 12)),
+        dt + TimeDelta::seconds(3600 + 60 + 1),
+        Utc.ymd(2014, 5, 6).unwrap().and_hms(8, 9, 10).unwrap()
+    );
+    assert_eq!(
+        dt.signed_duration_since(edt.ymd(2014, 5, 6).unwrap().and_hms(10, 11, 12).unwrap()),
         TimeDelta::seconds(-7 * 3600 - 3 * 60 - 3)
     );
 
-    assert_eq!(*Utc.ymd(2014, 5, 6).and_hms(7, 8, 9).offset(), Utc);
-    assert_eq!(*edt.ymd(2014, 5, 6).and_hms(7, 8, 9).offset(), edt);
-    assert!(*edt.ymd(2014, 5, 6).and_hms(7, 8, 9).offset() != est);
+    assert_eq!(*Utc.ymd(2014, 5, 6).unwrap().and_hms(7, 8, 9).unwrap().offset(), Utc);
+    assert_eq!(*edt.ymd(2014, 5, 6).unwrap().and_hms(7, 8, 9).unwrap().offset(), edt);
+    assert!(*edt.ymd(2014, 5, 6).unwrap().and_hms(7, 8, 9).unwrap().offset() != est);
 }
 
 #[test]
 fn test_datetime_date_and_time() {
-    let tz = FixedOffset::east(5 * 60 * 60);
-    let d = tz.ymd(2014, 5, 6).and_hms(7, 8, 9);
-    assert_eq!(d.time(), NaiveTime::from_hms(7, 8, 9));
-    assert_eq!(d.date(), tz.ymd(2014, 5, 6));
-    assert_eq!(d.date().naive_local(), NaiveDate::from_ymd(2014, 5, 6));
-    assert_eq!(d.date().and_time(d.time()), Some(d));
+    let tz = FixedOffset::east(5 * 60 * 60).unwrap();
+    let d = tz.ymd(2014, 5, 6).unwrap().and_hms(7, 8, 9).unwrap();
+    assert_eq!(d.time(), NaiveTime::from_hms(7, 8, 9).unwrap());
+    assert_eq!(d.date(), tz.ymd(2014, 5, 6).unwrap().unwrap());
+    assert_eq!(d.date().naive_local(), ymd!(2014, 5, 6));
+    assert_eq!(d.date().and_time(d.time()), Ok(d));
 
-    let tz = FixedOffset::east(4 * 60 * 60);
-    let d = tz.ymd(2016, 5, 4).and_hms(3, 2, 1);
-    assert_eq!(d.time(), NaiveTime::from_hms(3, 2, 1));
-    assert_eq!(d.date(), tz.ymd(2016, 5, 4));
-    assert_eq!(d.date().naive_local(), NaiveDate::from_ymd(2016, 5, 4));
-    assert_eq!(d.date().and_time(d.time()), Some(d));
+    let tz = FixedOffset::east(4 * 60 * 60).unwrap();
+    let d = tz.ymd(2016, 5, 4).unwrap().and_hms(3, 2, 1).unwrap();
+    assert_eq!(d.time(), NaiveTime::from_hms(3, 2, 1).unwrap());
+    assert_eq!(d.date(), tz.ymd(2016, 5, 4).unwrap().unwrap());
+    assert_eq!(d.date().naive_local(), ymd!(2016, 5, 4));
+    assert_eq!(d.date().and_time(d.time()), Ok(d));
 
-    let tz = FixedOffset::west(13 * 60 * 60);
-    let d = tz.ymd(2017, 8, 9).and_hms(12, 34, 56);
-    assert_eq!(d.time(), NaiveTime::from_hms(12, 34, 56));
-    assert_eq!(d.date(), tz.ymd(2017, 8, 9));
-    assert_eq!(d.date().naive_local(), NaiveDate::from_ymd(2017, 8, 9));
-    assert_eq!(d.date().and_time(d.time()), Some(d));
+    let tz = FixedOffset::west(13 * 60 * 60).unwrap();
+    let d = tz.ymd(2017, 8, 9).unwrap().and_hms(12, 34, 56).unwrap();
+    assert_eq!(d.time(), NaiveTime::from_hms(12, 34, 56).unwrap());
+    assert_eq!(d.date(), tz.ymd(2017, 8, 9).unwrap().unwrap());
+    assert_eq!(d.date().naive_local(), ymd!(2017, 8, 9));
+    assert_eq!(d.date().and_time(d.time()), Ok(d));
 
-    let utc_d = Utc.ymd(2017, 8, 9).and_hms(12, 34, 56);
+    let utc_d = Utc.ymd(2017, 8, 9).unwrap().and_hms(12, 34, 56).unwrap();
     assert!(utc_d < d);
 }
 
 #[test]
 #[cfg(feature = "clock")]
 fn test_datetime_with_timezone() {
-    let local_now = Local::now();
-    let utc_now = local_now.with_timezone(&Utc);
-    let local_now2 = utc_now.with_timezone(&Local);
+    let local_now = Local::now().unwrap();
+    let utc_now = local_now.with_timezone(&Utc).unwrap();
+    let local_now2 = utc_now.with_timezone(&Local).unwrap();
     assert_eq!(local_now, local_now2);
 }
 
 #[test]
 fn test_datetime_rfc2822_and_rfc3339() {
-    let edt = FixedOffset::east(5 * 60 * 60);
+    let edt = FixedOffset::east(5 * 60 * 60).unwrap();
     assert_eq!(
-        Utc.ymd(2015, 2, 18).and_hms(23, 16, 9).to_rfc2822(),
+        Utc.ymd(2015, 2, 18).unwrap().and_hms(23, 16, 9).unwrap().to_rfc2822(),
         "Wed, 18 Feb 2015 23:16:09 +0000"
     );
-    assert_eq!(Utc.ymd(2015, 2, 18).and_hms(23, 16, 9).to_rfc3339(), "2015-02-18T23:16:09+00:00");
     assert_eq!(
-        edt.ymd(2015, 2, 18).and_hms_milli(23, 16, 9, 150).to_rfc2822(),
+        Utc.ymd(2015, 2, 18).unwrap().and_hms(23, 16, 9).unwrap().to_rfc3339(),
+        "2015-02-18T23:16:09+00:00"
+    );
+    assert_eq!(
+        edt.ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap().to_rfc2822(),
         "Wed, 18 Feb 2015 23:16:09 +0500"
     );
     assert_eq!(
-        edt.ymd(2015, 2, 18).and_hms_milli(23, 16, 9, 150).to_rfc3339(),
+        edt.ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap().to_rfc3339(),
         "2015-02-18T23:16:09.150+05:00"
     );
     assert_eq!(
-        edt.ymd(2015, 2, 18).and_hms_micro(23, 59, 59, 1_234_567).to_rfc2822(),
+        edt.ymd(2015, 2, 18).unwrap().and_hms_micro(23, 59, 59, 1_234_567).unwrap().to_rfc2822(),
         "Wed, 18 Feb 2015 23:59:60 +0500"
     );
     assert_eq!(
-        edt.ymd(2015, 2, 18).and_hms_micro(23, 59, 59, 1_234_567).to_rfc3339(),
+        edt.ymd(2015, 2, 18).unwrap().and_hms_micro(23, 59, 59, 1_234_567).unwrap().to_rfc3339(),
         "2015-02-18T23:59:60.234567+05:00"
     );
 
     assert_eq!(
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +0000"),
-        Ok(FixedOffset::east(0).ymd(2015, 2, 18).and_hms(23, 16, 9))
+        Ok(FixedOffset::east(0).unwrap().ymd(2015, 2, 18).unwrap().and_hms(23, 16, 9).unwrap())
     );
     assert_eq!(
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 -0000"),
-        Ok(FixedOffset::east(0).ymd(2015, 2, 18).and_hms(23, 16, 9))
+        Ok(FixedOffset::east(0).unwrap().ymd(2015, 2, 18).unwrap().and_hms(23, 16, 9).unwrap())
     );
     assert_eq!(
         DateTime::parse_from_rfc3339("2015-02-18T23:16:09Z"),
-        Ok(FixedOffset::east(0).ymd(2015, 2, 18).and_hms(23, 16, 9))
+        Ok(FixedOffset::east(0).unwrap().ymd(2015, 2, 18).unwrap().and_hms(23, 16, 9).unwrap())
     );
     assert_eq!(
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:60 +0500"),
-        Ok(edt.ymd(2015, 2, 18).and_hms_milli(23, 59, 59, 1_000))
+        Ok(edt.ymd(2015, 2, 18).unwrap().and_hms_milli(23, 59, 59, 1_000).unwrap())
     );
     assert!(DateTime::parse_from_rfc2822("31 DEC 262143 23:59 -2359").is_err());
     assert_eq!(
         DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00"),
-        Ok(edt.ymd(2015, 2, 18).and_hms_micro(23, 59, 59, 1_234_567))
+        Ok(edt.ymd(2015, 2, 18).unwrap().and_hms_micro(23, 59, 59, 1_234_567).unwrap())
     );
 }
 
 #[test]
 fn test_rfc3339_opts() {
     use crate::SecondsFormat::*;
-    let pst = FixedOffset::east(8 * 60 * 60);
-    let dt = pst.ymd(2018, 1, 11).and_hms_nano(10, 5, 13, 84_660_000);
+    let pst = FixedOffset::east(8 * 60 * 60).unwrap();
+    let dt = pst.ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap();
     assert_eq!(dt.to_rfc3339_opts(Secs, false), "2018-01-11T10:05:13+08:00");
     assert_eq!(dt.to_rfc3339_opts(Secs, true), "2018-01-11T10:05:13+08:00");
     assert_eq!(dt.to_rfc3339_opts(Millis, false), "2018-01-11T10:05:13.084+08:00");
@@ -159,7 +201,7 @@ fn test_rfc3339_opts() {
 #[should_panic]
 fn test_rfc3339_opts_nonexhaustive() {
     use crate::SecondsFormat;
-    let dt = Utc.ymd(1999, 10, 9).and_hms(1, 2, 3);
+    let dt = Utc.ymd(1999, 10, 9).unwrap().and_hms(1, 2, 3).unwrap();
     dt.to_rfc3339_opts(SecondsFormat::__NonExhaustive, true);
 }
 
@@ -167,38 +209,53 @@ fn test_rfc3339_opts_nonexhaustive() {
 fn test_datetime_from_str() {
     assert_eq!(
         "2015-02-18T23:16:9.15Z".parse::<DateTime<FixedOffset>>(),
-        Ok(FixedOffset::east(0).ymd(2015, 2, 18).and_hms_milli(23, 16, 9, 150))
+        Ok(FixedOffset::east(0)
+            .unwrap()
+            .ymd(2015, 2, 18)
+            .unwrap()
+            .and_hms_milli(23, 16, 9, 150)
+            .unwrap())
     );
     assert_eq!(
         "2015-02-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
-        Ok(Utc.ymd(2015, 2, 18).and_hms_milli(23, 16, 9, 150))
+        Ok(Utc.ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap())
     );
     assert_eq!(
         "2015-02-18T23:16:9.15 UTC".parse::<DateTime<Utc>>(),
-        Ok(Utc.ymd(2015, 2, 18).and_hms_milli(23, 16, 9, 150))
+        Ok(Utc.ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap())
     );
     assert_eq!(
         "2015-02-18T23:16:9.15UTC".parse::<DateTime<Utc>>(),
-        Ok(Utc.ymd(2015, 2, 18).and_hms_milli(23, 16, 9, 150))
+        Ok(Utc.ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap())
     );
 
     assert_eq!(
         "2015-2-18T23:16:9.15Z".parse::<DateTime<FixedOffset>>(),
-        Ok(FixedOffset::east(0).ymd(2015, 2, 18).and_hms_milli(23, 16, 9, 150))
+        Ok(FixedOffset::east(0)
+            .unwrap()
+            .ymd(2015, 2, 18)
+            .unwrap()
+            .and_hms_milli(23, 16, 9, 150)
+            .unwrap())
     );
     assert_eq!(
         "2015-2-18T13:16:9.15-10:00".parse::<DateTime<FixedOffset>>(),
-        Ok(FixedOffset::west(10 * 3600).ymd(2015, 2, 18).and_hms_milli(13, 16, 9, 150))
+        Ok(FixedOffset::west(10 * 3600)
+            .unwrap()
+            .ymd(2015, 2, 18)
+            .unwrap()
+            .and_hms_milli(13, 16, 9, 150)
+            .unwrap())
     );
     assert!("2015-2-18T23:16:9.15".parse::<DateTime<FixedOffset>>().is_err());
 
     assert_eq!(
         "2015-2-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
-        Ok(Utc.ymd(2015, 2, 18).and_hms_milli(23, 16, 9, 150))
+        Ok(Utc.ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap())
     );
     assert_eq!(
         "2015-2-18T13:16:9.15-10:00".parse::<DateTime<Utc>>(),
-        Ok(Utc.ymd(2015, 2, 18).and_hms_milli(23, 16, 9, 150))
+        Ok(Utc.ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap())
     );
     assert!("2015-2-18T23:16:9.15".parse::<DateTime<Utc>>().is_err());
 
@@ -207,7 +264,9 @@ fn test_datetime_from_str() {
 
 #[test]
 fn test_datetime_parse_from_str() {
-    let ymdhms = |y, m, d, h, n, s, off| FixedOffset::east(off).ymd(y, m, d).and_hms(h, n, s);
+    let ymdhms = |y, m, d, h, n, s, off| {
+        FixedOffset::east(off).unwrap().ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap()
+    };
     assert_eq!(
         DateTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
         Ok(ymdhms(2014, 5, 7, 12, 34, 56, 570 * 60))
@@ -217,26 +276,26 @@ fn test_datetime_parse_from_str() {
         .is_err());
     assert_eq!(
         Utc.datetime_from_str("Fri, 09 Aug 2013 23:54:35 GMT", "%a, %d %b %Y %H:%M:%S GMT"),
-        Ok(Utc.ymd(2013, 8, 9).and_hms(23, 54, 35))
+        Ok(Utc.ymd(2013, 8, 9).unwrap().and_hms(23, 54, 35).unwrap())
     );
 }
 
 #[test]
 fn test_to_string_round_trip() {
-    let dt = Utc.ymd(2000, 1, 1).and_hms(0, 0, 0);
+    let dt = Utc.ymd(2000, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
     let _dt: DateTime<Utc> = dt.to_string().parse().unwrap();
 
-    let ndt_fixed = dt.with_timezone(&FixedOffset::east(3600));
+    let ndt_fixed = dt.with_fixed_timezone(&FixedOffset::east(3600).unwrap());
     let _dt: DateTime<FixedOffset> = ndt_fixed.to_string().parse().unwrap();
 
-    let ndt_fixed = dt.with_timezone(&FixedOffset::east(0));
+    let ndt_fixed = dt.with_fixed_timezone(&FixedOffset::east(0).unwrap());
     let _dt: DateTime<FixedOffset> = ndt_fixed.to_string().parse().unwrap();
 }
 
 #[test]
 #[cfg(feature = "clock")]
 fn test_to_string_round_trip_with_local() {
-    let ndt = Local::now();
+    let ndt = Local::now().unwrap();
     let _dt: DateTime<FixedOffset> = ndt.to_string().parse().unwrap();
 }
 
@@ -244,15 +303,15 @@ fn test_to_string_round_trip_with_local() {
 #[cfg(feature = "clock")]
 fn test_datetime_format_with_local() {
     // if we are not around the year boundary, local and UTC date should have the same year
-    let dt = Local::now().with_month(5).unwrap();
-    assert_eq!(dt.format("%Y").to_string(), dt.with_timezone(&Utc).format("%Y").to_string());
+    let dt = Local::now().unwrap().with_month(5).unwrap();
+    assert_eq!(dt.format("%Y").to_string(), dt.with_fixed_timezone(&Utc).format("%Y").to_string());
 }
 
 #[test]
 #[cfg(feature = "clock")]
 fn test_datetime_is_copy() {
     // UTC is known to be `Copy`.
-    let a = Utc::now();
+    let a = Utc::now().unwrap();
     let b = a;
     assert_eq!(a, b);
 }
@@ -273,7 +332,7 @@ fn test_datetime_is_send() {
 
 #[test]
 fn test_subsecond_part() {
-    let datetime = Utc.ymd(2014, 7, 8).and_hms_nano(9, 10, 11, 1234567);
+    let datetime = Utc.ymd(2014, 7, 8).unwrap().and_hms_nano(9, 10, 11, 1234567).unwrap();
 
     assert_eq!(1, datetime.timestamp_subsec_millis());
     assert_eq!(1234, datetime.timestamp_subsec_micros());
@@ -285,83 +344,102 @@ fn test_subsecond_part() {
 fn test_from_system_time() {
     use std::time::Duration;
 
-    let epoch = Utc.ymd(1970, 1, 1).and_hms(0, 0, 0);
+    let epoch = Utc.ymd(1970, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
     let nanos = 999_999_999;
 
     // SystemTime -> DateTime<Utc>
     assert_eq!(DateTime::<Utc>::from(UNIX_EPOCH), epoch);
     assert_eq!(
         DateTime::<Utc>::from(UNIX_EPOCH + Duration::new(999_999_999, nanos)),
-        Utc.ymd(2001, 9, 9).and_hms_nano(1, 46, 39, nanos)
+        Utc.ymd(2001, 9, 9).unwrap().and_hms_nano(1, 46, 39, nanos).unwrap()
     );
     assert_eq!(
         DateTime::<Utc>::from(UNIX_EPOCH - Duration::new(999_999_999, nanos)),
-        Utc.ymd(1938, 4, 24).and_hms_nano(22, 13, 20, 1)
+        Utc.ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 20, 1).unwrap()
     );
 
     // DateTime<Utc> -> SystemTime
     assert_eq!(SystemTime::from(epoch), UNIX_EPOCH);
     assert_eq!(
-        SystemTime::from(Utc.ymd(2001, 9, 9).and_hms_nano(1, 46, 39, nanos)),
+        SystemTime::from(Utc.ymd(2001, 9, 9).unwrap().and_hms_nano(1, 46, 39, nanos).unwrap()),
         UNIX_EPOCH + Duration::new(999_999_999, nanos)
     );
     assert_eq!(
-        SystemTime::from(Utc.ymd(1938, 4, 24).and_hms_nano(22, 13, 20, 1)),
+        SystemTime::from(Utc.ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 20, 1).unwrap()),
         UNIX_EPOCH - Duration::new(999_999_999, 999_999_999)
     );
 
     // DateTime<any tz> -> SystemTime (via `with_timezone`)
     #[cfg(feature = "clock")]
     {
-        assert_eq!(SystemTime::from(epoch.with_timezone(&Local)), UNIX_EPOCH);
+        assert_eq!(SystemTime::from(epoch.with_timezone(&Local).unwrap()), UNIX_EPOCH);
     }
-    assert_eq!(SystemTime::from(epoch.with_timezone(&FixedOffset::east(32400))), UNIX_EPOCH);
-    assert_eq!(SystemTime::from(epoch.with_timezone(&FixedOffset::west(28800))), UNIX_EPOCH);
+    assert_eq!(
+        SystemTime::from(epoch.with_fixed_timezone(&FixedOffset::east(32400).unwrap())),
+        UNIX_EPOCH
+    );
+    assert_eq!(
+        SystemTime::from(epoch.with_fixed_timezone(&FixedOffset::west(28800).unwrap())),
+        UNIX_EPOCH
+    );
 }
 
 #[test]
 #[cfg(target_os = "windows")]
 fn test_from_system_time() {
+    use std::convert::TryFrom;
     use std::time::Duration;
 
     let nanos = 999_999_000;
 
-    let epoch = Utc.ymd(1970, 1, 1).and_hms(0, 0, 0);
+    let epoch = Utc.ymd(1970, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
 
     // SystemTime -> DateTime<Utc>
     assert_eq!(DateTime::<Utc>::from(UNIX_EPOCH), epoch);
     assert_eq!(
         DateTime::<Utc>::from(UNIX_EPOCH + Duration::new(999_999_999, nanos)),
-        Utc.ymd(2001, 9, 9).and_hms_nano(1, 46, 39, nanos)
+        Utc.ymd(2001, 9, 9).unwrap().and_hms_nano(1, 46, 39, nanos).unwrap()
     );
     assert_eq!(
         DateTime::<Utc>::from(UNIX_EPOCH - Duration::new(999_999_999, nanos)),
-        Utc.ymd(1938, 4, 24).and_hms_nano(22, 13, 20, 1_000)
+        Utc.ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 20, 1_000).unwrap()
     );
 
     // DateTime<Utc> -> SystemTime
-    assert_eq!(SystemTime::from(epoch), UNIX_EPOCH);
+    assert_eq!(SystemTime::try_from(epoch).unwrap(), UNIX_EPOCH);
     assert_eq!(
-        SystemTime::from(Utc.ymd(2001, 9, 9).and_hms_nano(1, 46, 39, nanos)),
+        SystemTime::try_from(Utc.ymd(2001, 9, 9).unwrap().and_hms_nano(1, 46, 39, nanos).unwrap())
+            .unwrap(),
         UNIX_EPOCH + Duration::new(999_999_999, nanos)
     );
     assert_eq!(
-        SystemTime::from(Utc.ymd(1938, 4, 24).and_hms_nano(22, 13, 20, 1_000)),
+        SystemTime::try_from(
+            Utc.ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 20, 1_000).unwrap()
+        )
+        .unwrap(),
         UNIX_EPOCH - Duration::new(999_999_999, nanos)
     );
 
     // DateTime<any tz> -> SystemTime (via `with_timezone`)
     #[cfg(feature = "clock")]
     {
-        assert_eq!(SystemTime::from(epoch.with_timezone(&Local)), UNIX_EPOCH);
+        assert_eq!(SystemTime::try_from(epoch.with_timezone(&Local).unwrap()).unwrap(), UNIX_EPOCH);
     }
-    assert_eq!(SystemTime::from(epoch.with_timezone(&FixedOffset::east(32400))), UNIX_EPOCH);
-    assert_eq!(SystemTime::from(epoch.with_timezone(&FixedOffset::west(28800))), UNIX_EPOCH);
+    assert_eq!(
+        SystemTime::try_from(epoch.with_fixed_timezone(&FixedOffset::east(32400).unwrap()))
+            .unwrap(),
+        UNIX_EPOCH
+    );
+    assert_eq!(
+        SystemTime::try_from(epoch.with_fixed_timezone(&FixedOffset::west(28800).unwrap()))
+            .unwrap(),
+        UNIX_EPOCH
+    );
 }
 
 #[test]
 fn test_datetime_format_alignment() {
-    let datetime = Utc.ymd(2007, 1, 2);
+    let datetime = Utc.ymd(2007, 1, 2).unwrap().unwrap();
 
     // Item::Literal
     let percent = datetime.format("%%");
@@ -392,21 +470,21 @@ fn test_datetime_format_alignment() {
 #[test]
 fn test_datetime_from_local() {
     // 2000-01-12T02:00:00Z
-    let naivedatetime_utc = NaiveDate::from_ymd(2000, 1, 12).and_hms(2, 0, 0);
+    let naivedatetime_utc = ymd!(2000, 1, 12).and_hms(2, 0, 0).unwrap();
     let datetime_utc = DateTime::<Utc>::from_utc(naivedatetime_utc, Utc);
 
     // 2000-01-12T10:00:00+8:00:00
-    let timezone_east = FixedOffset::east(8 * 60 * 60);
-    let naivedatetime_east = NaiveDate::from_ymd(2000, 1, 12).and_hms(10, 0, 0);
+    let timezone_east = FixedOffset::east(8 * 60 * 60).unwrap();
+    let naivedatetime_east = ymd!(2000, 1, 12).and_hms(10, 0, 0).unwrap();
     let datetime_east = DateTime::<FixedOffset>::from_local(naivedatetime_east, timezone_east);
 
     // 2000-01-11T19:00:00-7:00:00
-    let timezone_west = FixedOffset::west(7 * 60 * 60);
-    let naivedatetime_west = NaiveDate::from_ymd(2000, 1, 11).and_hms(19, 0, 0);
+    let timezone_west = FixedOffset::west(7 * 60 * 60).unwrap();
+    let naivedatetime_west = ymd!(2000, 1, 11).and_hms(19, 0, 0).unwrap();
     let datetime_west = DateTime::<FixedOffset>::from_local(naivedatetime_west, timezone_west);
 
-    assert_eq!(datetime_east, datetime_utc.with_timezone(&timezone_east));
-    assert_eq!(datetime_west, datetime_utc.with_timezone(&timezone_west));
+    assert_eq!(datetime_east, datetime_utc.with_fixed_timezone(&timezone_east));
+    assert_eq!(datetime_west, datetime_utc.with_fixed_timezone(&timezone_west));
 }
 
 #[test]
@@ -415,36 +493,38 @@ fn test_years_elapsed() {
     const WEEKS_PER_YEAR: f32 = 52.1775;
 
     // This is always at least one year because 1 year = 52.1775 weeks.
-    let one_year_ago = Utc::today() - TimeDelta::weeks((WEEKS_PER_YEAR * 1.5).ceil() as i64);
+    let one_year_ago =
+        Utc::today().unwrap() - TimeDelta::weeks((WEEKS_PER_YEAR * 1.5).ceil() as i64);
     // A bit more than 2 years.
-    let two_year_ago = Utc::today() - TimeDelta::weeks((WEEKS_PER_YEAR * 2.5).ceil() as i64);
+    let two_year_ago =
+        Utc::today().unwrap() - TimeDelta::weeks((WEEKS_PER_YEAR * 2.5).ceil() as i64);
 
-    assert_eq!(Utc::today().years_since(one_year_ago), Some(1));
-    assert_eq!(Utc::today().years_since(two_year_ago), Some(2));
+    assert_eq!(Utc::today().unwrap().years_since(one_year_ago), Some(1));
+    assert_eq!(Utc::today().unwrap().years_since(two_year_ago), Some(2));
 
     // If the given DateTime is later than now, the function will always return 0.
-    let future = Utc::today() + TimeDelta::weeks(12);
-    assert_eq!(Utc::today().years_since(future), None);
+    let future = Utc::today().unwrap() + TimeDelta::weeks(12);
+    assert_eq!(Utc::today().unwrap().years_since(future), None);
 }
 
 #[test]
 fn test_datetime_add_assign() {
-    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0);
+    let naivedatetime = ymd!(2000, 1, 1).and_hms(0, 0, 0).unwrap();
     let datetime = DateTime::<Utc>::from_utc(naivedatetime, Utc);
     let mut datetime_add = datetime;
 
     datetime_add += TimeDelta::seconds(60);
     assert_eq!(datetime_add, datetime + TimeDelta::seconds(60));
 
-    let timezone = FixedOffset::east(60 * 60);
-    let datetime = datetime.with_timezone(&timezone);
-    let datetime_add = datetime_add.with_timezone(&timezone);
+    let timezone = FixedOffset::east(60 * 60).unwrap();
+    let datetime = datetime.with_timezone(&timezone).unwrap();
+    let datetime_add = datetime_add.with_timezone(&timezone).unwrap();
 
     assert_eq!(datetime_add, datetime + TimeDelta::seconds(60));
 
-    let timezone = FixedOffset::west(2 * 60 * 60);
-    let datetime = datetime.with_timezone(&timezone);
-    let datetime_add = datetime_add.with_timezone(&timezone);
+    let timezone = FixedOffset::west(2 * 60 * 60).unwrap();
+    let datetime = datetime.with_timezone(&timezone).unwrap();
+    let datetime_add = datetime_add.with_timezone(&timezone).unwrap();
 
     assert_eq!(datetime_add, datetime + TimeDelta::seconds(60));
 }
@@ -452,10 +532,10 @@ fn test_datetime_add_assign() {
 #[test]
 #[cfg(feature = "clock")]
 fn test_datetime_add_assign_local() {
-    let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0);
+    let naivedatetime = ymd!(2022, 1, 1).and_hms(0, 0, 0).unwrap();
 
-    let datetime = Local.from_utc_datetime(&naivedatetime);
-    let mut datetime_add = Local.from_utc_datetime(&naivedatetime);
+    let datetime = Local.from_utc_datetime(&naivedatetime).unwrap();
+    let mut datetime_add = Local.from_utc_datetime(&naivedatetime).unwrap();
 
     // ensure we cross a DST transition
     for i in 1..=365 {
@@ -466,22 +546,22 @@ fn test_datetime_add_assign_local() {
 
 #[test]
 fn test_datetime_sub_assign() {
-    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).and_hms(12, 0, 0);
+    let naivedatetime = ymd!(2000, 1, 1).and_hms(12, 0, 0).unwrap();
     let datetime = DateTime::<Utc>::from_utc(naivedatetime, Utc);
     let mut datetime_sub = datetime;
 
     datetime_sub -= TimeDelta::minutes(90);
     assert_eq!(datetime_sub, datetime - TimeDelta::minutes(90));
 
-    let timezone = FixedOffset::east(60 * 60);
-    let datetime = datetime.with_timezone(&timezone);
-    let datetime_sub = datetime_sub.with_timezone(&timezone);
+    let timezone = FixedOffset::east(60 * 60).unwrap();
+    let datetime = datetime.with_timezone(&timezone).unwrap();
+    let datetime_sub = datetime_sub.with_timezone(&timezone).unwrap();
 
     assert_eq!(datetime_sub, datetime - TimeDelta::minutes(90));
 
-    let timezone = FixedOffset::west(2 * 60 * 60);
-    let datetime = datetime.with_timezone(&timezone);
-    let datetime_sub = datetime_sub.with_timezone(&timezone);
+    let timezone = FixedOffset::west(2 * 60 * 60).unwrap();
+    let datetime = datetime.with_timezone(&timezone).unwrap();
+    let datetime_sub = datetime_sub.with_timezone(&timezone).unwrap();
 
     assert_eq!(datetime_sub, datetime - TimeDelta::minutes(90));
 }
@@ -489,10 +569,10 @@ fn test_datetime_sub_assign() {
 #[test]
 #[cfg(feature = "clock")]
 fn test_datetime_sub_assign_local() {
-    let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).and_hms(0, 0, 0);
+    let naivedatetime = ymd!(2022, 1, 1).and_hms(0, 0, 0).unwrap();
 
-    let datetime = Local.from_utc_datetime(&naivedatetime);
-    let mut datetime_sub = Local.from_utc_datetime(&naivedatetime);
+    let datetime = Local.from_utc_datetime(&naivedatetime).unwrap();
+    let mut datetime_sub = Local.from_utc_datetime(&naivedatetime).unwrap();
 
     // ensure we cross a DST transition
     for i in 1..=365 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,88 @@
+use core::fmt;
+#[cfg(windows)]
+use std::io;
+
+/// Internal representation of the chrono error.
+#[derive(Debug)]
+pub(crate) enum ChronoErrorKind {
+    InvalidDate,
+    InvalidTime,
+    InvalidDateTime,
+    InvalidTimeZone,
+    AmbiguousDate,
+    #[cfg(unix)]
+    MissingDate,
+    #[cfg(windows)]
+    SystemTimeBeforeEpoch,
+    #[cfg(windows)]
+    SystemError(io::Error),
+}
+
+/// The error raised for an invalid date time.
+#[derive(Debug)]
+pub struct ChronoError {
+    kind: ChronoErrorKind,
+}
+
+impl ChronoError {
+    /// Internal constructor for a chrono error.
+    #[inline]
+    pub(crate) fn new(kind: ChronoErrorKind) -> Self {
+        Self { kind }
+    }
+}
+
+impl fmt::Display for ChronoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            ChronoErrorKind::InvalidDate => write!(f, "invalid date"),
+            ChronoErrorKind::InvalidTime => write!(f, "invalid time"),
+            ChronoErrorKind::InvalidDateTime => write!(f, "invalid date time"),
+            ChronoErrorKind::InvalidTimeZone => write!(f, "invalid time zone"),
+            ChronoErrorKind::AmbiguousDate => write!(f, "tried to operate over ambiguous date"),
+            #[cfg(unix)]
+            ChronoErrorKind::MissingDate => write!(f, "missing date"),
+            #[cfg(windows)]
+            ChronoErrorKind::SystemTimeBeforeEpoch => write!(f, "system time before Unix epoch"),
+            #[cfg(windows)]
+            ChronoErrorKind::SystemError(error) => write!(f, "system error: {error}"),
+        }
+    }
+}
+
+impl From<ChronoErrorKind> for ChronoError {
+    #[inline]
+    fn from(kind: ChronoErrorKind) -> Self {
+        Self::new(kind)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for ChronoError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.kind {
+            #[cfg(windows)]
+            ChronoErrorKind::SystemError(error) => Some(error),
+            _ => None,
+        }
+    }
+}
+
+/// Implementation used in many test cases.
+#[cfg(test)]
+impl PartialEq for ChronoError {
+    fn eq(&self, other: &Self) -> bool {
+        self.kind == other.kind
+    }
+}
+
+#[cfg(test)]
+impl PartialEq for ChronoErrorKind {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            #[cfg(windows)]
+            (Self::SystemError(l0), Self::SystemError(r0)) => l0.kind() == r0.kind(),
+            _ => core::mem::discriminant(self) == core::mem::discriminant(other),
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,4 @@
 use core::fmt;
-#[cfg(windows)]
-use std::io;
 
 /// Internal representation of the chrono error.
 #[derive(Debug)]
@@ -10,12 +8,12 @@ pub(crate) enum ChronoErrorKind {
     InvalidDateTime,
     InvalidTimeZone,
     AmbiguousDate,
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "clock"))]
     MissingDate,
-    #[cfg(windows)]
+    #[cfg(all(windows, feature = "clock"))]
     SystemTimeBeforeEpoch,
-    #[cfg(windows)]
-    SystemError(io::Error),
+    #[cfg(all(windows, feature = "clock"))]
+    SystemError(std::io::Error),
 }
 
 /// The error raised for an invalid date time.
@@ -40,11 +38,11 @@ impl fmt::Display for ChronoError {
             ChronoErrorKind::InvalidDateTime => write!(f, "invalid date time"),
             ChronoErrorKind::InvalidTimeZone => write!(f, "invalid time zone"),
             ChronoErrorKind::AmbiguousDate => write!(f, "tried to operate over ambiguous date"),
-            #[cfg(unix)]
+            #[cfg(all(unix, feature = "clock"))]
             ChronoErrorKind::MissingDate => write!(f, "missing date"),
-            #[cfg(windows)]
+            #[cfg(all(windows, feature = "clock"))]
             ChronoErrorKind::SystemTimeBeforeEpoch => write!(f, "system time before Unix epoch"),
-            #[cfg(windows)]
+            #[cfg(all(windows, feature = "clock"))]
             ChronoErrorKind::SystemError(error) => write!(f, "system error: {error}"),
         }
     }
@@ -61,7 +59,7 @@ impl From<ChronoErrorKind> for ChronoError {
 impl std::error::Error for ChronoError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match &self.kind {
-            #[cfg(windows)]
+            #[cfg(all(windows, feature = "clock"))]
             ChronoErrorKind::SystemError(error) => Some(error),
             _ => None,
         }
@@ -80,7 +78,7 @@ impl PartialEq for ChronoError {
 impl PartialEq for ChronoErrorKind {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            #[cfg(windows)]
+            #[cfg(all(windows, feature = "clock"))]
             (Self::SystemError(l0), Self::SystemError(r0)) => l0.kind() == r0.kind(),
             _ => core::mem::discriminant(self) == core::mem::discriminant(other),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use core::fmt;
 
 /// Internal representation of the chrono error.
 #[derive(Debug)]
-pub(crate) enum ChronoErrorKind {
+pub(crate) enum ErrorKind {
     InvalidDate,
     InvalidTime,
     InvalidDateTime,
@@ -18,49 +18,49 @@ pub(crate) enum ChronoErrorKind {
 
 /// The error raised for an invalid date time.
 #[derive(Debug)]
-pub struct ChronoError {
-    kind: ChronoErrorKind,
+pub struct Error {
+    kind: ErrorKind,
 }
 
-impl ChronoError {
+impl Error {
     /// Internal constructor for a chrono error.
     #[inline]
-    pub(crate) fn new(kind: ChronoErrorKind) -> Self {
+    pub(crate) fn new(kind: ErrorKind) -> Self {
         Self { kind }
     }
 }
 
-impl fmt::Display for ChronoError {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.kind {
-            ChronoErrorKind::InvalidDate => write!(f, "invalid date"),
-            ChronoErrorKind::InvalidTime => write!(f, "invalid time"),
-            ChronoErrorKind::InvalidDateTime => write!(f, "invalid date time"),
-            ChronoErrorKind::InvalidTimeZone => write!(f, "invalid time zone"),
-            ChronoErrorKind::AmbiguousDate => write!(f, "tried to operate over ambiguous date"),
+            ErrorKind::InvalidDate => write!(f, "invalid date"),
+            ErrorKind::InvalidTime => write!(f, "invalid time"),
+            ErrorKind::InvalidDateTime => write!(f, "invalid date time"),
+            ErrorKind::InvalidTimeZone => write!(f, "invalid time zone"),
+            ErrorKind::AmbiguousDate => write!(f, "tried to operate over ambiguous date"),
             #[cfg(all(unix, feature = "clock"))]
-            ChronoErrorKind::MissingDate => write!(f, "missing date"),
+            ErrorKind::MissingDate => write!(f, "missing date"),
             #[cfg(all(windows, feature = "clock"))]
-            ChronoErrorKind::SystemTimeBeforeEpoch => write!(f, "system time before Unix epoch"),
+            ErrorKind::SystemTimeBeforeEpoch => write!(f, "system time before Unix epoch"),
             #[cfg(all(windows, feature = "clock"))]
-            ChronoErrorKind::SystemError(error) => write!(f, "system error: {}", error),
+            ErrorKind::SystemError(error) => write!(f, "system error: {}", error),
         }
     }
 }
 
-impl From<ChronoErrorKind> for ChronoError {
+impl From<ErrorKind> for Error {
     #[inline]
-    fn from(kind: ChronoErrorKind) -> Self {
+    fn from(kind: ErrorKind) -> Self {
         Self::new(kind)
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for ChronoError {
+impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match &self.kind {
             #[cfg(all(windows, feature = "clock"))]
-            ChronoErrorKind::SystemError(error) => Some(error),
+            ErrorKind::SystemError(error) => Some(error),
             _ => None,
         }
     }
@@ -68,14 +68,14 @@ impl std::error::Error for ChronoError {
 
 /// Implementation used in many test cases.
 #[cfg(test)]
-impl PartialEq for ChronoError {
+impl PartialEq for Error {
     fn eq(&self, other: &Self) -> bool {
         self.kind == other.kind
     }
 }
 
 #[cfg(test)]
-impl PartialEq for ChronoErrorKind {
+impl PartialEq for ErrorKind {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             #[cfg(all(windows, feature = "clock"))]

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,7 +43,7 @@ impl fmt::Display for ChronoError {
             #[cfg(all(windows, feature = "clock"))]
             ChronoErrorKind::SystemTimeBeforeEpoch => write!(f, "system time before Unix epoch"),
             #[cfg(all(windows, feature = "clock"))]
-            ChronoErrorKind::SystemError(error) => write!(f, "system error: {error}"),
+            ChronoErrorKind::SystemError(error) => write!(f, "system error: {}", error),
         }
     }
 }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -20,14 +20,14 @@
 //! # use std::error::Error;
 //! use chrono::prelude::*;
 //!
-//! let date_time = Utc.ymd(2020, 11, 10).and_hms(0, 1, 32);
+//! let date_time = Utc.ymd(2020, 11, 10)?.and_hms(0, 1, 32)?;
 //!
 //! let formatted = format!("{}", date_time.format("%Y-%m-%d %H:%M:%S"));
 //! assert_eq!(formatted, "2020-11-10 00:01:32");
 //!
 //! let parsed = Utc.datetime_from_str(&formatted, "%Y-%m-%d %H:%M:%S")?;
 //! assert_eq!(parsed, date_time);
-//! # Ok::<(), chrono::ParseError>(())
+//! # Ok::<_, Box<dyn std::error::Error>>(())
 //! ```
 
 #[cfg(feature = "alloc")]
@@ -430,7 +430,7 @@ impl Error for ParseError {
 }
 
 // to be used in this module and submodules
-const OUT_OF_RANGE: ParseError = ParseError(ParseErrorKind::OutOfRange);
+pub(crate) const OUT_OF_RANGE: ParseError = ParseError(ParseErrorKind::OutOfRange);
 const IMPOSSIBLE: ParseError = ParseError(ParseErrorKind::Impossible);
 const NOT_ENOUGH: ParseError = ParseError(ParseErrorKind::NotEnough);
 const INVALID: ParseError = ParseError(ParseErrorKind::Invalid);

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -892,7 +892,7 @@ fn parse_rfc850() {
     static RFC850_FMT: &str = "%A, %d-%b-%y %T GMT";
 
     let dt_str = "Sunday, 06-Nov-94 08:49:37 GMT";
-    let dt = Utc.ymd(1994, 11, 6).and_hms(8, 49, 37);
+    let dt = Utc.ymd(1994, 11, 6).unwrap().and_hms(8, 49, 37).unwrap();
 
     // Check that the format is what we expect
     assert_eq!(dt.format(RFC850_FMT).to_string(), dt_str);
@@ -903,12 +903,30 @@ fn parse_rfc850() {
     // Check that the rest of the weekdays parse correctly (this test originally failed because
     // Sunday parsed incorrectly).
     let testdates = [
-        (Utc.ymd(1994, 11, 7).and_hms(8, 49, 37), "Monday, 07-Nov-94 08:49:37 GMT"),
-        (Utc.ymd(1994, 11, 8).and_hms(8, 49, 37), "Tuesday, 08-Nov-94 08:49:37 GMT"),
-        (Utc.ymd(1994, 11, 9).and_hms(8, 49, 37), "Wednesday, 09-Nov-94 08:49:37 GMT"),
-        (Utc.ymd(1994, 11, 10).and_hms(8, 49, 37), "Thursday, 10-Nov-94 08:49:37 GMT"),
-        (Utc.ymd(1994, 11, 11).and_hms(8, 49, 37), "Friday, 11-Nov-94 08:49:37 GMT"),
-        (Utc.ymd(1994, 11, 12).and_hms(8, 49, 37), "Saturday, 12-Nov-94 08:49:37 GMT"),
+        (
+            Utc.ymd(1994, 11, 7).unwrap().and_hms(8, 49, 37).unwrap(),
+            "Monday, 07-Nov-94 08:49:37 GMT",
+        ),
+        (
+            Utc.ymd(1994, 11, 8).unwrap().and_hms(8, 49, 37).unwrap(),
+            "Tuesday, 08-Nov-94 08:49:37 GMT",
+        ),
+        (
+            Utc.ymd(1994, 11, 9).unwrap().and_hms(8, 49, 37).unwrap(),
+            "Wednesday, 09-Nov-94 08:49:37 GMT",
+        ),
+        (
+            Utc.ymd(1994, 11, 10).unwrap().and_hms(8, 49, 37).unwrap(),
+            "Thursday, 10-Nov-94 08:49:37 GMT",
+        ),
+        (
+            Utc.ymd(1994, 11, 11).unwrap().and_hms(8, 49, 37).unwrap(),
+            "Friday, 11-Nov-94 08:49:37 GMT",
+        ),
+        (
+            Utc.ymd(1994, 11, 12).unwrap().and_hms(8, 49, 37).unwrap(),
+            "Saturday, 12-Nov-94 08:49:37 GMT",
+        ),
     ];
 
     for val in &testdates {

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -433,7 +433,7 @@ impl Parsed {
                     + weekday.num_days_from_sunday() as i32;
                 let date = newyear
                     .checked_add_signed(TimeDelta::days(i64::from(ndays)))
-                    .map_err(|_| OUT_OF_RANGE)?;
+                    .ok_or(OUT_OF_RANGE)?;
                 if date.year() != year {
                     return Err(OUT_OF_RANGE);
                 } // early exit for correct error
@@ -467,7 +467,7 @@ impl Parsed {
                     + weekday.num_days_from_monday() as i32;
                 let date = newyear
                     .checked_add_signed(TimeDelta::days(i64::from(ndays)))
-                    .map_err(|_| OUT_OF_RANGE)?;
+                    .ok_or(OUT_OF_RANGE)?;
                 if date.year() != year {
                     return Err(OUT_OF_RANGE);
                 } // early exit for correct error
@@ -635,7 +635,7 @@ impl Parsed {
         // TODO: is this still needed?
         datetime
             .checked_sub_signed(TimeDelta::seconds(i64::from(offset.local_minus_utc())))
-            .map_err(|_| OUT_OF_RANGE)?;
+            .ok_or(OUT_OF_RANGE)?;
 
         offset.from_local_datetime(&datetime).and_then(|dt| dt.single()).map_err(|_| OUT_OF_RANGE)
     }

--- a/src/format/scan.rs
+++ b/src/format/scan.rs
@@ -306,8 +306,8 @@ where
     }
 }
 
-/// Same as `timezone_offset` but also allows for RFC 2822 legacy timezones.
-/// May return `None` which indicates an insufficient offset data (i.e. `-0000`).
+/// Same as `timezone_offset` but also allows for RFC 2822 legacy timezones. May
+/// return `None` which indicates an insufficient offset data (i.e. `-0000`).
 pub(super) fn timezone_offset_2822(s: &str) -> ParseResult<(&str, Option<i32>)> {
     // tries to parse legacy time zone names
     let upto = s

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -552,7 +552,12 @@ fn test_strftime_items() {
 fn test_strftime_docs() {
     use crate::{DateTime, FixedOffset, TimeZone, Timelike, Utc};
 
-    let dt = FixedOffset::east(34200).ymd(2001, 7, 8).and_hms_nano(0, 34, 59, 1_026_490_708);
+    let dt = FixedOffset::east(34200)
+        .unwrap()
+        .ymd(2001, 7, 8)
+        .unwrap()
+        .and_hms_nano(0, 34, 59, 1_026_490_708)
+        .unwrap();
 
     // date specifiers
     assert_eq!(dt.format("%Y").to_string(), "2001");
@@ -617,19 +622,19 @@ fn test_strftime_docs() {
     assert_eq!(dt.format("%+").to_string(), "2001-07-08T00:34:60.026490708+09:30");
 
     assert_eq!(
-        dt.with_timezone(&Utc).format("%+").to_string(),
+        dt.with_timezone(&Utc).unwrap().format("%+").to_string(),
         "2001-07-07T15:04:60.026490708+00:00"
     );
     assert_eq!(
-        dt.with_timezone(&Utc),
+        dt.with_timezone(&Utc).unwrap(),
         DateTime::parse_from_str("2001-07-07T15:04:60.026490708Z", "%+").unwrap()
     );
     assert_eq!(
-        dt.with_timezone(&Utc),
+        dt.with_timezone(&Utc).unwrap(),
         DateTime::parse_from_str("2001-07-07T15:04:60.026490708UTC", "%+").unwrap()
     );
     assert_eq!(
-        dt.with_timezone(&Utc),
+        dt.with_timezone(&Utc).unwrap(),
         DateTime::parse_from_str("2001-07-07t15:04:60.026490708utc", "%+").unwrap()
     );
 
@@ -650,7 +655,12 @@ fn test_strftime_docs() {
 fn test_strftime_docs_localized() {
     use crate::{FixedOffset, TimeZone};
 
-    let dt = FixedOffset::east(34200).ymd(2001, 7, 8).and_hms_nano(0, 34, 59, 1_026_490_708);
+    let dt = FixedOffset::east(34200)
+        .unwrap()
+        .ymd(2001, 7, 8)
+        .unwrap()
+        .and_hms_nano(0, 34, 59, 1_026_490_708)
+        .unwrap();
 
     // date specifiers
     assert_eq!(dt.format_localized("%b", Locale::fr_BE).to_string(), "jui");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@
 //! let utc: DateTime<Utc> = Utc::now()?; // e.g. `2014-11-28T12:45:59.324310806Z`
 //! let local: DateTime<Local> = Local::now()?; // e.g. `2014-11-28T21:45:59.324310806+09:00`
 //! # let _ = utc; let _ = local;
-//! # Ok::<_, chrono::ChronoError>(())
+//! # Ok::<_, chrono::Error>(())
 //! ```
 //!
 //! Alternatively, you can create your own date and time.
@@ -133,7 +133,7 @@
 //! let fixed_dt = FixedOffset::east(9 * 3600)?.ymd(2014, 7, 8)?.and_hms_milli(18, 10, 11, 12)?;
 //! assert_eq!(dt, fixed_dt);
 //! # let _ = local_dt;
-//! # Ok::<_, chrono::ChronoError>(())
+//! # Ok::<_, chrono::Error>(())
 //! ```
 //!
 //! Various properties are available to the date and time, and can be altered individually.
@@ -177,7 +177,7 @@
 //!            Utc.ymd(2001, 9, 9)?.and_hms(1, 46, 40)?);
 //! assert_eq!(Utc.ymd(1970, 1, 1)?.and_hms(0, 0, 0)? - TimeDelta::seconds(1_000_000_000),
 //!            Utc.ymd(1938, 4, 24)?.and_hms(22, 13, 20)?);
-//! # Ok::<_, chrono::ChronoError>(())
+//! # Ok::<_, chrono::Error>(())
 //! ```
 //!
 //! ### Formatting and Parsing
@@ -207,7 +207,7 @@
 //! use chrono::prelude::*;
 //!
 //! # #[cfg(feature = "unstable-locales")]
-//! # fn main() -> Result<(), chrono::ChronoError> {
+//! # fn main() -> Result<(), chrono::Error> {
 //! let dt = Utc.ymd(2014, 11, 28)?.and_hms(12, 0, 9)?;
 //! assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2014-11-28 12:00:09");
 //! assert_eq!(dt.format("%a %b %e %T %Y").to_string(), "Fri Nov 28 12:00:09 2014");
@@ -330,7 +330,7 @@
 //! assert!(Utc.ymd(2014, 11, 31).is_err());
 //! assert_eq!(Utc.ymd(2014, 11, 28)?.and_hms_milli(7, 8, 9, 10)?.format("%H%M%S").to_string(),
 //!            "070809");
-//! # Ok::<_, chrono::ChronoError>(())
+//! # Ok::<_, chrono::Error>(())
 //! ```
 //!
 //! There is no timezone-aware `Time` due to the lack of usefulness and also the complexity.
@@ -374,9 +374,9 @@
 //!
 //! Chrono inherently does not support an inaccurate or partial date and time
 //! representation. Any operation that can be ambiguous will return
-//! `Err(ChronoError)` in such cases. For example, "a month later" of 2014-01-30
+//! `Err(Error)` in such cases. For example, "a month later" of 2014-01-30
 //! is not well-defined and consequently `Utc.ymd(2014, 1, 30)?.with_month(2)?`
-//! returns `Err(ChronoError)`.
+//! returns `Err(Error)`.
 //!
 //! Non ISO week handling is not yet supported. For now you can use the
 //! [chrono_ext] crate ([sources]).
@@ -414,9 +414,9 @@ doctest!("../README.md");
 /// A convenience module appropriate for glob imports (`use chrono::prelude::*;`).
 pub mod prelude {
     #[doc(no_inline)]
-    pub use crate::ChronoError;
-    #[doc(no_inline)]
     pub use crate::Date;
+    #[doc(no_inline)]
+    pub use crate::Error;
     #[cfg(feature = "clock")]
     #[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
     #[doc(no_inline)]
@@ -448,7 +448,7 @@ mod datetime;
 pub use datetime::{DateTime, SecondsFormat, MAX_DATETIME, MIN_DATETIME};
 
 mod error;
-pub use self::error::ChronoError;
+pub use self::error::Error;
 
 pub mod format;
 /// L10n locales.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,30 +357,35 @@
 //!
 //! ## Limitations
 //!
-//! Only proleptic Gregorian calendar (i.e. extended to support older dates) is supported.
-//! Be very careful if you really have to deal with pre-20C dates, they can be in Julian or others.
+//! Only proleptic Gregorian calendar (i.e. extended to support older dates) is
+//! supported. Be very careful if you really have to deal with pre-20C dates,
+//! they can be in Julian or others.
 //!
 //! Date types are limited in about +/- 262,000 years from the common epoch.
 //! Time types are limited in the nanosecond accuracy.
 //!
-//! [Leap seconds are supported in the representation but
-//! Chrono doesn't try to make use of them](./naive/struct.NaiveTime.html#leap-second-handling).
-//! (The main reason is that leap seconds are not really predictable.)
-//! Almost *every* operation over the possible leap seconds will ignore them.
-//! Consider using `NaiveDateTime` with the implicit TAI (International Atomic Time) scale
-//! if you want.
+//! [Leap seconds] are supported in the representation but Chrono doesn't try to
+//! make use of them. (The main reason is that leap seconds are not really
+//! predictable.) Almost *every* operation over the possible leap seconds will
+//! ignore them. Consider using `NaiveDateTime` with the implicit TAI
+//! (International Atomic Time) scale if you want.
 //!
-//! Chrono inherently does not support an inaccurate or partial date and time representation.
-//! Any operation that can be ambiguous will return `None` in such cases.
-//! For example, "a month later" of 2014-01-30 is not well-defined
-//! and consequently `Utc.ymd(2014, 1, 30).with_month(2)` returns `None`.
+//! Chrono inherently does not support an inaccurate or partial date and time
+//! representation. Any operation that can be ambiguous will return
+//! `Err(ChronoError)` in such cases. For example, "a month later" of 2014-01-30
+//! is not well-defined and consequently `Utc.ymd(2014, 1, 30)?.with_month(2)?`
+//! returns `Err(ChronoError)`.
 //!
-//! Non ISO week handling is not yet supported.
-//! For now you can use the [chrono_ext](https://crates.io/crates/chrono_ext)
-//! crate ([sources](https://github.com/bcourtine/chrono-ext/)).
+//! Non ISO week handling is not yet supported. For now you can use the
+//! [chrono_ext] crate ([sources]).
 //!
 //! Advanced time zone handling is not yet supported.
 //! For now you can try the [Chrono-tz](https://github.com/chronotope/chrono-tz/) crate instead.
+//!
+//! [chrono_ext]: https://crates.io/crates/chrono_ext
+//! [Chrono-tz]: https://github.com/chronotope/chrono-tz/
+//! [Leap seconds]: ./naive/struct.NaiveTime.html#leap-second-handling
+//! [sources]: https://github.com/bcourtine/chrono-ext/
 
 #![doc(html_root_url = "https://docs.rs/chrono/latest/")]
 #![cfg_attr(feature = "bench", feature(test))] // lib stability features as per RFC #507

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,8 @@
 //! let dt_nano = Utc.ymd(2014, 11, 28)?.and_hms_nano(12, 0, 9, 1)?;
 //! assert_eq!(format!("{:?}", dt_nano), "2014-11-28T12:00:09.000000001Z");
 //! # Ok(()) }
+//! # #[cfg(not(feature = "unstable-locales"))]
+//! # fn main() {}
 //! ```
 //!
 //! Parsing can be done with three methods:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,6 +412,8 @@ doctest!("../README.md");
 /// A convenience module appropriate for glob imports (`use chrono::prelude::*;`).
 pub mod prelude {
     #[doc(no_inline)]
+    pub use crate::ChronoError;
+    #[doc(no_inline)]
     pub use crate::Date;
     #[cfg(feature = "clock")]
     #[cfg_attr(docsrs, doc(cfg(feature = "clock")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,7 +161,7 @@
 //! // time zone accessor and manipulation
 //! assert_eq!(dt.offset().fix().local_minus_utc(), 9 * 3600);
 //! assert_eq!(dt.timezone(), FixedOffset::east(9 * 3600)?);
-//! assert_eq!(dt.with_fixed_timezone(&Utc), Utc.ymd(2014, 11, 28)?.and_hms_nano(12, 45, 59, 324310806)?);
+//! assert_eq!(dt.with_timezone(&Utc)?, Utc.ymd(2014, 11, 28)?.and_hms_nano(12, 45, 59, 324310806)?);
 //!
 //! // a sample of property manipulations (validates dynamically)
 //! assert_eq!(dt.with_day(29)?.weekday(), Weekday::Sat); // 2014-11-29 is Saturday

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,9 +99,10 @@
 //! ```rust
 //! use chrono::prelude::*;
 //!
-//! let utc: DateTime<Utc> = Utc::now();       // e.g. `2014-11-28T12:45:59.324310806Z`
-//! let local: DateTime<Local> = Local::now(); // e.g. `2014-11-28T21:45:59.324310806+09:00`
+//! let utc: DateTime<Utc> = Utc::now()?; // e.g. `2014-11-28T12:45:59.324310806Z`
+//! let local: DateTime<Local> = Local::now()?; // e.g. `2014-11-28T21:45:59.324310806+09:00`
 //! # let _ = utc; let _ = local;
+//! # Ok::<_, chrono::ChronoError>(())
 //! ```
 //!
 //! Alternatively, you can create your own date and time.
@@ -110,30 +111,29 @@
 //!
 //! ```rust
 //! use chrono::prelude::*;
-//! use chrono::offset::LocalResult;
 //!
-//! let dt = Utc.ymd(2014, 7, 8).and_hms(9, 10, 11); // `2014-07-08T09:10:11Z`
+//! let dt = Utc.ymd(2014, 7, 8)?.and_hms(9, 10, 11)?; // `2014-07-08T09:10:11Z`
 //! // July 8 is 188th day of the year 2014 (`o` for "ordinal")
-//! assert_eq!(dt, Utc.yo(2014, 189).and_hms(9, 10, 11));
+//! assert_eq!(dt, Utc.yo(2014, 189)?.and_hms(9, 10, 11)?);
 //! // July 8 is Tuesday in ISO week 28 of the year 2014.
-//! assert_eq!(dt, Utc.isoywd(2014, 28, Weekday::Tue).and_hms(9, 10, 11));
+//! assert_eq!(dt, Utc.isoywd(2014, 28, Weekday::Tue)?.and_hms(9, 10, 11)?);
 //!
-//! let dt = Utc.ymd(2014, 7, 8).and_hms_milli(9, 10, 11, 12); // `2014-07-08T09:10:11.012Z`
-//! assert_eq!(dt, Utc.ymd(2014, 7, 8).and_hms_micro(9, 10, 11, 12_000));
-//! assert_eq!(dt, Utc.ymd(2014, 7, 8).and_hms_nano(9, 10, 11, 12_000_000));
+//! let dt = Utc.ymd(2014, 7, 8)?.and_hms_milli(9, 10, 11, 12)?; // `2014-07-08T09:10:11.012Z`
+//! assert_eq!(dt, Utc.ymd(2014, 7, 8)?.and_hms_micro(9, 10, 11, 12_000)?);
+//! assert_eq!(dt, Utc.ymd(2014, 7, 8)?.and_hms_nano(9, 10, 11, 12_000_000)?);
 //!
 //! // dynamic verification
-//! assert_eq!(Utc.ymd_opt(2014, 7, 8).and_hms_opt(21, 15, 33),
-//!            LocalResult::Single(Utc.ymd(2014, 7, 8).and_hms(21, 15, 33)));
-//! assert_eq!(Utc.ymd_opt(2014, 7, 8).and_hms_opt(80, 15, 33), LocalResult::None);
-//! assert_eq!(Utc.ymd_opt(2014, 7, 38).and_hms_opt(21, 15, 33), LocalResult::None);
+//! assert!(Utc.ymd(2014, 7, 8)?.and_hms(21, 15, 33).is_ok());
+//! assert!(Utc.ymd(2014, 7, 8)?.and_hms(80, 15, 33).is_err());
+//! assert!(Utc.ymd(2014, 7, 38).is_err());
 //!
 //! // other time zone objects can be used to construct a local datetime.
 //! // obviously, `local_dt` is normally different from `dt`, but `fixed_dt` should be identical.
-//! let local_dt = Local.ymd(2014, 7, 8).and_hms_milli(9, 10, 11, 12);
-//! let fixed_dt = FixedOffset::east(9 * 3600).ymd(2014, 7, 8).and_hms_milli(18, 10, 11, 12);
+//! let local_dt = Local.ymd(2014, 7, 8)?.and_hms_milli(9, 10, 11, 12)?;
+//! let fixed_dt = FixedOffset::east(9 * 3600)?.ymd(2014, 7, 8)?.and_hms_milli(18, 10, 11, 12)?;
 //! assert_eq!(dt, fixed_dt);
 //! # let _ = local_dt;
+//! # Ok::<_, chrono::ChronoError>(())
 //! ```
 //!
 //! Various properties are available to the date and time, and can be altered individually.
@@ -147,7 +147,7 @@
 //! use chrono::TimeDelta;
 //!
 //! // assume this returned `2014-11-28T21:45:59.324310806+09:00`:
-//! let dt = FixedOffset::east(9*3600).ymd(2014, 11, 28).and_hms_nano(21, 45, 59, 324310806);
+//! let dt = FixedOffset::east(9*3600)?.ymd(2014, 11, 28)?.and_hms_nano(21, 45, 59, 324310806)?;
 //!
 //! // property accessors
 //! assert_eq!((dt.year(), dt.month(), dt.day()), (2014, 11, 28));
@@ -160,23 +160,24 @@
 //!
 //! // time zone accessor and manipulation
 //! assert_eq!(dt.offset().fix().local_minus_utc(), 9 * 3600);
-//! assert_eq!(dt.timezone(), FixedOffset::east(9 * 3600));
-//! assert_eq!(dt.with_timezone(&Utc), Utc.ymd(2014, 11, 28).and_hms_nano(12, 45, 59, 324310806));
+//! assert_eq!(dt.timezone(), FixedOffset::east(9 * 3600)?);
+//! assert_eq!(dt.with_fixed_timezone(&Utc), Utc.ymd(2014, 11, 28)?.and_hms_nano(12, 45, 59, 324310806)?);
 //!
 //! // a sample of property manipulations (validates dynamically)
-//! assert_eq!(dt.with_day(29).unwrap().weekday(), Weekday::Sat); // 2014-11-29 is Saturday
-//! assert_eq!(dt.with_day(32), None);
-//! assert_eq!(dt.with_year(-300).unwrap().num_days_from_ce(), -109606); // November 29, 301 BCE
+//! assert_eq!(dt.with_day(29)?.weekday(), Weekday::Sat); // 2014-11-29 is Saturday
+//! assert!(dt.with_day(32).is_err());
+//! assert_eq!(dt.with_year(-300)?.num_days_from_ce(), -109606); // November 29, 301 BCE
 //!
 //! // arithmetic operations
-//! let dt1 = Utc.ymd(2014, 11, 14).and_hms(8, 9, 10);
-//! let dt2 = Utc.ymd(2014, 11, 14).and_hms(10, 9, 8);
+//! let dt1 = Utc.ymd(2014, 11, 14)?.and_hms(8, 9, 10)?;
+//! let dt2 = Utc.ymd(2014, 11, 14)?.and_hms(10, 9, 8)?;
 //! assert_eq!(dt1.signed_duration_since(dt2), TimeDelta::seconds(-2 * 3600 + 2));
 //! assert_eq!(dt2.signed_duration_since(dt1), TimeDelta::seconds(2 * 3600 - 2));
-//! assert_eq!(Utc.ymd(1970, 1, 1).and_hms(0, 0, 0) + TimeDelta::seconds(1_000_000_000),
-//!            Utc.ymd(2001, 9, 9).and_hms(1, 46, 40));
-//! assert_eq!(Utc.ymd(1970, 1, 1).and_hms(0, 0, 0) - TimeDelta::seconds(1_000_000_000),
-//!            Utc.ymd(1938, 4, 24).and_hms(22, 13, 20));
+//! assert_eq!(Utc.ymd(1970, 1, 1)?.and_hms(0, 0, 0)? + TimeDelta::seconds(1_000_000_000),
+//!            Utc.ymd(2001, 9, 9)?.and_hms(1, 46, 40)?);
+//! assert_eq!(Utc.ymd(1970, 1, 1)?.and_hms(0, 0, 0)? - TimeDelta::seconds(1_000_000_000),
+//!            Utc.ymd(1938, 4, 24)?.and_hms(22, 13, 20)?);
+//! # Ok::<_, chrono::ChronoError>(())
 //! ```
 //!
 //! ### Formatting and Parsing
@@ -206,8 +207,8 @@
 //! use chrono::prelude::*;
 //!
 //! # #[cfg(feature = "unstable-locales")]
-//! # fn test() {
-//! let dt = Utc.ymd(2014, 11, 28).and_hms(12, 0, 9);
+//! # fn main() -> Result<(), chrono::ChronoError> {
+//! let dt = Utc.ymd(2014, 11, 28)?.and_hms(12, 0, 9)?;
 //! assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2014-11-28 12:00:09");
 //! assert_eq!(dt.format("%a %b %e %T %Y").to_string(), "Fri Nov 28 12:00:09 2014");
 //! assert_eq!(dt.format_localized("%A %e %B %Y, %T", Locale::fr_BE).to_string(), "vendredi 28 novembre 2014, 12:00:09");
@@ -219,14 +220,9 @@
 //! assert_eq!(format!("{:?}", dt), "2014-11-28T12:00:09Z");
 //!
 //! // Note that milli/nanoseconds are only printed if they are non-zero
-//! let dt_nano = Utc.ymd(2014, 11, 28).and_hms_nano(12, 0, 9, 1);
+//! let dt_nano = Utc.ymd(2014, 11, 28)?.and_hms_nano(12, 0, 9, 1)?;
 //! assert_eq!(format!("{:?}", dt_nano), "2014-11-28T12:00:09.000000001Z");
-//! # }
-//! # #[cfg(not(feature = "unstable-locales"))]
-//! # fn test() {}
-//! # if cfg!(feature = "unstable-locales") {
-//! #    test();
-//! # }
+//! # Ok(()) }
 //! ```
 //!
 //! Parsing can be done with three methods:
@@ -259,24 +255,24 @@
 //! ```rust
 //! use chrono::prelude::*;
 //!
-//! let dt = Utc.ymd(2014, 11, 28).and_hms(12, 0, 9);
-//! let fixed_dt = dt.with_timezone(&FixedOffset::east(9*3600));
+//! let dt = Utc.ymd(2014, 11, 28)?.and_hms(12, 0, 9)?;
+//! let fixed_dt = dt.with_timezone(&FixedOffset::east(9*3600)?)?;
 //!
 //! // method 1
-//! assert_eq!("2014-11-28T12:00:09Z".parse::<DateTime<Utc>>(), Ok(dt.clone()));
-//! assert_eq!("2014-11-28T21:00:09+09:00".parse::<DateTime<Utc>>(), Ok(dt.clone()));
-//! assert_eq!("2014-11-28T21:00:09+09:00".parse::<DateTime<FixedOffset>>(), Ok(fixed_dt.clone()));
+//! assert_eq!("2014-11-28T12:00:09Z".parse::<DateTime<Utc>>()?, dt.clone());
+//! assert_eq!("2014-11-28T21:00:09+09:00".parse::<DateTime<Utc>>()?, dt.clone());
+//! assert_eq!("2014-11-28T21:00:09+09:00".parse::<DateTime<FixedOffset>>()?, fixed_dt.clone());
 //!
 //! // method 2
-//! assert_eq!(DateTime::parse_from_str("2014-11-28 21:00:09 +09:00", "%Y-%m-%d %H:%M:%S %z"),
-//!            Ok(fixed_dt.clone()));
-//! assert_eq!(DateTime::parse_from_rfc2822("Fri, 28 Nov 2014 21:00:09 +0900"),
-//!            Ok(fixed_dt.clone()));
-//! assert_eq!(DateTime::parse_from_rfc3339("2014-11-28T21:00:09+09:00"), Ok(fixed_dt.clone()));
+//! assert_eq!(DateTime::parse_from_str("2014-11-28 21:00:09 +09:00", "%Y-%m-%d %H:%M:%S %z")?,
+//!            fixed_dt.clone());
+//! assert_eq!(DateTime::parse_from_rfc2822("Fri, 28 Nov 2014 21:00:09 +0900")?,
+//!            fixed_dt.clone());
+//! assert_eq!(DateTime::parse_from_rfc3339("2014-11-28T21:00:09+09:00")?, fixed_dt.clone());
 //!
 //! // method 3
-//! assert_eq!(Utc.datetime_from_str("2014-11-28 12:00:09", "%Y-%m-%d %H:%M:%S"), Ok(dt.clone()));
-//! assert_eq!(Utc.datetime_from_str("Fri Nov 28 12:00:09 2014", "%a %b %e %T %Y"), Ok(dt.clone()));
+//! assert_eq!(Utc.datetime_from_str("2014-11-28 12:00:09", "%Y-%m-%d %H:%M:%S")?, dt.clone());
+//! assert_eq!(Utc.datetime_from_str("Fri Nov 28 12:00:09 2014", "%a %b %e %T %Y")?, dt.clone());
 //!
 //! // oops, the year is missing!
 //! assert!(Utc.datetime_from_str("Fri Nov 28 12:00:09", "%a %b %e %T %Y").is_err());
@@ -284,6 +280,7 @@
 //! assert!(Utc.datetime_from_str("Fri Nov 28 12:00:09", "%a %b %e %T").is_err());
 //! // oops, the weekday is incorrect!
 //! assert!(Utc.datetime_from_str("Sat Nov 28 12:00:09 2014", "%a %b %e %T %Y").is_err());
+//! # Ok::<_, Box<dyn std::error::Error>>(())
 //! ```
 //!
 //! Again : See [`format::strftime`](./format/strftime/index.html#specifiers)
@@ -305,12 +302,13 @@
 //! use chrono::{DateTime, TimeZone, Utc};
 //!
 //! // Construct a datetime from epoch:
-//! let dt = Utc.timestamp(1_500_000_000, 0);
+//! let dt = Utc.timestamp(1_500_000_000, 0)?;
 //! assert_eq!(dt.to_rfc2822(), "Fri, 14 Jul 2017 02:40:00 +0000");
 //!
 //! // Get epoch value from a datetime:
-//! let dt = DateTime::parse_from_rfc2822("Fri, 14 Jul 2017 02:40:00 +0000").unwrap();
+//! let dt = DateTime::parse_from_rfc2822("Fri, 14 Jul 2017 02:40:00 +0000")?;
 //! assert_eq!(dt.timestamp(), 1_500_000_000);
+//! # Ok::<_, Box<dyn std::error::Error>>(())
 //! ```
 //!
 //! ### Individual date
@@ -321,16 +319,16 @@
 //!
 //! ```rust
 //! use chrono::prelude::*;
-//! use chrono::offset::LocalResult;
 //!
 //! # // these *may* fail, but only very rarely. just rerun the test if you were that unfortunate ;)
-//! assert_eq!(Utc::today(), Utc::now().date());
-//! assert_eq!(Local::today(), Local::now().date());
+//! assert_eq!(Utc::today()?, Utc::now()?.date());
+//! assert_eq!(Local::today()?, Local::now()?.date());
 //!
-//! assert_eq!(Utc.ymd(2014, 11, 28).weekday(), Weekday::Fri);
-//! assert_eq!(Utc.ymd_opt(2014, 11, 31), LocalResult::None);
-//! assert_eq!(Utc.ymd(2014, 11, 28).and_hms_milli(7, 8, 9, 10).format("%H%M%S").to_string(),
+//! assert_eq!(Utc.ymd(2014, 11, 28)?.single()?.weekday(), Weekday::Fri);
+//! assert!(Utc.ymd(2014, 11, 31).is_err());
+//! assert_eq!(Utc.ymd(2014, 11, 28)?.and_hms_milli(7, 8, 9, 10)?.format("%H%M%S").to_string(),
 //!            "070809");
+//! # Ok::<_, chrono::ChronoError>(())
 //! ```
 //!
 //! There is no timezone-aware `Time` due to the lack of usefulness and also the complexity.
@@ -439,6 +437,9 @@ pub use date::{Date, MAX_DATE, MIN_DATE};
 mod datetime;
 #[allow(deprecated)]
 pub use datetime::{DateTime, SecondsFormat, MAX_DATETIME, MIN_DATETIME};
+
+mod error;
+pub use self::error::ChronoError;
 
 pub mod format;
 /// L10n locales.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,35 +359,30 @@
 //!
 //! ## Limitations
 //!
-//! Only proleptic Gregorian calendar (i.e. extended to support older dates) is
-//! supported. Be very careful if you really have to deal with pre-20C dates,
-//! they can be in Julian or others.
+//! Only proleptic Gregorian calendar (i.e. extended to support older dates) is supported.
+//! Be very careful if you really have to deal with pre-20C dates, they can be in Julian or others.
 //!
 //! Date types are limited in about +/- 262,000 years from the common epoch.
 //! Time types are limited in the nanosecond accuracy.
 //!
-//! [Leap seconds] are supported in the representation but Chrono doesn't try to
-//! make use of them. (The main reason is that leap seconds are not really
-//! predictable.) Almost *every* operation over the possible leap seconds will
-//! ignore them. Consider using `NaiveDateTime` with the implicit TAI
-//! (International Atomic Time) scale if you want.
+//! [Leap seconds are supported in the representation but
+//! Chrono doesn't try to make use of them](./naive/struct.NaiveTime.html#leap-second-handling).
+//! (The main reason is that leap seconds are not really predictable.)
+//! Almost *every* operation over the possible leap seconds will ignore them.
+//! Consider using `NaiveDateTime` with the implicit TAI (International Atomic Time) scale
+//! if you want.
 //!
-//! Chrono inherently does not support an inaccurate or partial date and time
-//! representation. Any operation that can be ambiguous will return
-//! `Err(Error)` in such cases. For example, "a month later" of 2014-01-30
-//! is not well-defined and consequently `Utc.ymd(2014, 1, 30)?.with_month(2)?`
-//! returns `Err(Error)`.
+//! Chrono inherently does not support an inaccurate or partial date and time representation.
+//! Any operation that can be ambiguous will return `Err(chrono::Error)` in such cases.
+//! For example, "a month later" of 2014-01-30 is not well-defined
+//! and consequently `Utc.ymd(2014, 1, 30)?.with_month(2)?` returns `Err(chrono::Error)`.
 //!
-//! Non ISO week handling is not yet supported. For now you can use the
-//! [chrono_ext] crate ([sources]).
+//! Non ISO week handling is not yet supported.
+//! For now you can use the [chrono_ext](https://crates.io/crates/chrono_ext)
+//! crate ([sources](https://github.com/bcourtine/chrono-ext/)).
 //!
 //! Advanced time zone handling is not yet supported.
 //! For now you can try the [Chrono-tz](https://github.com/chronotope/chrono-tz/) crate instead.
-//!
-//! [chrono_ext]: https://crates.io/crates/chrono_ext
-//! [Chrono-tz]: https://github.com/chronotope/chrono-tz/
-//! [Leap seconds]: ./naive/struct.NaiveTime.html#leap-second-handling
-//! [sources]: https://github.com/bcourtine/chrono-ext/
 
 #![doc(html_root_url = "https://docs.rs/chrono/latest/")]
 #![cfg_attr(feature = "bench", feature(test))] // lib stability features as per RFC #507

--- a/src/month.rs
+++ b/src/month.rs
@@ -17,9 +17,9 @@ use crate::OutOfRange;
 /// use std::convert::TryFrom;
 /// let date = Utc.ymd(2019, 10, 28)?.and_hms(9, 10, 11)?;
 /// // `2019-10-28T09:10:11Z`
-/// let month = Month::try_from(u8::try_from(date.month()).unwrap()).ok();
+/// let month = Month::try_from(u8::try_from(date.month())?).ok();
 /// assert_eq!(month, Some(Month::October));
-/// # Ok::<_, chrono::ChronoError>(())
+/// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 ///
 /// Or from a Month to an integer usable by dates

--- a/src/month.rs
+++ b/src/month.rs
@@ -29,7 +29,7 @@ use crate::OutOfRange;
 /// let month = Month::January;
 /// let dt = Utc.ymd(2019, month.number_from_month(), 28)?.and_hms(9, 10, 11)?;
 /// assert_eq!((dt.year(), dt.month(), dt.day()), (2019, 1, 28));
-/// # Ok::<_, chrono::ChronoError>(())
+/// # Ok::<_, chrono::Error>(())
 /// ```
 /// Allows mapping from and to month, from 1-January to 12-December.
 /// Can be Serialized/Deserialized with serde

--- a/src/month.rs
+++ b/src/month.rs
@@ -10,21 +10,26 @@ use crate::OutOfRange;
 /// This enum is just a convenience implementation.
 /// The month in dates created by DateLike objects does not return this enum.
 ///
-/// It is possible to convert from a date to a month independently
+/// It is possible to convert from a date to a month independently.
+///
 /// ```
 /// use chrono::prelude::*;
 /// use std::convert::TryFrom;
-/// let date = Utc.ymd(2019, 10, 28).and_hms(9, 10, 11);
+/// let date = Utc.ymd(2019, 10, 28)?.and_hms(9, 10, 11)?;
 /// // `2019-10-28T09:10:11Z`
 /// let month = Month::try_from(u8::try_from(date.month()).unwrap()).ok();
-/// assert_eq!(month, Some(Month::October))
+/// assert_eq!(month, Some(Month::October));
+/// # Ok::<_, chrono::ChronoError>(())
 /// ```
+///
 /// Or from a Month to an integer usable by dates
+///
 /// ```
 /// # use chrono::prelude::*;
 /// let month = Month::January;
-/// let dt = Utc.ymd(2019, month.number_from_month(), 28).and_hms(9, 10, 11);
+/// let dt = Utc.ymd(2019, month.number_from_month(), 28)?.and_hms(9, 10, 11)?;
 /// assert_eq!((dt.year(), dt.month(), dt.day()), (2019, 1, 28));
+/// # Ok::<_, chrono::ChronoError>(())
 /// ```
 /// Allows mapping from and to month, from 1-January to 12-December.
 /// Can be Serialized/Deserialized with serde
@@ -317,11 +322,11 @@ mod tests {
         assert_eq!(Month::try_from(12), Ok(Month::December));
         assert_eq!(Month::try_from(13), Err(OutOfRange::new()));
 
-        let date = Utc.ymd(2019, 10, 28).and_hms(9, 10, 11);
+        let date = Utc.ymd(2019, 10, 28).unwrap().and_hms(9, 10, 11).unwrap();
         assert_eq!(Month::try_from(date.month() as u8), Ok(Month::October));
 
         let month = Month::January;
-        let dt = Utc.ymd(2019, month.number_from_month(), 28).and_hms(9, 10, 11);
+        let dt = Utc.ymd(2019, month.number_from_month(), 28).unwrap().and_hms(9, 10, 11).unwrap();
         assert_eq!((dt.year(), dt.month(), dt.day()), (2019, 1, 28));
     }
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -747,6 +747,7 @@ impl NaiveDate {
     }
 
     /// Makes a new `NaiveDateTime` with the time set to midnight.
+    #[cfg(feature = "clock")]
     pub(crate) fn and_midnight(&self) -> NaiveDateTime {
         self.and_time(NaiveTime::midnight())
     }

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1415,7 +1415,8 @@ impl Datelike for NaiveDate {
 
     /// Makes a new `NaiveDate` with the year number changed.
     ///
-    /// Returns `Err(ChronoError)` when the resulting `NaiveDate` would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting `NaiveDate` would be
+    /// invalid.
     ///
     /// # Example
     ///
@@ -1427,7 +1428,8 @@ impl Datelike for NaiveDate {
     /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     ///
-    /// A leap day (February 29) is a good example that this method can return `None`.
+    /// A leap day (February 29) is a good example that this method can return
+    /// an error.
     ///
     /// ```
     /// # use chrono::{NaiveDate, Datelike};

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -13,13 +13,14 @@ use num_integer::div_mod_floor;
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
 
+use crate::error::ChronoErrorKind;
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use crate::format::DelayedFormat;
 use crate::format::{parse, ParseError, ParseResult, Parsed, StrftimeItems};
 use crate::format::{Item, Numeric, Pad};
 use crate::month::Months;
 use crate::naive::{IsoWeek, NaiveDateTime, NaiveTime};
-use crate::{Datelike, TimeDelta, Weekday};
+use crate::{ChronoError, Datelike, TimeDelta, Weekday};
 
 use super::internals::{self, DateImpl, Mdf, Of, YearFlags};
 use super::isoweek;
@@ -66,9 +67,10 @@ impl NaiveWeek {
     /// ```
     /// use chrono::{NaiveDate, Weekday};
     ///
-    /// let date = NaiveDate::from_ymd(2022, 4, 18);
+    /// let date = NaiveDate::from_ymd(2022, 4, 18)?;
     /// let week = date.week(Weekday::Mon);
     /// assert!(week.first_day() <= date);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     pub fn first_day(&self) -> NaiveDate {
@@ -85,9 +87,10 @@ impl NaiveWeek {
     /// ```
     /// use chrono::{NaiveDate, Weekday};
     ///
-    /// let date = NaiveDate::from_ymd(2022, 4, 18);
+    /// let date = NaiveDate::from_ymd(2022, 4, 18)?;
     /// let week = date.week(Weekday::Mon);
     /// assert!(week.last_day() >= date);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     pub fn last_day(&self) -> NaiveDate {
@@ -103,10 +106,11 @@ impl NaiveWeek {
     /// ```
     /// use chrono::{NaiveDate, Weekday};
     ///
-    /// let date = NaiveDate::from_ymd(2022, 4, 18);
+    /// let date = NaiveDate::from_ymd(2022, 4, 18)?;
     /// let week = date.week(Weekday::Mon);
     /// let days = week.days();
     /// assert!(days.contains(&date));
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     pub fn days(&self) -> RangeInclusive<NaiveDate> {
@@ -191,61 +195,41 @@ pub const MIN_DATE: NaiveDate = NaiveDate::MIN;
 #[deprecated(since = "0.4.20", note = "Use NaiveDate::MAX instead")]
 pub const MAX_DATE: NaiveDate = NaiveDate::MAX;
 
-// as it is hard to verify year flags in `NaiveDate::MIN` and `NaiveDate::MAX`,
-// we use a separate run-time test.
-#[test]
-fn test_date_bounds() {
-    let calculated_min = NaiveDate::from_ymd(MIN_YEAR, 1, 1);
-    let calculated_max = NaiveDate::from_ymd(MAX_YEAR, 12, 31);
-    assert!(
-        NaiveDate::MIN == calculated_min,
-        "`NaiveDate::MIN` should have a year flag {:?}",
-        calculated_min.of().flags()
-    );
-    assert!(
-        NaiveDate::MAX == calculated_max,
-        "`NaiveDate::MAX` should have a year flag {:?}",
-        calculated_max.of().flags()
-    );
-
-    // let's also check that the entire range do not exceed 2^44 seconds
-    // (sometimes used for bounding `TimeDelta` against overflow)
-    let maxsecs = NaiveDate::MAX.signed_duration_since(NaiveDate::MIN).num_seconds();
-    let maxsecs = maxsecs + 86401; // also take care of DateTime
-    assert!(
-        maxsecs < (1 << MAX_BITS),
-        "The entire `NaiveDate` range somehow exceeds 2^{} seconds",
-        MAX_BITS
-    );
-}
-
 impl NaiveDate {
+    /// The minimum possible `NaiveDate` (January 1, 262145 BCE).
+    pub const MIN: NaiveDate = NaiveDate { ymdf: (MIN_YEAR << 13) | (1 << 4) | 0o07 /*FE*/ };
+    /// The maximum possible `NaiveDate` (December 31, 262143 CE).
+    pub const MAX: NaiveDate = NaiveDate { ymdf: (MAX_YEAR << 13) | (365 << 4) | 0o17 /*F*/ };
+    /// Date that corresponds to the start of the unix epoch.
+    pub(crate) const UNIX_EPOCH: NaiveDate = NaiveDate { ymdf: (1970 << 13) | (1 << 4) | 0o12 };
+
     /// Makes a new `NaiveDate` from year and packed ordinal-flags, with a verification.
-    fn from_of(year: i32, of: Of) -> Option<NaiveDate> {
+    fn from_of(year: i32, of: Of) -> Result<NaiveDate, ChronoError> {
         if (MIN_YEAR..=MAX_YEAR).contains(&year) && of.valid() {
             let Of(of) = of;
-            Some(NaiveDate { ymdf: (year << 13) | (of as DateImpl) })
+            Ok(NaiveDate { ymdf: (year << 13) | (of as DateImpl) })
         } else {
-            None
+            Err(ChronoError::new(ChronoErrorKind::InvalidDate))
         }
     }
 
     /// Makes a new `NaiveDate` from year and packed month-day-flags, with a verification.
-    fn from_mdf(year: i32, mdf: Mdf) -> Option<NaiveDate> {
+    fn from_mdf(year: i32, mdf: Mdf) -> Result<NaiveDate, ChronoError> {
         NaiveDate::from_of(year, mdf.to_of())
     }
 
-    /// Makes a new `NaiveDate` from the [calendar date](#calendar-date)
-    /// (year, month and day).
+    /// Makes a new `NaiveDate` from the [calendar date](#calendar-date) (year,
+    /// month and day).
     ///
-    /// Panics on the out-of-range date, invalid month and/or day.
+    /// Returns `Err(ChronoError)` on the out-of-range date, invalid month
+    /// and/or day.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
-    /// let d = NaiveDate::from_ymd(2015, 3, 14);
+    /// let d = NaiveDate::from_ymd(2015, 3, 14)?;
     /// assert_eq!(d.year(), 2015);
     /// assert_eq!(d.month(), 3);
     /// assert_eq!(d.day(), 14);
@@ -254,46 +238,36 @@ impl NaiveDate {
     /// assert_eq!(d.iso_week().week(), 11);
     /// assert_eq!(d.weekday(), Weekday::Sat);
     /// assert_eq!(d.num_days_from_ce(), 735671); // days since January 1, 1 CE
+    ///
+    /// let from_ymd = NaiveDate::from_ymd;
+    ///
+    /// assert!(from_ymd(2015, 3, 14).is_ok());
+    /// assert!(from_ymd(2015, 0, 14).is_err());
+    /// assert!(from_ymd(2015, 2, 29).is_err());
+    /// assert!(from_ymd(-4, 2, 29).is_ok()); // 5 BCE is a leap year
+    /// assert!(from_ymd(400000, 1, 1).is_err());
+    /// assert!(from_ymd(-400000, 1, 1).is_err());
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn from_ymd(year: i32, month: u32, day: u32) -> NaiveDate {
-        NaiveDate::from_ymd_opt(year, month, day).expect("invalid or out-of-range date")
-    }
-
-    /// Makes a new `NaiveDate` from the [calendar date](#calendar-date)
-    /// (year, month and day).
-    ///
-    /// Returns `None` on the out-of-range date, invalid month and/or day.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use chrono::NaiveDate;
-    ///
-    /// let from_ymd_opt = NaiveDate::from_ymd_opt;
-    ///
-    /// assert!(from_ymd_opt(2015, 3, 14).is_some());
-    /// assert!(from_ymd_opt(2015, 0, 14).is_none());
-    /// assert!(from_ymd_opt(2015, 2, 29).is_none());
-    /// assert!(from_ymd_opt(-4, 2, 29).is_some()); // 5 BCE is a leap year
-    /// assert!(from_ymd_opt(400000, 1, 1).is_none());
-    /// assert!(from_ymd_opt(-400000, 1, 1).is_none());
-    /// ```
-    pub fn from_ymd_opt(year: i32, month: u32, day: u32) -> Option<NaiveDate> {
+    pub fn from_ymd(year: i32, month: u32, day: u32) -> Result<NaiveDate, ChronoError> {
         let flags = YearFlags::from_year(year);
         NaiveDate::from_mdf(year, Mdf::new(month, day, flags))
     }
 
-    /// Makes a new `NaiveDate` from the [ordinal date](#ordinal-date)
-    /// (year and day of the year).
+    /// Makes a new `NaiveDate` from the [ordinal date](#ordinal-date) (year and
+    /// day of the year).
     ///
-    /// Panics on the out-of-range date and/or invalid day of year.
+    /// Returns `Err(ChronoError)` on the out-of-range date and/or invalid day
+    /// of year.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
-    /// let d = NaiveDate::from_yo(2015, 73);
+    /// let from_yo = NaiveDate::from_yo;
+    ///
+    /// let d = from_yo(2015, 73)?;
     /// assert_eq!(d.ordinal(), 73);
     /// assert_eq!(d.year(), 2015);
     /// assert_eq!(d.month(), 3);
@@ -302,48 +276,35 @@ impl NaiveDate {
     /// assert_eq!(d.iso_week().week(), 11);
     /// assert_eq!(d.weekday(), Weekday::Sat);
     /// assert_eq!(d.num_days_from_ce(), 735671); // days since January 1, 1 CE
+    ///
+    /// assert!(from_yo(2015, 100).is_ok());
+    /// assert!(from_yo(2015, 0).is_err());
+    /// assert!(from_yo(2015, 365).is_ok());
+    /// assert!(from_yo(2015, 366).is_err());
+    /// assert!(from_yo(-4, 366).is_ok()); // 5 BCE is a leap year
+    /// assert!(from_yo(400000, 1).is_err());
+    /// assert!(from_yo(-400000, 1).is_err());
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn from_yo(year: i32, ordinal: u32) -> NaiveDate {
-        NaiveDate::from_yo_opt(year, ordinal).expect("invalid or out-of-range date")
-    }
-
-    /// Makes a new `NaiveDate` from the [ordinal date](#ordinal-date)
-    /// (year and day of the year).
-    ///
-    /// Returns `None` on the out-of-range date and/or invalid day of year.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use chrono::NaiveDate;
-    ///
-    /// let from_yo_opt = NaiveDate::from_yo_opt;
-    ///
-    /// assert!(from_yo_opt(2015, 100).is_some());
-    /// assert!(from_yo_opt(2015, 0).is_none());
-    /// assert!(from_yo_opt(2015, 365).is_some());
-    /// assert!(from_yo_opt(2015, 366).is_none());
-    /// assert!(from_yo_opt(-4, 366).is_some()); // 5 BCE is a leap year
-    /// assert!(from_yo_opt(400000, 1).is_none());
-    /// assert!(from_yo_opt(-400000, 1).is_none());
-    /// ```
-    pub fn from_yo_opt(year: i32, ordinal: u32) -> Option<NaiveDate> {
+    pub fn from_yo(year: i32, ordinal: u32) -> Result<NaiveDate, ChronoError> {
         let flags = YearFlags::from_year(year);
         NaiveDate::from_of(year, Of::new(ordinal, flags))
     }
 
-    /// Makes a new `NaiveDate` from the [ISO week date](#week-date)
-    /// (year, week number and day of the week).
-    /// The resulting `NaiveDate` may have a different year from the input year.
+    /// Makes a new `NaiveDate` from the [ISO week date](#week-date) (year, week
+    /// number and day of the week). The resulting `NaiveDate` may have a
+    /// different year from the input year.
     ///
-    /// Panics on the out-of-range date and/or invalid week number.
+    /// Returns `Err(ChronoError)` on the out-of-range date and/or invalid week
+    /// number.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
-    /// let d = NaiveDate::from_isoywd(2015, 11, Weekday::Sat);
+    /// let d = NaiveDate::from_isoywd(2015, 11, Weekday::Sat)?;
+    ///
     /// assert_eq!(d.iso_week().year(), 2015);
     /// assert_eq!(d.iso_week().week(), 11);
     /// assert_eq!(d.weekday(), Weekday::Sat);
@@ -352,32 +313,23 @@ impl NaiveDate {
     /// assert_eq!(d.day(), 14);
     /// assert_eq!(d.ordinal(), 73); // day of year
     /// assert_eq!(d.num_days_from_ce(), 735671); // days since January 1, 1 CE
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn from_isoywd(year: i32, week: u32, weekday: Weekday) -> NaiveDate {
-        NaiveDate::from_isoywd_opt(year, week, weekday).expect("invalid or out-of-range date")
-    }
-
-    /// Makes a new `NaiveDate` from the [ISO week date](#week-date)
-    /// (year, week number and day of the week).
-    /// The resulting `NaiveDate` may have a different year from the input year.
     ///
-    /// Returns `None` on the out-of-range date and/or invalid week number.
-    ///
-    /// # Example
+    /// Examples showcasing errors.
     ///
     /// ```
-    /// use chrono::{NaiveDate, Weekday};
+    /// # use chrono::{NaiveDate, Weekday};
+    /// # let from_ymd = NaiveDate::from_ymd;
+    /// # let from_isoywd = NaiveDate::from_isoywd;
+    /// assert!(from_isoywd(2015, 0, Weekday::Sun).is_err());
+    /// assert_eq!(from_isoywd(2015, 10, Weekday::Sun)?, from_ymd(2015, 3, 8)?);
+    /// assert_eq!(from_isoywd(2015, 30, Weekday::Mon)?, from_ymd(2015, 7, 20)?);
+    /// assert!(from_isoywd(2015, 60, Weekday::Mon).is_err());
     ///
-    /// let from_ymd = NaiveDate::from_ymd;
-    /// let from_isoywd_opt = NaiveDate::from_isoywd_opt;
-    ///
-    /// assert_eq!(from_isoywd_opt(2015, 0, Weekday::Sun), None);
-    /// assert_eq!(from_isoywd_opt(2015, 10, Weekday::Sun), Some(from_ymd(2015, 3, 8)));
-    /// assert_eq!(from_isoywd_opt(2015, 30, Weekday::Mon), Some(from_ymd(2015, 7, 20)));
-    /// assert_eq!(from_isoywd_opt(2015, 60, Weekday::Mon), None);
-    ///
-    /// assert_eq!(from_isoywd_opt(400000, 10, Weekday::Fri), None);
-    /// assert_eq!(from_isoywd_opt(-400000, 10, Weekday::Sat), None);
+    /// assert!(from_isoywd(400000, 10, Weekday::Fri).is_err());
+    /// assert!(from_isoywd(-400000, 10, Weekday::Sat).is_err());
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     ///
     /// The year number of ISO week date may differ from that of the calendar date.
@@ -385,23 +337,24 @@ impl NaiveDate {
     /// ```
     /// # use chrono::{NaiveDate, Weekday};
     /// # let from_ymd = NaiveDate::from_ymd;
-    /// # let from_isoywd_opt = NaiveDate::from_isoywd_opt;
+    /// # let from_isoywd = NaiveDate::from_isoywd;
     /// //           Mo Tu We Th Fr Sa Su
     /// // 2014-W52  22 23 24 25 26 27 28    has 4+ days of new year,
     /// // 2015-W01  29 30 31  1  2  3  4 <- so this is the first week
-    /// assert_eq!(from_isoywd_opt(2014, 52, Weekday::Sun), Some(from_ymd(2014, 12, 28)));
-    /// assert_eq!(from_isoywd_opt(2014, 53, Weekday::Mon), None);
-    /// assert_eq!(from_isoywd_opt(2015, 1, Weekday::Mon), Some(from_ymd(2014, 12, 29)));
+    /// assert_eq!(from_isoywd(2014, 52, Weekday::Sun)?, from_ymd(2014, 12, 28)?);
+    /// assert!(from_isoywd(2014, 53, Weekday::Mon).is_err());
+    /// assert_eq!(from_isoywd(2015, 1, Weekday::Mon)?, from_ymd(2014, 12, 29)?);
     ///
     /// // 2015-W52  21 22 23 24 25 26 27    has 4+ days of old year,
     /// // 2015-W53  28 29 30 31  1  2  3 <- so this is the last week
     /// // 2016-W01   4  5  6  7  8  9 10
-    /// assert_eq!(from_isoywd_opt(2015, 52, Weekday::Sun), Some(from_ymd(2015, 12, 27)));
-    /// assert_eq!(from_isoywd_opt(2015, 53, Weekday::Sun), Some(from_ymd(2016, 1, 3)));
-    /// assert_eq!(from_isoywd_opt(2015, 54, Weekday::Mon), None);
-    /// assert_eq!(from_isoywd_opt(2016, 1, Weekday::Mon), Some(from_ymd(2016, 1, 4)));
+    /// assert_eq!(from_isoywd(2015, 52, Weekday::Sun)?, from_ymd(2015, 12, 27)?);
+    /// assert_eq!(from_isoywd(2015, 53, Weekday::Sun)?, from_ymd(2016, 1, 3)?);
+    /// assert!(from_isoywd(2015, 54, Weekday::Mon).is_err());
+    /// assert_eq!(from_isoywd(2016, 1, Weekday::Mon)?, from_ymd(2016, 1, 4)?);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn from_isoywd_opt(year: i32, week: u32, weekday: Weekday) -> Option<NaiveDate> {
+    pub fn from_isoywd(year: i32, week: u32, weekday: Weekday) -> Result<NaiveDate, ChronoError> {
         let flags = YearFlags::from_year(year);
         let nweeks = flags.nisoweeks();
         if 1 <= week && week <= nweeks {
@@ -428,7 +381,7 @@ impl NaiveDate {
                 }
             }
         } else {
-            None
+            Err(ChronoError::new(ChronoErrorKind::InvalidDate))
         }
     }
 
@@ -442,7 +395,7 @@ impl NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
-    /// let d = NaiveDate::from_num_days_from_ce(735671);
+    /// let d = NaiveDate::from_num_days_from_ce(735671)?;
     /// assert_eq!(d.num_days_from_ce(), 735671); // days since January 1, 1 CE
     /// assert_eq!(d.year(), 2015);
     /// assert_eq!(d.month(), 3);
@@ -451,6 +404,7 @@ impl NaiveDate {
     /// assert_eq!(d.iso_week().year(), 2015);
     /// assert_eq!(d.iso_week().week(), 11);
     /// assert_eq!(d.weekday(), Weekday::Sat);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     ///
     /// While not directly supported by Chrono,
@@ -460,47 +414,31 @@ impl NaiveDate {
     /// (Note that this panics when `jd` is out of range.)
     ///
     /// ```
-    /// use chrono::NaiveDate;
+    /// use chrono::{NaiveDate, ChronoError};
     ///
-    /// fn jd_to_date(jd: i32) -> NaiveDate {
+    /// fn jd_to_date(jd: i32) -> Result<NaiveDate, ChronoError> {
     ///     // keep in mind that the Julian day number is 0-based
     ///     // while this method requires an 1-based number.
     ///     NaiveDate::from_num_days_from_ce(jd - 1721425)
     /// }
     ///
     /// // January 1, 4713 BCE in Julian = November 24, 4714 BCE in Gregorian
-    /// assert_eq!(jd_to_date(0), NaiveDate::from_ymd(-4713, 11, 24));
+    /// assert_eq!(jd_to_date(0)?, NaiveDate::from_ymd(-4713, 11, 24)?);
     ///
-    /// assert_eq!(jd_to_date(1721426), NaiveDate::from_ymd(1, 1, 1));
-    /// assert_eq!(jd_to_date(2450000), NaiveDate::from_ymd(1995, 10, 9));
-    /// assert_eq!(jd_to_date(2451545), NaiveDate::from_ymd(2000, 1, 1));
+    /// assert_eq!(jd_to_date(1721426)?, NaiveDate::from_ymd(1, 1, 1)?);
+    /// assert_eq!(jd_to_date(2450000)?, NaiveDate::from_ymd(1995, 10, 9)?);
+    /// assert_eq!(jd_to_date(2451545)?, NaiveDate::from_ymd(2000, 1, 1)?);
+    ///
+    /// assert_eq!(NaiveDate::from_num_days_from_ce(730_000)?, NaiveDate::from_ymd(1999, 9, 3)?);
+    /// assert_eq!(NaiveDate::from_num_days_from_ce(1)?, NaiveDate::from_ymd(1, 1, 1)?);
+    /// assert_eq!(NaiveDate::from_num_days_from_ce(0)?, NaiveDate::from_ymd(0, 12, 31)?);
+    /// assert_eq!(NaiveDate::from_num_days_from_ce(-1)?, NaiveDate::from_ymd(0, 12, 30)?);
+    /// assert!(NaiveDate::from_num_days_from_ce(100_000_000).is_err());
+    /// assert!(NaiveDate::from_num_days_from_ce(-100_000_000).is_err());
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
-    pub fn from_num_days_from_ce(days: i32) -> NaiveDate {
-        NaiveDate::from_num_days_from_ce_opt(days).expect("out-of-range date")
-    }
-
-    /// Makes a new `NaiveDate` from a day's number in the proleptic Gregorian calendar, with
-    /// January 1, 1 being day 1.
-    ///
-    /// Returns `None` if the date is out of range.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use chrono::NaiveDate;
-    ///
-    /// let from_ndays_opt = NaiveDate::from_num_days_from_ce_opt;
-    /// let from_ymd = NaiveDate::from_ymd;
-    ///
-    /// assert_eq!(from_ndays_opt(730_000),      Some(from_ymd(1999, 9, 3)));
-    /// assert_eq!(from_ndays_opt(1),            Some(from_ymd(1, 1, 1)));
-    /// assert_eq!(from_ndays_opt(0),            Some(from_ymd(0, 12, 31)));
-    /// assert_eq!(from_ndays_opt(-1),           Some(from_ymd(0, 12, 30)));
-    /// assert_eq!(from_ndays_opt(100_000_000),  None);
-    /// assert_eq!(from_ndays_opt(-100_000_000), None);
-    /// ```
-    pub fn from_num_days_from_ce_opt(days: i32) -> Option<NaiveDate> {
+    pub fn from_num_days_from_ce(days: i32) -> Result<NaiveDate, ChronoError> {
         let days = days + 365; // make December 31, 1 BCE equal to day 0
         let (year_div_400, cycle) = div_mod_floor(days, 146_097);
         let (year_mod_400, ordinal) = internals::cycle_to_yo(cycle as u32);
@@ -508,16 +446,14 @@ impl NaiveDate {
         NaiveDate::from_of(year_div_400 * 400 + year_mod_400 as i32, Of::new(ordinal, flags))
     }
 
-    /// Makes a new `NaiveDate` by counting the number of occurrences of a particular day-of-week
-    /// since the beginning of the given month.  For instance, if you want the 2nd Friday of March
-    /// 2017, you would use `NaiveDate::from_weekday_of_month(2017, 3, Weekday::Fri, 2)`.
+    /// Makes a new `NaiveDate` by counting the number of occurrences of a
+    /// particular day-of-week since the beginning of the given month.  For
+    /// instance, if you want the 2nd Friday of March 2017, you would use
+    /// `NaiveDate::from_weekday_of_month(2017, 3, Weekday::Fri, 2)`.
     ///
-    /// # Panics
-    ///
-    /// The resulting `NaiveDate` is guaranteed to be in `month`.  If `n` is larger than the number
-    /// of `weekday` in `month` (eg. the 6th Friday of March 2017) then this function will panic.
-    ///
-    /// `n` is 1-indexed.  Passing `n=0` will cause a panic.
+    /// Returns `Err(ChronoError)` if `n` out-of-range; ie. if `n` is larger
+    /// than the number of `weekday` in `month` (eg. the 6th Friday of March
+    /// 2017), or if `n == 0`.
     ///
     /// # Example
     ///
@@ -527,41 +463,27 @@ impl NaiveDate {
     /// let from_weekday_of_month = NaiveDate::from_weekday_of_month;
     /// let from_ymd = NaiveDate::from_ymd;
     ///
-    /// assert_eq!(from_weekday_of_month(2018, 8, Weekday::Wed, 1), from_ymd(2018, 8, 1));
-    /// assert_eq!(from_weekday_of_month(2018, 8, Weekday::Fri, 1), from_ymd(2018, 8, 3));
-    /// assert_eq!(from_weekday_of_month(2018, 8, Weekday::Tue, 2), from_ymd(2018, 8, 14));
-    /// assert_eq!(from_weekday_of_month(2018, 8, Weekday::Fri, 4), from_ymd(2018, 8, 24));
-    /// assert_eq!(from_weekday_of_month(2018, 8, Weekday::Fri, 5), from_ymd(2018, 8, 31));
+    /// assert_eq!(from_weekday_of_month(2018, 8, Weekday::Wed, 1)?, from_ymd(2018, 8, 1)?);
+    /// assert_eq!(from_weekday_of_month(2018, 8, Weekday::Fri, 1)?, from_ymd(2018, 8, 3)?);
+    /// assert_eq!(from_weekday_of_month(2018, 8, Weekday::Tue, 2)?, from_ymd(2018, 8, 14)?);
+    /// assert_eq!(from_weekday_of_month(2018, 8, Weekday::Fri, 4)?, from_ymd(2018, 8, 24)?);
+    /// assert_eq!(from_weekday_of_month(2018, 8, Weekday::Fri, 5)?, from_ymd(2018, 8, 31)?);
+    /// assert_eq!(NaiveDate::from_weekday_of_month(2017, 3, Weekday::Fri, 2)?, NaiveDate::from_ymd(2017, 3, 10)?);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn from_weekday_of_month(year: i32, month: u32, weekday: Weekday, n: u8) -> NaiveDate {
-        NaiveDate::from_weekday_of_month_opt(year, month, weekday, n).expect("out-of-range date")
-    }
-
-    /// Makes a new `NaiveDate` by counting the number of occurrences of a particular day-of-week
-    /// since the beginning of the given month.  For instance, if you want the 2nd Friday of March
-    /// 2017, you would use `NaiveDate::from_weekday_of_month(2017, 3, Weekday::Fri, 2)`.  `n` is 1-indexed.
-    ///
-    /// ```
-    /// use chrono::{NaiveDate, Weekday};
-    /// assert_eq!(NaiveDate::from_weekday_of_month_opt(2017, 3, Weekday::Fri, 2),
-    ///            NaiveDate::from_ymd_opt(2017, 3, 10))
-    /// ```
-    ///
-    /// Returns `None` if `n` out-of-range; ie. if `n` is larger than the number of `weekday` in
-    /// `month` (eg. the 6th Friday of March 2017), or if `n == 0`.
-    pub fn from_weekday_of_month_opt(
+    pub fn from_weekday_of_month(
         year: i32,
         month: u32,
         weekday: Weekday,
         n: u8,
-    ) -> Option<NaiveDate> {
+    ) -> Result<NaiveDate, ChronoError> {
         if n == 0 {
-            return None;
+            return Err(ChronoError::new(ChronoErrorKind::InvalidDate));
         }
-        let first = NaiveDate::from_ymd(year, month, 1).weekday();
+        let first = NaiveDate::from_ymd(year, month, 1)?.weekday();
         let first_to_dow = (7 + weekday.number_from_monday() - first.number_from_monday()) % 7;
         let day = (u32::from(n) - 1) * 7 + first_to_dow + 1;
-        NaiveDate::from_ymd_opt(year, month, day)
+        NaiveDate::from_ymd(year, month, day)
     }
 
     /// Parses a string with the specified format string and returns a new `NaiveDate`.
@@ -575,10 +497,11 @@ impl NaiveDate {
     ///
     /// let parse_from_str = NaiveDate::parse_from_str;
     ///
-    /// assert_eq!(parse_from_str("2015-09-05", "%Y-%m-%d"),
-    ///            Ok(NaiveDate::from_ymd(2015, 9, 5)));
-    /// assert_eq!(parse_from_str("5sep2015", "%d%b%Y"),
-    ///            Ok(NaiveDate::from_ymd(2015, 9, 5)));
+    /// assert_eq!(parse_from_str("2015-09-05", "%Y-%m-%d")?,
+    ///            NaiveDate::from_ymd(2015, 9, 5)?);
+    /// assert_eq!(parse_from_str("5sep2015", "%d%b%Y")?,
+    ///            NaiveDate::from_ymd(2015, 9, 5)?);
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     ///
     /// Time and offset is ignored for the purpose of parsing.
@@ -586,8 +509,9 @@ impl NaiveDate {
     /// ```
     /// # use chrono::NaiveDate;
     /// # let parse_from_str = NaiveDate::parse_from_str;
-    /// assert_eq!(parse_from_str("2014-5-17T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
-    ///            Ok(NaiveDate::from_ymd(2014, 5, 17)));
+    /// assert_eq!(parse_from_str("2014-5-17T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z")?,
+    ///            NaiveDate::from_ymd(2014, 5, 17)?);
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     ///
     /// Out-of-bound dates or insufficient fields are errors.
@@ -616,62 +540,64 @@ impl NaiveDate {
     ///
     /// If the day would be out of range for the resulting month, use the last day for that month.
     ///
-    /// Returns `None` if the resulting date would be out of range.
+    /// Returns `Err(ChronoError)` if the resulting date would be out of range.
     ///
     /// ```
     /// # use chrono::{NaiveDate, Months};
     /// assert_eq!(
-    ///     NaiveDate::from_ymd(2022, 2, 20).checked_add_months(Months::new(6)),
-    ///     Some(NaiveDate::from_ymd(2022, 8, 20))
+    ///     NaiveDate::from_ymd(2022, 2, 20)?.checked_add_months(Months::new(6))?,
+    ///     NaiveDate::from_ymd(2022, 8, 20)?
     /// );
     /// assert_eq!(
-    ///     NaiveDate::from_ymd(2022, 7, 31).checked_add_months(Months::new(2)),
-    ///     Some(NaiveDate::from_ymd(2022, 9, 30))
+    ///     NaiveDate::from_ymd(2022, 7, 31)?.checked_add_months(Months::new(2))?,
+    ///     NaiveDate::from_ymd(2022, 9, 30)?
     /// );
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn checked_add_months(self, months: Months) -> Option<Self> {
+    pub fn checked_add_months(self, months: Months) -> Result<Self, ChronoError> {
         if months.0 == 0 {
-            return Some(self);
+            return Ok(self);
         }
 
-        match months.0 <= core::i32::MAX as u32 {
-            true => self.diff_months(months.0 as i32),
-            false => None,
-        }
+        let d = i32::try_from(months.0).ok().ok_or(ChronoErrorKind::InvalidDate)?;
+        self.diff_months(d)
     }
 
     /// Subtract a duration in [`Months`] from the date
     ///
     /// If the day would be out of range for the resulting month, use the last day for that month.
     ///
-    /// Returns `None` if the resulting date would be out of range.
+    /// Returns `Err(ChronoError)` if the resulting date would be out of range.
     ///
     /// ```
-    /// # use chrono::{NaiveDate, Months};
-    /// assert_eq!(
-    ///     NaiveDate::from_ymd(2022, 2, 20).checked_sub_months(Months::new(6)),
-    ///     Some(NaiveDate::from_ymd(2021, 8, 20))
-    /// );
+    /// use chrono::{NaiveDate, Months};
     ///
     /// assert_eq!(
-    ///     NaiveDate::from_ymd(2014, 1, 1)
-    ///         .checked_sub_months(Months::new(core::i32::MAX as u32 + 1)),
-    ///     None
+    ///     NaiveDate::from_ymd(2022, 2, 20)?.checked_sub_months(Months::new(6))?,
+    ///     NaiveDate::from_ymd(2021, 8, 20)?
     /// );
+    ///
+    /// assert!(
+    ///     NaiveDate::from_ymd(2014, 1, 1)?
+    ///         .checked_sub_months(Months::new(core::i32::MAX as u32 + 1))
+    ///         .is_err()
+    /// );
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn checked_sub_months(self, months: Months) -> Option<Self> {
+    pub fn checked_sub_months(self, months: Months) -> Result<Self, ChronoError> {
         if months.0 == 0 {
-            return Some(self);
+            return Ok(self);
         }
 
-        // Copy `i32::MAX` here so we don't have to do a complicated cast
-        match months.0 <= 2_147_483_647 {
-            true => self.diff_months(-(months.0 as i32)),
-            false => None,
-        }
+        let d = i32::try_from(months.0)
+            .ok()
+            .and_then(|n| n.checked_neg())
+            .ok_or(ChronoErrorKind::InvalidDate)?;
+
+        self.diff_months(d)
     }
 
-    fn diff_months(self, months: i32) -> Option<Self> {
+    fn diff_months(self, months: i32) -> Result<Self, ChronoError> {
         let (years, left) = ((months / 12), (months % 12));
 
         // Determine new year (without taking months into account for now
@@ -679,7 +605,7 @@ impl NaiveDate {
         let year = if (years > 0 && years > (MAX_YEAR - self.year()))
             || (years < 0 && years < (MIN_YEAR - self.year()))
         {
-            return None;
+            return Err(ChronoError::new(ChronoErrorKind::InvalidDate));
         } else {
             self.year() + years
         };
@@ -689,13 +615,13 @@ impl NaiveDate {
         let month = self.month() as i32 + left;
         let (year, month) = if month <= 0 {
             if year == MIN_YEAR {
-                return None;
+                return Err(ChronoError::new(ChronoErrorKind::InvalidDate));
             }
 
             (year - 1, month + 12)
         } else if month > 12 {
             if year == MAX_YEAR {
-                return None;
+                return Err(ChronoError::new(ChronoErrorKind::InvalidDate));
             }
 
             (year + 1, month - 12)
@@ -715,47 +641,56 @@ impl NaiveDate {
 
     /// Add a duration in [`Days`] to the date
     ///
-    /// Returns `None` if the resulting date would be out of range.
+    /// Returns `Err(ChronoError)` if the resulting date would be out of range.
     ///
     /// ```
-    /// # use chrono::{NaiveDate, Days};
+    /// use chrono::{NaiveDate, Days};
+    ///
     /// assert_eq!(
-    ///     NaiveDate::from_ymd(2022, 2, 20).checked_add_days(Days::new(9)),
-    ///     Some(NaiveDate::from_ymd(2022, 3, 1))
+    ///     NaiveDate::from_ymd(2022, 2, 20)?.checked_add_days(Days::new(9))?,
+    ///     NaiveDate::from_ymd(2022, 3, 1)?
     /// );
     /// assert_eq!(
-    ///     NaiveDate::from_ymd(2022, 7, 31).checked_add_days(Days::new(2)),
-    ///     Some(NaiveDate::from_ymd(2022, 8, 2))
+    ///     NaiveDate::from_ymd(2022, 7, 31)?.checked_add_days(Days::new(2))?,
+    ///     NaiveDate::from_ymd(2022, 8, 2)?
     /// );
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn checked_add_days(self, days: Days) -> Option<Self> {
+    pub fn checked_add_days(self, days: Days) -> Result<Self, ChronoError> {
         if days.0 == 0 {
-            return Some(self);
+            return Ok(self);
         }
 
-        i64::try_from(days.0).ok().and_then(|d| self.diff_days(d))
+        let d = i64::try_from(days.0).ok().ok_or(ChronoErrorKind::InvalidDate)?;
+        self.diff_days(d)
     }
 
     /// Subtract a duration in [`Days`] from the date
     ///
-    /// Returns `None` if the resulting date would be out of range.
+    /// Returns `Err(ChronoError)` if the resulting date would be out of range.
     ///
     /// ```
-    /// # use chrono::{NaiveDate, Days};
+    /// use chrono::{NaiveDate, Days};
+    ///
     /// assert_eq!(
-    ///     NaiveDate::from_ymd(2022, 2, 20).checked_sub_days(Days::new(6)),
-    ///     Some(NaiveDate::from_ymd(2022, 2, 14))
+    ///     NaiveDate::from_ymd(2022, 2, 20)?.checked_sub_days(Days::new(6))?,
+    ///     NaiveDate::from_ymd(2022, 2, 14)?
     /// );
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn checked_sub_days(self, days: Days) -> Option<Self> {
+    pub fn checked_sub_days(self, days: Days) -> Result<Self, ChronoError> {
         if days.0 == 0 {
-            return Some(self);
+            return Ok(self);
         }
 
-        i64::try_from(days.0).ok().and_then(|d| self.diff_days(-d))
+        let d = i64::try_from(days.0)
+            .ok()
+            .and_then(|n| n.checked_neg())
+            .ok_or(ChronoErrorKind::InvalidDate)?;
+        self.diff_days(d)
     }
 
-    fn diff_days(self, days: i64) -> Option<Self> {
+    fn diff_days(self, days: i64) -> Result<Self, ChronoError> {
         self.checked_add_signed(TimeDelta::days(days))
     }
 
@@ -766,12 +701,13 @@ impl NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, NaiveTime, NaiveDateTime};
     ///
-    /// let d = NaiveDate::from_ymd(2015, 6, 3);
-    /// let t = NaiveTime::from_hms_milli(12, 34, 56, 789);
+    /// let d = NaiveDate::from_ymd(2015, 6, 3)?;
+    /// let t = NaiveTime::from_hms_milli(12, 34, 56, 789)?;
     ///
     /// let dt: NaiveDateTime = d.and_time(t);
     /// assert_eq!(dt.date(), d);
     /// assert_eq!(dt.time(), t);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     pub fn and_time(&self, time: NaiveTime) -> NaiveDateTime {
@@ -790,95 +726,72 @@ impl NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike, Timelike, Weekday};
     ///
-    /// let d = NaiveDate::from_ymd(2015, 6, 3);
+    /// let d = NaiveDate::from_ymd(2015, 6, 3)?;
     ///
-    /// let dt: NaiveDateTime = d.and_hms(12, 34, 56);
+    /// let dt: NaiveDateTime = d.and_hms(12, 34, 56)?;
     /// assert_eq!(dt.year(), 2015);
     /// assert_eq!(dt.weekday(), Weekday::Wed);
     /// assert_eq!(dt.second(), 56);
+    ///
+    /// let d = NaiveDate::from_ymd(2015, 6, 3)?;
+    /// assert!(d.and_hms(12, 34, 56).is_ok());
+    /// assert!(d.and_hms(12, 34, 60).is_err()); // use `and_hms_milli` instead
+    /// assert!(d.and_hms(12, 60, 56).is_err());
+    /// assert!(d.and_hms(24, 34, 56).is_err());
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
-    pub fn and_hms(&self, hour: u32, min: u32, sec: u32) -> NaiveDateTime {
-        self.and_hms_opt(hour, min, sec).expect("invalid time")
+    pub fn and_hms(&self, hour: u32, min: u32, sec: u32) -> Result<NaiveDateTime, ChronoError> {
+        let time = NaiveTime::from_hms(hour, min, sec)?;
+        Ok(self.and_time(time))
     }
 
-    /// Makes a new `NaiveDateTime` from the current date, hour, minute and second.
-    ///
-    /// No [leap second](./struct.NaiveTime.html#leap-second-handling) is allowed here;
-    /// use `NaiveDate::and_hms_*_opt` methods with a subsecond parameter instead.
-    ///
-    /// Returns `None` on invalid hour, minute and/or second.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use chrono::NaiveDate;
-    ///
-    /// let d = NaiveDate::from_ymd(2015, 6, 3);
-    /// assert!(d.and_hms_opt(12, 34, 56).is_some());
-    /// assert!(d.and_hms_opt(12, 34, 60).is_none()); // use `and_hms_milli_opt` instead
-    /// assert!(d.and_hms_opt(12, 60, 56).is_none());
-    /// assert!(d.and_hms_opt(24, 34, 56).is_none());
-    /// ```
-    #[inline]
-    pub fn and_hms_opt(&self, hour: u32, min: u32, sec: u32) -> Option<NaiveDateTime> {
-        NaiveTime::from_hms_opt(hour, min, sec).map(|time| self.and_time(time))
+    /// Makes a new `NaiveDateTime` with the time set to midnight.
+    pub(crate) fn and_midnight(&self) -> NaiveDateTime {
+        self.and_time(NaiveTime::midnight())
     }
 
-    /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and millisecond.
+    /// Makes a new `NaiveDateTime` from the current date, hour, minute, second
+    /// and millisecond.
     ///
-    /// The millisecond part can exceed 1,000
-    /// in order to represent the [leap second](./struct.NaiveTime.html#leap-second-handling).
+    /// The millisecond part can exceed 1,000 in order to represent the [leap
+    /// second](./struct.NaiveTime.html#leap-second-handling).
     ///
-    /// Panics on invalid hour, minute, second and/or millisecond.
+    /// Returns `Err(ChronoError)` on invalid hour, minute, second and/or
+    /// millisecond.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike, Timelike, Weekday};
     ///
-    /// let d = NaiveDate::from_ymd(2015, 6, 3);
+    /// let d = NaiveDate::from_ymd(2015, 6, 3)?;
     ///
-    /// let dt: NaiveDateTime = d.and_hms_milli(12, 34, 56, 789);
+    /// let dt: NaiveDateTime = d.and_hms_milli(12, 34, 56, 789)?;
     /// assert_eq!(dt.year(), 2015);
     /// assert_eq!(dt.weekday(), Weekday::Wed);
     /// assert_eq!(dt.second(), 56);
     /// assert_eq!(dt.nanosecond(), 789_000_000);
+    ///
+    /// let d = NaiveDate::from_ymd(2015, 6, 3)?;
+    /// assert!(d.and_hms_milli(12, 34, 56,   789).is_ok());
+    /// assert!(d.and_hms_milli(12, 34, 59, 1_789).is_ok()); // leap second
+    /// assert!(d.and_hms_milli(12, 34, 59, 2_789).is_err());
+    /// assert!(d.and_hms_milli(12, 34, 60,   789).is_err());
+    /// assert!(d.and_hms_milli(12, 60, 56,   789).is_err());
+    /// assert!(d.and_hms_milli(24, 34, 56,   789).is_err());
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
-    pub fn and_hms_milli(&self, hour: u32, min: u32, sec: u32, milli: u32) -> NaiveDateTime {
-        self.and_hms_milli_opt(hour, min, sec, milli).expect("invalid time")
-    }
-
-    /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and millisecond.
-    ///
-    /// The millisecond part can exceed 1,000
-    /// in order to represent the [leap second](./struct.NaiveTime.html#leap-second-handling).
-    ///
-    /// Returns `None` on invalid hour, minute, second and/or millisecond.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use chrono::NaiveDate;
-    ///
-    /// let d = NaiveDate::from_ymd(2015, 6, 3);
-    /// assert!(d.and_hms_milli_opt(12, 34, 56,   789).is_some());
-    /// assert!(d.and_hms_milli_opt(12, 34, 59, 1_789).is_some()); // leap second
-    /// assert!(d.and_hms_milli_opt(12, 34, 59, 2_789).is_none());
-    /// assert!(d.and_hms_milli_opt(12, 34, 60,   789).is_none());
-    /// assert!(d.and_hms_milli_opt(12, 60, 56,   789).is_none());
-    /// assert!(d.and_hms_milli_opt(24, 34, 56,   789).is_none());
-    /// ```
-    #[inline]
-    pub fn and_hms_milli_opt(
+    pub fn and_hms_milli(
         &self,
         hour: u32,
         min: u32,
         sec: u32,
         milli: u32,
-    ) -> Option<NaiveDateTime> {
-        NaiveTime::from_hms_milli_opt(hour, min, sec, milli).map(|time| self.and_time(time))
+    ) -> Result<NaiveDateTime, ChronoError> {
+        let time = NaiveTime::from_hms_milli(hour, min, sec, milli)?;
+        Ok(self.and_time(time))
     }
 
     /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and microsecond.
@@ -886,55 +799,40 @@ impl NaiveDate {
     /// The microsecond part can exceed 1,000,000
     /// in order to represent the [leap second](./struct.NaiveTime.html#leap-second-handling).
     ///
-    /// Panics on invalid hour, minute, second and/or microsecond.
+    /// Returns `Err(ChronoError)` on invalid hour, minute, second and/or microsecond.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike, Timelike, Weekday};
     ///
-    /// let d = NaiveDate::from_ymd(2015, 6, 3);
+    /// let d = NaiveDate::from_ymd(2015, 6, 3)?;
     ///
-    /// let dt: NaiveDateTime = d.and_hms_micro(12, 34, 56, 789_012);
+    /// let dt: NaiveDateTime = d.and_hms_micro(12, 34, 56, 789_012)?;
     /// assert_eq!(dt.year(), 2015);
     /// assert_eq!(dt.weekday(), Weekday::Wed);
     /// assert_eq!(dt.second(), 56);
     /// assert_eq!(dt.nanosecond(), 789_012_000);
+    ///
+    /// let d = NaiveDate::from_ymd(2015, 6, 3)?;
+    /// assert!(d.and_hms_micro(12, 34, 56, 789_012).is_ok());
+    /// assert!(d.and_hms_micro(12, 34, 59, 1_789_012).is_ok()); // leap second
+    /// assert!(d.and_hms_micro(12, 34, 59, 2_789_012).is_err());
+    /// assert!(d.and_hms_micro(12, 34, 60, 789_012).is_err());
+    /// assert!(d.and_hms_micro(12, 60, 56, 789_012).is_err());
+    /// assert!(d.and_hms_micro(24, 34, 56, 789_012).is_err());
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
-    pub fn and_hms_micro(&self, hour: u32, min: u32, sec: u32, micro: u32) -> NaiveDateTime {
-        self.and_hms_micro_opt(hour, min, sec, micro).expect("invalid time")
-    }
-
-    /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and microsecond.
-    ///
-    /// The microsecond part can exceed 1,000,000
-    /// in order to represent the [leap second](./struct.NaiveTime.html#leap-second-handling).
-    ///
-    /// Returns `None` on invalid hour, minute, second and/or microsecond.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use chrono::NaiveDate;
-    ///
-    /// let d = NaiveDate::from_ymd(2015, 6, 3);
-    /// assert!(d.and_hms_micro_opt(12, 34, 56,   789_012).is_some());
-    /// assert!(d.and_hms_micro_opt(12, 34, 59, 1_789_012).is_some()); // leap second
-    /// assert!(d.and_hms_micro_opt(12, 34, 59, 2_789_012).is_none());
-    /// assert!(d.and_hms_micro_opt(12, 34, 60,   789_012).is_none());
-    /// assert!(d.and_hms_micro_opt(12, 60, 56,   789_012).is_none());
-    /// assert!(d.and_hms_micro_opt(24, 34, 56,   789_012).is_none());
-    /// ```
-    #[inline]
-    pub fn and_hms_micro_opt(
+    pub fn and_hms_micro(
         &self,
         hour: u32,
         min: u32,
         sec: u32,
         micro: u32,
-    ) -> Option<NaiveDateTime> {
-        NaiveTime::from_hms_micro_opt(hour, min, sec, micro).map(|time| self.and_time(time))
+    ) -> Result<NaiveDateTime, ChronoError> {
+        let time = NaiveTime::from_hms_micro(hour, min, sec, micro)?;
+        Ok(self.and_time(time))
     }
 
     /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and nanosecond.
@@ -942,55 +840,40 @@ impl NaiveDate {
     /// The nanosecond part can exceed 1,000,000,000
     /// in order to represent the [leap second](./struct.NaiveTime.html#leap-second-handling).
     ///
-    /// Panics on invalid hour, minute, second and/or nanosecond.
+    /// Returns `Err(ChronoError)` on invalid hour, minute, second and/or nanosecond.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike, Timelike, Weekday};
     ///
-    /// let d = NaiveDate::from_ymd(2015, 6, 3);
+    /// let d = NaiveDate::from_ymd(2015, 6, 3)?;
     ///
-    /// let dt: NaiveDateTime = d.and_hms_nano(12, 34, 56, 789_012_345);
+    /// let dt: NaiveDateTime = d.and_hms_nano(12, 34, 56, 789_012_345)?;
     /// assert_eq!(dt.year(), 2015);
     /// assert_eq!(dt.weekday(), Weekday::Wed);
     /// assert_eq!(dt.second(), 56);
     /// assert_eq!(dt.nanosecond(), 789_012_345);
+    ///
+    /// let d = NaiveDate::from_ymd(2015, 6, 3)?;
+    /// assert!(d.and_hms_nano(12, 34, 56, 789_012_345).is_ok());
+    /// assert!(d.and_hms_nano(12, 34, 59, 1_789_012_345).is_ok()); // leap second
+    /// assert!(d.and_hms_nano(12, 34, 59, 2_789_012_345).is_err());
+    /// assert!(d.and_hms_nano(12, 34, 60, 789_012_345).is_err());
+    /// assert!(d.and_hms_nano(12, 60, 56, 789_012_345).is_err());
+    /// assert!(d.and_hms_nano(24, 34, 56, 789_012_345).is_err());
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
-    pub fn and_hms_nano(&self, hour: u32, min: u32, sec: u32, nano: u32) -> NaiveDateTime {
-        self.and_hms_nano_opt(hour, min, sec, nano).expect("invalid time")
-    }
-
-    /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and nanosecond.
-    ///
-    /// The nanosecond part can exceed 1,000,000,000
-    /// in order to represent the [leap second](./struct.NaiveTime.html#leap-second-handling).
-    ///
-    /// Returns `None` on invalid hour, minute, second and/or nanosecond.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use chrono::NaiveDate;
-    ///
-    /// let d = NaiveDate::from_ymd(2015, 6, 3);
-    /// assert!(d.and_hms_nano_opt(12, 34, 56,   789_012_345).is_some());
-    /// assert!(d.and_hms_nano_opt(12, 34, 59, 1_789_012_345).is_some()); // leap second
-    /// assert!(d.and_hms_nano_opt(12, 34, 59, 2_789_012_345).is_none());
-    /// assert!(d.and_hms_nano_opt(12, 34, 60,   789_012_345).is_none());
-    /// assert!(d.and_hms_nano_opt(12, 60, 56,   789_012_345).is_none());
-    /// assert!(d.and_hms_nano_opt(24, 34, 56,   789_012_345).is_none());
-    /// ```
-    #[inline]
-    pub fn and_hms_nano_opt(
+    pub fn and_hms_nano(
         &self,
         hour: u32,
         min: u32,
         sec: u32,
         nano: u32,
-    ) -> Option<NaiveDateTime> {
-        NaiveTime::from_hms_nano_opt(hour, min, sec, nano).map(|time| self.and_time(time))
+    ) -> Result<NaiveDateTime, ChronoError> {
+        let time = NaiveTime::from_hms_nano(hour, min, sec, nano)?;
+        Ok(self.and_time(time))
     }
 
     /// Returns the packed month-day-flags.
@@ -1007,120 +890,104 @@ impl NaiveDate {
 
     /// Makes a new `NaiveDate` with the packed month-day-flags changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting `NaiveDate` would be invalid.
     #[inline]
-    fn with_mdf(&self, mdf: Mdf) -> Option<NaiveDate> {
+    fn with_mdf(&self, mdf: Mdf) -> Result<NaiveDate, ChronoError> {
         self.with_of(mdf.to_of())
     }
 
     /// Makes a new `NaiveDate` with the packed ordinal-flags changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting `NaiveDate` would be invalid.
     #[inline]
-    fn with_of(&self, of: Of) -> Option<NaiveDate> {
+    fn with_of(&self, of: Of) -> Result<NaiveDate, ChronoError> {
         if of.valid() {
             let Of(of) = of;
-            Some(NaiveDate { ymdf: (self.ymdf & !0b1_1111_1111_1111) | of as DateImpl })
+            Ok(NaiveDate { ymdf: (self.ymdf & !0b1_1111_1111_1111) | of as DateImpl })
         } else {
-            None
+            Err(ChronoError::new(ChronoErrorKind::InvalidDate))
         }
     }
 
     /// Makes a new `NaiveDate` for the next calendar date.
     ///
-    /// Panics when `self` is the last representable date.
+    /// Returns `Err(ChronoError)` when `self` is the last representable date.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015,  6,  3).succ(), NaiveDate::from_ymd(2015, 6, 4));
-    /// assert_eq!(NaiveDate::from_ymd(2015,  6, 30).succ(), NaiveDate::from_ymd(2015, 7, 1));
-    /// assert_eq!(NaiveDate::from_ymd(2015, 12, 31).succ(), NaiveDate::from_ymd(2016, 1, 1));
+    /// assert_eq!(NaiveDate::from_ymd(2015,  6,  3)?.succ()?, NaiveDate::from_ymd(2015, 6, 4)?);
+    /// assert_eq!(NaiveDate::from_ymd(2015,  6, 30)?.succ()?, NaiveDate::from_ymd(2015, 7, 1)?);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 12, 31)?.succ()?, NaiveDate::from_ymd(2016, 1, 1)?);
+    ///
+    /// assert_eq!(NaiveDate::from_ymd(2015, 6, 3)?.succ()?,
+    ///            NaiveDate::from_ymd(2015, 6, 4)?);
+    /// assert!(NaiveDate::MAX.succ().is_err());
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
-    pub fn succ(&self) -> NaiveDate {
-        self.succ_opt().expect("out of bound")
-    }
-
-    /// Makes a new `NaiveDate` for the next calendar date.
-    ///
-    /// Returns `None` when `self` is the last representable date.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use chrono::NaiveDate;
-    ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 6, 3).succ_opt(),
-    ///            Some(NaiveDate::from_ymd(2015, 6, 4)));
-    /// assert_eq!(NaiveDate::MAX.succ_opt(), None);
-    /// ```
-    #[inline]
-    pub fn succ_opt(&self) -> Option<NaiveDate> {
-        self.with_of(self.of().succ()).or_else(|| NaiveDate::from_ymd_opt(self.year() + 1, 1, 1))
+    pub fn succ(&self) -> Result<NaiveDate, ChronoError> {
+        match self.with_of(self.of().succ()) {
+            Ok(date) => Ok(date),
+            Err(..) => NaiveDate::from_ymd(self.year() + 1, 1, 1),
+        }
     }
 
     /// Makes a new `NaiveDate` for the previous calendar date.
     ///
-    /// Panics when `self` is the first representable date.
+    /// Returns `Err(ChronoError)` when `self` is the first representable date.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 6, 3).pred(), NaiveDate::from_ymd(2015,  6,  2));
-    /// assert_eq!(NaiveDate::from_ymd(2015, 6, 1).pred(), NaiveDate::from_ymd(2015,  5, 31));
-    /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1).pred(), NaiveDate::from_ymd(2014, 12, 31));
+    /// assert_eq!(NaiveDate::from_ymd(2015, 6, 3)?.pred()?, NaiveDate::from_ymd(2015, 6, 2)?);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 6, 1)?.pred()?, NaiveDate::from_ymd(2015, 5, 31)?);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1)?.pred()?, NaiveDate::from_ymd(2014, 12, 31)?);
+    ///
+    /// assert_eq!(NaiveDate::from_ymd(2015, 6, 3)?.pred()?,
+    ///            NaiveDate::from_ymd(2015, 6, 2)?);
+    /// assert!(NaiveDate::MIN.pred().is_err());
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
-    pub fn pred(&self) -> NaiveDate {
-        self.pred_opt().expect("out of bound")
-    }
-
-    /// Makes a new `NaiveDate` for the previous calendar date.
-    ///
-    /// Returns `None` when `self` is the first representable date.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use chrono::NaiveDate;
-    ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 6, 3).pred_opt(),
-    ///            Some(NaiveDate::from_ymd(2015, 6, 2)));
-    /// assert_eq!(NaiveDate::MIN.pred_opt(), None);
-    /// ```
-    #[inline]
-    pub fn pred_opt(&self) -> Option<NaiveDate> {
-        self.with_of(self.of().pred()).or_else(|| NaiveDate::from_ymd_opt(self.year() - 1, 12, 31))
+    pub fn pred(&self) -> Result<NaiveDate, ChronoError> {
+        match self.with_of(self.of().pred()) {
+            Ok(date) => Ok(date),
+            Err(..) => NaiveDate::from_ymd(self.year() - 1, 12, 31),
+        }
     }
 
     /// Adds the `days` part of given `Duration` to the current date.
     ///
-    /// Returns `None` when it will result in overflow.
+    /// Returns `Err(ChronoError)` when it will result in overflow.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{TimeDelta, NaiveDate};
     ///
-    /// let d = NaiveDate::from_ymd(2015, 9, 5);
-    /// assert_eq!(d.checked_add_signed(TimeDelta::days(40)),
-    ///            Some(NaiveDate::from_ymd(2015, 10, 15)));
-    /// assert_eq!(d.checked_add_signed(TimeDelta::days(-40)),
-    ///            Some(NaiveDate::from_ymd(2015, 7, 27)));
-    /// assert_eq!(d.checked_add_signed(TimeDelta::days(1_000_000_000)), None);
-    /// assert_eq!(d.checked_add_signed(TimeDelta::days(-1_000_000_000)), None);
-    /// assert_eq!(NaiveDate::MAX.checked_add_signed(TimeDelta::days(1)), None);
+    /// let d = NaiveDate::from_ymd(2015, 9, 5)?;
+    /// assert_eq!(d.checked_add_signed(TimeDelta::days(40))?,
+    ///            NaiveDate::from_ymd(2015, 10, 15)?);
+    /// assert_eq!(d.checked_add_signed(TimeDelta::days(-40))?,
+    ///            NaiveDate::from_ymd(2015, 7, 27)?);
+    /// assert!(d.checked_add_signed(TimeDelta::days(1_000_000_000)).is_err());
+    /// assert!(d.checked_add_signed(TimeDelta::days(-1_000_000_000)).is_err());
+    /// assert!(NaiveDate::MAX.checked_add_signed(TimeDelta::days(1)).is_err());
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn checked_add_signed(self, rhs: TimeDelta) -> Option<NaiveDate> {
+    pub fn checked_add_signed(self, rhs: TimeDelta) -> Result<NaiveDate, ChronoError> {
         let year = self.year();
         let (mut year_div_400, year_mod_400) = div_mod_floor(year, 400);
         let cycle = internals::yo_to_cycle(year_mod_400 as u32, self.of().ordinal());
-        let cycle = (cycle as i32).checked_add(i32::try_from(rhs.num_days()).ok()?)?;
+        let cycle = i32::try_from(rhs.num_days())
+            .ok()
+            .and_then(|n| (cycle as i32).checked_add(n))
+            .ok_or(ChronoErrorKind::InvalidDate)?;
         let (cycle_div_400y, cycle) = div_mod_floor(cycle, 146_097);
         year_div_400 += cycle_div_400y;
 
@@ -1131,27 +998,31 @@ impl NaiveDate {
 
     /// Subtracts the `days` part of given `TimeDelta` from the current date.
     ///
-    /// Returns `None` when it will result in overflow.
+    /// Returns `Err(ChronoError)` when it will result in overflow.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{TimeDelta, NaiveDate};
     ///
-    /// let d = NaiveDate::from_ymd(2015, 9, 5);
-    /// assert_eq!(d.checked_sub_signed(TimeDelta::days(40)),
-    ///            Some(NaiveDate::from_ymd(2015, 7, 27)));
-    /// assert_eq!(d.checked_sub_signed(TimeDelta::days(-40)),
-    ///            Some(NaiveDate::from_ymd(2015, 10, 15)));
-    /// assert_eq!(d.checked_sub_signed(TimeDelta::days(1_000_000_000)), None);
-    /// assert_eq!(d.checked_sub_signed(TimeDelta::days(-1_000_000_000)), None);
-    /// assert_eq!(NaiveDate::MIN.checked_sub_signed(TimeDelta::days(1)), None);
+    /// let d = NaiveDate::from_ymd(2015, 9, 5)?;
+    /// assert_eq!(d.checked_sub_signed(TimeDelta::days(40))?,
+    ///            NaiveDate::from_ymd(2015, 7, 27)?);
+    /// assert_eq!(d.checked_sub_signed(TimeDelta::days(-40))?,
+    ///            NaiveDate::from_ymd(2015, 10, 15)?);
+    /// assert!(d.checked_sub_signed(TimeDelta::days(1_000_000_000)).is_err());
+    /// assert!(d.checked_sub_signed(TimeDelta::days(-1_000_000_000)).is_err());
+    /// assert!(NaiveDate::MIN.checked_sub_signed(TimeDelta::days(1)).is_err());
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn checked_sub_signed(self, rhs: TimeDelta) -> Option<NaiveDate> {
+    pub fn checked_sub_signed(self, rhs: TimeDelta) -> Result<NaiveDate, ChronoError> {
         let year = self.year();
         let (mut year_div_400, year_mod_400) = div_mod_floor(year, 400);
         let cycle = internals::yo_to_cycle(year_mod_400 as u32, self.of().ordinal());
-        let cycle = (cycle as i32).checked_sub(i32::try_from(rhs.num_days()).ok()?)?;
+        let cycle = i32::try_from(rhs.num_days())
+            .ok()
+            .and_then(|n| (cycle as i32).checked_sub(n))
+            .ok_or(ChronoErrorKind::InvalidDate)?;
         let (cycle_div_400y, cycle) = div_mod_floor(cycle, 146_097);
         year_div_400 += cycle_div_400y;
 
@@ -1174,13 +1045,14 @@ impl NaiveDate {
     /// let from_ymd = NaiveDate::from_ymd;
     /// let since = NaiveDate::signed_duration_since;
     ///
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2014, 1, 1)), TimeDelta::zero());
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2013, 12, 31)), TimeDelta::days(1));
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2014, 1, 2)), TimeDelta::days(-1));
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2013, 9, 23)), TimeDelta::days(100));
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2013, 1, 1)), TimeDelta::days(365));
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2010, 1, 1)), TimeDelta::days(365*4 + 1));
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(1614, 1, 1)), TimeDelta::days(365*400 + 97));
+    /// assert_eq!(since(from_ymd(2014, 1, 1)?, from_ymd(2014, 1, 1)?), TimeDelta::zero());
+    /// assert_eq!(since(from_ymd(2014, 1, 1)?, from_ymd(2013, 12, 31)?), TimeDelta::days(1));
+    /// assert_eq!(since(from_ymd(2014, 1, 1)?, from_ymd(2014, 1, 2)?), TimeDelta::days(-1));
+    /// assert_eq!(since(from_ymd(2014, 1, 1)?, from_ymd(2013, 9, 23)?), TimeDelta::days(100));
+    /// assert_eq!(since(from_ymd(2014, 1, 1)?, from_ymd(2013, 1, 1)?), TimeDelta::days(365));
+    /// assert_eq!(since(from_ymd(2014, 1, 1)?, from_ymd(2010, 1, 1)?), TimeDelta::days(365*4 + 1));
+    /// assert_eq!(since(from_ymd(2014, 1, 1)?, from_ymd(1614, 1, 1)?), TimeDelta::days(365*400 + 97));
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     pub fn signed_duration_since(self, rhs: NaiveDate) -> TimeDelta {
         let year1 = self.year();
@@ -1207,9 +1079,10 @@ impl NaiveDate {
     /// use chrono::format::strftime::StrftimeItems;
     ///
     /// let fmt = StrftimeItems::new("%Y-%m-%d");
-    /// let d = NaiveDate::from_ymd(2015, 9, 5);
+    /// let d = NaiveDate::from_ymd(2015, 9, 5)?;
     /// assert_eq!(d.format_with_items(fmt.clone()).to_string(), "2015-09-05");
-    /// assert_eq!(d.format("%Y-%m-%d").to_string(),             "2015-09-05");
+    /// assert_eq!(d.format("%Y-%m-%d").to_string(), "2015-09-05");
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     ///
     /// The resulting `DelayedFormat` can be formatted directly via the `Display` trait.
@@ -1218,8 +1091,9 @@ impl NaiveDate {
     /// # use chrono::NaiveDate;
     /// # use chrono::format::strftime::StrftimeItems;
     /// # let fmt = StrftimeItems::new("%Y-%m-%d").clone();
-    /// # let d = NaiveDate::from_ymd(2015, 9, 5);
+    /// # let d = NaiveDate::from_ymd(2015, 9, 5)?;
     /// assert_eq!(format!("{}", d.format_with_items(fmt)), "2015-09-05");
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
@@ -1251,18 +1125,20 @@ impl NaiveDate {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let d = NaiveDate::from_ymd(2015, 9, 5);
+    /// let d = NaiveDate::from_ymd(2015, 9, 5)?;
     /// assert_eq!(d.format("%Y-%m-%d").to_string(), "2015-09-05");
     /// assert_eq!(d.format("%A, %-d %B, %C%y").to_string(), "Saturday, 5 September, 2015");
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     ///
     /// The resulting `DelayedFormat` can be formatted directly via the `Display` trait.
     ///
     /// ```
     /// # use chrono::NaiveDate;
-    /// # let d = NaiveDate::from_ymd(2015, 9, 5);
+    /// # let d = NaiveDate::from_ymd(2015, 9, 5)?;
     /// assert_eq!(format!("{}", d.format("%Y-%m-%d")), "2015-09-05");
     /// assert_eq!(format!("{}", d.format("%A, %-d %B, %C%y")), "Saturday, 5 September, 2015");
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
@@ -1279,23 +1155,24 @@ impl NaiveDate {
     /// # use chrono::NaiveDate;
     ///
     /// let expected = [
-    ///     NaiveDate::from_ymd(2016, 2, 27),
-    ///     NaiveDate::from_ymd(2016, 2, 28),
-    ///     NaiveDate::from_ymd(2016, 2, 29),
-    ///     NaiveDate::from_ymd(2016, 3, 1),
+    ///     NaiveDate::from_ymd(2016, 2, 27)?,
+    ///     NaiveDate::from_ymd(2016, 2, 28)?,
+    ///     NaiveDate::from_ymd(2016, 2, 29)?,
+    ///     NaiveDate::from_ymd(2016, 3, 1)?,
     /// ];
     ///
     /// let mut count = 0;
-    /// for (idx, d) in NaiveDate::from_ymd(2016, 2, 27).iter_days().take(4).enumerate() {
+    /// for (idx, d) in NaiveDate::from_ymd(2016, 2, 27)?.iter_days().take(4).enumerate() {
     ///    assert_eq!(d, expected[idx]);
     ///    count += 1;
     /// }
     /// assert_eq!(count, 4);
     ///
-    /// for d in NaiveDate::from_ymd(2016, 3, 1).iter_days().rev().take(4) {
+    /// for d in NaiveDate::from_ymd(2016, 3, 1)?.iter_days().rev().take(4) {
     ///     count -= 1;
     ///     assert_eq!(d, expected[count]);
     /// }
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     pub fn iter_days(&self) -> NaiveDateDaysIterator {
@@ -1310,23 +1187,24 @@ impl NaiveDate {
     /// # use chrono::NaiveDate;
     ///
     /// let expected = [
-    ///     NaiveDate::from_ymd(2016, 2, 27),
-    ///     NaiveDate::from_ymd(2016, 3, 5),
-    ///     NaiveDate::from_ymd(2016, 3, 12),
-    ///     NaiveDate::from_ymd(2016, 3, 19),
+    ///     NaiveDate::from_ymd(2016, 2, 27)?,
+    ///     NaiveDate::from_ymd(2016, 3, 5)?,
+    ///     NaiveDate::from_ymd(2016, 3, 12)?,
+    ///     NaiveDate::from_ymd(2016, 3, 19)?,
     /// ];
     ///
     /// let mut count = 0;
-    /// for (idx, d) in NaiveDate::from_ymd(2016, 2, 27).iter_weeks().take(4).enumerate() {
+    /// for (idx, d) in NaiveDate::from_ymd(2016, 2, 27)?.iter_weeks().take(4).enumerate() {
     ///    assert_eq!(d, expected[idx]);
     ///    count += 1;
     /// }
     /// assert_eq!(count, 4);
     ///
-    /// for d in NaiveDate::from_ymd(2016, 3, 19).iter_weeks().rev().take(4) {
+    /// for d in NaiveDate::from_ymd(2016, 3, 19)?.iter_weeks().rev().take(4) {
     ///     count -= 1;
     ///     assert_eq!(d, expected[count]);
     /// }
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     pub fn iter_weeks(&self) -> NaiveDateWeeksIterator {
@@ -1339,11 +1217,6 @@ impl NaiveDate {
     pub fn week(&self, start: Weekday) -> NaiveWeek {
         NaiveWeek { date: *self, start }
     }
-
-    /// The minimum possible `NaiveDate` (January 1, 262145 BCE).
-    pub const MIN: NaiveDate = NaiveDate { ymdf: (MIN_YEAR << 13) | (1 << 4) | 0o07 /*FE*/ };
-    /// The maximum possible `NaiveDate` (December 31, 262143 CE).
-    pub const MAX: NaiveDate = NaiveDate { ymdf: (MAX_YEAR << 13) | (365 << 4) | 0o17 /*F*/ };
 }
 
 impl Datelike for NaiveDate {
@@ -1354,8 +1227,9 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).year(), 2015);
-    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).year(), -308); // 309 BCE
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8)?.year(), 2015);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14)?.year(), -308); // 309 BCE
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     fn year(&self) -> i32 {
@@ -1371,8 +1245,9 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).month(), 9);
-    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).month(), 3);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8)?.month(), 9);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14)?.month(), 3);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     fn month(&self) -> u32 {
@@ -1388,8 +1263,9 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).month0(), 8);
-    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).month0(), 2);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8)?.month0(), 8);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14)?.month0(), 2);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     fn month0(&self) -> u32 {
@@ -1405,8 +1281,9 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).day(), 8);
-    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).day(), 14);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8)?.day(), 8);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14)?.day(), 14);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     ///
     /// Combined with [`NaiveDate::pred`](#method.pred),
@@ -1414,22 +1291,23 @@ impl Datelike for NaiveDate {
     /// (Note that this panics when `year` is out of range.)
     ///
     /// ```
-    /// use chrono::{NaiveDate, Datelike};
+    /// use chrono::{NaiveDate, Datelike, ChronoError};
     ///
-    /// fn ndays_in_month(year: i32, month: u32) -> u32 {
+    /// fn ndays_in_month(year: i32, month: u32) -> Result<u32, ChronoError> {
     ///     // the first day of the next month...
     ///     let (y, m) = if month == 12 { (year + 1, 1) } else { (year, month + 1) };
-    ///     let d = NaiveDate::from_ymd(y, m, 1);
+    ///     let d = NaiveDate::from_ymd(y, m, 1)?;
     ///
     ///     // ...is preceded by the last day of the original month
-    ///     d.pred().day()
+    ///     Ok(d.pred()?.day())
     /// }
     ///
-    /// assert_eq!(ndays_in_month(2015, 8), 31);
-    /// assert_eq!(ndays_in_month(2015, 9), 30);
-    /// assert_eq!(ndays_in_month(2015, 12), 31);
-    /// assert_eq!(ndays_in_month(2016, 2), 29);
-    /// assert_eq!(ndays_in_month(2017, 2), 28);
+    /// assert_eq!(ndays_in_month(2015, 8)?, 31);
+    /// assert_eq!(ndays_in_month(2015, 9)?, 30);
+    /// assert_eq!(ndays_in_month(2015, 12)?, 31);
+    /// assert_eq!(ndays_in_month(2016, 2)?, 29);
+    /// assert_eq!(ndays_in_month(2017, 2)?, 28);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     fn day(&self) -> u32 {
@@ -1445,8 +1323,9 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).day0(), 7);
-    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).day0(), 13);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8)?.day0(), 7);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14)?.day0(), 13);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     fn day0(&self) -> u32 {
@@ -1462,8 +1341,9 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).ordinal(), 251);
-    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).ordinal(), 74);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8)?.ordinal(), 251);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14)?.ordinal(), 74);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     ///
     /// Combined with [`NaiveDate::pred`](#method.pred),
@@ -1471,21 +1351,22 @@ impl Datelike for NaiveDate {
     /// (Note that this panics when `year` is out of range.)
     ///
     /// ```
-    /// use chrono::{NaiveDate, Datelike};
+    /// use chrono::{NaiveDate, Datelike, ChronoError};
     ///
-    /// fn ndays_in_year(year: i32) -> u32 {
+    /// fn ndays_in_year(year: i32) -> Result<u32, ChronoError> {
     ///     // the first day of the next year...
-    ///     let d = NaiveDate::from_ymd(year + 1, 1, 1);
+    ///     let d = NaiveDate::from_ymd(year + 1, 1, 1)?;
     ///
     ///     // ...is preceded by the last day of the original year
-    ///     d.pred().ordinal()
+    ///     Ok(d.pred()?.ordinal())
     /// }
     ///
-    /// assert_eq!(ndays_in_year(2015), 365);
-    /// assert_eq!(ndays_in_year(2016), 366);
-    /// assert_eq!(ndays_in_year(2017), 365);
-    /// assert_eq!(ndays_in_year(2000), 366);
-    /// assert_eq!(ndays_in_year(2100), 365);
+    /// assert_eq!(ndays_in_year(2015)?, 365);
+    /// assert_eq!(ndays_in_year(2016)?, 366);
+    /// assert_eq!(ndays_in_year(2017)?, 365);
+    /// assert_eq!(ndays_in_year(2000)?, 366);
+    /// assert_eq!(ndays_in_year(2100)?, 365);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     fn ordinal(&self) -> u32 {
@@ -1501,8 +1382,9 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).ordinal0(), 250);
-    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).ordinal0(), 73);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8)?.ordinal0(), 250);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14)?.ordinal0(), 73);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     fn ordinal0(&self) -> u32 {
@@ -1516,8 +1398,9 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).weekday(), Weekday::Tue);
-    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).weekday(), Weekday::Fri);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8)?.weekday(), Weekday::Tue);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14)?.weekday(), Weekday::Fri);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     fn weekday(&self) -> Weekday {
@@ -1531,28 +1414,28 @@ impl Datelike for NaiveDate {
 
     /// Makes a new `NaiveDate` with the year number changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting `NaiveDate` would be invalid.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_year(2016),
-    ///            Some(NaiveDate::from_ymd(2016, 9, 8)));
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_year(-308),
-    ///            Some(NaiveDate::from_ymd(-308, 9, 8)));
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8)?.with_year(2016)?, NaiveDate::from_ymd(2016, 9, 8)?);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8)?.with_year(-308)?, NaiveDate::from_ymd(-308, 9, 8)?);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     ///
     /// A leap day (February 29) is a good example that this method can return `None`.
     ///
     /// ```
     /// # use chrono::{NaiveDate, Datelike};
-    /// assert!(NaiveDate::from_ymd(2016, 2, 29).with_year(2015).is_none());
-    /// assert!(NaiveDate::from_ymd(2016, 2, 29).with_year(2020).is_some());
+    /// assert!(NaiveDate::from_ymd(2016, 2, 29)?.with_year(2015).is_err());
+    /// assert!(NaiveDate::from_ymd(2016, 2, 29)?.with_year(2020).is_ok());
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
-    fn with_year(&self, year: i32) -> Option<NaiveDate> {
+    fn with_year(&self, year: i32) -> Result<NaiveDate, ChronoError> {
         // we need to operate with `mdf` since we should keep the month and day number as is
         let mdf = self.mdf();
 
@@ -1565,125 +1448,128 @@ impl Datelike for NaiveDate {
 
     /// Makes a new `NaiveDate` with the month number (starting from 1) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting `NaiveDate` would be
+    /// invalid.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_month(10),
-    ///            Some(NaiveDate::from_ymd(2015, 10, 8)));
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_month(13), None); // no month 13
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 30).with_month(2), None); // no February 30
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8)?.with_month(10)?, NaiveDate::from_ymd(2015, 10, 8)?);
+    /// assert!(NaiveDate::from_ymd(2015, 9, 8)?.with_month(13).is_err()); // no month 13
+    /// assert!(NaiveDate::from_ymd(2015, 9, 30)?.with_month(2).is_err()); // no February 30
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
-    fn with_month(&self, month: u32) -> Option<NaiveDate> {
+    fn with_month(&self, month: u32) -> Result<NaiveDate, ChronoError> {
         self.with_mdf(self.mdf().with_month(month))
     }
 
     /// Makes a new `NaiveDate` with the month number (starting from 0) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting `NaiveDate` would be
+    /// invalid.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_month0(9),
-    ///            Some(NaiveDate::from_ymd(2015, 10, 8)));
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_month0(12), None); // no month 13
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 30).with_month0(1), None); // no February 30
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8)?.with_month0(9)?,
+    ///            NaiveDate::from_ymd(2015, 10, 8)?);
+    /// assert!(NaiveDate::from_ymd(2015, 9, 8)?.with_month0(12).is_err()); // no month 13
+    /// assert!(NaiveDate::from_ymd(2015, 9, 30)?.with_month0(1).is_err()); // no February 30
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
-    fn with_month0(&self, month0: u32) -> Option<NaiveDate> {
+    fn with_month0(&self, month0: u32) -> Result<NaiveDate, ChronoError> {
         self.with_mdf(self.mdf().with_month(month0 + 1))
     }
 
     /// Makes a new `NaiveDate` with the day of month (starting from 1) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting `NaiveDate` would be invalid.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_day(30),
-    ///            Some(NaiveDate::from_ymd(2015, 9, 30)));
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_day(31),
-    ///            None); // no September 31
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8)?.with_day(30)?,
+    ///            NaiveDate::from_ymd(2015, 9, 30)?);
+    /// assert!(NaiveDate::from_ymd(2015, 9, 8)?.with_day(31).is_err()); // no September 31
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
-    fn with_day(&self, day: u32) -> Option<NaiveDate> {
+    fn with_day(&self, day: u32) -> Result<NaiveDate, ChronoError> {
         self.with_mdf(self.mdf().with_day(day))
     }
 
     /// Makes a new `NaiveDate` with the day of month (starting from 0) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting `NaiveDate` would be invalid.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_day0(29),
-    ///            Some(NaiveDate::from_ymd(2015, 9, 30)));
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).with_day0(30),
-    ///            None); // no September 31
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8)?.with_day0(29)?,
+    ///            NaiveDate::from_ymd(2015, 9, 30)?);
+    /// assert!(NaiveDate::from_ymd(2015, 9, 8)?.with_day0(30).is_err()); // no September 31
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
-    fn with_day0(&self, day0: u32) -> Option<NaiveDate> {
+    fn with_day0(&self, day0: u32) -> Result<NaiveDate, ChronoError> {
         self.with_mdf(self.mdf().with_day(day0 + 1))
     }
 
     /// Makes a new `NaiveDate` with the day of year (starting from 1) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting `NaiveDate` would be invalid.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1).with_ordinal(60),
-    ///            Some(NaiveDate::from_ymd(2015, 3, 1)));
-    /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1).with_ordinal(366),
-    ///            None); // 2015 had only 365 days
+    /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1)?.with_ordinal(60)?,
+    ///            NaiveDate::from_ymd(2015, 3, 1)?);
+    /// assert!(NaiveDate::from_ymd(2015, 1, 1)?.with_ordinal(366).is_err()); // 2015 had only 365 days
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1).with_ordinal(60),
-    ///            Some(NaiveDate::from_ymd(2016, 2, 29)));
-    /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1).with_ordinal(366),
-    ///            Some(NaiveDate::from_ymd(2016, 12, 31)));
+    /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1)?.with_ordinal(60)?,
+    ///            NaiveDate::from_ymd(2016, 2, 29)?);
+    /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1)?.with_ordinal(366)?,
+    ///            NaiveDate::from_ymd(2016, 12, 31)?);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
-    fn with_ordinal(&self, ordinal: u32) -> Option<NaiveDate> {
+    fn with_ordinal(&self, ordinal: u32) -> Result<NaiveDate, ChronoError> {
         self.with_of(self.of().with_ordinal(ordinal))
     }
 
     /// Makes a new `NaiveDate` with the day of year (starting from 0) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting `NaiveDate` would be invalid.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1).with_ordinal0(59),
-    ///            Some(NaiveDate::from_ymd(2015, 3, 1)));
-    /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1).with_ordinal0(365),
-    ///            None); // 2015 had only 365 days
+    /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1)?.with_ordinal0(59)?,
+    ///            NaiveDate::from_ymd(2015, 3, 1)?);
+    /// assert!(NaiveDate::from_ymd(2015, 1, 1)?.with_ordinal0(365).is_err()); // 2015 had only 365 days
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1).with_ordinal0(59),
-    ///            Some(NaiveDate::from_ymd(2016, 2, 29)));
-    /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1).with_ordinal0(365),
-    ///            Some(NaiveDate::from_ymd(2016, 12, 31)));
+    /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1)?.with_ordinal0(59)?,
+    ///            NaiveDate::from_ymd(2016, 2, 29)?);
+    /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1)?.with_ordinal0(365)?,
+    ///            NaiveDate::from_ymd(2016, 12, 31)?);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
-    fn with_ordinal0(&self, ordinal0: u32) -> Option<NaiveDate> {
+    fn with_ordinal0(&self, ordinal0: u32) -> Result<NaiveDate, ChronoError> {
         self.with_of(self.of().with_ordinal(ordinal0 + 1))
     }
 }
@@ -1701,14 +1587,15 @@ impl Datelike for NaiveDate {
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
-/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::zero(),             from_ymd(2014, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::seconds(86399),     from_ymd(2014, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::seconds(-86399),    from_ymd(2014, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(1),            from_ymd(2014, 1, 2));
-/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(-1),           from_ymd(2013, 12, 31));
-/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(364),          from_ymd(2014, 12, 31));
-/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(365*4 + 1),    from_ymd(2018, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(365*400 + 97), from_ymd(2414, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1)? + TimeDelta::zero(), from_ymd(2014, 1, 1)?);
+/// assert_eq!(from_ymd(2014, 1, 1)? + TimeDelta::seconds(86399), from_ymd(2014, 1, 1)?);
+/// assert_eq!(from_ymd(2014, 1, 1)? + TimeDelta::seconds(-86399), from_ymd(2014, 1, 1)?);
+/// assert_eq!(from_ymd(2014, 1, 1)? + TimeDelta::days(1), from_ymd(2014, 1, 2)?);
+/// assert_eq!(from_ymd(2014, 1, 1)? + TimeDelta::days(-1), from_ymd(2013, 12, 31)?);
+/// assert_eq!(from_ymd(2014, 1, 1)? + TimeDelta::days(364), from_ymd(2014, 12, 31)?);
+/// assert_eq!(from_ymd(2014, 1, 1)? + TimeDelta::days(365*4 + 1), from_ymd(2018, 1, 1)?);
+/// assert_eq!(from_ymd(2014, 1, 1)? + TimeDelta::days(365*400 + 97), from_ymd(2414, 1, 1)?);
+/// # Ok::<_, chrono::ChronoError>(())
 /// ```
 impl Add<TimeDelta> for NaiveDate {
     type Output = NaiveDate;
@@ -1742,12 +1629,13 @@ impl Add<Months> for NaiveDate {
     ///
     /// let from_ymd = NaiveDate::from_ymd;
     ///
-    /// assert_eq!(from_ymd(2014, 1, 1) + Months::new(1), from_ymd(2014, 2, 1));
-    /// assert_eq!(from_ymd(2014, 1, 1) + Months::new(11), from_ymd(2014, 12, 1));
-    /// assert_eq!(from_ymd(2014, 1, 1) + Months::new(12), from_ymd(2015, 1, 1));
-    /// assert_eq!(from_ymd(2014, 1, 1) + Months::new(13), from_ymd(2015, 2, 1));
-    /// assert_eq!(from_ymd(2014, 1, 31) + Months::new(1), from_ymd(2014, 2, 28));
-    /// assert_eq!(from_ymd(2020, 1, 31) + Months::new(1), from_ymd(2020, 2, 29));
+    /// assert_eq!(from_ymd(2014, 1, 1)? + Months::new(1), from_ymd(2014, 2, 1)?);
+    /// assert_eq!(from_ymd(2014, 1, 1)? + Months::new(11), from_ymd(2014, 12, 1)?);
+    /// assert_eq!(from_ymd(2014, 1, 1)? + Months::new(12), from_ymd(2015, 1, 1)?);
+    /// assert_eq!(from_ymd(2014, 1, 1)? + Months::new(13), from_ymd(2015, 2, 1)?);
+    /// assert_eq!(from_ymd(2014, 1, 31)? + Months::new(1), from_ymd(2014, 2, 28)?);
+    /// assert_eq!(from_ymd(2020, 1, 31)? + Months::new(1), from_ymd(2020, 2, 29)?);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     fn add(self, months: Months) -> Self::Output {
         self.checked_add_months(months).unwrap()
@@ -1770,9 +1658,10 @@ impl Sub<Months> for NaiveDate {
     ///
     /// let from_ymd = NaiveDate::from_ymd;
     ///
-    /// assert_eq!(from_ymd(2014, 1, 1) - Months::new(11), from_ymd(2013, 2, 1));
-    /// assert_eq!(from_ymd(2014, 1, 1) - Months::new(12), from_ymd(2013, 1, 1));
-    /// assert_eq!(from_ymd(2014, 1, 1) - Months::new(13), from_ymd(2012, 12, 1));
+    /// assert_eq!(from_ymd(2014, 1, 1)? - Months::new(11), from_ymd(2013, 2, 1)?);
+    /// assert_eq!(from_ymd(2014, 1, 1)? - Months::new(12), from_ymd(2013, 1, 1)?);
+    /// assert_eq!(from_ymd(2014, 1, 1)? - Months::new(13), from_ymd(2012, 12, 1)?);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     fn sub(self, months: Months) -> Self::Output {
         self.checked_sub_months(months).unwrap()
@@ -1809,14 +1698,15 @@ impl Sub<Days> for NaiveDate {
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
-/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::zero(),             from_ymd(2014, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::seconds(86399),     from_ymd(2014, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::seconds(-86399),    from_ymd(2014, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(1),            from_ymd(2013, 12, 31));
-/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(-1),           from_ymd(2014, 1, 2));
-/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(364),          from_ymd(2013, 1, 2));
-/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(365*4 + 1),    from_ymd(2010, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(365*400 + 97), from_ymd(1614, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1)? - TimeDelta::zero(), from_ymd(2014, 1, 1)?);
+/// assert_eq!(from_ymd(2014, 1, 1)? - TimeDelta::seconds(86399), from_ymd(2014, 1, 1)?);
+/// assert_eq!(from_ymd(2014, 1, 1)? - TimeDelta::seconds(-86399), from_ymd(2014, 1, 1)?);
+/// assert_eq!(from_ymd(2014, 1, 1)? - TimeDelta::days(1), from_ymd(2013, 12, 31)?);
+/// assert_eq!(from_ymd(2014, 1, 1)? - TimeDelta::days(-1), from_ymd(2014, 1, 2)?);
+/// assert_eq!(from_ymd(2014, 1, 1)? - TimeDelta::days(364), from_ymd(2013, 1, 2)?);
+/// assert_eq!(from_ymd(2014, 1, 1)? - TimeDelta::days(365*4 + 1), from_ymd(2010, 1, 1)?);
+/// assert_eq!(from_ymd(2014, 1, 1)? - TimeDelta::days(365*400 + 97), from_ymd(1614, 1, 1)?);
+/// # Ok::<_, chrono::ChronoError>(())
 /// ```
 impl Sub<TimeDelta> for NaiveDate {
     type Output = NaiveDate;
@@ -1850,13 +1740,14 @@ impl SubAssign<TimeDelta> for NaiveDate {
 ///
 /// let from_ymd = NaiveDate::from_ymd;
 ///
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2014, 1, 1), TimeDelta::zero());
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 12, 31), TimeDelta::days(1));
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2014, 1, 2), TimeDelta::days(-1));
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 9, 23), TimeDelta::days(100));
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 1, 1), TimeDelta::days(365));
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2010, 1, 1), TimeDelta::days(365*4 + 1));
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(1614, 1, 1), TimeDelta::days(365*400 + 97));
+/// assert_eq!(from_ymd(2014, 1, 1)? - from_ymd(2014, 1, 1)?, TimeDelta::zero());
+/// assert_eq!(from_ymd(2014, 1, 1)? - from_ymd(2013, 12, 31)?, TimeDelta::days(1));
+/// assert_eq!(from_ymd(2014, 1, 1)? - from_ymd(2014, 1, 2)?, TimeDelta::days(-1));
+/// assert_eq!(from_ymd(2014, 1, 1)? - from_ymd(2013, 9, 23)?, TimeDelta::days(100));
+/// assert_eq!(from_ymd(2014, 1, 1)? - from_ymd(2013, 1, 1)?, TimeDelta::days(365));
+/// assert_eq!(from_ymd(2014, 1, 1)? - from_ymd(2010, 1, 1)?, TimeDelta::days(365*4 + 1));
+/// assert_eq!(from_ymd(2014, 1, 1)? - from_ymd(1614, 1, 1)?, TimeDelta::days(365*400 + 97));
+/// # Ok::<_, chrono::ChronoError>(())
 /// ```
 impl Sub<NaiveDate> for NaiveDate {
     type Output = TimeDelta;
@@ -1883,7 +1774,7 @@ impl Iterator for NaiveDateDaysIterator {
         // current < NaiveDate::MAX from here on:
         let current = self.value;
         // This can't panic because current is < NaiveDate::MAX:
-        self.value = current.succ();
+        self.value = current.succ().ok()?;
         Some(current)
     }
 
@@ -1901,7 +1792,7 @@ impl DoubleEndedIterator for NaiveDateDaysIterator {
             return None;
         }
         let current = self.value;
-        self.value = current.pred();
+        self.value = current.pred().ok()?;
         Some(current)
     }
 }
@@ -1956,22 +1847,25 @@ impl DoubleEndedIterator for NaiveDateWeeksIterator {
 /// ```
 /// use chrono::NaiveDate;
 ///
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(2015,  9,  5)), "2015-09-05");
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(   0,  1,  1)), "0000-01-01");
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(9999, 12, 31)), "9999-12-31");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(2015, 9, 5)?), "2015-09-05");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(0, 1, 1)?), "0000-01-01");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(9999, 12, 31)?), "9999-12-31");
+/// # Ok::<_, chrono::ChronoError>(())
 /// ```
 ///
 /// ISO 8601 requires an explicit sign for years before 1 BCE or after 9999 CE.
 ///
 /// ```
 /// # use chrono::NaiveDate;
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(   -1,  1,  1)),  "-0001-01-01");
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(10000, 12, 31)), "+10000-12-31");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(-1, 1, 1)?), "-0001-01-01");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(10000, 12, 31)?), "+10000-12-31");
+/// # Ok::<_, chrono::ChronoError>(())
 /// ```
 impl fmt::Debug for NaiveDate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let year = self.year();
         let mdf = self.mdf();
+
         if (0..=9999).contains(&year) {
             write!(f, "{:04}-{:02}-{:02}", year, mdf.month(), mdf.day())
         } else {
@@ -1991,17 +1885,19 @@ impl fmt::Debug for NaiveDate {
 /// ```
 /// use chrono::NaiveDate;
 ///
-/// assert_eq!(format!("{}", NaiveDate::from_ymd(2015,  9,  5)), "2015-09-05");
-/// assert_eq!(format!("{}", NaiveDate::from_ymd(   0,  1,  1)), "0000-01-01");
-/// assert_eq!(format!("{}", NaiveDate::from_ymd(9999, 12, 31)), "9999-12-31");
+/// assert_eq!(format!("{}", NaiveDate::from_ymd(2015, 9, 5)?), "2015-09-05");
+/// assert_eq!(format!("{}", NaiveDate::from_ymd(0, 1, 1)?), "0000-01-01");
+/// assert_eq!(format!("{}", NaiveDate::from_ymd(9999, 12, 31)?), "9999-12-31");
+/// # Ok::<_, chrono::ChronoError>(())
 /// ```
 ///
 /// ISO 8601 requires an explicit sign for years before 1 BCE or after 9999 CE.
 ///
 /// ```
 /// # use chrono::NaiveDate;
-/// assert_eq!(format!("{}", NaiveDate::from_ymd(   -1,  1,  1)),  "-0001-01-01");
-/// assert_eq!(format!("{}", NaiveDate::from_ymd(10000, 12, 31)), "+10000-12-31");
+/// assert_eq!(format!("{}", NaiveDate::from_ymd(-1, 1, 1)?),  "-0001-01-01");
+/// assert_eq!(format!("{}", NaiveDate::from_ymd(10000, 12, 31)?), "+10000-12-31");
+/// # Ok::<_, chrono::ChronoError>(())
 /// ```
 impl fmt::Display for NaiveDate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -2017,13 +1913,14 @@ impl fmt::Display for NaiveDate {
 /// ```
 /// use chrono::NaiveDate;
 ///
-/// let d = NaiveDate::from_ymd(2015, 9, 18);
-/// assert_eq!("2015-09-18".parse::<NaiveDate>(), Ok(d));
+/// let d = NaiveDate::from_ymd(2015, 9, 18)?;
+/// assert_eq!("2015-09-18".parse::<NaiveDate>()?, d);
 ///
-/// let d = NaiveDate::from_ymd(12345, 6, 7);
-/// assert_eq!("+12345-6-7".parse::<NaiveDate>(), Ok(d));
+/// let d = NaiveDate::from_ymd(12345, 6, 7)?;
+/// assert_eq!("+12345-6-7".parse::<NaiveDate>()?, d);
 ///
 /// assert!("foo".parse::<NaiveDate>().is_err());
+/// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 impl str::FromStr for NaiveDate {
     type Err = ParseError;
@@ -2054,11 +1951,12 @@ impl str::FromStr for NaiveDate {
 /// use chrono::NaiveDate;
 ///
 /// let default_date = NaiveDate::default();
-/// assert_eq!(default_date, NaiveDate::from_ymd(1970, 1, 1));
+/// assert_eq!(default_date, NaiveDate::from_ymd(1970, 1, 1)?);
+/// # Ok::<_, chrono::ChronoError>(())
 /// ```
 impl Default for NaiveDate {
     fn default() -> Self {
-        NaiveDate::from_ymd(1970, 1, 1)
+        NaiveDate::UNIX_EPOCH
     }
 }
 
@@ -2068,9 +1966,18 @@ where
     F: Fn(&NaiveDate) -> Result<String, E>,
     E: ::std::fmt::Debug,
 {
-    assert_eq!(to_string(&NaiveDate::from_ymd(2014, 7, 24)).ok(), Some(r#""2014-07-24""#.into()));
-    assert_eq!(to_string(&NaiveDate::from_ymd(0, 1, 1)).ok(), Some(r#""0000-01-01""#.into()));
-    assert_eq!(to_string(&NaiveDate::from_ymd(-1, 12, 31)).ok(), Some(r#""-0001-12-31""#.into()));
+    assert_eq!(
+        to_string(&NaiveDate::from_ymd(2014, 7, 24).unwrap()).ok(),
+        Some(r#""2014-07-24""#.into())
+    );
+    assert_eq!(
+        to_string(&NaiveDate::from_ymd(0, 1, 1).unwrap()).ok(),
+        Some(r#""0000-01-01""#.into())
+    );
+    assert_eq!(
+        to_string(&NaiveDate::from_ymd(-1, 12, 31).unwrap()).ok(),
+        Some(r#""-0001-12-31""#.into())
+    );
     assert_eq!(to_string(&NaiveDate::MIN).ok(), Some(r#""-262144-01-01""#.into()));
     assert_eq!(to_string(&NaiveDate::MAX).ok(), Some(r#""+262143-12-31""#.into()));
 }
@@ -2083,14 +1990,14 @@ where
 {
     use std::{i32, i64};
 
-    assert_eq!(from_str(r#""2016-07-08""#).ok(), Some(NaiveDate::from_ymd(2016, 7, 8)));
-    assert_eq!(from_str(r#""2016-7-8""#).ok(), Some(NaiveDate::from_ymd(2016, 7, 8)));
-    assert_eq!(from_str(r#""+002016-07-08""#).ok(), Some(NaiveDate::from_ymd(2016, 7, 8)));
-    assert_eq!(from_str(r#""0000-01-01""#).ok(), Some(NaiveDate::from_ymd(0, 1, 1)));
-    assert_eq!(from_str(r#""0-1-1""#).ok(), Some(NaiveDate::from_ymd(0, 1, 1)));
-    assert_eq!(from_str(r#""-0001-12-31""#).ok(), Some(NaiveDate::from_ymd(-1, 12, 31)));
-    assert_eq!(from_str(r#""-262144-01-01""#).ok(), Some(NaiveDate::MIN));
-    assert_eq!(from_str(r#""+262143-12-31""#).ok(), Some(NaiveDate::MAX));
+    assert_eq!(from_str(r#""2016-07-08""#).unwrap(), NaiveDate::from_ymd(2016, 7, 8).unwrap());
+    assert_eq!(from_str(r#""2016-7-8""#).unwrap(), NaiveDate::from_ymd(2016, 7, 8).unwrap());
+    assert_eq!(from_str(r#""+002016-07-08""#).unwrap(), NaiveDate::from_ymd(2016, 7, 8).unwrap());
+    assert_eq!(from_str(r#""0000-01-01""#).unwrap(), NaiveDate::from_ymd(0, 1, 1).unwrap());
+    assert_eq!(from_str(r#""0-1-1""#).unwrap(), NaiveDate::from_ymd(0, 1, 1).unwrap());
+    assert_eq!(from_str(r#""-0001-12-31""#).unwrap(), NaiveDate::from_ymd(-1, 12, 31).unwrap());
+    assert_eq!(from_str(r#""-262144-01-01""#).unwrap(), NaiveDate::MIN);
+    assert_eq!(from_str(r#""+262143-12-31""#).unwrap(), NaiveDate::MAX);
 
     // bad formats
     assert!(from_str(r#""""#).is_err());
@@ -2190,7 +2097,7 @@ mod serde {
         // it is not self-describing.
         use bincode::{deserialize, serialize};
 
-        let d = NaiveDate::from_ymd(2014, 7, 24);
+        let d = NaiveDate::from_ymd(2014, 7, 24).unwrap();
         let encoded = serialize(&d).unwrap();
         let decoded: NaiveDate = deserialize(&encoded).unwrap();
         assert_eq!(d, decoded);
@@ -2200,95 +2107,99 @@ mod serde {
 #[cfg(test)]
 mod tests {
     use super::{
-        Days, Months, NaiveDate, MAX_DAYS_FROM_YEAR_0, MAX_YEAR, MIN_DAYS_FROM_YEAR_0, MIN_YEAR,
+        Days, Months, NaiveDate, MAX_BITS, MAX_DAYS_FROM_YEAR_0, MAX_YEAR, MIN_DAYS_FROM_YEAR_0,
+        MIN_YEAR,
     };
+    use crate::error::ChronoErrorKind;
     use crate::time_delta::TimeDelta;
-    use crate::{Datelike, Weekday};
+    use crate::{ChronoError, Datelike, Weekday};
     use std::{
         convert::{TryFrom, TryInto},
         i32, u32,
     };
 
+    macro_rules! ymd {
+        ($year:expr, $month:expr, $day:expr) => {
+            NaiveDate::from_ymd($year, $month, $day).unwrap()
+        };
+    }
+
+    // as it is hard to verify year flags in `NaiveDate::MIN` and `NaiveDate::MAX`,
+    // we use a separate run-time test.
+    #[test]
+    fn test_date_bounds() {
+        let calculated_min = ymd!(MIN_YEAR, 1, 1);
+        let calculated_max = ymd!(MAX_YEAR, 12, 31);
+        assert!(
+            NaiveDate::MIN == calculated_min,
+            "`NaiveDate::MIN` should have a year flag {:?}",
+            calculated_min.of().flags()
+        );
+        assert!(
+            NaiveDate::MAX == calculated_max,
+            "`NaiveDate::MAX` should have a year flag {:?}",
+            calculated_max.of().flags()
+        );
+
+        // let's also check that the entire range do not exceed 2^44 seconds
+        // (sometimes used for bounding `TimeDelta` against overflow)
+        let maxsecs = NaiveDate::MAX.signed_duration_since(NaiveDate::MIN).num_seconds();
+        let maxsecs = maxsecs + 86401; // also take care of DateTime
+        assert!(
+            maxsecs < (1 << MAX_BITS),
+            "The entire `NaiveDate` range somehow exceeds 2^{} seconds",
+            MAX_BITS
+        );
+    }
+
     #[test]
     fn diff_months() {
         // identity
-        assert_eq!(
-            NaiveDate::from_ymd(2022, 8, 3).checked_add_months(Months::new(0)),
-            Some(NaiveDate::from_ymd(2022, 8, 3))
-        );
+        assert_eq!(ymd!(2022, 8, 3).checked_add_months(Months::new(0)), Ok(ymd!(2022, 8, 3)));
 
         // add with months exceeding `i32::MAX`
-        assert_eq!(
-            NaiveDate::from_ymd(2022, 8, 3).checked_add_months(Months::new(i32::MAX as u32 + 1)),
-            None
-        );
+        assert!(ymd!(2022, 8, 3).checked_add_months(Months::new(i32::MAX as u32 + 1)).is_err());
 
         // sub with months exceeindg `i32::MIN`
-        assert_eq!(
-            NaiveDate::from_ymd(2022, 8, 3)
-                .checked_sub_months(Months::new((i32::MIN as i64).abs() as u32 + 1)),
-            None
-        );
+        assert!(ymd!(2022, 8, 3)
+            .checked_sub_months(Months::new((i32::MIN as i64).abs() as u32 + 1))
+            .is_err());
 
         // add overflowing year
-        assert_eq!(NaiveDate::MAX.checked_add_months(Months::new(1)), None);
+        assert!(NaiveDate::MAX.checked_add_months(Months::new(1)).is_err());
 
         // add underflowing year
-        assert_eq!(NaiveDate::MIN.checked_sub_months(Months::new(1)), None);
+        assert!(NaiveDate::MIN.checked_sub_months(Months::new(1)).is_err());
 
         // sub crossing year 0 boundary
         assert_eq!(
-            NaiveDate::from_ymd(2022, 8, 3).checked_sub_months(Months::new(2050 * 12)),
-            Some(NaiveDate::from_ymd(-28, 8, 3))
+            ymd!(2022, 8, 3).checked_sub_months(Months::new(2050 * 12)),
+            Ok(ymd!(-28, 8, 3))
         );
 
         // add crossing year boundary
-        assert_eq!(
-            NaiveDate::from_ymd(2022, 8, 3).checked_add_months(Months::new(6)),
-            Some(NaiveDate::from_ymd(2023, 2, 3))
-        );
+        assert_eq!(ymd!(2022, 8, 3).checked_add_months(Months::new(6)), Ok(ymd!(2023, 2, 3)));
 
         // sub crossing year boundary
-        assert_eq!(
-            NaiveDate::from_ymd(2022, 8, 3).checked_sub_months(Months::new(10)),
-            Some(NaiveDate::from_ymd(2021, 10, 3))
-        );
+        assert_eq!(ymd!(2022, 8, 3).checked_sub_months(Months::new(10)), Ok(ymd!(2021, 10, 3)));
 
         // add clamping day, non-leap year
-        assert_eq!(
-            NaiveDate::from_ymd(2022, 1, 29).checked_add_months(Months::new(1)),
-            Some(NaiveDate::from_ymd(2022, 2, 28))
-        );
+        assert_eq!(ymd!(2022, 1, 29).checked_add_months(Months::new(1)), Ok(ymd!(2022, 2, 28)));
 
         // add to leap day
-        assert_eq!(
-            NaiveDate::from_ymd(2022, 10, 29).checked_add_months(Months::new(16)),
-            Some(NaiveDate::from_ymd(2024, 2, 29))
-        );
+        assert_eq!(ymd!(2022, 10, 29).checked_add_months(Months::new(16)), Ok(ymd!(2024, 2, 29)));
 
         // add into december
-        assert_eq!(
-            NaiveDate::from_ymd(2022, 10, 31).checked_add_months(Months::new(2)),
-            Some(NaiveDate::from_ymd(2022, 12, 31))
-        );
+        assert_eq!(ymd!(2022, 10, 31).checked_add_months(Months::new(2)), Ok(ymd!(2022, 12, 31)));
 
         // sub into december
-        assert_eq!(
-            NaiveDate::from_ymd(2022, 10, 31).checked_sub_months(Months::new(10)),
-            Some(NaiveDate::from_ymd(2021, 12, 31))
-        );
+        assert_eq!(ymd!(2022, 10, 31).checked_sub_months(Months::new(10)), Ok(ymd!(2021, 12, 31)));
 
         // add into january
-        assert_eq!(
-            NaiveDate::from_ymd(2022, 8, 3).checked_add_months(Months::new(5)),
-            Some(NaiveDate::from_ymd(2023, 1, 3))
-        );
+        assert_eq!(ymd!(2022, 8, 3).checked_add_months(Months::new(5)), Ok(ymd!(2023, 1, 3)));
 
         // sub into january
-        assert_eq!(
-            NaiveDate::from_ymd(2022, 8, 3).checked_sub_months(Months::new(7)),
-            Some(NaiveDate::from_ymd(2022, 1, 3))
-        );
+        assert_eq!(ymd!(2022, 8, 3).checked_sub_months(Months::new(7)), Ok(ymd!(2022, 1, 3)));
     }
 
     #[test]
@@ -2297,20 +2208,20 @@ mod tests {
 
         for y in range_inclusive(NaiveDate::MIN.year(), NaiveDate::MAX.year()) {
             // even months
-            let d4 = NaiveDate::from_ymd(y, 4, 4);
-            let d6 = NaiveDate::from_ymd(y, 6, 6);
-            let d8 = NaiveDate::from_ymd(y, 8, 8);
-            let d10 = NaiveDate::from_ymd(y, 10, 10);
-            let d12 = NaiveDate::from_ymd(y, 12, 12);
+            let d4 = ymd!(y, 4, 4);
+            let d6 = ymd!(y, 6, 6);
+            let d8 = ymd!(y, 8, 8);
+            let d10 = ymd!(y, 10, 10);
+            let d12 = ymd!(y, 12, 12);
 
             // nine to five, seven-eleven
-            let d59 = NaiveDate::from_ymd(y, 5, 9);
-            let d95 = NaiveDate::from_ymd(y, 9, 5);
-            let d711 = NaiveDate::from_ymd(y, 7, 11);
-            let d117 = NaiveDate::from_ymd(y, 11, 7);
+            let d59 = ymd!(y, 5, 9);
+            let d95 = ymd!(y, 9, 5);
+            let d711 = ymd!(y, 7, 11);
+            let d117 = ymd!(y, 11, 7);
 
             // "March 0"
-            let d30 = NaiveDate::from_ymd(y, 3, 1).pred();
+            let d30 = ymd!(y, 3, 1).pred().unwrap();
 
             let weekday = d30.weekday();
             let other_dates = [d4, d6, d8, d10, d12, d59, d95, d711, d117];
@@ -2320,77 +2231,76 @@ mod tests {
 
     #[test]
     fn test_date_from_ymd() {
-        let ymd_opt = NaiveDate::from_ymd_opt;
+        let from_ymd = NaiveDate::from_ymd;
 
-        assert!(ymd_opt(2012, 0, 1).is_none());
-        assert!(ymd_opt(2012, 1, 1).is_some());
-        assert!(ymd_opt(2012, 2, 29).is_some());
-        assert!(ymd_opt(2014, 2, 29).is_none());
-        assert!(ymd_opt(2014, 3, 0).is_none());
-        assert!(ymd_opt(2014, 3, 1).is_some());
-        assert!(ymd_opt(2014, 3, 31).is_some());
-        assert!(ymd_opt(2014, 3, 32).is_none());
-        assert!(ymd_opt(2014, 12, 31).is_some());
-        assert!(ymd_opt(2014, 13, 1).is_none());
+        assert!(from_ymd(2012, 0, 1).is_err());
+        assert!(from_ymd(2012, 1, 1).is_ok());
+        assert!(from_ymd(2012, 2, 29).is_ok());
+        assert!(from_ymd(2014, 2, 29).is_err());
+        assert!(from_ymd(2014, 3, 0).is_err());
+        assert!(from_ymd(2014, 3, 1).is_ok());
+        assert!(from_ymd(2014, 3, 31).is_ok());
+        assert!(from_ymd(2014, 3, 32).is_err());
+        assert!(from_ymd(2014, 12, 31).is_ok());
+        assert!(from_ymd(2014, 13, 1).is_err());
     }
 
     #[test]
     fn test_date_from_yo() {
-        let yo_opt = NaiveDate::from_yo_opt;
+        let from_yo = NaiveDate::from_yo;
         let ymd = NaiveDate::from_ymd;
 
-        assert_eq!(yo_opt(2012, 0), None);
-        assert_eq!(yo_opt(2012, 1), Some(ymd(2012, 1, 1)));
-        assert_eq!(yo_opt(2012, 2), Some(ymd(2012, 1, 2)));
-        assert_eq!(yo_opt(2012, 32), Some(ymd(2012, 2, 1)));
-        assert_eq!(yo_opt(2012, 60), Some(ymd(2012, 2, 29)));
-        assert_eq!(yo_opt(2012, 61), Some(ymd(2012, 3, 1)));
-        assert_eq!(yo_opt(2012, 100), Some(ymd(2012, 4, 9)));
-        assert_eq!(yo_opt(2012, 200), Some(ymd(2012, 7, 18)));
-        assert_eq!(yo_opt(2012, 300), Some(ymd(2012, 10, 26)));
-        assert_eq!(yo_opt(2012, 366), Some(ymd(2012, 12, 31)));
-        assert_eq!(yo_opt(2012, 367), None);
+        assert!(from_yo(2012, 0).is_err());
+        assert_eq!(from_yo(2012, 1), Ok(ymd(2012, 1, 1).unwrap()));
+        assert_eq!(from_yo(2012, 2), Ok(ymd(2012, 1, 2).unwrap()));
+        assert_eq!(from_yo(2012, 32), Ok(ymd(2012, 2, 1).unwrap()));
+        assert_eq!(from_yo(2012, 60), Ok(ymd(2012, 2, 29).unwrap()));
+        assert_eq!(from_yo(2012, 61), Ok(ymd(2012, 3, 1).unwrap()));
+        assert_eq!(from_yo(2012, 100), Ok(ymd(2012, 4, 9).unwrap()));
+        assert_eq!(from_yo(2012, 200), Ok(ymd(2012, 7, 18).unwrap()));
+        assert_eq!(from_yo(2012, 300), Ok(ymd(2012, 10, 26).unwrap()));
+        assert_eq!(from_yo(2012, 366), Ok(ymd(2012, 12, 31).unwrap()));
+        assert!(from_yo(2012, 367).is_err());
 
-        assert_eq!(yo_opt(2014, 0), None);
-        assert_eq!(yo_opt(2014, 1), Some(ymd(2014, 1, 1)));
-        assert_eq!(yo_opt(2014, 2), Some(ymd(2014, 1, 2)));
-        assert_eq!(yo_opt(2014, 32), Some(ymd(2014, 2, 1)));
-        assert_eq!(yo_opt(2014, 59), Some(ymd(2014, 2, 28)));
-        assert_eq!(yo_opt(2014, 60), Some(ymd(2014, 3, 1)));
-        assert_eq!(yo_opt(2014, 100), Some(ymd(2014, 4, 10)));
-        assert_eq!(yo_opt(2014, 200), Some(ymd(2014, 7, 19)));
-        assert_eq!(yo_opt(2014, 300), Some(ymd(2014, 10, 27)));
-        assert_eq!(yo_opt(2014, 365), Some(ymd(2014, 12, 31)));
-        assert_eq!(yo_opt(2014, 366), None);
+        assert!(from_yo(2014, 0).is_err());
+        assert_eq!(from_yo(2014, 1), Ok(ymd(2014, 1, 1).unwrap()));
+        assert_eq!(from_yo(2014, 2), Ok(ymd(2014, 1, 2).unwrap()));
+        assert_eq!(from_yo(2014, 32), Ok(ymd(2014, 2, 1).unwrap()));
+        assert_eq!(from_yo(2014, 59), Ok(ymd(2014, 2, 28).unwrap()));
+        assert_eq!(from_yo(2014, 60), Ok(ymd(2014, 3, 1).unwrap()));
+        assert_eq!(from_yo(2014, 100), Ok(ymd(2014, 4, 10).unwrap()));
+        assert_eq!(from_yo(2014, 200), Ok(ymd(2014, 7, 19).unwrap()));
+        assert_eq!(from_yo(2014, 300), Ok(ymd(2014, 10, 27).unwrap()));
+        assert_eq!(from_yo(2014, 365), Ok(ymd(2014, 12, 31).unwrap()));
+        assert!(from_yo(2014, 366).is_err());
     }
 
     #[test]
     fn test_date_from_isoywd() {
-        let isoywd_opt = NaiveDate::from_isoywd_opt;
-        let ymd = NaiveDate::from_ymd;
+        let from_isoywd = NaiveDate::from_isoywd;
 
-        assert_eq!(isoywd_opt(2004, 0, Weekday::Sun), None);
-        assert_eq!(isoywd_opt(2004, 1, Weekday::Mon), Some(ymd(2003, 12, 29)));
-        assert_eq!(isoywd_opt(2004, 1, Weekday::Sun), Some(ymd(2004, 1, 4)));
-        assert_eq!(isoywd_opt(2004, 2, Weekday::Mon), Some(ymd(2004, 1, 5)));
-        assert_eq!(isoywd_opt(2004, 2, Weekday::Sun), Some(ymd(2004, 1, 11)));
-        assert_eq!(isoywd_opt(2004, 52, Weekday::Mon), Some(ymd(2004, 12, 20)));
-        assert_eq!(isoywd_opt(2004, 52, Weekday::Sun), Some(ymd(2004, 12, 26)));
-        assert_eq!(isoywd_opt(2004, 53, Weekday::Mon), Some(ymd(2004, 12, 27)));
-        assert_eq!(isoywd_opt(2004, 53, Weekday::Sun), Some(ymd(2005, 1, 2)));
-        assert_eq!(isoywd_opt(2004, 54, Weekday::Mon), None);
+        assert!(from_isoywd(2004, 0, Weekday::Sun).is_err());
+        assert_eq!(from_isoywd(2004, 1, Weekday::Mon), Ok(ymd!(2003, 12, 29)));
+        assert_eq!(from_isoywd(2004, 1, Weekday::Sun), Ok(ymd!(2004, 1, 4)));
+        assert_eq!(from_isoywd(2004, 2, Weekday::Mon), Ok(ymd!(2004, 1, 5)));
+        assert_eq!(from_isoywd(2004, 2, Weekday::Sun), Ok(ymd!(2004, 1, 11)));
+        assert_eq!(from_isoywd(2004, 52, Weekday::Mon), Ok(ymd!(2004, 12, 20)));
+        assert_eq!(from_isoywd(2004, 52, Weekday::Sun), Ok(ymd!(2004, 12, 26)));
+        assert_eq!(from_isoywd(2004, 53, Weekday::Mon), Ok(ymd!(2004, 12, 27)));
+        assert_eq!(from_isoywd(2004, 53, Weekday::Sun), Ok(ymd!(2005, 1, 2)));
+        assert!(from_isoywd(2004, 54, Weekday::Mon).is_err());
 
-        assert_eq!(isoywd_opt(2011, 0, Weekday::Sun), None);
-        assert_eq!(isoywd_opt(2011, 1, Weekday::Mon), Some(ymd(2011, 1, 3)));
-        assert_eq!(isoywd_opt(2011, 1, Weekday::Sun), Some(ymd(2011, 1, 9)));
-        assert_eq!(isoywd_opt(2011, 2, Weekday::Mon), Some(ymd(2011, 1, 10)));
-        assert_eq!(isoywd_opt(2011, 2, Weekday::Sun), Some(ymd(2011, 1, 16)));
+        assert!(from_isoywd(2011, 0, Weekday::Sun).is_err());
+        assert_eq!(from_isoywd(2011, 1, Weekday::Mon), Ok(ymd!(2011, 1, 3)));
+        assert_eq!(from_isoywd(2011, 1, Weekday::Sun), Ok(ymd!(2011, 1, 9)));
+        assert_eq!(from_isoywd(2011, 2, Weekday::Mon), Ok(ymd!(2011, 1, 10)));
+        assert_eq!(from_isoywd(2011, 2, Weekday::Sun), Ok(ymd!(2011, 1, 16)));
 
-        assert_eq!(isoywd_opt(2018, 51, Weekday::Mon), Some(ymd(2018, 12, 17)));
-        assert_eq!(isoywd_opt(2018, 51, Weekday::Sun), Some(ymd(2018, 12, 23)));
-        assert_eq!(isoywd_opt(2018, 52, Weekday::Mon), Some(ymd(2018, 12, 24)));
-        assert_eq!(isoywd_opt(2018, 52, Weekday::Sun), Some(ymd(2018, 12, 30)));
-        assert_eq!(isoywd_opt(2018, 53, Weekday::Mon), None);
+        assert_eq!(from_isoywd(2018, 51, Weekday::Mon), Ok(ymd!(2018, 12, 17)));
+        assert_eq!(from_isoywd(2018, 51, Weekday::Sun), Ok(ymd!(2018, 12, 23)));
+        assert_eq!(from_isoywd(2018, 52, Weekday::Mon), Ok(ymd!(2018, 12, 24)));
+        assert_eq!(from_isoywd(2018, 52, Weekday::Sun), Ok(ymd!(2018, 12, 30)));
+        assert!(from_isoywd(2018, 53, Weekday::Mon).is_err());
     }
 
     #[test]
@@ -2408,8 +2318,9 @@ mod tests {
                 ]
                 .iter()
                 {
-                    let d = NaiveDate::from_isoywd_opt(year, week, weekday);
-                    if let Some(d) = d {
+                    let d = NaiveDate::from_isoywd(year, week, weekday);
+
+                    if let Ok(d) = d {
                         assert_eq!(d.weekday(), weekday);
                         let w = d.iso_week();
                         assert_eq!(w.year(), year);
@@ -2422,10 +2333,11 @@ mod tests {
         for year in 2000..2401 {
             for month in 1..13 {
                 for day in 1..32 {
-                    let d = NaiveDate::from_ymd_opt(year, month, day);
-                    if let Some(d) = d {
+                    let d = NaiveDate::from_ymd(year, month, day);
+
+                    if let Ok(d) = d {
                         let w = d.iso_week();
-                        let d_ = NaiveDate::from_isoywd(w.year(), w.week(), d.weekday());
+                        let d_ = NaiveDate::from_isoywd(w.year(), w.week(), d.weekday()).unwrap();
                         assert_eq!(d, d_);
                     }
                 }
@@ -2435,63 +2347,63 @@ mod tests {
 
     #[test]
     fn test_date_from_num_days_from_ce() {
-        let from_ndays_from_ce = NaiveDate::from_num_days_from_ce_opt;
-        assert_eq!(from_ndays_from_ce(1), Some(NaiveDate::from_ymd(1, 1, 1)));
-        assert_eq!(from_ndays_from_ce(2), Some(NaiveDate::from_ymd(1, 1, 2)));
-        assert_eq!(from_ndays_from_ce(31), Some(NaiveDate::from_ymd(1, 1, 31)));
-        assert_eq!(from_ndays_from_ce(32), Some(NaiveDate::from_ymd(1, 2, 1)));
-        assert_eq!(from_ndays_from_ce(59), Some(NaiveDate::from_ymd(1, 2, 28)));
-        assert_eq!(from_ndays_from_ce(60), Some(NaiveDate::from_ymd(1, 3, 1)));
-        assert_eq!(from_ndays_from_ce(365), Some(NaiveDate::from_ymd(1, 12, 31)));
-        assert_eq!(from_ndays_from_ce(365 + 1), Some(NaiveDate::from_ymd(2, 1, 1)));
-        assert_eq!(from_ndays_from_ce(365 * 2 + 1), Some(NaiveDate::from_ymd(3, 1, 1)));
-        assert_eq!(from_ndays_from_ce(365 * 3 + 1), Some(NaiveDate::from_ymd(4, 1, 1)));
-        assert_eq!(from_ndays_from_ce(365 * 4 + 2), Some(NaiveDate::from_ymd(5, 1, 1)));
-        assert_eq!(from_ndays_from_ce(146097 + 1), Some(NaiveDate::from_ymd(401, 1, 1)));
-        assert_eq!(from_ndays_from_ce(146097 * 5 + 1), Some(NaiveDate::from_ymd(2001, 1, 1)));
-        assert_eq!(from_ndays_from_ce(719163), Some(NaiveDate::from_ymd(1970, 1, 1)));
-        assert_eq!(from_ndays_from_ce(0), Some(NaiveDate::from_ymd(0, 12, 31))); // 1 BCE
-        assert_eq!(from_ndays_from_ce(-365), Some(NaiveDate::from_ymd(0, 1, 1)));
-        assert_eq!(from_ndays_from_ce(-366), Some(NaiveDate::from_ymd(-1, 12, 31))); // 2 BCE
+        let from_ndays_from_ce = NaiveDate::from_num_days_from_ce;
+        assert_eq!(from_ndays_from_ce(1), Ok(ymd!(1, 1, 1)));
+        assert_eq!(from_ndays_from_ce(2), Ok(ymd!(1, 1, 2)));
+        assert_eq!(from_ndays_from_ce(31), Ok(ymd!(1, 1, 31)));
+        assert_eq!(from_ndays_from_ce(32), Ok(ymd!(1, 2, 1)));
+        assert_eq!(from_ndays_from_ce(59), Ok(ymd!(1, 2, 28)));
+        assert_eq!(from_ndays_from_ce(60), Ok(ymd!(1, 3, 1)));
+        assert_eq!(from_ndays_from_ce(365), Ok(ymd!(1, 12, 31)));
+        assert_eq!(from_ndays_from_ce(365 + 1), Ok(ymd!(2, 1, 1)));
+        assert_eq!(from_ndays_from_ce(365 * 2 + 1), Ok(ymd!(3, 1, 1)));
+        assert_eq!(from_ndays_from_ce(365 * 3 + 1), Ok(ymd!(4, 1, 1)));
+        assert_eq!(from_ndays_from_ce(365 * 4 + 2), Ok(ymd!(5, 1, 1)));
+        assert_eq!(from_ndays_from_ce(146097 + 1), Ok(ymd!(401, 1, 1)));
+        assert_eq!(from_ndays_from_ce(146097 * 5 + 1), Ok(ymd!(2001, 1, 1)));
+        assert_eq!(from_ndays_from_ce(719163), Ok(ymd!(1970, 1, 1)));
+        assert_eq!(from_ndays_from_ce(0), Ok(ymd!(0, 12, 31))); // 1 BCE
+        assert_eq!(from_ndays_from_ce(-365), Ok(ymd!(0, 1, 1)));
+        assert_eq!(from_ndays_from_ce(-366), Ok(ymd!(-1, 12, 31))); // 2 BCE
 
         for days in (-9999..10001).map(|x| x * 100) {
-            assert_eq!(from_ndays_from_ce(days).map(|d| d.num_days_from_ce()), Some(days));
+            assert_eq!(from_ndays_from_ce(days).map(|d| d.num_days_from_ce()), Ok(days));
         }
 
-        assert_eq!(from_ndays_from_ce(NaiveDate::MIN.num_days_from_ce()), Some(NaiveDate::MIN));
-        assert_eq!(from_ndays_from_ce(NaiveDate::MIN.num_days_from_ce() - 1), None);
-        assert_eq!(from_ndays_from_ce(NaiveDate::MAX.num_days_from_ce()), Some(NaiveDate::MAX));
-        assert_eq!(from_ndays_from_ce(NaiveDate::MAX.num_days_from_ce() + 1), None);
+        assert_eq!(from_ndays_from_ce(NaiveDate::MIN.num_days_from_ce()), Ok(NaiveDate::MIN));
+        assert!(from_ndays_from_ce(NaiveDate::MIN.num_days_from_ce() - 1).is_err());
+        assert_eq!(from_ndays_from_ce(NaiveDate::MAX.num_days_from_ce()), Ok(NaiveDate::MAX));
+        assert!(from_ndays_from_ce(NaiveDate::MAX.num_days_from_ce() + 1).is_err());
     }
 
     #[test]
-    fn test_date_from_weekday_of_month_opt() {
-        let ymwd = NaiveDate::from_weekday_of_month_opt;
-        assert_eq!(ymwd(2018, 8, Weekday::Tue, 0), None);
-        assert_eq!(ymwd(2018, 8, Weekday::Wed, 1), Some(NaiveDate::from_ymd(2018, 8, 1)));
-        assert_eq!(ymwd(2018, 8, Weekday::Thu, 1), Some(NaiveDate::from_ymd(2018, 8, 2)));
-        assert_eq!(ymwd(2018, 8, Weekday::Sun, 1), Some(NaiveDate::from_ymd(2018, 8, 5)));
-        assert_eq!(ymwd(2018, 8, Weekday::Mon, 1), Some(NaiveDate::from_ymd(2018, 8, 6)));
-        assert_eq!(ymwd(2018, 8, Weekday::Tue, 1), Some(NaiveDate::from_ymd(2018, 8, 7)));
-        assert_eq!(ymwd(2018, 8, Weekday::Wed, 2), Some(NaiveDate::from_ymd(2018, 8, 8)));
-        assert_eq!(ymwd(2018, 8, Weekday::Sun, 2), Some(NaiveDate::from_ymd(2018, 8, 12)));
-        assert_eq!(ymwd(2018, 8, Weekday::Thu, 3), Some(NaiveDate::from_ymd(2018, 8, 16)));
-        assert_eq!(ymwd(2018, 8, Weekday::Thu, 4), Some(NaiveDate::from_ymd(2018, 8, 23)));
-        assert_eq!(ymwd(2018, 8, Weekday::Thu, 5), Some(NaiveDate::from_ymd(2018, 8, 30)));
-        assert_eq!(ymwd(2018, 8, Weekday::Fri, 5), Some(NaiveDate::from_ymd(2018, 8, 31)));
-        assert_eq!(ymwd(2018, 8, Weekday::Sat, 5), None);
+    fn test_from_weekday_of_month() {
+        let from_weekday_of_month = NaiveDate::from_weekday_of_month;
+        assert!(from_weekday_of_month(2018, 8, Weekday::Tue, 0).is_err());
+        assert_eq!(from_weekday_of_month(2018, 8, Weekday::Wed, 1).unwrap(), ymd!(2018, 8, 1));
+        assert_eq!(from_weekday_of_month(2018, 8, Weekday::Thu, 1).unwrap(), ymd!(2018, 8, 2));
+        assert_eq!(from_weekday_of_month(2018, 8, Weekday::Sun, 1).unwrap(), ymd!(2018, 8, 5));
+        assert_eq!(from_weekday_of_month(2018, 8, Weekday::Mon, 1).unwrap(), ymd!(2018, 8, 6));
+        assert_eq!(from_weekday_of_month(2018, 8, Weekday::Tue, 1).unwrap(), ymd!(2018, 8, 7));
+        assert_eq!(from_weekday_of_month(2018, 8, Weekday::Wed, 2).unwrap(), ymd!(2018, 8, 8));
+        assert_eq!(from_weekday_of_month(2018, 8, Weekday::Sun, 2).unwrap(), ymd!(2018, 8, 12));
+        assert_eq!(from_weekday_of_month(2018, 8, Weekday::Thu, 3).unwrap(), ymd!(2018, 8, 16));
+        assert_eq!(from_weekday_of_month(2018, 8, Weekday::Thu, 4).unwrap(), ymd!(2018, 8, 23));
+        assert_eq!(from_weekday_of_month(2018, 8, Weekday::Thu, 5).unwrap(), ymd!(2018, 8, 30));
+        assert_eq!(from_weekday_of_month(2018, 8, Weekday::Fri, 5).unwrap(), ymd!(2018, 8, 31));
+        assert!(from_weekday_of_month(2018, 8, Weekday::Sat, 5).is_err());
     }
 
     #[test]
     fn test_date_fields() {
         fn check(year: i32, month: u32, day: u32, ordinal: u32) {
-            let d1 = NaiveDate::from_ymd(year, month, day);
+            let d1 = ymd!(year, month, day);
             assert_eq!(d1.year(), year);
             assert_eq!(d1.month(), month);
             assert_eq!(d1.day(), day);
             assert_eq!(d1.ordinal(), ordinal);
 
-            let d2 = NaiveDate::from_yo(year, ordinal);
+            let d2 = NaiveDate::from_yo(year, ordinal).unwrap();
             assert_eq!(d2.year(), year);
             assert_eq!(d2.month(), month);
             assert_eq!(d2.day(), day);
@@ -2523,118 +2435,136 @@ mod tests {
 
     #[test]
     fn test_date_weekday() {
-        assert_eq!(NaiveDate::from_ymd(1582, 10, 15).weekday(), Weekday::Fri);
+        assert_eq!(ymd!(1582, 10, 15).weekday(), Weekday::Fri);
         // May 20, 1875 = ISO 8601 reference date
-        assert_eq!(NaiveDate::from_ymd(1875, 5, 20).weekday(), Weekday::Thu);
-        assert_eq!(NaiveDate::from_ymd(2000, 1, 1).weekday(), Weekday::Sat);
+        assert_eq!(ymd!(1875, 5, 20).weekday(), Weekday::Thu);
+        assert_eq!(ymd!(2000, 1, 1).weekday(), Weekday::Sat);
     }
 
     #[test]
     fn test_date_with_fields() {
-        let d = NaiveDate::from_ymd(2000, 2, 29);
-        assert_eq!(d.with_year(-400), Some(NaiveDate::from_ymd(-400, 2, 29)));
-        assert_eq!(d.with_year(-100), None);
-        assert_eq!(d.with_year(1600), Some(NaiveDate::from_ymd(1600, 2, 29)));
-        assert_eq!(d.with_year(1900), None);
-        assert_eq!(d.with_year(2000), Some(NaiveDate::from_ymd(2000, 2, 29)));
-        assert_eq!(d.with_year(2001), None);
-        assert_eq!(d.with_year(2004), Some(NaiveDate::from_ymd(2004, 2, 29)));
-        assert_eq!(d.with_year(i32::MAX), None);
+        let d = ymd!(2000, 2, 29);
+        assert_eq!(d.with_year(-400), Ok(ymd!(-400, 2, 29)));
+        assert!(d.with_year(-100).is_err());
+        assert_eq!(d.with_year(1600), Ok(ymd!(1600, 2, 29)));
+        assert!(d.with_year(1900).is_err());
+        assert_eq!(d.with_year(2000), Ok(ymd!(2000, 2, 29)));
+        assert!(d.with_year(2001).is_err());
+        assert_eq!(d.with_year(2004), Ok(ymd!(2004, 2, 29)));
+        assert!(d.with_year(i32::MAX).is_err());
 
-        let d = NaiveDate::from_ymd(2000, 4, 30);
-        assert_eq!(d.with_month(0), None);
-        assert_eq!(d.with_month(1), Some(NaiveDate::from_ymd(2000, 1, 30)));
-        assert_eq!(d.with_month(2), None);
-        assert_eq!(d.with_month(3), Some(NaiveDate::from_ymd(2000, 3, 30)));
-        assert_eq!(d.with_month(4), Some(NaiveDate::from_ymd(2000, 4, 30)));
-        assert_eq!(d.with_month(12), Some(NaiveDate::from_ymd(2000, 12, 30)));
-        assert_eq!(d.with_month(13), None);
-        assert_eq!(d.with_month(u32::MAX), None);
+        let d = ymd!(2000, 4, 30);
+        assert!(d.with_month(0).is_err());
+        assert_eq!(d.with_month(1), Ok(ymd!(2000, 1, 30)));
+        assert!(d.with_month(2).is_err());
+        assert_eq!(d.with_month(3), Ok(ymd!(2000, 3, 30)));
+        assert_eq!(d.with_month(4), Ok(ymd!(2000, 4, 30)));
+        assert_eq!(d.with_month(12), Ok(ymd!(2000, 12, 30)));
+        assert!(d.with_month(13).is_err());
+        assert!(d.with_month(u32::MAX).is_err());
 
-        let d = NaiveDate::from_ymd(2000, 2, 8);
-        assert_eq!(d.with_day(0), None);
-        assert_eq!(d.with_day(1), Some(NaiveDate::from_ymd(2000, 2, 1)));
-        assert_eq!(d.with_day(29), Some(NaiveDate::from_ymd(2000, 2, 29)));
-        assert_eq!(d.with_day(30), None);
-        assert_eq!(d.with_day(u32::MAX), None);
+        let d = ymd!(2000, 2, 8);
+        assert!(d.with_day(0).is_err());
+        assert_eq!(d.with_day(1), Ok(ymd!(2000, 2, 1)));
+        assert_eq!(d.with_day(29), Ok(ymd!(2000, 2, 29)));
+        assert!(d.with_day(30).is_err());
+        assert!(d.with_day(u32::MAX).is_err());
 
-        let d = NaiveDate::from_ymd(2000, 5, 5);
-        assert_eq!(d.with_ordinal(0), None);
-        assert_eq!(d.with_ordinal(1), Some(NaiveDate::from_ymd(2000, 1, 1)));
-        assert_eq!(d.with_ordinal(60), Some(NaiveDate::from_ymd(2000, 2, 29)));
-        assert_eq!(d.with_ordinal(61), Some(NaiveDate::from_ymd(2000, 3, 1)));
-        assert_eq!(d.with_ordinal(366), Some(NaiveDate::from_ymd(2000, 12, 31)));
-        assert_eq!(d.with_ordinal(367), None);
-        assert_eq!(d.with_ordinal(u32::MAX), None);
+        let d = ymd!(2000, 5, 5);
+        assert!(d.with_ordinal(0).is_err());
+        assert_eq!(d.with_ordinal(1), Ok(ymd!(2000, 1, 1)));
+        assert_eq!(d.with_ordinal(60), Ok(ymd!(2000, 2, 29)));
+        assert_eq!(d.with_ordinal(61), Ok(ymd!(2000, 3, 1)));
+        assert_eq!(d.with_ordinal(366), Ok(ymd!(2000, 12, 31)));
+        assert!(d.with_ordinal(367).is_err());
+        assert!(d.with_ordinal(u32::MAX).is_err());
     }
 
     #[test]
     fn test_date_num_days_from_ce() {
-        assert_eq!(NaiveDate::from_ymd(1, 1, 1).num_days_from_ce(), 1);
+        assert_eq!(ymd!(1, 1, 1).num_days_from_ce(), 1);
 
         for year in -9999..10001 {
             assert_eq!(
-                NaiveDate::from_ymd(year, 1, 1).num_days_from_ce(),
-                NaiveDate::from_ymd(year - 1, 12, 31).num_days_from_ce() + 1
+                ymd!(year, 1, 1).num_days_from_ce(),
+                ymd!(year - 1, 12, 31).num_days_from_ce() + 1
             );
         }
     }
 
     #[test]
     fn test_date_succ() {
-        let ymd = NaiveDate::from_ymd;
-        assert_eq!(ymd(2014, 5, 6).succ_opt(), Some(ymd(2014, 5, 7)));
-        assert_eq!(ymd(2014, 5, 31).succ_opt(), Some(ymd(2014, 6, 1)));
-        assert_eq!(ymd(2014, 12, 31).succ_opt(), Some(ymd(2015, 1, 1)));
-        assert_eq!(ymd(2016, 2, 28).succ_opt(), Some(ymd(2016, 2, 29)));
-        assert_eq!(ymd(NaiveDate::MAX.year(), 12, 31).succ_opt(), None);
+        assert_eq!(ymd!(2014, 5, 6).succ(), Ok(ymd!(2014, 5, 7)));
+        assert_eq!(ymd!(2014, 5, 31).succ(), Ok(ymd!(2014, 6, 1)));
+        assert_eq!(ymd!(2014, 12, 31).succ(), Ok(ymd!(2015, 1, 1)));
+        assert_eq!(ymd!(2016, 2, 28).succ(), Ok(ymd!(2016, 2, 29)));
+        assert!(ymd!(NaiveDate::MAX.year(), 12, 31).succ().is_err());
     }
 
     #[test]
     fn test_date_pred() {
-        let ymd = NaiveDate::from_ymd;
-        assert_eq!(ymd(2016, 3, 1).pred_opt(), Some(ymd(2016, 2, 29)));
-        assert_eq!(ymd(2015, 1, 1).pred_opt(), Some(ymd(2014, 12, 31)));
-        assert_eq!(ymd(2014, 6, 1).pred_opt(), Some(ymd(2014, 5, 31)));
-        assert_eq!(ymd(2014, 5, 7).pred_opt(), Some(ymd(2014, 5, 6)));
-        assert_eq!(ymd(NaiveDate::MIN.year(), 1, 1).pred_opt(), None);
+        assert_eq!(ymd!(2016, 3, 1).pred(), Ok(ymd!(2016, 2, 29)));
+        assert_eq!(ymd!(2015, 1, 1).pred(), Ok(ymd!(2014, 12, 31)));
+        assert_eq!(ymd!(2014, 6, 1).pred(), Ok(ymd!(2014, 5, 31)));
+        assert_eq!(ymd!(2014, 5, 7).pred(), Ok(ymd!(2014, 5, 6)));
+        assert!(ymd!(NaiveDate::MIN.year(), 1, 1).pred().is_err());
     }
 
     #[test]
     fn test_date_add() {
-        fn check((y1, m1, d1): (i32, u32, u32), rhs: TimeDelta, ymd: Option<(i32, u32, u32)>) {
-            let lhs = NaiveDate::from_ymd(y1, m1, d1);
-            let sum = ymd.map(|(y, m, d)| NaiveDate::from_ymd(y, m, d));
+        fn check(
+            (y1, m1, d1): (i32, u32, u32),
+            rhs: TimeDelta,
+            ymd: Result<(i32, u32, u32), ChronoError>,
+        ) {
+            let lhs = ymd!(y1, m1, d1);
+            let sum = ymd.map(|(y, m, d)| ymd!(y, m, d));
             assert_eq!(lhs.checked_add_signed(rhs), sum);
             assert_eq!(lhs.checked_sub_signed(-rhs), sum);
         }
 
-        check((2014, 1, 1), TimeDelta::zero(), Some((2014, 1, 1)));
-        check((2014, 1, 1), TimeDelta::seconds(86399), Some((2014, 1, 1)));
+        check((2014, 1, 1), TimeDelta::zero(), Ok((2014, 1, 1)));
+        check((2014, 1, 1), TimeDelta::seconds(86399), Ok((2014, 1, 1)));
         // always round towards zero
-        check((2014, 1, 1), TimeDelta::seconds(-86399), Some((2014, 1, 1)));
-        check((2014, 1, 1), TimeDelta::days(1), Some((2014, 1, 2)));
-        check((2014, 1, 1), TimeDelta::days(-1), Some((2013, 12, 31)));
-        check((2014, 1, 1), TimeDelta::days(364), Some((2014, 12, 31)));
-        check((2014, 1, 1), TimeDelta::days(365 * 4 + 1), Some((2018, 1, 1)));
-        check((2014, 1, 1), TimeDelta::days(365 * 400 + 97), Some((2414, 1, 1)));
+        check((2014, 1, 1), TimeDelta::seconds(-86399), Ok((2014, 1, 1)));
+        check((2014, 1, 1), TimeDelta::days(1), Ok((2014, 1, 2)));
+        check((2014, 1, 1), TimeDelta::days(-1), Ok((2013, 12, 31)));
+        check((2014, 1, 1), TimeDelta::days(364), Ok((2014, 12, 31)));
+        check((2014, 1, 1), TimeDelta::days(365 * 4 + 1), Ok((2018, 1, 1)));
+        check((2014, 1, 1), TimeDelta::days(365 * 400 + 97), Ok((2414, 1, 1)));
 
-        check((-7, 1, 1), TimeDelta::days(365 * 12 + 3), Some((5, 1, 1)));
+        check((-7, 1, 1), TimeDelta::days(365 * 12 + 3), Ok((5, 1, 1)));
 
         // overflow check
-        check((0, 1, 1), TimeDelta::days(MAX_DAYS_FROM_YEAR_0 as i64), Some((MAX_YEAR, 12, 31)));
-        check((0, 1, 1), TimeDelta::days(MAX_DAYS_FROM_YEAR_0 as i64 + 1), None);
-        check((0, 1, 1), TimeDelta::max_value(), None);
-        check((0, 1, 1), TimeDelta::days(MIN_DAYS_FROM_YEAR_0 as i64), Some((MIN_YEAR, 1, 1)));
-        check((0, 1, 1), TimeDelta::days(MIN_DAYS_FROM_YEAR_0 as i64 - 1), None);
-        check((0, 1, 1), TimeDelta::min_value(), None);
+        check((0, 1, 1), TimeDelta::days(MAX_DAYS_FROM_YEAR_0 as i64), Ok((MAX_YEAR, 12, 31)));
+        check(
+            (0, 1, 1),
+            TimeDelta::days(MAX_DAYS_FROM_YEAR_0 as i64 + 1),
+            Err(ChronoError::new(ChronoErrorKind::InvalidDate)),
+        );
+        check(
+            (0, 1, 1),
+            TimeDelta::max_value(),
+            Err(ChronoError::new(ChronoErrorKind::InvalidDate)),
+        );
+        check((0, 1, 1), TimeDelta::days(MIN_DAYS_FROM_YEAR_0 as i64), Ok((MIN_YEAR, 1, 1)));
+        check(
+            (0, 1, 1),
+            TimeDelta::days(MIN_DAYS_FROM_YEAR_0 as i64 - 1),
+            Err(ChronoError::new(ChronoErrorKind::InvalidDate)),
+        );
+        check(
+            (0, 1, 1),
+            TimeDelta::min_value(),
+            Err(ChronoError::new(ChronoErrorKind::InvalidDate)),
+        );
     }
 
     #[test]
     fn test_date_sub() {
         fn check((y1, m1, d1): (i32, u32, u32), (y2, m2, d2): (i32, u32, u32), diff: TimeDelta) {
-            let lhs = NaiveDate::from_ymd(y1, m1, d1);
-            let rhs = NaiveDate::from_ymd(y2, m2, d2);
+            let lhs = ymd!(y1, m1, d1);
+            let rhs = ymd!(y2, m2, d2);
             assert_eq!(lhs.signed_duration_since(rhs), diff);
             assert_eq!(rhs.signed_duration_since(lhs), -diff);
         }
@@ -2652,35 +2582,43 @@ mod tests {
 
     #[test]
     fn test_date_add_days() {
-        fn check((y1, m1, d1): (i32, u32, u32), rhs: Days, ymd: Option<(i32, u32, u32)>) {
-            let lhs = NaiveDate::from_ymd(y1, m1, d1);
-            let sum = ymd.map(|(y, m, d)| NaiveDate::from_ymd(y, m, d));
+        fn check(
+            (y1, m1, d1): (i32, u32, u32),
+            rhs: Days,
+            ymd: Result<(i32, u32, u32), ChronoError>,
+        ) {
+            let lhs = ymd!(y1, m1, d1);
+            let sum = ymd.map(|(y, m, d)| ymd!(y, m, d));
             assert_eq!(lhs.checked_add_days(rhs), sum);
         }
 
-        check((2014, 1, 1), Days::new(0), Some((2014, 1, 1)));
+        check((2014, 1, 1), Days::new(0), Ok((2014, 1, 1)));
         // always round towards zero
-        check((2014, 1, 1), Days::new(1), Some((2014, 1, 2)));
-        check((2014, 1, 1), Days::new(364), Some((2014, 12, 31)));
-        check((2014, 1, 1), Days::new(365 * 4 + 1), Some((2018, 1, 1)));
-        check((2014, 1, 1), Days::new(365 * 400 + 97), Some((2414, 1, 1)));
+        check((2014, 1, 1), Days::new(1), Ok((2014, 1, 2)));
+        check((2014, 1, 1), Days::new(364), Ok((2014, 12, 31)));
+        check((2014, 1, 1), Days::new(365 * 4 + 1), Ok((2018, 1, 1)));
+        check((2014, 1, 1), Days::new(365 * 400 + 97), Ok((2414, 1, 1)));
 
-        check((-7, 1, 1), Days::new(365 * 12 + 3), Some((5, 1, 1)));
+        check((-7, 1, 1), Days::new(365 * 12 + 3), Ok((5, 1, 1)));
 
         // overflow check
         check(
             (0, 1, 1),
             Days::new(MAX_DAYS_FROM_YEAR_0.try_into().unwrap()),
-            Some((MAX_YEAR, 12, 31)),
+            Ok((MAX_YEAR, 12, 31)),
         );
-        check((0, 1, 1), Days::new(u64::try_from(MAX_DAYS_FROM_YEAR_0).unwrap() + 1), None);
+        check(
+            (0, 1, 1),
+            Days::new(u64::try_from(MAX_DAYS_FROM_YEAR_0).unwrap() + 1),
+            Err(ChronoError::new(ChronoErrorKind::InvalidDate)),
+        );
     }
 
     #[test]
     fn test_date_sub_days() {
         fn check((y1, m1, d1): (i32, u32, u32), (y2, m2, d2): (i32, u32, u32), diff: Days) {
-            let lhs = NaiveDate::from_ymd(y1, m1, d1);
-            let rhs = NaiveDate::from_ymd(y2, m2, d2);
+            let lhs = ymd!(y1, m1, d1);
+            let rhs = ymd!(y2, m2, d2);
             assert_eq!(lhs - diff, rhs);
         }
 
@@ -2697,39 +2635,37 @@ mod tests {
 
     #[test]
     fn test_date_addassignment() {
-        let ymd = NaiveDate::from_ymd;
-        let mut date = ymd(2016, 10, 1);
+        let mut date = ymd!(2016, 10, 1);
         date += TimeDelta::days(10);
-        assert_eq!(date, ymd(2016, 10, 11));
+        assert_eq!(date, ymd!(2016, 10, 11));
         date += TimeDelta::days(30);
-        assert_eq!(date, ymd(2016, 11, 10));
+        assert_eq!(date, ymd!(2016, 11, 10));
     }
 
     #[test]
     fn test_date_subassignment() {
-        let ymd = NaiveDate::from_ymd;
-        let mut date = ymd(2016, 10, 11);
+        let mut date = ymd!(2016, 10, 11);
         date -= TimeDelta::days(10);
-        assert_eq!(date, ymd(2016, 10, 1));
+        assert_eq!(date, ymd!(2016, 10, 1));
         date -= TimeDelta::days(2);
-        assert_eq!(date, ymd(2016, 9, 29));
+        assert_eq!(date, ymd!(2016, 9, 29));
     }
 
     #[test]
     fn test_date_fmt() {
-        assert_eq!(format!("{:?}", NaiveDate::from_ymd(2012, 3, 4)), "2012-03-04");
-        assert_eq!(format!("{:?}", NaiveDate::from_ymd(0, 3, 4)), "0000-03-04");
-        assert_eq!(format!("{:?}", NaiveDate::from_ymd(-307, 3, 4)), "-0307-03-04");
-        assert_eq!(format!("{:?}", NaiveDate::from_ymd(12345, 3, 4)), "+12345-03-04");
+        assert_eq!(format!("{:?}", ymd!(2012, 3, 4)), "2012-03-04");
+        assert_eq!(format!("{:?}", ymd!(0, 3, 4)), "0000-03-04");
+        assert_eq!(format!("{:?}", ymd!(-307, 3, 4)), "-0307-03-04");
+        assert_eq!(format!("{:?}", ymd!(12345, 3, 4)), "+12345-03-04");
 
-        assert_eq!(NaiveDate::from_ymd(2012, 3, 4).to_string(), "2012-03-04");
-        assert_eq!(NaiveDate::from_ymd(0, 3, 4).to_string(), "0000-03-04");
-        assert_eq!(NaiveDate::from_ymd(-307, 3, 4).to_string(), "-0307-03-04");
-        assert_eq!(NaiveDate::from_ymd(12345, 3, 4).to_string(), "+12345-03-04");
+        assert_eq!(ymd!(2012, 3, 4).to_string(), "2012-03-04");
+        assert_eq!(ymd!(0, 3, 4).to_string(), "0000-03-04");
+        assert_eq!(ymd!(-307, 3, 4).to_string(), "-0307-03-04");
+        assert_eq!(ymd!(12345, 3, 4).to_string(), "+12345-03-04");
 
         // the format specifier should have no effect on `NaiveTime`
-        assert_eq!(format!("{:+30?}", NaiveDate::from_ymd(1234, 5, 6)), "1234-05-06");
-        assert_eq!(format!("{:30?}", NaiveDate::from_ymd(12345, 6, 7)), "+12345-06-07");
+        assert_eq!(format!("{:+30?}", ymd!(1234, 5, 6)), "1234-05-06");
+        assert_eq!(format!("{:30?}", ymd!(12345, 6, 7)), "+12345-06-07");
     }
 
     #[test]
@@ -2785,18 +2721,17 @@ mod tests {
 
     #[test]
     fn test_date_parse_from_str() {
-        let ymd = NaiveDate::from_ymd;
         assert_eq!(
             NaiveDate::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
-            Ok(ymd(2014, 5, 7))
+            Ok(ymd!(2014, 5, 7))
         ); // ignore time and offset
         assert_eq!(
             NaiveDate::parse_from_str("2015-W06-1=2015-033", "%G-W%V-%u = %Y-%j"),
-            Ok(ymd(2015, 2, 2))
+            Ok(ymd!(2015, 2, 2))
         );
         assert_eq!(
             NaiveDate::parse_from_str("Fri, 09 Aug 13", "%a, %d %b %y"),
-            Ok(ymd(2013, 8, 9))
+            Ok(ymd!(2013, 8, 9))
         );
         assert!(NaiveDate::parse_from_str("Sat, 09 Aug 2013", "%a, %d %b %Y").is_err());
         assert!(NaiveDate::parse_from_str("2014-57", "%Y-%m-%d").is_err());
@@ -2805,7 +2740,7 @@ mod tests {
 
     #[test]
     fn test_date_format() {
-        let d = NaiveDate::from_ymd(2012, 3, 4);
+        let d = ymd!(2012, 3, 4);
         assert_eq!(d.format("%Y,%C,%y,%G,%g").to_string(), "2012,20,12,2012,12");
         assert_eq!(d.format("%m,%b,%h,%B").to_string(), "03,Mar,Mar,March");
         assert_eq!(d.format("%d,%e").to_string(), "04, 4");
@@ -2818,44 +2753,38 @@ mod tests {
         assert_eq!(d.format("%t%n%%%n%t").to_string(), "\t\n%\n\t");
 
         // non-four-digit years
-        assert_eq!(NaiveDate::from_ymd(12345, 1, 1).format("%Y").to_string(), "+12345");
-        assert_eq!(NaiveDate::from_ymd(1234, 1, 1).format("%Y").to_string(), "1234");
-        assert_eq!(NaiveDate::from_ymd(123, 1, 1).format("%Y").to_string(), "0123");
-        assert_eq!(NaiveDate::from_ymd(12, 1, 1).format("%Y").to_string(), "0012");
-        assert_eq!(NaiveDate::from_ymd(1, 1, 1).format("%Y").to_string(), "0001");
-        assert_eq!(NaiveDate::from_ymd(0, 1, 1).format("%Y").to_string(), "0000");
-        assert_eq!(NaiveDate::from_ymd(-1, 1, 1).format("%Y").to_string(), "-0001");
-        assert_eq!(NaiveDate::from_ymd(-12, 1, 1).format("%Y").to_string(), "-0012");
-        assert_eq!(NaiveDate::from_ymd(-123, 1, 1).format("%Y").to_string(), "-0123");
-        assert_eq!(NaiveDate::from_ymd(-1234, 1, 1).format("%Y").to_string(), "-1234");
-        assert_eq!(NaiveDate::from_ymd(-12345, 1, 1).format("%Y").to_string(), "-12345");
+        assert_eq!(ymd!(12345, 1, 1).format("%Y").to_string(), "+12345");
+        assert_eq!(ymd!(1234, 1, 1).format("%Y").to_string(), "1234");
+        assert_eq!(ymd!(123, 1, 1).format("%Y").to_string(), "0123");
+        assert_eq!(ymd!(12, 1, 1).format("%Y").to_string(), "0012");
+        assert_eq!(ymd!(1, 1, 1).format("%Y").to_string(), "0001");
+        assert_eq!(ymd!(0, 1, 1).format("%Y").to_string(), "0000");
+        assert_eq!(ymd!(-1, 1, 1).format("%Y").to_string(), "-0001");
+        assert_eq!(ymd!(-12, 1, 1).format("%Y").to_string(), "-0012");
+        assert_eq!(ymd!(-123, 1, 1).format("%Y").to_string(), "-0123");
+        assert_eq!(ymd!(-1234, 1, 1).format("%Y").to_string(), "-1234");
+        assert_eq!(ymd!(-12345, 1, 1).format("%Y").to_string(), "-12345");
 
         // corner cases
-        assert_eq!(
-            NaiveDate::from_ymd(2007, 12, 31).format("%G,%g,%U,%W,%V").to_string(),
-            "2008,08,53,53,01"
-        );
-        assert_eq!(
-            NaiveDate::from_ymd(2010, 1, 3).format("%G,%g,%U,%W,%V").to_string(),
-            "2009,09,01,00,53"
-        );
+        assert_eq!(ymd!(2007, 12, 31).format("%G,%g,%U,%W,%V").to_string(), "2008,08,53,53,01");
+        assert_eq!(ymd!(2010, 1, 3).format("%G,%g,%U,%W,%V").to_string(), "2009,09,01,00,53");
     }
 
     #[test]
     fn test_day_iterator_limit() {
-        assert_eq!(NaiveDate::from_ymd(262143, 12, 29).iter_days().take(4).count(), 2);
-        assert_eq!(NaiveDate::from_ymd(-262144, 1, 3).iter_days().rev().take(4).count(), 2);
+        assert_eq!(ymd!(262143, 12, 29).iter_days().take(4).count(), 2);
+        assert_eq!(ymd!(-262144, 1, 3).iter_days().rev().take(4).count(), 2);
     }
 
     #[test]
     fn test_week_iterator_limit() {
-        assert_eq!(NaiveDate::from_ymd(262143, 12, 12).iter_weeks().take(4).count(), 2);
-        assert_eq!(NaiveDate::from_ymd(-262144, 1, 15).iter_weeks().rev().take(4).count(), 2);
+        assert_eq!(ymd!(262143, 12, 12).iter_weeks().take(4).count(), 2);
+        assert_eq!(ymd!(-262144, 1, 15).iter_weeks().rev().take(4).count(), 2);
     }
 
     #[test]
     fn test_naiveweek() {
-        let date = NaiveDate::from_ymd(2022, 5, 18);
+        let date = ymd!(2022, 5, 18);
         let asserts = vec![
             (Weekday::Mon, "2022-05-16", "2022-05-22"),
             (Weekday::Tue, "2022-05-17", "2022-05-23"),

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -468,20 +468,20 @@ impl NaiveDateTime {
     /// let d = NaiveDate::from_ymd(2016, 7, 8)?;
     ///
     /// let hms = |h, m, s| d.and_hms(h, m, s);
-    /// assert_eq!(hms(3, 5, 7)?.checked_add_signed(TimeDelta::zero())?,
-    ///            hms(3, 5, 7)?);
-    /// assert_eq!(hms(3, 5, 7)?.checked_add_signed(TimeDelta::seconds(1))?,
-    ///            hms(3, 5, 8)?);
-    /// assert_eq!(hms(3, 5, 7)?.checked_add_signed(TimeDelta::seconds(-1))?,
-    ///            hms(3, 5, 6)?);
-    /// assert_eq!(hms(3, 5, 7)?.checked_add_signed(TimeDelta::seconds(3600 + 60))?,
-    ///            hms(4, 6, 7)?);
-    /// assert_eq!(hms(3, 5, 7)?.checked_add_signed(TimeDelta::seconds(86_400))?,
-    ///            NaiveDate::from_ymd(2016, 7, 9)?.and_hms(3, 5, 7)?);
+    /// assert_eq!(hms(3, 5, 7)?.checked_add_signed(TimeDelta::zero()),
+    ///            Some(hms(3, 5, 7)?));
+    /// assert_eq!(hms(3, 5, 7)?.checked_add_signed(TimeDelta::seconds(1)),
+    ///            Some(hms(3, 5, 8)?));
+    /// assert_eq!(hms(3, 5, 7)?.checked_add_signed(TimeDelta::seconds(-1)),
+    ///            Some(hms(3, 5, 6)?));
+    /// assert_eq!(hms(3, 5, 7)?.checked_add_signed(TimeDelta::seconds(3600 + 60)),
+    ///            Some(hms(4, 6, 7)?));
+    /// assert_eq!(hms(3, 5, 7)?.checked_add_signed(TimeDelta::seconds(86_400)),
+    ///            Some(NaiveDate::from_ymd(2016, 7, 9)?.and_hms(3, 5, 7)?));
     ///
     /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli);
-    /// assert_eq!(hmsm(3, 5, 7, 980)?.checked_add_signed(TimeDelta::milliseconds(450))?,
-    ///            hmsm(3, 5, 8, 430)?);
+    /// assert_eq!(hmsm(3, 5, 7, 980)?.checked_add_signed(TimeDelta::milliseconds(450)),
+    ///            Some(hmsm(3, 5, 8, 430)?));
     /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     ///
@@ -489,7 +489,7 @@ impl NaiveDateTime {
     ///
     /// ```
     /// use chrono::{TimeDelta, NaiveDate};
-    /// assert!(NaiveDate::from_ymd(2016, 7, 8)?.and_hms(3, 5, 7)?.checked_add_signed(TimeDelta::days(1_000_000_000)).is_err());
+    /// assert!(NaiveDate::from_ymd(2016, 7, 8)?.and_hms(3, 5, 7)?.checked_add_signed(TimeDelta::days(1_000_000_000)).is_none());
     /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     ///
@@ -501,32 +501,32 @@ impl NaiveDateTime {
     /// # let from_ymd = NaiveDate::from_ymd;
     /// # let hmsm = |h, m, s, milli| Ok::<_, chrono::ChronoError>(from_ymd(2016, 7, 8)?.and_hms_milli(h, m, s, milli)?);
     /// let leap = hmsm(3, 5, 59, 1_300)?;
-    /// assert_eq!(leap.checked_add_signed(TimeDelta::zero())?,
-    ///            hmsm(3, 5, 59, 1_300)?);
-    /// assert_eq!(leap.checked_add_signed(TimeDelta::milliseconds(-500))?,
-    ///            hmsm(3, 5, 59, 800)?);
-    /// assert_eq!(leap.checked_add_signed(TimeDelta::milliseconds(500))?,
-    ///            hmsm(3, 5, 59, 1_800)?);
-    /// assert_eq!(leap.checked_add_signed(TimeDelta::milliseconds(800))?,
-    ///            hmsm(3, 6, 0, 100)?);
-    /// assert_eq!(leap.checked_add_signed(TimeDelta::seconds(10))?,
-    ///            hmsm(3, 6, 9, 300)?);
-    /// assert_eq!(leap.checked_add_signed(TimeDelta::seconds(-10))?,
-    ///            hmsm(3, 5, 50, 300)?);
-    /// assert_eq!(leap.checked_add_signed(TimeDelta::days(1))?,
-    ///            from_ymd(2016, 7, 9)?.and_hms_milli(3, 5, 59, 300)?);
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::zero()),
+    ///            Some(hmsm(3, 5, 59, 1_300)?));
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::milliseconds(-500)),
+    ///            Some(hmsm(3, 5, 59, 800)?));
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::milliseconds(500)),
+    ///            Some(hmsm(3, 5, 59, 1_800)?));
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::milliseconds(800)),
+    ///            Some(hmsm(3, 6, 0, 100)?));
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::seconds(10)),
+    ///            Some(hmsm(3, 6, 9, 300)?));
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::seconds(-10)),
+    ///            Some(hmsm(3, 5, 50, 300)?));
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::days(1)),
+    ///            Some(from_ymd(2016, 7, 9)?.and_hms_milli(3, 5, 59, 300)?));
     /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn checked_add_signed(self, rhs: TimeDelta) -> Result<NaiveDateTime, ChronoError> {
+    pub fn checked_add_signed(self, rhs: TimeDelta) -> Option<Self> {
         let (time, rhs) = self.time.overflowing_add_signed(rhs);
 
         // early checking to avoid overflow in OldTimeDelta::seconds
         if rhs <= (-1 << MAX_SECS_BITS) || rhs >= (1 << MAX_SECS_BITS) {
-            return Err(ChronoError::new(ChronoErrorKind::InvalidDateTime));
+            return None;
         }
 
         let date = self.date.checked_add_signed(TimeDelta::seconds(rhs))?;
-        Ok(NaiveDateTime { date, time })
+        Some(Self { date, time })
     }
 
     /// Adds given `Months` to the current date and time.
@@ -541,19 +541,19 @@ impl NaiveDateTime {
     ///
     /// assert_eq!(
     ///     NaiveDate::from_ymd(2014, 1, 1)?.and_hms(1, 0, 0)?
-    ///         .checked_add_months(Months::new(1))?,
-    ///     NaiveDate::from_ymd(2014, 2, 1)?.and_hms(1, 0, 0)?
+    ///         .checked_add_months(Months::new(1)),
+    ///     Some(NaiveDate::from_ymd(2014, 2, 1)?.and_hms(1, 0, 0)?)
     /// );
     ///
     /// assert!(
     ///     NaiveDate::from_ymd(2014, 1, 1)?.and_hms(1, 0, 0)?
     ///         .checked_add_months(Months::new(core::i32::MAX as u32 + 1))
-    ///         .is_err()
+    ///         .is_none()
     /// );
     /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn checked_add_months(self, rhs: Months) -> Result<NaiveDateTime, ChronoError> {
-        Ok(Self { date: self.date.checked_add_months(rhs)?, time: self.time })
+    pub fn checked_add_months(self, rhs: Months) -> Option<Self> {
+        Some(Self { date: self.date.checked_add_months(rhs)?, time: self.time })
     }
 
     /// Subtracts given `TimeDelta` from the current date and time.
@@ -572,22 +572,22 @@ impl NaiveDateTime {
     ///
     /// let d = NaiveDate::from_ymd(2016, 7, 8)?;
     ///
-    /// assert_eq!(d.and_hms(3, 5, 7)?.checked_sub_signed(TimeDelta::zero())?,
-    ///            d.and_hms(3, 5, 7)?);
-    /// assert_eq!(d.and_hms(3, 5, 7)?.checked_sub_signed(TimeDelta::seconds(1))?,
-    ///            d.and_hms(3, 5, 6)?);
-    /// assert_eq!(d.and_hms(3, 5, 7)?.checked_sub_signed(TimeDelta::seconds(-1))?,
-    ///            d.and_hms(3, 5, 8)?);
-    /// assert_eq!(d.and_hms(3, 5, 7)?.checked_sub_signed(TimeDelta::seconds(3600 + 60))?,
-    ///            d.and_hms(2, 4, 7)?);
-    /// assert_eq!(d.and_hms(3, 5, 7)?.checked_sub_signed(TimeDelta::seconds(86_400))?,
-    ///            NaiveDate::from_ymd(2016, 7, 7)?.and_hms(3, 5, 7)?);
+    /// assert_eq!(d.and_hms(3, 5, 7)?.checked_sub_signed(TimeDelta::zero()),
+    ///            Some(d.and_hms(3, 5, 7)?));
+    /// assert_eq!(d.and_hms(3, 5, 7)?.checked_sub_signed(TimeDelta::seconds(1)),
+    ///            Some(d.and_hms(3, 5, 6)?));
+    /// assert_eq!(d.and_hms(3, 5, 7)?.checked_sub_signed(TimeDelta::seconds(-1)),
+    ///            Some(d.and_hms(3, 5, 8)?));
+    /// assert_eq!(d.and_hms(3, 5, 7)?.checked_sub_signed(TimeDelta::seconds(3600 + 60)),
+    ///            Some(d.and_hms(2, 4, 7)?));
+    /// assert_eq!(d.and_hms(3, 5, 7)?.checked_sub_signed(TimeDelta::seconds(86_400)),
+    ///            Some(NaiveDate::from_ymd(2016, 7, 7)?.and_hms(3, 5, 7)?));
     ///
-    /// assert_eq!(d.and_hms_milli(3, 5, 7, 450)?.checked_sub_signed(TimeDelta::milliseconds(670))?,
-    ///            d.and_hms_milli(3, 5, 6, 780)?);
+    /// assert_eq!(d.and_hms_milli(3, 5, 7, 450)?.checked_sub_signed(TimeDelta::milliseconds(670)),
+    ///            Some(d.and_hms_milli(3, 5, 6, 780)?));
     ///
     /// let dt = NaiveDate::from_ymd(2016, 7, 8)?.and_hms(3, 5, 7)?;
-    /// assert!(dt.checked_sub_signed(TimeDelta::days(1_000_000_000)).is_err());
+    /// assert!(dt.checked_sub_signed(TimeDelta::days(1_000_000_000)).is_none());
     /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     ///
@@ -599,28 +599,28 @@ impl NaiveDateTime {
     /// # let from_ymd = NaiveDate::from_ymd;
     /// # let hmsm = |h, m, s, milli| Ok::<_, chrono::ChronoError>(from_ymd(2016, 7, 8)?.and_hms_milli(h, m, s, milli)?);
     /// let leap = hmsm(3, 5, 59, 1_300)?;
-    /// assert_eq!(leap.checked_sub_signed(TimeDelta::zero())?,
-    ///            hmsm(3, 5, 59, 1_300)?);
-    /// assert_eq!(leap.checked_sub_signed(TimeDelta::milliseconds(200))?,
-    ///            hmsm(3, 5, 59, 1_100)?);
-    /// assert_eq!(leap.checked_sub_signed(TimeDelta::milliseconds(500))?,
-    ///            hmsm(3, 5, 59, 800)?);
-    /// assert_eq!(leap.checked_sub_signed(TimeDelta::seconds(60))?,
-    ///            hmsm(3, 5, 0, 300)?);
-    /// assert_eq!(leap.checked_sub_signed(TimeDelta::days(1))?,
-    ///            from_ymd(2016, 7, 7)?.and_hms_milli(3, 6, 0, 300)?);
+    /// assert_eq!(leap.checked_sub_signed(TimeDelta::zero()),
+    ///            Some(hmsm(3, 5, 59, 1_300)?));
+    /// assert_eq!(leap.checked_sub_signed(TimeDelta::milliseconds(200)),
+    ///            Some(hmsm(3, 5, 59, 1_100)?));
+    /// assert_eq!(leap.checked_sub_signed(TimeDelta::milliseconds(500)),
+    ///            Some(hmsm(3, 5, 59, 800)?));
+    /// assert_eq!(leap.checked_sub_signed(TimeDelta::seconds(60)),
+    ///            Some(hmsm(3, 5, 0, 300)?));
+    /// assert_eq!(leap.checked_sub_signed(TimeDelta::days(1)),
+    ///            Some(from_ymd(2016, 7, 7)?.and_hms_milli(3, 6, 0, 300)?));
     /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn checked_sub_signed(self, rhs: TimeDelta) -> Result<NaiveDateTime, ChronoError> {
+    pub fn checked_sub_signed(self, rhs: TimeDelta) -> Option<Self> {
         let (time, rhs) = self.time.overflowing_sub_signed(rhs);
 
         // early checking to avoid overflow in OldTimeDelta::seconds
         if rhs <= (-1 << MAX_SECS_BITS) || rhs >= (1 << MAX_SECS_BITS) {
-            return Err(ChronoError::new(ChronoErrorKind::InvalidDateTime));
+            return None;
         }
 
         let date = self.date.checked_sub_signed(TimeDelta::seconds(rhs))?;
-        Ok(NaiveDateTime { date, time })
+        Some(Self { date, time })
     }
 
     /// Subtracts given `Months` from the current date and time.
@@ -635,34 +635,34 @@ impl NaiveDateTime {
     ///
     /// assert_eq!(
     ///     NaiveDate::from_ymd(2014, 1, 1)?.and_hms(1, 0, 0)?
-    ///         .checked_sub_months(Months::new(1))?,
-    ///     NaiveDate::from_ymd(2013, 12, 1)?.and_hms(1, 0, 0)?
+    ///         .checked_sub_months(Months::new(1)),
+    ///     Some(NaiveDate::from_ymd(2013, 12, 1)?.and_hms(1, 0, 0)?)
     /// );
     ///
     /// assert!(
     ///     NaiveDate::from_ymd(2014, 1, 1)?.and_hms(1, 0, 0)?
     ///         .checked_sub_months(Months::new(core::i32::MAX as u32 + 1))
-    ///         .is_err()
+    ///         .is_none()
     /// );
     /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn checked_sub_months(self, rhs: Months) -> Result<NaiveDateTime, ChronoError> {
-        Ok(Self { date: self.date.checked_sub_months(rhs)?, time: self.time })
+    pub fn checked_sub_months(self, rhs: Months) -> Option<Self> {
+        Some(Self { date: self.date.checked_sub_months(rhs)?, time: self.time })
     }
 
     /// Add a duration in [`Days`] to the date part of the `NaiveDateTime`
     ///
     /// Returns `Err(ChronoError)` if the resulting date would be out of range.
-    pub fn checked_add_days(self, days: Days) -> Result<Self, ChronoError> {
-        Ok(Self { date: self.date.checked_add_days(days)?, ..self })
+    pub fn checked_add_days(self, days: Days) -> Option<Self> {
+        Some(Self { date: self.date.checked_add_days(days)?, ..self })
     }
 
     /// Subtract a duration in [`Days`] from the date part of the
     /// `NaiveDateTime`
     ///
     /// Returns `Err(ChronoError)` if the resulting date would be out of range.
-    pub fn checked_sub_days(self, days: Days) -> Result<Self, ChronoError> {
-        Ok(Self { date: self.date.checked_sub_days(days)?, ..self })
+    pub fn checked_sub_days(self, days: Days) -> Option<Self> {
+        Some(Self { date: self.date.checked_sub_days(days)?, ..self })
     }
 
     /// Subtracts another `NaiveDateTime` from the current date and time.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -145,7 +145,7 @@ impl NaiveDateTime {
         let date = i32::try_from(days)
             .ok()
             .and_then(|days| days.checked_add(719_163))
-            .ok_or(ChronoError::new(ChronoErrorKind::InvalidDateTime))
+            .ok_or_else(|| ChronoError::new(ChronoErrorKind::InvalidDateTime))
             .and_then(NaiveDate::from_num_days_from_ce)?;
 
         let time = NaiveTime::from_num_seconds_from_midnight(secs as u32, nsecs)?;

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -533,8 +533,6 @@ impl NaiveDateTime {
     ///
     /// Returns `Err(ChronoError)` when it will result in overflow.
     ///
-    /// Overflow returns `None`.
-    ///
     /// # Example
     ///
     /// ```
@@ -587,20 +585,14 @@ impl NaiveDateTime {
     ///
     /// assert_eq!(d.and_hms_milli(3, 5, 7, 450)?.checked_sub_signed(TimeDelta::milliseconds(670))?,
     ///            d.and_hms_milli(3, 5, 6, 780)?);
-    /// # Ok::<_, chrono::ChronoError>(())
-    /// ```
     ///
-    /// Overflow returns `None`.
-    ///
-    /// ```
-    /// # use chrono::{TimeDelta, NaiveDate};
     /// let dt = NaiveDate::from_ymd(2016, 7, 8)?.and_hms(3, 5, 7)?;
     /// assert!(dt.checked_sub_signed(TimeDelta::days(1_000_000_000)).is_err());
     /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     ///
-    /// Leap seconds are handled,
-    /// but the subtraction assumes that it is the only leap second happened.
+    /// Leap seconds are handled, but the subtraction assumes that it is the
+    /// only leap second happened.
     ///
     /// ```
     /// # use chrono::{TimeDelta, NaiveDate};
@@ -634,8 +626,6 @@ impl NaiveDateTime {
     /// Subtracts given `Months` from the current date and time.
     ///
     /// Returns `Err(ChronoError)` when it will result in overflow.
-    ///
-    /// Overflow returns `None`.
     ///
     /// # Example
     ///
@@ -815,7 +805,7 @@ impl NaiveDateTime {
     ///
     /// ```
     /// use chrono::{NaiveDate, Utc};
-    /// let dt = NaiveDate::from_ymd(2015, 9, 5)?.and_hms(23, 56, 4)?.and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 9, 5)?.and_hms(23, 56, 4)?.and_local_timezone(Utc)?;
     /// assert_eq!(dt.timezone(), Utc);
     /// # Ok::<_, chrono::ChronoError>(())
     /// ```

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -1,14 +1,13 @@
 use super::NaiveDateTime;
 use crate::naive::NaiveDate;
 use crate::time_delta::TimeDelta;
-use crate::{ChronoError, Datelike, FixedOffset, Utc};
+use crate::{Datelike, Error, FixedOffset, Utc};
 use std::i64;
 
 #[test]
 fn test_datetime_from_timestamp() {
     let from_timestamp = |secs| NaiveDateTime::from_timestamp(secs, 0);
-    let ymdhms =
-        |y, m, d, h, n, s| Ok::<_, ChronoError>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?);
+    let ymdhms = |y, m, d, h, n, s| Ok::<_, Error>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?);
     assert_eq!(from_timestamp(-1), Ok(ymdhms(1969, 12, 31, 23, 59, 59).unwrap()));
     assert_eq!(from_timestamp(0), Ok(ymdhms(1970, 1, 1, 0, 0, 0).unwrap()));
     assert_eq!(from_timestamp(1), Ok(ymdhms(1970, 1, 1, 0, 0, 1).unwrap()));
@@ -70,8 +69,7 @@ fn test_datetime_add() {
 
 #[test]
 fn test_datetime_sub() {
-    let ymdhms =
-        |y, m, d, h, n, s| Ok::<_, ChronoError>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?);
+    let ymdhms = |y, m, d, h, n, s| Ok::<_, Error>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?);
     let since = NaiveDateTime::signed_duration_since;
     assert_eq!(
         since(ymdhms(2014, 5, 6, 7, 8, 9).unwrap(), ymdhms(2014, 5, 6, 7, 8, 9).unwrap()),
@@ -97,8 +95,7 @@ fn test_datetime_sub() {
 
 #[test]
 fn test_datetime_addassignment() {
-    let ymdhms =
-        |y, m, d, h, n, s| Ok::<_, ChronoError>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?);
+    let ymdhms = |y, m, d, h, n, s| Ok::<_, Error>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?);
     let mut date = ymdhms(2016, 10, 1, 10, 10, 10).unwrap();
     date += TimeDelta::minutes(10_000_000);
     assert_eq!(date, ymdhms(2035, 10, 6, 20, 50, 10).unwrap());
@@ -108,8 +105,7 @@ fn test_datetime_addassignment() {
 
 #[test]
 fn test_datetime_subassignment() {
-    let ymdhms =
-        |y, m, d, h, n, s| Ok::<_, ChronoError>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?);
+    let ymdhms = |y, m, d, h, n, s| Ok::<_, Error>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?);
     let mut date = ymdhms(2016, 10, 1, 10, 10, 10).unwrap();
     date -= TimeDelta::minutes(10_000_000);
     assert_eq!(date, ymdhms(1997, 9, 26, 23, 30, 10).unwrap());
@@ -120,7 +116,7 @@ fn test_datetime_subassignment() {
 #[test]
 fn test_datetime_timestamp() {
     let to_timestamp = |y, m, d, h, n, s| {
-        Ok::<_, ChronoError>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?.timestamp())
+        Ok::<_, Error>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?.timestamp())
     };
     assert_eq!(to_timestamp(1969, 12, 31, 23, 59, 59).unwrap(), -1);
     assert_eq!(to_timestamp(1970, 1, 1, 0, 0, 0).unwrap(), 0);
@@ -176,10 +172,9 @@ fn test_datetime_from_str() {
 
 #[test]
 fn test_datetime_parse_from_str() {
-    let ymdhms =
-        |y, m, d, h, n, s| Ok::<_, ChronoError>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?);
+    let ymdhms = |y, m, d, h, n, s| Ok::<_, Error>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?);
     let ymdhmsn = |y, m, d, h, n, s, nano| {
-        Ok::<_, ChronoError>(NaiveDate::from_ymd(y, m, d)?.and_hms_nano(h, n, s, nano)?)
+        Ok::<_, Error>(NaiveDate::from_ymd(y, m, d)?.and_hms_nano(h, n, s, nano)?)
     };
     assert_eq!(
         NaiveDateTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -1,112 +1,140 @@
 use super::NaiveDateTime;
+use crate::error::ChronoErrorKind;
 use crate::naive::NaiveDate;
 use crate::time_delta::TimeDelta;
-use crate::{Datelike, FixedOffset, Utc};
+use crate::{ChronoError, Datelike, FixedOffset, Utc};
 use std::i64;
 
 #[test]
 fn test_datetime_from_timestamp() {
-    let from_timestamp = |secs| NaiveDateTime::from_timestamp_opt(secs, 0);
-    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).and_hms(h, n, s);
-    assert_eq!(from_timestamp(-1), Some(ymdhms(1969, 12, 31, 23, 59, 59)));
-    assert_eq!(from_timestamp(0), Some(ymdhms(1970, 1, 1, 0, 0, 0)));
-    assert_eq!(from_timestamp(1), Some(ymdhms(1970, 1, 1, 0, 0, 1)));
-    assert_eq!(from_timestamp(1_000_000_000), Some(ymdhms(2001, 9, 9, 1, 46, 40)));
-    assert_eq!(from_timestamp(0x7fffffff), Some(ymdhms(2038, 1, 19, 3, 14, 7)));
-    assert_eq!(from_timestamp(i64::MIN), None);
-    assert_eq!(from_timestamp(i64::MAX), None);
+    let from_timestamp = |secs| NaiveDateTime::from_timestamp(secs, 0);
+    let ymdhms =
+        |y, m, d, h, n, s| Ok::<_, ChronoError>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?);
+    assert_eq!(from_timestamp(-1), Ok(ymdhms(1969, 12, 31, 23, 59, 59).unwrap()));
+    assert_eq!(from_timestamp(0), Ok(ymdhms(1970, 1, 1, 0, 0, 0).unwrap()));
+    assert_eq!(from_timestamp(1), Ok(ymdhms(1970, 1, 1, 0, 0, 1).unwrap()));
+    assert_eq!(from_timestamp(1_000_000_000), Ok(ymdhms(2001, 9, 9, 1, 46, 40).unwrap()));
+    assert_eq!(from_timestamp(0x7fffffff), Ok(ymdhms(2038, 1, 19, 3, 14, 7).unwrap()));
+    assert!(from_timestamp(i64::MIN).is_err());
+    assert!(from_timestamp(i64::MAX).is_err());
 }
 
 #[test]
 fn test_datetime_add() {
-    fn check(
-        (y, m, d, h, n, s): (i32, u32, u32, u32, u32, u32),
-        rhs: TimeDelta,
-        result: Option<(i32, u32, u32, u32, u32, u32)>,
-    ) {
-        let lhs = NaiveDate::from_ymd(y, m, d).and_hms(h, n, s);
-        let sum = result.map(|(y, m, d, h, n, s)| NaiveDate::from_ymd(y, m, d).and_hms(h, n, s));
-        assert_eq!(lhs.checked_add_signed(rhs), sum);
-        assert_eq!(lhs.checked_sub_signed(-rhs), sum);
+    macro_rules! check {
+        ($input:expr, $rhs:expr, $result:expr $(,)?) => {{
+            let (y, m, d, h, n, s) = $input;
+            let lhs = NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
+            let sum = $result
+                .and_then(|(y, m, d, h, n, s)| NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s));
+            assert_eq!(lhs.checked_add_signed($rhs), sum);
+            assert_eq!(lhs.checked_sub_signed(-$rhs), sum);
+        }};
     }
 
-    check((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(3600 + 60 + 1), Some((2014, 5, 6, 8, 9, 10)));
-    check((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(-(3600 + 60 + 1)), Some((2014, 5, 6, 6, 7, 8)));
-    check((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(86399), Some((2014, 5, 7, 7, 8, 8)));
-    check((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(86_400 * 10), Some((2014, 5, 16, 7, 8, 9)));
-    check((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(-86_400 * 10), Some((2014, 4, 26, 7, 8, 9)));
-    check((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(86_400 * 10), Some((2014, 5, 16, 7, 8, 9)));
+    check!((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(3600 + 60 + 1), Ok((2014, 5, 6, 8, 9, 10)));
+    check!((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(-(3600 + 60 + 1)), Ok((2014, 5, 6, 6, 7, 8)));
+    check!((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(86399), Ok((2014, 5, 7, 7, 8, 8)));
+    check!((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(86_400 * 10), Ok((2014, 5, 16, 7, 8, 9)));
+    check!((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(-86_400 * 10), Ok((2014, 4, 26, 7, 8, 9)));
+    check!((2014, 5, 6, 7, 8, 9), TimeDelta::seconds(86_400 * 10), Ok((2014, 5, 16, 7, 8, 9)));
 
     // overflow check
     // assumes that we have correct values for MAX/MIN_DAYS_FROM_YEAR_0 from `naive::date`.
     // (they are private constants, but the equivalence is tested in that module.)
-    let max_days_from_year_0 = NaiveDate::MAX.signed_duration_since(NaiveDate::from_ymd(0, 1, 1));
-    check((0, 1, 1, 0, 0, 0), max_days_from_year_0, Some((NaiveDate::MAX.year(), 12, 31, 0, 0, 0)));
-    check(
+    let max_days_from_year_0 =
+        NaiveDate::MAX.signed_duration_since(NaiveDate::from_ymd(0, 1, 1).unwrap());
+    check!((0, 1, 1, 0, 0, 0), max_days_from_year_0, Ok((NaiveDate::MAX.year(), 12, 31, 0, 0, 0)));
+    check!(
         (0, 1, 1, 0, 0, 0),
         max_days_from_year_0 + TimeDelta::seconds(86399),
-        Some((NaiveDate::MAX.year(), 12, 31, 23, 59, 59)),
+        Ok((NaiveDate::MAX.year(), 12, 31, 23, 59, 59)),
     );
-    check((0, 1, 1, 0, 0, 0), max_days_from_year_0 + TimeDelta::seconds(86_400), None);
-    check((0, 1, 1, 0, 0, 0), TimeDelta::max_value(), None);
+    check!(
+        (0, 1, 1, 0, 0, 0),
+        max_days_from_year_0 + TimeDelta::seconds(86_400),
+        Err(ChronoError::new(ChronoErrorKind::InvalidDate)),
+    );
+    check!(
+        (0, 1, 1, 0, 0, 0),
+        TimeDelta::max_value(),
+        Err(ChronoError::new(ChronoErrorKind::InvalidDateTime)),
+    );
 
-    let min_days_from_year_0 = NaiveDate::MIN.signed_duration_since(NaiveDate::from_ymd(0, 1, 1));
-    check((0, 1, 1, 0, 0, 0), min_days_from_year_0, Some((NaiveDate::MIN.year(), 1, 1, 0, 0, 0)));
-    check((0, 1, 1, 0, 0, 0), min_days_from_year_0 - TimeDelta::seconds(1), None);
-    check((0, 1, 1, 0, 0, 0), TimeDelta::min_value(), None);
+    let min_days_from_year_0 =
+        NaiveDate::MIN.signed_duration_since(NaiveDate::from_ymd(0, 1, 1).unwrap());
+    check!((0, 1, 1, 0, 0, 0), min_days_from_year_0, Ok((NaiveDate::MIN.year(), 1, 1, 0, 0, 0)));
+    check!(
+        (0, 1, 1, 0, 0, 0),
+        min_days_from_year_0 - TimeDelta::seconds(1),
+        Err(ChronoError::new(ChronoErrorKind::InvalidDate)),
+    );
+    check!(
+        (0, 1, 1, 0, 0, 0),
+        TimeDelta::min_value(),
+        Err(ChronoError::new(ChronoErrorKind::InvalidDateTime)),
+    );
 }
 
 #[test]
 fn test_datetime_sub() {
-    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).and_hms(h, n, s);
+    let ymdhms =
+        |y, m, d, h, n, s| Ok::<_, ChronoError>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?);
     let since = NaiveDateTime::signed_duration_since;
-    assert_eq!(since(ymdhms(2014, 5, 6, 7, 8, 9), ymdhms(2014, 5, 6, 7, 8, 9)), TimeDelta::zero());
     assert_eq!(
-        since(ymdhms(2014, 5, 6, 7, 8, 10), ymdhms(2014, 5, 6, 7, 8, 9)),
+        since(ymdhms(2014, 5, 6, 7, 8, 9).unwrap(), ymdhms(2014, 5, 6, 7, 8, 9).unwrap()),
+        TimeDelta::zero()
+    );
+    assert_eq!(
+        since(ymdhms(2014, 5, 6, 7, 8, 10).unwrap(), ymdhms(2014, 5, 6, 7, 8, 9).unwrap()),
         TimeDelta::seconds(1)
     );
     assert_eq!(
-        since(ymdhms(2014, 5, 6, 7, 8, 9), ymdhms(2014, 5, 6, 7, 8, 10)),
+        since(ymdhms(2014, 5, 6, 7, 8, 9).unwrap(), ymdhms(2014, 5, 6, 7, 8, 10).unwrap()),
         TimeDelta::seconds(-1)
     );
     assert_eq!(
-        since(ymdhms(2014, 5, 7, 7, 8, 9), ymdhms(2014, 5, 6, 7, 8, 10)),
+        since(ymdhms(2014, 5, 7, 7, 8, 9).unwrap(), ymdhms(2014, 5, 6, 7, 8, 10).unwrap()),
         TimeDelta::seconds(86399)
     );
     assert_eq!(
-        since(ymdhms(2001, 9, 9, 1, 46, 39), ymdhms(1970, 1, 1, 0, 0, 0)),
+        since(ymdhms(2001, 9, 9, 1, 46, 39).unwrap(), ymdhms(1970, 1, 1, 0, 0, 0).unwrap()),
         TimeDelta::seconds(999_999_999)
     );
 }
 
 #[test]
 fn test_datetime_addassignment() {
-    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).and_hms(h, n, s);
-    let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
+    let ymdhms =
+        |y, m, d, h, n, s| Ok::<_, ChronoError>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?);
+    let mut date = ymdhms(2016, 10, 1, 10, 10, 10).unwrap();
     date += TimeDelta::minutes(10_000_000);
-    assert_eq!(date, ymdhms(2035, 10, 6, 20, 50, 10));
+    assert_eq!(date, ymdhms(2035, 10, 6, 20, 50, 10).unwrap());
     date += TimeDelta::days(10);
-    assert_eq!(date, ymdhms(2035, 10, 16, 20, 50, 10));
+    assert_eq!(date, ymdhms(2035, 10, 16, 20, 50, 10).unwrap());
 }
 
 #[test]
 fn test_datetime_subassignment() {
-    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).and_hms(h, n, s);
-    let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
+    let ymdhms =
+        |y, m, d, h, n, s| Ok::<_, ChronoError>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?);
+    let mut date = ymdhms(2016, 10, 1, 10, 10, 10).unwrap();
     date -= TimeDelta::minutes(10_000_000);
-    assert_eq!(date, ymdhms(1997, 9, 26, 23, 30, 10));
+    assert_eq!(date, ymdhms(1997, 9, 26, 23, 30, 10).unwrap());
     date -= TimeDelta::days(10);
-    assert_eq!(date, ymdhms(1997, 9, 16, 23, 30, 10));
+    assert_eq!(date, ymdhms(1997, 9, 16, 23, 30, 10).unwrap());
 }
 
 #[test]
 fn test_datetime_timestamp() {
-    let to_timestamp = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).and_hms(h, n, s).timestamp();
-    assert_eq!(to_timestamp(1969, 12, 31, 23, 59, 59), -1);
-    assert_eq!(to_timestamp(1970, 1, 1, 0, 0, 0), 0);
-    assert_eq!(to_timestamp(1970, 1, 1, 0, 0, 1), 1);
-    assert_eq!(to_timestamp(2001, 9, 9, 1, 46, 40), 1_000_000_000);
-    assert_eq!(to_timestamp(2038, 1, 19, 3, 14, 7), 0x7fffffff);
+    let to_timestamp = |y, m, d, h, n, s| {
+        Ok::<_, ChronoError>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?.timestamp())
+    };
+    assert_eq!(to_timestamp(1969, 12, 31, 23, 59, 59).unwrap(), -1);
+    assert_eq!(to_timestamp(1970, 1, 1, 0, 0, 0).unwrap(), 0);
+    assert_eq!(to_timestamp(1970, 1, 1, 0, 0, 1).unwrap(), 1);
+    assert_eq!(to_timestamp(2001, 9, 9, 1, 46, 40).unwrap(), 1_000_000_000);
+    assert_eq!(to_timestamp(2038, 1, 19, 3, 14, 7).unwrap(), 0x7fffffff);
 }
 
 #[test]
@@ -156,19 +184,22 @@ fn test_datetime_from_str() {
 
 #[test]
 fn test_datetime_parse_from_str() {
-    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).and_hms(h, n, s);
-    let ymdhmsn = |y, m, d, h, n, s, nano| NaiveDate::from_ymd(y, m, d).and_hms_nano(h, n, s, nano);
+    let ymdhms =
+        |y, m, d, h, n, s| Ok::<_, ChronoError>(NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?);
+    let ymdhmsn = |y, m, d, h, n, s, nano| {
+        Ok::<_, ChronoError>(NaiveDate::from_ymd(y, m, d)?.and_hms_nano(h, n, s, nano)?)
+    };
     assert_eq!(
         NaiveDateTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
-        Ok(ymdhms(2014, 5, 7, 12, 34, 56))
+        Ok(ymdhms(2014, 5, 7, 12, 34, 56).unwrap())
     ); // ignore offset
     assert_eq!(
         NaiveDateTime::parse_from_str("2015-W06-1 000000", "%G-W%V-%u%H%M%S"),
-        Ok(ymdhms(2015, 2, 2, 0, 0, 0))
+        Ok(ymdhms(2015, 2, 2, 0, 0, 0).unwrap())
     );
     assert_eq!(
         NaiveDateTime::parse_from_str("Fri, 09 Aug 2013 23:54:35 GMT", "%a, %d %b %Y %H:%M:%S GMT"),
-        Ok(ymdhms(2013, 8, 9, 23, 54, 35))
+        Ok(ymdhms(2013, 8, 9, 23, 54, 35).unwrap())
     );
     assert!(NaiveDateTime::parse_from_str(
         "Sat, 09 Aug 2013 23:54:35 GMT",
@@ -179,35 +210,35 @@ fn test_datetime_parse_from_str() {
     assert!(NaiveDateTime::parse_from_str("12:34:56", "%H:%M:%S").is_err()); // insufficient
     assert_eq!(
         NaiveDateTime::parse_from_str("1441497364", "%s"),
-        Ok(ymdhms(2015, 9, 5, 23, 56, 4))
+        Ok(ymdhms(2015, 9, 5, 23, 56, 4).unwrap())
     );
     assert_eq!(
         NaiveDateTime::parse_from_str("1283929614.1234", "%s.%f"),
-        Ok(ymdhmsn(2010, 9, 8, 7, 6, 54, 1234))
+        Ok(ymdhmsn(2010, 9, 8, 7, 6, 54, 1234).unwrap())
     );
     assert_eq!(
         NaiveDateTime::parse_from_str("1441497364.649", "%s%.3f"),
-        Ok(ymdhmsn(2015, 9, 5, 23, 56, 4, 649000000))
+        Ok(ymdhmsn(2015, 9, 5, 23, 56, 4, 649000000).unwrap())
     );
     assert_eq!(
         NaiveDateTime::parse_from_str("1497854303.087654", "%s%.6f"),
-        Ok(ymdhmsn(2017, 6, 19, 6, 38, 23, 87654000))
+        Ok(ymdhmsn(2017, 6, 19, 6, 38, 23, 87654000).unwrap())
     );
     assert_eq!(
         NaiveDateTime::parse_from_str("1437742189.918273645", "%s%.9f"),
-        Ok(ymdhmsn(2015, 7, 24, 12, 49, 49, 918273645))
+        Ok(ymdhmsn(2015, 7, 24, 12, 49, 49, 918273645).unwrap())
     );
 }
 
 #[test]
 fn test_datetime_format() {
-    let dt = NaiveDate::from_ymd(2010, 9, 8).and_hms_milli(7, 6, 54, 321);
+    let dt = NaiveDate::from_ymd(2010, 9, 8).unwrap().and_hms_milli(7, 6, 54, 321).unwrap();
     assert_eq!(dt.format("%c").to_string(), "Wed Sep  8 07:06:54 2010");
     assert_eq!(dt.format("%s").to_string(), "1283929614");
     assert_eq!(dt.format("%t%n%%%n%t").to_string(), "\t\n%\n\t");
 
     // a horror of leap second: coming near to you.
-    let dt = NaiveDate::from_ymd(2012, 6, 30).and_hms_milli(23, 59, 59, 1_000);
+    let dt = NaiveDate::from_ymd(2012, 6, 30).unwrap().and_hms_milli(23, 59, 59, 1_000).unwrap();
     assert_eq!(dt.format("%c").to_string(), "Sat Jun 30 23:59:60 2012");
     assert_eq!(dt.format("%s").to_string(), "1341100799"); // not 1341100800, it's intentional.
 }
@@ -215,7 +246,7 @@ fn test_datetime_format() {
 #[test]
 fn test_datetime_add_sub_invariant() {
     // issue #37
-    let base = NaiveDate::from_ymd(2000, 1, 1).and_hms(0, 0, 0);
+    let base = NaiveDate::from_ymd(2000, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
     let t = -946684799990000;
     let time = base + TimeDelta::microseconds(t);
     assert_eq!(t, time.signed_duration_since(base).num_microseconds().unwrap());
@@ -229,7 +260,7 @@ fn test_nanosecond_range() {
     let nanos = parsed.timestamp_nanos();
     assert_eq!(
         parsed,
-        NaiveDateTime::from_timestamp(nanos / A_BILLION, (nanos % A_BILLION) as u32)
+        NaiveDateTime::from_timestamp(nanos / A_BILLION, (nanos % A_BILLION) as u32).unwrap()
     );
 
     let minimum = "1677-09-21T00:12:44.000000000";
@@ -237,18 +268,18 @@ fn test_nanosecond_range() {
     let nanos = parsed.timestamp_nanos();
     assert_eq!(
         parsed,
-        NaiveDateTime::from_timestamp(nanos / A_BILLION, (nanos % A_BILLION) as u32)
+        NaiveDateTime::from_timestamp(nanos / A_BILLION, (nanos % A_BILLION) as u32).unwrap()
     );
 }
 
 #[test]
 fn test_and_timezone() {
-    let ndt = NaiveDate::from_ymd(2022, 6, 15).and_hms(18, 59, 36);
+    let ndt = NaiveDate::from_ymd(2022, 6, 15).unwrap().and_hms(18, 59, 36).unwrap();
     let dt_utc = ndt.and_local_timezone(Utc).unwrap();
     assert_eq!(dt_utc.naive_local(), ndt);
     assert_eq!(dt_utc.timezone(), Utc);
 
-    let offset_tz = FixedOffset::west(4 * 3600);
+    let offset_tz = FixedOffset::west(4 * 3600).unwrap();
     let dt_offset = ndt.and_local_timezone(offset_tz).unwrap();
     assert_eq!(dt_offset.naive_local(), ndt);
     assert_eq!(dt_offset.timezone(), offset_tz);

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -57,8 +57,9 @@ impl IsoWeek {
     /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
-    /// let d = NaiveDate::from_isoywd(2015, 1, Weekday::Mon);
+    /// let d = NaiveDate::from_isoywd(2015, 1, Weekday::Mon)?;
     /// assert_eq!(d.iso_week().year(), 2015);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     ///
     /// This year number might not match the calendar year number.
@@ -66,9 +67,10 @@ impl IsoWeek {
     ///
     /// ```
     /// # use chrono::{NaiveDate, Datelike, Weekday};
-    /// # let d = NaiveDate::from_isoywd(2015, 1, Weekday::Mon);
+    /// # let d = NaiveDate::from_isoywd(2015, 1, Weekday::Mon)?;
     /// assert_eq!(d.year(), 2014);
-    /// assert_eq!(d, NaiveDate::from_ymd(2014, 12, 29));
+    /// assert_eq!(d, NaiveDate::from_ymd(2014, 12, 29)?);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     pub fn year(&self) -> i32 {
@@ -84,8 +86,9 @@ impl IsoWeek {
     /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
-    /// let d = NaiveDate::from_isoywd(2015, 15, Weekday::Mon);
+    /// let d = NaiveDate::from_isoywd(2015, 15, Weekday::Mon)?;
     /// assert_eq!(d.iso_week().week(), 15);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     pub fn week(&self) -> u32 {
@@ -101,8 +104,9 @@ impl IsoWeek {
     /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
-    /// let d = NaiveDate::from_isoywd(2015, 15, Weekday::Mon);
+    /// let d = NaiveDate::from_isoywd(2015, 15, Weekday::Mon)?;
     /// assert_eq!(d.iso_week().week0(), 14);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     #[inline]
     pub fn week0(&self) -> u32 {
@@ -119,17 +123,19 @@ impl IsoWeek {
 /// ```
 /// use chrono::{NaiveDate, Datelike};
 ///
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(2015,  9,  5).iso_week()), "2015-W36");
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(   0,  1,  3).iso_week()), "0000-W01");
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(9999, 12, 31).iso_week()), "9999-W52");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(2015, 9, 5)?.iso_week()), "2015-W36");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(0, 1, 3)?.iso_week()), "0000-W01");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(9999, 12, 31)?.iso_week()), "9999-W52");
+/// # Ok::<_, chrono::ChronoError>(())
 /// ```
 ///
 /// ISO 8601 requires an explicit sign for years before 1 BCE or after 9999 CE.
 ///
 /// ```
 /// # use chrono::{NaiveDate, Datelike};
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(    0,  1,  2).iso_week()),  "-0001-W52");
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(10000, 12, 31).iso_week()), "+10000-W52");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(0, 1, 2)?.iso_week()), "-0001-W52");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(10000, 12, 31)?.iso_week()), "+10000-W52");
+/// # Ok::<_, chrono::ChronoError>(())
 /// ```
 impl fmt::Debug for IsoWeek {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -59,7 +59,7 @@ impl IsoWeek {
     ///
     /// let d = NaiveDate::from_isoywd(2015, 1, Weekday::Mon)?;
     /// assert_eq!(d.iso_week().year(), 2015);
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     ///
     /// This year number might not match the calendar year number.
@@ -70,7 +70,7 @@ impl IsoWeek {
     /// # let d = NaiveDate::from_isoywd(2015, 1, Weekday::Mon)?;
     /// assert_eq!(d.year(), 2014);
     /// assert_eq!(d, NaiveDate::from_ymd(2014, 12, 29)?);
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     #[inline]
     pub fn year(&self) -> i32 {
@@ -88,7 +88,7 @@ impl IsoWeek {
     ///
     /// let d = NaiveDate::from_isoywd(2015, 15, Weekday::Mon)?;
     /// assert_eq!(d.iso_week().week(), 15);
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     #[inline]
     pub fn week(&self) -> u32 {
@@ -106,7 +106,7 @@ impl IsoWeek {
     ///
     /// let d = NaiveDate::from_isoywd(2015, 15, Weekday::Mon)?;
     /// assert_eq!(d.iso_week().week0(), 14);
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     #[inline]
     pub fn week0(&self) -> u32 {
@@ -126,7 +126,7 @@ impl IsoWeek {
 /// assert_eq!(format!("{:?}", NaiveDate::from_ymd(2015, 9, 5)?.iso_week()), "2015-W36");
 /// assert_eq!(format!("{:?}", NaiveDate::from_ymd(0, 1, 3)?.iso_week()), "0000-W01");
 /// assert_eq!(format!("{:?}", NaiveDate::from_ymd(9999, 12, 31)?.iso_week()), "9999-W52");
-/// # Ok::<_, chrono::ChronoError>(())
+/// # Ok::<_, chrono::Error>(())
 /// ```
 ///
 /// ISO 8601 requires an explicit sign for years before 1 BCE or after 9999 CE.
@@ -135,7 +135,7 @@ impl IsoWeek {
 /// # use chrono::{NaiveDate, Datelike};
 /// assert_eq!(format!("{:?}", NaiveDate::from_ymd(0, 1, 2)?.iso_week()), "-0001-W52");
 /// assert_eq!(format!("{:?}", NaiveDate::from_ymd(10000, 12, 31)?.iso_week()), "+10000-W52");
-/// # Ok::<_, chrono::ChronoError>(())
+/// # Ok::<_, chrono::Error>(())
 /// ```
 impl fmt::Debug for IsoWeek {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -181,8 +181,8 @@ mod tests;
 ///
 /// let dt = Utc.ymd(2015, 6, 30)?.and_hms(23, 56, 5)?;
 /// assert_eq!(format!("{:?}", dt), "2015-06-30T23:56:05Z");
-/// assert_eq!(DateTime::parse_from_rfc3339("2015-06-30T23:56:05Z").unwrap(), dt);
-/// # Ok::<_, chrono::ChronoError>(())
+/// assert_eq!(DateTime::parse_from_rfc3339("2015-06-30T23:56:05Z")?, dt);
+/// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 ///
 /// Since Chrono alone cannot determine any existence of leap seconds,
@@ -858,7 +858,8 @@ impl Timelike for NaiveTime {
 
     /// Makes a new `NaiveTime` with the hour number changed.
     ///
-    /// Returns `None` when the resulting `NaiveTime` would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting `NaiveTime` would be
+    /// invalid.
     ///
     /// # Example
     ///
@@ -881,7 +882,8 @@ impl Timelike for NaiveTime {
 
     /// Makes a new `NaiveTime` with the minute number changed.
     ///
-    /// Returns `None` when the resulting `NaiveTime` would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting `NaiveTime` would be
+    /// invalid.
     ///
     /// # Example
     ///
@@ -904,9 +906,9 @@ impl Timelike for NaiveTime {
 
     /// Makes a new `NaiveTime` with the second number changed.
     ///
-    /// Returns `None` when the resulting `NaiveTime` would be invalid.
-    /// As with the [`second`](#method.second) method,
-    /// the input range is restricted to 0 through 59.
+    /// Returns `Err(ChronoError)` when the resulting `NaiveTime` would be
+    /// invalid. As with the [`second`](#method.second) method, the input range
+    /// is restricted to 0 through 59.
     ///
     /// # Example
     ///
@@ -927,11 +929,12 @@ impl Timelike for NaiveTime {
         Ok(NaiveTime { secs, ..*self })
     }
 
-    /// Makes a new `NaiveTime` with nanoseconds since the whole non-leap second changed.
+    /// Makes a new `NaiveTime` with nanoseconds since the whole non-leap second
+    /// changed.
     ///
-    /// Returns `None` when the resulting `NaiveTime` would be invalid.
-    /// As with the [`nanosecond`](#method.nanosecond) method,
-    /// the input range can exceed 1,000,000,000 for leap seconds.
+    /// Returns `Err(ChronoError)` when the resulting `NaiveTime` would be
+    /// invalid. As with the [`nanosecond`](#method.nanosecond) method, the
+    /// input range can exceed 1,000,000,000 for leap seconds.
     ///
     /// # Example
     ///
@@ -944,10 +947,10 @@ impl Timelike for NaiveTime {
     /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     ///
-    /// Leap seconds can theoretically follow *any* whole second.
-    /// The following would be a proper leap second at the time zone offset of UTC-00:03:57
-    /// (there are several historical examples comparable to this "non-sense" offset),
-    /// and therefore is allowed.
+    /// Leap seconds can theoretically follow *any* whole second. The following
+    /// would be a proper leap second at the time zone offset of UTC-00:03:57
+    /// (there are several historical examples comparable to this "non-sense"
+    /// offset), and therefore is allowed.
     ///
     /// ```
     /// # use chrono::{NaiveTime, Timelike};

--- a/src/naive/time/serde.rs
+++ b/src/naive/time/serde.rs
@@ -58,7 +58,7 @@ fn test_serde_bincode() {
     // it is not self-describing.
     use bincode::{deserialize, serialize};
 
-    let t = NaiveTime::from_hms_nano(3, 5, 7, 98765432);
+    let t = NaiveTime::from_hms_nano(3, 5, 7, 98765432).unwrap();
     let encoded = serialize(&t).unwrap();
     let decoded: NaiveTime = deserialize(&encoded).unwrap();
     assert_eq!(t, decoded);

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -6,64 +6,82 @@ use crate::{TimeDelta, Timelike};
 #[test]
 fn test_time_from_hms_milli() {
     assert_eq!(
-        NaiveTime::from_hms_milli_opt(3, 5, 7, 0),
-        Some(NaiveTime::from_hms_nano(3, 5, 7, 0))
+        NaiveTime::from_hms_milli(3, 5, 7, 0).unwrap(),
+        NaiveTime::from_hms_nano(3, 5, 7, 0).unwrap()
     );
     assert_eq!(
-        NaiveTime::from_hms_milli_opt(3, 5, 7, 777),
-        Some(NaiveTime::from_hms_nano(3, 5, 7, 777_000_000))
+        NaiveTime::from_hms_milli(3, 5, 7, 777).unwrap(),
+        NaiveTime::from_hms_nano(3, 5, 7, 777_000_000).unwrap()
     );
     assert_eq!(
-        NaiveTime::from_hms_milli_opt(3, 5, 7, 1_999),
-        Some(NaiveTime::from_hms_nano(3, 5, 7, 1_999_000_000))
+        NaiveTime::from_hms_milli(3, 5, 7, 1_999).unwrap(),
+        NaiveTime::from_hms_nano(3, 5, 7, 1_999_000_000).unwrap()
     );
-    assert_eq!(NaiveTime::from_hms_milli_opt(3, 5, 7, 2_000), None);
-    assert_eq!(NaiveTime::from_hms_milli_opt(3, 5, 7, 5_000), None); // overflow check
-    assert_eq!(NaiveTime::from_hms_milli_opt(3, 5, 7, u32::MAX), None);
+    assert!(NaiveTime::from_hms_milli(3, 5, 7, 2_000).is_err());
+    assert!(NaiveTime::from_hms_milli(3, 5, 7, 5_000).is_err()); // overflow check
+    assert!(NaiveTime::from_hms_milli(3, 5, 7, u32::MAX).is_err());
 }
 
 #[test]
 fn test_time_from_hms_micro() {
     assert_eq!(
-        NaiveTime::from_hms_micro_opt(3, 5, 7, 0),
-        Some(NaiveTime::from_hms_nano(3, 5, 7, 0))
+        NaiveTime::from_hms_micro(3, 5, 7, 0).unwrap(),
+        NaiveTime::from_hms_nano(3, 5, 7, 0).unwrap()
     );
     assert_eq!(
-        NaiveTime::from_hms_micro_opt(3, 5, 7, 333),
-        Some(NaiveTime::from_hms_nano(3, 5, 7, 333_000))
+        NaiveTime::from_hms_micro(3, 5, 7, 333).unwrap(),
+        NaiveTime::from_hms_nano(3, 5, 7, 333_000).unwrap()
     );
     assert_eq!(
-        NaiveTime::from_hms_micro_opt(3, 5, 7, 777_777),
-        Some(NaiveTime::from_hms_nano(3, 5, 7, 777_777_000))
+        NaiveTime::from_hms_micro(3, 5, 7, 777_777).unwrap(),
+        NaiveTime::from_hms_nano(3, 5, 7, 777_777_000).unwrap()
     );
     assert_eq!(
-        NaiveTime::from_hms_micro_opt(3, 5, 7, 1_999_999),
-        Some(NaiveTime::from_hms_nano(3, 5, 7, 1_999_999_000))
+        NaiveTime::from_hms_micro(3, 5, 7, 1_999_999).unwrap(),
+        NaiveTime::from_hms_nano(3, 5, 7, 1_999_999_000).unwrap()
     );
-    assert_eq!(NaiveTime::from_hms_micro_opt(3, 5, 7, 2_000_000), None);
-    assert_eq!(NaiveTime::from_hms_micro_opt(3, 5, 7, 5_000_000), None); // overflow check
-    assert_eq!(NaiveTime::from_hms_micro_opt(3, 5, 7, u32::MAX), None);
+    assert!(NaiveTime::from_hms_micro(3, 5, 7, 2_000_000).is_err());
+    assert!(NaiveTime::from_hms_micro(3, 5, 7, 5_000_000).is_err()); // overflow check
+    assert!(NaiveTime::from_hms_micro(3, 5, 7, u32::MAX).is_err());
 }
 
 #[test]
 fn test_time_hms() {
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).hour(), 3);
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).with_hour(0), Some(NaiveTime::from_hms(0, 5, 7)));
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).with_hour(23), Some(NaiveTime::from_hms(23, 5, 7)));
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).with_hour(24), None);
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).with_hour(u32::MAX), None);
+    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().hour(), 3);
+    assert_eq!(
+        NaiveTime::from_hms(3, 5, 7).unwrap().with_hour(0).unwrap(),
+        NaiveTime::from_hms(0, 5, 7).unwrap()
+    );
+    assert_eq!(
+        NaiveTime::from_hms(3, 5, 7).unwrap().with_hour(23).unwrap(),
+        NaiveTime::from_hms(23, 5, 7).unwrap()
+    );
+    assert!(NaiveTime::from_hms(3, 5, 7).unwrap().with_hour(24).is_err());
+    assert!(NaiveTime::from_hms(3, 5, 7).unwrap().with_hour(u32::MAX).is_err());
 
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).minute(), 5);
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).with_minute(0), Some(NaiveTime::from_hms(3, 0, 7)));
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).with_minute(59), Some(NaiveTime::from_hms(3, 59, 7)));
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).with_minute(60), None);
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).with_minute(u32::MAX), None);
+    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().minute(), 5);
+    assert_eq!(
+        NaiveTime::from_hms(3, 5, 7).unwrap().with_minute(0).unwrap(),
+        NaiveTime::from_hms(3, 0, 7).unwrap()
+    );
+    assert_eq!(
+        NaiveTime::from_hms(3, 5, 7).unwrap().with_minute(59).unwrap(),
+        NaiveTime::from_hms(3, 59, 7).unwrap()
+    );
+    assert!(NaiveTime::from_hms(3, 5, 7).unwrap().with_minute(60).is_err());
+    assert!(NaiveTime::from_hms(3, 5, 7).unwrap().with_minute(u32::MAX).is_err());
 
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).second(), 7);
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).with_second(0), Some(NaiveTime::from_hms(3, 5, 0)));
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).with_second(59), Some(NaiveTime::from_hms(3, 5, 59)));
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).with_second(60), None);
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).with_second(u32::MAX), None);
+    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().second(), 7);
+    assert_eq!(
+        NaiveTime::from_hms(3, 5, 7).unwrap().with_second(0).unwrap(),
+        NaiveTime::from_hms(3, 5, 0).unwrap()
+    );
+    assert_eq!(
+        NaiveTime::from_hms(3, 5, 7).unwrap().with_second(59).unwrap(),
+        NaiveTime::from_hms(3, 5, 59).unwrap()
+    );
+    assert!(NaiveTime::from_hms(3, 5, 7).unwrap().with_second(60).is_err());
+    assert!(NaiveTime::from_hms(3, 5, 7).unwrap().with_second(u32::MAX).is_err());
 }
 
 #[test]
@@ -77,23 +95,51 @@ fn test_time_add() {
 
     let hmsm = NaiveTime::from_hms_milli;
 
-    check!(hmsm(3, 5, 7, 900), TimeDelta::zero(), hmsm(3, 5, 7, 900));
-    check!(hmsm(3, 5, 7, 900), TimeDelta::milliseconds(100), hmsm(3, 5, 8, 0));
-    check!(hmsm(3, 5, 7, 1_300), TimeDelta::milliseconds(-1800), hmsm(3, 5, 6, 500));
-    check!(hmsm(3, 5, 7, 1_300), TimeDelta::milliseconds(-800), hmsm(3, 5, 7, 500));
-    check!(hmsm(3, 5, 7, 1_300), TimeDelta::milliseconds(-100), hmsm(3, 5, 7, 1_200));
-    check!(hmsm(3, 5, 7, 1_300), TimeDelta::milliseconds(100), hmsm(3, 5, 7, 1_400));
-    check!(hmsm(3, 5, 7, 1_300), TimeDelta::milliseconds(800), hmsm(3, 5, 8, 100));
-    check!(hmsm(3, 5, 7, 1_300), TimeDelta::milliseconds(1800), hmsm(3, 5, 9, 100));
-    check!(hmsm(3, 5, 7, 900), TimeDelta::seconds(86399), hmsm(3, 5, 6, 900)); // overwrap
-    check!(hmsm(3, 5, 7, 900), TimeDelta::seconds(-86399), hmsm(3, 5, 8, 900));
-    check!(hmsm(3, 5, 7, 900), TimeDelta::days(12345), hmsm(3, 5, 7, 900));
-    check!(hmsm(3, 5, 7, 1_300), TimeDelta::days(1), hmsm(3, 5, 7, 300));
-    check!(hmsm(3, 5, 7, 1_300), TimeDelta::days(-1), hmsm(3, 5, 8, 300));
+    check!(hmsm(3, 5, 7, 900).unwrap(), TimeDelta::zero(), hmsm(3, 5, 7, 900).unwrap());
+    check!(hmsm(3, 5, 7, 900).unwrap(), TimeDelta::milliseconds(100), hmsm(3, 5, 8, 0).unwrap());
+    check!(
+        hmsm(3, 5, 7, 1_300).unwrap(),
+        TimeDelta::milliseconds(-1800),
+        hmsm(3, 5, 6, 500).unwrap()
+    );
+    check!(
+        hmsm(3, 5, 7, 1_300).unwrap(),
+        TimeDelta::milliseconds(-800),
+        hmsm(3, 5, 7, 500).unwrap()
+    );
+    check!(
+        hmsm(3, 5, 7, 1_300).unwrap(),
+        TimeDelta::milliseconds(-100),
+        hmsm(3, 5, 7, 1_200).unwrap()
+    );
+    check!(
+        hmsm(3, 5, 7, 1_300).unwrap(),
+        TimeDelta::milliseconds(100),
+        hmsm(3, 5, 7, 1_400).unwrap()
+    );
+    check!(
+        hmsm(3, 5, 7, 1_300).unwrap(),
+        TimeDelta::milliseconds(800),
+        hmsm(3, 5, 8, 100).unwrap()
+    );
+    check!(
+        hmsm(3, 5, 7, 1_300).unwrap(),
+        TimeDelta::milliseconds(1800),
+        hmsm(3, 5, 9, 100).unwrap()
+    );
+    check!(hmsm(3, 5, 7, 900).unwrap(), TimeDelta::seconds(86399), hmsm(3, 5, 6, 900).unwrap()); // overwrap
+    check!(hmsm(3, 5, 7, 900).unwrap(), TimeDelta::seconds(-86399), hmsm(3, 5, 8, 900).unwrap());
+    check!(hmsm(3, 5, 7, 900).unwrap(), TimeDelta::days(12345), hmsm(3, 5, 7, 900).unwrap());
+    check!(hmsm(3, 5, 7, 1_300).unwrap(), TimeDelta::days(1), hmsm(3, 5, 7, 300).unwrap());
+    check!(hmsm(3, 5, 7, 1_300).unwrap(), TimeDelta::days(-1), hmsm(3, 5, 8, 300).unwrap());
 
     // regression tests for #37
-    check!(hmsm(0, 0, 0, 0), TimeDelta::milliseconds(-990), hmsm(23, 59, 59, 10));
-    check!(hmsm(0, 0, 0, 0), TimeDelta::milliseconds(-9990), hmsm(23, 59, 50, 10));
+    check!(hmsm(0, 0, 0, 0).unwrap(), TimeDelta::milliseconds(-990), hmsm(23, 59, 59, 10).unwrap());
+    check!(
+        hmsm(0, 0, 0, 0).unwrap(),
+        TimeDelta::milliseconds(-9990),
+        hmsm(23, 59, 50, 10).unwrap()
+    );
 }
 
 #[test]
@@ -101,47 +147,47 @@ fn test_time_overflowing_add() {
     let hmsm = NaiveTime::from_hms_milli;
 
     assert_eq!(
-        hmsm(3, 4, 5, 678).overflowing_add_signed(TimeDelta::hours(11)),
-        (hmsm(14, 4, 5, 678), 0)
+        hmsm(3, 4, 5, 678).unwrap().overflowing_add_signed(TimeDelta::hours(11)),
+        (hmsm(14, 4, 5, 678).unwrap(), 0)
     );
     assert_eq!(
-        hmsm(3, 4, 5, 678).overflowing_add_signed(TimeDelta::hours(23)),
-        (hmsm(2, 4, 5, 678), 86_400)
+        hmsm(3, 4, 5, 678).unwrap().overflowing_add_signed(TimeDelta::hours(23)),
+        (hmsm(2, 4, 5, 678).unwrap(), 86_400)
     );
     assert_eq!(
-        hmsm(3, 4, 5, 678).overflowing_add_signed(TimeDelta::hours(-7)),
-        (hmsm(20, 4, 5, 678), -86_400)
+        hmsm(3, 4, 5, 678).unwrap().overflowing_add_signed(TimeDelta::hours(-7)),
+        (hmsm(20, 4, 5, 678).unwrap(), -86_400)
     );
 
     // overflowing_add_signed with leap seconds may be counter-intuitive
     assert_eq!(
-        hmsm(3, 4, 5, 1_678).overflowing_add_signed(TimeDelta::days(1)),
-        (hmsm(3, 4, 5, 678), 86_400)
+        hmsm(3, 4, 5, 1_678).unwrap().overflowing_add_signed(TimeDelta::days(1)),
+        (hmsm(3, 4, 5, 678).unwrap(), 86_400)
     );
     assert_eq!(
-        hmsm(3, 4, 5, 1_678).overflowing_add_signed(TimeDelta::days(-1)),
-        (hmsm(3, 4, 6, 678), -86_400)
+        hmsm(3, 4, 5, 1_678).unwrap().overflowing_add_signed(TimeDelta::days(-1)),
+        (hmsm(3, 4, 6, 678).unwrap(), -86_400)
     );
 }
 
 #[test]
 fn test_time_addassignment() {
     let hms = NaiveTime::from_hms;
-    let mut time = hms(12, 12, 12);
+    let mut time = hms(12, 12, 12).unwrap();
     time += TimeDelta::hours(10);
-    assert_eq!(time, hms(22, 12, 12));
+    assert_eq!(time, hms(22, 12, 12).unwrap());
     time += TimeDelta::hours(10);
-    assert_eq!(time, hms(8, 12, 12));
+    assert_eq!(time, hms(8, 12, 12).unwrap());
 }
 
 #[test]
 fn test_time_subassignment() {
     let hms = NaiveTime::from_hms;
-    let mut time = hms(12, 12, 12);
+    let mut time = hms(12, 12, 12).unwrap();
     time -= TimeDelta::hours(10);
-    assert_eq!(time, hms(2, 12, 12));
+    assert_eq!(time, hms(2, 12, 12).unwrap());
     time -= TimeDelta::hours(10);
-    assert_eq!(time, hms(16, 12, 12));
+    assert_eq!(time, hms(16, 12, 12).unwrap());
 }
 
 #[test]
@@ -156,37 +202,68 @@ fn test_time_sub() {
 
     let hmsm = NaiveTime::from_hms_milli;
 
-    check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 900), TimeDelta::zero());
-    check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 600), TimeDelta::milliseconds(300));
-    check!(hmsm(3, 5, 7, 200), hmsm(2, 4, 6, 200), TimeDelta::seconds(3600 + 60 + 1));
+    check!(hmsm(3, 5, 7, 900).unwrap(), hmsm(3, 5, 7, 900).unwrap(), TimeDelta::zero());
+    check!(hmsm(3, 5, 7, 900).unwrap(), hmsm(3, 5, 7, 600).unwrap(), TimeDelta::milliseconds(300));
     check!(
-        hmsm(3, 5, 7, 200),
-        hmsm(2, 4, 6, 300),
+        hmsm(3, 5, 7, 200).unwrap(),
+        hmsm(2, 4, 6, 200).unwrap(),
+        TimeDelta::seconds(3600 + 60 + 1)
+    );
+    check!(
+        hmsm(3, 5, 7, 200).unwrap(),
+        hmsm(2, 4, 6, 300).unwrap(),
         TimeDelta::seconds(3600 + 60) + TimeDelta::milliseconds(900)
     );
 
     // treats the leap second as if it coincides with the prior non-leap second,
     // as required by `time1 - time2 = duration` and `time2 - time1 = -duration` equivalence.
-    check!(hmsm(3, 5, 7, 200), hmsm(3, 5, 6, 1_800), TimeDelta::milliseconds(400));
-    check!(hmsm(3, 5, 7, 1_200), hmsm(3, 5, 6, 1_800), TimeDelta::milliseconds(1400));
-    check!(hmsm(3, 5, 7, 1_200), hmsm(3, 5, 6, 800), TimeDelta::milliseconds(1400));
+    check!(
+        hmsm(3, 5, 7, 200).unwrap(),
+        hmsm(3, 5, 6, 1_800).unwrap(),
+        TimeDelta::milliseconds(400)
+    );
+    check!(
+        hmsm(3, 5, 7, 1_200).unwrap(),
+        hmsm(3, 5, 6, 1_800).unwrap(),
+        TimeDelta::milliseconds(1400)
+    );
+    check!(
+        hmsm(3, 5, 7, 1_200).unwrap(),
+        hmsm(3, 5, 6, 800).unwrap(),
+        TimeDelta::milliseconds(1400)
+    );
 
     // additional equality: `time1 + duration = time2` is equivalent to
     // `time2 - time1 = duration` IF AND ONLY IF `time2` represents a non-leap second.
-    assert_eq!(hmsm(3, 5, 6, 800) + TimeDelta::milliseconds(400), hmsm(3, 5, 7, 200));
-    assert_eq!(hmsm(3, 5, 6, 1_800) + TimeDelta::milliseconds(400), hmsm(3, 5, 7, 200));
+    assert_eq!(
+        hmsm(3, 5, 6, 800).unwrap() + TimeDelta::milliseconds(400),
+        hmsm(3, 5, 7, 200).unwrap()
+    );
+    assert_eq!(
+        hmsm(3, 5, 6, 1_800).unwrap() + TimeDelta::milliseconds(400),
+        hmsm(3, 5, 7, 200).unwrap()
+    );
 }
 
 #[test]
 fn test_time_fmt() {
-    assert_eq!(format!("{}", NaiveTime::from_hms_milli(23, 59, 59, 999)), "23:59:59.999");
-    assert_eq!(format!("{}", NaiveTime::from_hms_milli(23, 59, 59, 1_000)), "23:59:60");
-    assert_eq!(format!("{}", NaiveTime::from_hms_milli(23, 59, 59, 1_001)), "23:59:60.001");
-    assert_eq!(format!("{}", NaiveTime::from_hms_micro(0, 0, 0, 43210)), "00:00:00.043210");
-    assert_eq!(format!("{}", NaiveTime::from_hms_nano(0, 0, 0, 6543210)), "00:00:00.006543210");
+    assert_eq!(format!("{}", NaiveTime::from_hms_milli(23, 59, 59, 999).unwrap()), "23:59:59.999");
+    assert_eq!(format!("{}", NaiveTime::from_hms_milli(23, 59, 59, 1_000).unwrap()), "23:59:60");
+    assert_eq!(
+        format!("{}", NaiveTime::from_hms_milli(23, 59, 59, 1_001).unwrap()),
+        "23:59:60.001"
+    );
+    assert_eq!(
+        format!("{}", NaiveTime::from_hms_micro(0, 0, 0, 43210).unwrap()),
+        "00:00:00.043210"
+    );
+    assert_eq!(
+        format!("{}", NaiveTime::from_hms_nano(0, 0, 0, 6543210).unwrap()),
+        "00:00:00.006543210"
+    );
 
     // the format specifier should have no effect on `NaiveTime`
-    assert_eq!(format!("{:30}", NaiveTime::from_hms_milli(3, 5, 7, 9)), "03:05:07.009");
+    assert_eq!(format!("{:30}", NaiveTime::from_hms_milli(3, 5, 7, 9).unwrap()), "03:05:07.009");
 }
 
 #[test]
@@ -242,15 +319,15 @@ fn test_time_parse_from_str() {
     let hms = NaiveTime::from_hms;
     assert_eq!(
         NaiveTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
-        Ok(hms(12, 34, 56))
+        Ok(hms(12, 34, 56).unwrap())
     ); // ignore date and offset
-    assert_eq!(NaiveTime::parse_from_str("PM 12:59", "%P %H:%M"), Ok(hms(12, 59, 0)));
+    assert_eq!(NaiveTime::parse_from_str("PM 12:59", "%P %H:%M"), Ok(hms(12, 59, 0).unwrap()));
     assert!(NaiveTime::parse_from_str("12:3456", "%H:%M:%S").is_err());
 }
 
 #[test]
 fn test_time_format() {
-    let t = NaiveTime::from_hms_nano(3, 5, 7, 98765432);
+    let t = NaiveTime::from_hms_nano(3, 5, 7, 98765432).unwrap();
     assert_eq!(t.format("%H,%k,%I,%l,%P,%p").to_string(), "03, 3,03, 3,am,AM");
     assert_eq!(t.format("%M").to_string(), "05");
     assert_eq!(t.format("%S,%f,%.f").to_string(), "07,098765432,.098765432");
@@ -260,19 +337,22 @@ fn test_time_format() {
     assert_eq!(t.format("%r").to_string(), "03:05:07 AM");
     assert_eq!(t.format("%t%n%%%n%t").to_string(), "\t\n%\n\t");
 
-    let t = NaiveTime::from_hms_micro(3, 5, 7, 432100);
+    let t = NaiveTime::from_hms_micro(3, 5, 7, 432100).unwrap();
     assert_eq!(t.format("%S,%f,%.f").to_string(), "07,432100000,.432100");
     assert_eq!(t.format("%.3f,%.6f,%.9f").to_string(), ".432,.432100,.432100000");
 
-    let t = NaiveTime::from_hms_milli(3, 5, 7, 210);
+    let t = NaiveTime::from_hms_milli(3, 5, 7, 210).unwrap();
     assert_eq!(t.format("%S,%f,%.f").to_string(), "07,210000000,.210");
     assert_eq!(t.format("%.3f,%.6f,%.9f").to_string(), ".210,.210000,.210000000");
 
-    let t = NaiveTime::from_hms(3, 5, 7);
+    let t = NaiveTime::from_hms(3, 5, 7).unwrap();
     assert_eq!(t.format("%S,%f,%.f").to_string(), "07,000000000,");
     assert_eq!(t.format("%.3f,%.6f,%.9f").to_string(), ".000,.000000,.000000000");
 
     // corner cases
-    assert_eq!(NaiveTime::from_hms(13, 57, 9).format("%r").to_string(), "01:57:09 PM");
-    assert_eq!(NaiveTime::from_hms_milli(23, 59, 59, 1_000).format("%X").to_string(), "23:59:60");
+    assert_eq!(NaiveTime::from_hms(13, 57, 9).unwrap().format("%r").to_string(), "01:57:09 PM");
+    assert_eq!(
+        NaiveTime::from_hms_milli(23, 59, 59, 1_000).unwrap().format("%X").to_string(),
+        "23:59:60"
+    );
 }

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -10,9 +10,9 @@ use num_integer::div_mod_floor;
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
 
-use super::{ChronoError, DateTime, FixedTimeZone, Offset, TimeZone};
+use super::{DateTime, Error, FixedTimeZone, Offset, TimeZone};
 use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
-use crate::offset::ChronoErrorKind;
+use crate::offset::ErrorKind;
 use crate::time_delta::TimeDelta;
 use crate::{LocalResult, Timelike};
 
@@ -35,7 +35,7 @@ impl FixedOffset {
     /// Makes a new `FixedOffset` for the Eastern Hemisphere with given timezone
     /// difference. The negative `secs` means the Western Hemisphere.
     ///
-    /// Returns `Err(ChronoError)` on the out-of-bound `secs`.
+    /// Returns `Err(Error)` on the out-of-bound `secs`.
     ///
     /// # Example
     ///
@@ -44,20 +44,20 @@ impl FixedOffset {
     /// let hour = 3600;
     /// let datetime = FixedOffset::east(5 * hour)?.ymd(2016, 11, 08)?.and_hms(0, 0, 0)?;
     /// assert_eq!(datetime.to_rfc3339(), "2016-11-08T00:00:00+05:00");
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
-    pub fn east(secs: i32) -> Result<FixedOffset, ChronoError> {
+    pub fn east(secs: i32) -> Result<FixedOffset, Error> {
         if -86_400 < secs && secs < 86_400 {
             Ok(FixedOffset { local_minus_utc: secs })
         } else {
-            Err(ChronoError::new(ChronoErrorKind::InvalidTimeZone))
+            Err(Error::new(ErrorKind::InvalidTimeZone))
         }
     }
 
     /// Makes a new `FixedOffset` for the Western Hemisphere with given timezone
     /// difference. The negative `secs` means the Eastern Hemisphere.
     ///
-    /// Returns `Err(ChronoError)` on the out-of-bound `secs`.
+    /// Returns `Err(Error)` on the out-of-bound `secs`.
     ///
     /// # Example
     ///
@@ -66,13 +66,13 @@ impl FixedOffset {
     /// let hour = 3600;
     /// let datetime = FixedOffset::west(5 * hour)?.ymd(2016, 11, 08)?.and_hms(0, 0, 0)?;
     /// assert_eq!(datetime.to_rfc3339(), "2016-11-08T00:00:00-05:00");
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
-    pub fn west(secs: i32) -> Result<FixedOffset, ChronoError> {
+    pub fn west(secs: i32) -> Result<FixedOffset, Error> {
         if -86_400 < secs && secs < 86_400 {
             Ok(FixedOffset { local_minus_utc: -secs })
         } else {
-            Err(ChronoError::new(ChronoErrorKind::InvalidTimeZone))
+            Err(Error::new(ErrorKind::InvalidTimeZone))
         }
     }
 
@@ -96,24 +96,21 @@ impl TimeZone for FixedOffset {
         *offset
     }
 
-    fn offset_from_local_date(
-        &self,
-        _: &NaiveDate,
-    ) -> Result<LocalResult<Self::Offset>, ChronoError> {
+    fn offset_from_local_date(&self, _: &NaiveDate) -> Result<LocalResult<Self::Offset>, Error> {
         Ok(LocalResult::Single(*self))
     }
 
     fn offset_from_local_datetime(
         &self,
         _: &NaiveDateTime,
-    ) -> Result<LocalResult<Self::Offset>, ChronoError> {
+    ) -> Result<LocalResult<Self::Offset>, Error> {
         Ok(LocalResult::Single(*self))
     }
 
-    fn offset_from_utc_date(&self, _utc: &NaiveDate) -> Result<Self, ChronoError> {
+    fn offset_from_utc_date(&self, _utc: &NaiveDate) -> Result<Self, Error> {
         Ok(*self)
     }
-    fn offset_from_utc_datetime(&self, _utc: &NaiveDateTime) -> Result<Self, ChronoError> {
+    fn offset_from_utc_datetime(&self, _utc: &NaiveDateTime) -> Result<Self, Error> {
         Ok(*self)
     }
 }

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -10,11 +10,11 @@ use num_integer::div_mod_floor;
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
 
-use super::{LocalResult, Offset, TimeZone};
+use super::{ChronoError, DateTime, FixedTimeZone, Offset, TimeZone};
 use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
+use crate::offset::ChronoErrorKind;
 use crate::time_delta::TimeDelta;
-use crate::DateTime;
-use crate::Timelike;
+use crate::{LocalResult, Timelike};
 
 /// The time zone with fixed offset, from UTC-23:59:59 to UTC+23:59:59.
 ///
@@ -29,63 +29,50 @@ pub struct FixedOffset {
 }
 
 impl FixedOffset {
-    /// Makes a new `FixedOffset` for the Eastern Hemisphere with given timezone difference.
-    /// The negative `secs` means the Western Hemisphere.
+    /// The fixed offset that matches UTC.
+    pub(crate) const UTC: FixedOffset = FixedOffset { local_minus_utc: 0 };
+
+    /// Makes a new `FixedOffset` for the Eastern Hemisphere with given timezone
+    /// difference. The negative `secs` means the Western Hemisphere.
     ///
-    /// Panics on the out-of-bound `secs`.
+    /// Returns `Err(ChronoError)` on the out-of-bound `secs`.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
-    /// let datetime = FixedOffset::east(5 * hour).ymd(2016, 11, 08)
-    ///                                           .and_hms(0, 0, 0);
-    /// assert_eq!(&datetime.to_rfc3339(), "2016-11-08T00:00:00+05:00")
+    /// let datetime = FixedOffset::east(5 * hour)?.ymd(2016, 11, 08)?.and_hms(0, 0, 0)?;
+    /// assert_eq!(datetime.to_rfc3339(), "2016-11-08T00:00:00+05:00");
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn east(secs: i32) -> FixedOffset {
-        FixedOffset::east_opt(secs).expect("FixedOffset::east out of bounds")
-    }
-
-    /// Makes a new `FixedOffset` for the Eastern Hemisphere with given timezone difference.
-    /// The negative `secs` means the Western Hemisphere.
-    ///
-    /// Returns `None` on the out-of-bound `secs`.
-    pub fn east_opt(secs: i32) -> Option<FixedOffset> {
+    pub fn east(secs: i32) -> Result<FixedOffset, ChronoError> {
         if -86_400 < secs && secs < 86_400 {
-            Some(FixedOffset { local_minus_utc: secs })
+            Ok(FixedOffset { local_minus_utc: secs })
         } else {
-            None
+            Err(ChronoError::new(ChronoErrorKind::InvalidTimeZone))
         }
     }
 
-    /// Makes a new `FixedOffset` for the Western Hemisphere with given timezone difference.
-    /// The negative `secs` means the Eastern Hemisphere.
+    /// Makes a new `FixedOffset` for the Western Hemisphere with given timezone
+    /// difference. The negative `secs` means the Eastern Hemisphere.
     ///
-    /// Panics on the out-of-bound `secs`.
+    /// Returns `Err(ChronoError)` on the out-of-bound `secs`.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
-    /// let datetime = FixedOffset::west(5 * hour).ymd(2016, 11, 08)
-    ///                                           .and_hms(0, 0, 0);
-    /// assert_eq!(&datetime.to_rfc3339(), "2016-11-08T00:00:00-05:00")
+    /// let datetime = FixedOffset::west(5 * hour)?.ymd(2016, 11, 08)?.and_hms(0, 0, 0)?;
+    /// assert_eq!(datetime.to_rfc3339(), "2016-11-08T00:00:00-05:00");
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    pub fn west(secs: i32) -> FixedOffset {
-        FixedOffset::west_opt(secs).expect("FixedOffset::west out of bounds")
-    }
-
-    /// Makes a new `FixedOffset` for the Western Hemisphere with given timezone difference.
-    /// The negative `secs` means the Eastern Hemisphere.
-    ///
-    /// Returns `None` on the out-of-bound `secs`.
-    pub fn west_opt(secs: i32) -> Option<FixedOffset> {
+    pub fn west(secs: i32) -> Result<FixedOffset, ChronoError> {
         if -86_400 < secs && secs < 86_400 {
-            Some(FixedOffset { local_minus_utc: -secs })
+            Ok(FixedOffset { local_minus_utc: -secs })
         } else {
-            None
+            Err(ChronoError::new(ChronoErrorKind::InvalidTimeZone))
         }
     }
 
@@ -105,21 +92,38 @@ impl FixedOffset {
 impl TimeZone for FixedOffset {
     type Offset = FixedOffset;
 
-    fn from_offset(offset: &FixedOffset) -> FixedOffset {
+    fn from_offset(offset: &Self::Offset) -> FixedOffset {
         *offset
     }
 
-    fn offset_from_local_date(&self, _local: &NaiveDate) -> LocalResult<FixedOffset> {
-        LocalResult::Single(*self)
-    }
-    fn offset_from_local_datetime(&self, _local: &NaiveDateTime) -> LocalResult<FixedOffset> {
-        LocalResult::Single(*self)
+    fn offset_from_local_date(
+        &self,
+        _: &NaiveDate,
+    ) -> Result<LocalResult<Self::Offset>, ChronoError> {
+        Ok(LocalResult::Single(*self))
     }
 
-    fn offset_from_utc_date(&self, _utc: &NaiveDate) -> FixedOffset {
+    fn offset_from_local_datetime(
+        &self,
+        _: &NaiveDateTime,
+    ) -> Result<LocalResult<Self::Offset>, ChronoError> {
+        Ok(LocalResult::Single(*self))
+    }
+
+    fn offset_from_utc_date(&self, _utc: &NaiveDate) -> Result<Self, ChronoError> {
+        Ok(*self)
+    }
+    fn offset_from_utc_datetime(&self, _utc: &NaiveDateTime) -> Result<Self, ChronoError> {
+        Ok(*self)
+    }
+}
+
+impl FixedTimeZone for FixedOffset {
+    fn offset_from_utc_date_fixed(&self, _: &NaiveDate) -> Self::Offset {
         *self
     }
-    fn offset_from_utc_datetime(&self, _utc: &NaiveDateTime) -> FixedOffset {
+
+    fn offset_from_utc_datetime_fixed(&self, _: &NaiveDateTime) -> Self::Offset {
         *self
     }
 }
@@ -229,20 +233,36 @@ mod tests {
         // starting from 0.3 we don't have an offset exceeding one day.
         // this makes everything easier!
         assert_eq!(
-            format!("{:?}", FixedOffset::east(86399).ymd(2012, 2, 29)),
-            "2012-02-29+23:59:59".to_string()
+            format!("{:?}", FixedOffset::east(86399).unwrap().ymd(2012, 2, 29).unwrap().unwrap()),
+            "2012-02-29+23:59:59"
         );
         assert_eq!(
-            format!("{:?}", FixedOffset::east(86399).ymd(2012, 2, 29).and_hms(5, 6, 7)),
-            "2012-02-29T05:06:07+23:59:59".to_string()
+            format!(
+                "{:?}",
+                FixedOffset::east(86399)
+                    .unwrap()
+                    .ymd(2012, 2, 29)
+                    .unwrap()
+                    .and_hms(5, 6, 7)
+                    .unwrap()
+            ),
+            "2012-02-29T05:06:07+23:59:59"
         );
         assert_eq!(
-            format!("{:?}", FixedOffset::west(86399).ymd(2012, 3, 4)),
-            "2012-03-04-23:59:59".to_string()
+            format!("{:?}", FixedOffset::west(86399).unwrap().ymd(2012, 3, 4).unwrap().unwrap()),
+            "2012-03-04-23:59:59"
         );
         assert_eq!(
-            format!("{:?}", FixedOffset::west(86399).ymd(2012, 3, 4).and_hms(5, 6, 7)),
-            "2012-03-04T05:06:07-23:59:59".to_string()
+            format!(
+                "{:?}",
+                FixedOffset::west(86399)
+                    .unwrap()
+                    .ymd(2012, 3, 4)
+                    .unwrap()
+                    .and_hms(5, 6, 7)
+                    .unwrap()
+            ),
+            "2012-03-04T05:06:07-23:59:59"
         );
     }
 }

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -173,7 +173,7 @@ impl TimeZone for Local {
         not(any(target_os = "emscripten", target_os = "wasi"))
     )))]
     fn from_utc_datetime(&self, utc: &NaiveDateTime) -> Result<DateTime<Local>, ChronoError> {
-        Ok(inner::naive_to_local(utc, false)?.single()?)
+        inner::naive_to_local(utc, false)?.single()
     }
 }
 

--- a/src/offset/local/stub.rs
+++ b/src/offset/local/stub.rs
@@ -11,9 +11,11 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::{FixedOffset, Local};
-use crate::{DateTime, Datelike, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
+use crate::{
+    ChronoError, DateTime, Datelike, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, Timelike,
+};
 
-pub(super) fn now() -> DateTime<Local> {
+pub(super) fn now() -> Result<DateTime<Local>, ChronoError> {
     tm_to_datetime(Timespec::now().local())
 }
 
@@ -23,7 +25,10 @@ pub(super) fn now() -> DateTime<Local> {
     feature = "wasmbind",
     not(any(target_os = "emscripten", target_os = "wasi"))
 )))]
-pub(super) fn naive_to_local(d: &NaiveDateTime, local: bool) -> LocalResult<DateTime<Local>> {
+pub(super) fn naive_to_local(
+    d: &NaiveDateTime,
+    local: bool,
+) -> Result<LocalResult<DateTime<Local>>, ChronoError> {
     let tm = Tm {
         tm_sec: d.second() as i32,
         tm_min: d.minute() as i32,
@@ -53,7 +58,7 @@ pub(super) fn naive_to_local(d: &NaiveDateTime, local: bool) -> LocalResult<Date
     assert_eq!(tm.tm_nsec, 0);
     tm.tm_nsec = d.nanosecond() as i32;
 
-    LocalResult::Single(tm_to_datetime(tm))
+    Ok(LocalResult::Single(tm_to_datetime(tm)?))
 }
 
 /// Converts a `time::Tm` struct into the timezone-aware `DateTime`.
@@ -63,22 +68,22 @@ pub(super) fn naive_to_local(d: &NaiveDateTime, local: bool) -> LocalResult<Date
     feature = "wasmbind",
     not(any(target_os = "emscripten", target_os = "wasi"))
 )))]
-fn tm_to_datetime(mut tm: Tm) -> DateTime<Local> {
+fn tm_to_datetime(mut tm: Tm) -> Result<DateTime<Local>, ChronoError> {
     if tm.tm_sec >= 60 {
         tm.tm_nsec += (tm.tm_sec - 59) * 1_000_000_000;
         tm.tm_sec = 59;
     }
 
-    let date = NaiveDate::from_yo(tm.tm_year + 1900, tm.tm_yday as u32 + 1);
+    let date = NaiveDate::from_yo(tm.tm_year + 1900, tm.tm_yday as u32 + 1)?;
     let time = NaiveTime::from_hms_nano(
         tm.tm_hour as u32,
         tm.tm_min as u32,
         tm.tm_sec as u32,
         tm.tm_nsec as u32,
-    );
+    )?;
 
-    let offset = FixedOffset::east(tm.tm_utcoff);
-    DateTime::from_utc(date.and_time(time) - offset, offset)
+    let offset = FixedOffset::east(tm.tm_utcoff)?;
+    Ok(DateTime::from_utc(date.and_time(time) - offset, offset))
 }
 
 /// A record specifying a time value in seconds and nanoseconds, where

--- a/src/offset/local/stub.rs
+++ b/src/offset/local/stub.rs
@@ -12,10 +12,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::{FixedOffset, Local};
 use crate::{
-    ChronoError, DateTime, Datelike, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, Timelike,
+    DateTime, Datelike, Error, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, Timelike,
 };
 
-pub(super) fn now() -> Result<DateTime<Local>, ChronoError> {
+pub(super) fn now() -> Result<DateTime<Local>, Error> {
     tm_to_datetime(Timespec::now().local())
 }
 
@@ -28,7 +28,7 @@ pub(super) fn now() -> Result<DateTime<Local>, ChronoError> {
 pub(super) fn naive_to_local(
     d: &NaiveDateTime,
     local: bool,
-) -> Result<LocalResult<DateTime<Local>>, ChronoError> {
+) -> Result<LocalResult<DateTime<Local>>, Error> {
     let tm = Tm {
         tm_sec: d.second() as i32,
         tm_min: d.minute() as i32,
@@ -68,7 +68,7 @@ pub(super) fn naive_to_local(
     feature = "wasmbind",
     not(any(target_os = "emscripten", target_os = "wasi"))
 )))]
-fn tm_to_datetime(mut tm: Tm) -> Result<DateTime<Local>, ChronoError> {
+fn tm_to_datetime(mut tm: Tm) -> Result<DateTime<Local>, Error> {
     if tm.tm_sec >= 60 {
         tm.tm_nsec += (tm.tm_sec - 59) * 1_000_000_000;
         tm.tm_sec = 59;

--- a/src/offset/local/tz_info/rule.rs
+++ b/src/offset/local/tz_info/rule.rs
@@ -6,6 +6,7 @@ use super::{
     rem_euclid, Error, CUMUL_DAY_IN_MONTHS_NORMAL_YEAR, DAYS_PER_WEEK, DAY_IN_MONTHS_NORMAL_YEAR,
     SECONDS_PER_DAY,
 };
+use crate::offset::LocalResult;
 
 /// Transition rule
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -84,10 +85,10 @@ impl TransitionRule {
         &self,
         local_time: i64,
         year: i32,
-    ) -> Result<crate::LocalResult<LocalTimeType>, Error> {
+    ) -> Result<Option<LocalResult<LocalTimeType>>, Error> {
         match self {
             TransitionRule::Fixed(local_time_type) => {
-                Ok(crate::LocalResult::Single(*local_time_type))
+                Ok(Some(LocalResult::Single(*local_time_type)))
             }
             TransitionRule::Alternate(alternate_time) => {
                 alternate_time.find_local_time_type_from_local(local_time, year)
@@ -232,7 +233,7 @@ impl AlternateTime {
         &self,
         local_time: i64,
         current_year: i32,
-    ) -> Result<crate::LocalResult<LocalTimeType>, Error> {
+    ) -> Result<Option<LocalResult<LocalTimeType>>, Error> {
         // Check if the current year is valid for the following computations
         if !(i32::min_value() + 2 <= current_year && current_year <= i32::max_value() - 2) {
             return Err(Error::OutOfRange("out of range date time"));
@@ -253,7 +254,7 @@ impl AlternateTime {
             - i64::from(self.dst.ut_offset);
 
         match self.std.ut_offset.cmp(&self.dst.ut_offset) {
-            Ordering::Equal => Ok(crate::LocalResult::Single(self.std)),
+            Ordering::Equal => Ok(Some(LocalResult::Single(self.std))),
             Ordering::Less => {
                 if self.dst_start.transition_date(current_year).0
                     < self.dst_end.transition_date(current_year).0
@@ -261,41 +262,41 @@ impl AlternateTime {
                     // northern hemisphere
                     // For the DST END transition, the `start` happens at a later timestamp than the `end`.
                     if local_time <= dst_start_transition_start {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(Some(LocalResult::Single(self.std)))
                     } else if local_time > dst_start_transition_start
                         && local_time < dst_start_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(None)
                     } else if local_time >= dst_start_transition_end
                         && local_time < dst_end_transition_end
                     {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(Some(LocalResult::Single(self.dst)))
                     } else if local_time >= dst_end_transition_end
                         && local_time <= dst_end_transition_start
                     {
-                        Ok(crate::LocalResult::Ambiguous(self.std, self.dst))
+                        Ok(Some(LocalResult::Ambiguous(self.std, self.dst)))
                     } else {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(Some(LocalResult::Single(self.std)))
                     }
                 } else {
                     // southern hemisphere regular DST
                     // For the DST END transition, the `start` happens at a later timestamp than the `end`.
                     if local_time < dst_end_transition_end {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(Some(LocalResult::Single(self.dst)))
                     } else if local_time >= dst_end_transition_end
                         && local_time <= dst_end_transition_start
                     {
-                        Ok(crate::LocalResult::Ambiguous(self.std, self.dst))
+                        Ok(Some(LocalResult::Ambiguous(self.std, self.dst)))
                     } else if local_time > dst_end_transition_end
                         && local_time < dst_start_transition_start
                     {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(Some(LocalResult::Single(self.std)))
                     } else if local_time >= dst_start_transition_start
                         && local_time < dst_start_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(None)
                     } else {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(Some(LocalResult::Single(self.dst)))
                     }
                 }
             }
@@ -306,41 +307,41 @@ impl AlternateTime {
                     // southern hemisphere reverse DST
                     // For the DST END transition, the `start` happens at a later timestamp than the `end`.
                     if local_time < dst_start_transition_end {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(Some(LocalResult::Single(self.std)))
                     } else if local_time >= dst_start_transition_end
                         && local_time <= dst_start_transition_start
                     {
-                        Ok(crate::LocalResult::Ambiguous(self.dst, self.std))
+                        Ok(Some(LocalResult::Ambiguous(self.dst, self.std)))
                     } else if local_time > dst_start_transition_start
                         && local_time < dst_end_transition_start
                     {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(Some(LocalResult::Single(self.dst)))
                     } else if local_time >= dst_end_transition_start
                         && local_time < dst_end_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(None)
                     } else {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(Some(LocalResult::Single(self.std)))
                     }
                 } else {
                     // northern hemisphere reverse DST
                     // For the DST END transition, the `start` happens at a later timestamp than the `end`.
                     if local_time <= dst_end_transition_start {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(Some(LocalResult::Single(self.dst)))
                     } else if local_time > dst_end_transition_start
                         && local_time < dst_end_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(None)
                     } else if local_time >= dst_end_transition_end
                         && local_time < dst_start_transition_end
                     {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(Some(LocalResult::Single(self.std)))
                     } else if local_time >= dst_start_transition_end
                         && local_time <= dst_start_transition_start
                     {
-                        Ok(crate::LocalResult::Ambiguous(self.dst, self.std))
+                        Ok(Some(LocalResult::Ambiguous(self.dst, self.std)))
                     } else {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(Some(LocalResult::Single(self.dst)))
                     }
                 }
             }

--- a/src/offset/local/tz_info/timezone.rs
+++ b/src/offset/local/tz_info/timezone.rs
@@ -7,6 +7,7 @@ use std::{cmp::Ordering, fmt, str};
 
 use super::rule::{AlternateTime, TransitionRule};
 use super::{parser, Error, DAYS_PER_WEEK, SECONDS_PER_DAY};
+use crate::offset::LocalResult;
 
 /// Time zone
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -123,7 +124,7 @@ impl TimeZone {
         &self,
         local_time: i64,
         year: i32,
-    ) -> Result<crate::LocalResult<LocalTimeType>, Error> {
+    ) -> Result<Option<LocalResult<LocalTimeType>>, Error> {
         self.as_ref().find_local_time_type_from_local(local_time, year)
     }
 
@@ -205,7 +206,7 @@ impl<'a> TimeZoneRef<'a> {
         &self,
         local_time: i64,
         year: i32,
-    ) -> Result<crate::LocalResult<LocalTimeType>, Error> {
+    ) -> Result<Option<LocalResult<LocalTimeType>>, Error> {
         // #TODO: this is wrong as we need 'local_time_to_local_leap_time ?
         // but ... does the local time even include leap seconds ??
         // let unix_leap_time = match self.unix_time_to_unix_leap_time(local_time) {
@@ -234,26 +235,26 @@ impl<'a> TimeZoneRef<'a> {
                         // bakwards transition, eg from DST to regular
                         // this means a given local time could have one of two possible offsets
                         if local_leap_time < transition_end {
-                            return Ok(crate::LocalResult::Single(prev.unwrap()));
+                            return Ok(Some(LocalResult::Single(prev.unwrap())));
                         } else if local_leap_time >= transition_end
                             && local_leap_time <= transition_start
                         {
                             if prev.unwrap().ut_offset < after_ltt.ut_offset {
-                                return Ok(crate::LocalResult::Ambiguous(prev.unwrap(), after_ltt));
+                                return Ok(Some(LocalResult::Ambiguous(prev.unwrap(), after_ltt)));
                             } else {
-                                return Ok(crate::LocalResult::Ambiguous(after_ltt, prev.unwrap()));
+                                return Ok(Some(LocalResult::Ambiguous(after_ltt, prev.unwrap())));
                             }
                         }
                     }
                     Ordering::Equal => {
                         // should this ever happen? presumably we have to handle it anyway.
                         if local_leap_time < transition_start {
-                            return Ok(crate::LocalResult::Single(prev.unwrap()));
+                            return Ok(Some(LocalResult::Single(prev.unwrap())));
                         } else if local_leap_time == transition_end {
                             if prev.unwrap().ut_offset < after_ltt.ut_offset {
-                                return Ok(crate::LocalResult::Ambiguous(prev.unwrap(), after_ltt));
+                                return Ok(Some(LocalResult::Ambiguous(prev.unwrap(), after_ltt)));
                             } else {
-                                return Ok(crate::LocalResult::Ambiguous(after_ltt, prev.unwrap()));
+                                return Ok(Some(LocalResult::Ambiguous(after_ltt, prev.unwrap())));
                             }
                         }
                     }
@@ -261,11 +262,11 @@ impl<'a> TimeZoneRef<'a> {
                         // forwards transition, eg from regular to DST
                         // this means that times that are skipped are invalid local times
                         if local_leap_time <= transition_start {
-                            return Ok(crate::LocalResult::Single(prev.unwrap()));
+                            return Ok(Some(LocalResult::Single(prev.unwrap())));
                         } else if local_leap_time < transition_end {
-                            return Ok(crate::LocalResult::None);
+                            return Ok(None);
                         } else if local_leap_time == transition_end {
-                            return Ok(crate::LocalResult::Single(after_ltt));
+                            return Ok(Some(LocalResult::Single(after_ltt)));
                         }
                     }
                 }
@@ -282,7 +283,7 @@ impl<'a> TimeZoneRef<'a> {
                 err => err,
             }
         } else {
-            Ok(crate::LocalResult::Single(self.local_time_types[0]))
+            Ok(Some(LocalResult::Single(self.local_time_types[0])))
         }
     }
 

--- a/src/offset/local/windows.rs
+++ b/src/offset/local/windows.rs
@@ -10,6 +10,7 @@
 
 use std::io;
 use std::mem;
+use std::ptr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use winapi::shared::minwindef::*;
@@ -245,7 +246,7 @@ fn time_to_local_tm(sec: i64, tm: &mut Tm) -> Result<(), ChronoError> {
         let mut utc = mem::zeroed();
         let mut local = mem::zeroed();
         call!(FileTimeToSystemTime(&ft, &mut utc));
-        call!(SystemTimeToTzSpecificLocalTime(0 as *const _, &mut utc, &mut local));
+        call!(SystemTimeToTzSpecificLocalTime(ptr::null(), &utc, &mut local));
         system_time_to_tm(&local, tm);
 
         let local = system_time_to_file_time(&local);
@@ -275,8 +276,8 @@ fn local_tm_to_time(tm: &Tm) -> Result<i64, ChronoError> {
     unsafe {
         let mut ft = mem::zeroed();
         let mut utc = mem::zeroed();
-        let mut sys_time = tm_to_system_time(tm);
-        call!(TzSpecificLocalTimeToSystemTime(0 as *mut _, &mut sys_time, &mut utc));
+        let sys_time = tm_to_system_time(tm);
+        call!(TzSpecificLocalTimeToSystemTime(ptr::null_mut(), &sys_time, &mut utc));
         call!(SystemTimeToFileTime(&utc, &mut ft));
         Ok(file_time_to_unix_seconds(&ft))
     }

--- a/src/offset/local/windows.rs
+++ b/src/offset/local/windows.rs
@@ -17,14 +17,19 @@ use winapi::um::minwinbase::SYSTEMTIME;
 use winapi::um::timezoneapi::*;
 
 use super::{FixedOffset, Local};
-use crate::{DateTime, Datelike, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
+use crate::error::{ChronoError, ChronoErrorKind};
+use crate::offset::LocalResult;
+use crate::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 
-pub(super) fn now() -> DateTime<Local> {
-    tm_to_datetime(Timespec::now().local())
+pub(super) fn now() -> Result<DateTime<Local>, ChronoError> {
+    tm_to_datetime(Timespec::now()?.local()?)
 }
 
 /// Converts a local `NaiveDateTime` to the `time::Timespec`.
-pub(super) fn naive_to_local(d: &NaiveDateTime, local: bool) -> LocalResult<DateTime<Local>> {
+pub(super) fn naive_to_local(
+    d: &NaiveDateTime,
+    local: bool,
+) -> Result<LocalResult<DateTime<Local>>, ChronoError> {
     let tm = Tm {
         tm_sec: d.second() as i32,
         tm_min: d.minute() as i32,
@@ -43,38 +48,38 @@ pub(super) fn naive_to_local(d: &NaiveDateTime, local: bool) -> LocalResult<Date
 
     let spec = Timespec {
         sec: match local {
-            false => utc_tm_to_time(&tm),
-            true => local_tm_to_time(&tm),
+            false => utc_tm_to_time(&tm)?,
+            true => local_tm_to_time(&tm)?,
         },
         nsec: tm.tm_nsec,
     };
 
     // Adjust for leap seconds
-    let mut tm = spec.local();
+    let mut tm = spec.local()?;
     assert_eq!(tm.tm_nsec, 0);
     tm.tm_nsec = d.nanosecond() as i32;
 
     // #TODO - there should be ambiguous cases, investigate?
-    LocalResult::Single(tm_to_datetime(tm))
+    Ok(LocalResult::Single(tm_to_datetime(tm)?))
 }
 
 /// Converts a `time::Tm` struct into the timezone-aware `DateTime`.
-fn tm_to_datetime(mut tm: Tm) -> DateTime<Local> {
+fn tm_to_datetime(mut tm: Tm) -> Result<DateTime<Local>, ChronoError> {
     if tm.tm_sec >= 60 {
         tm.tm_nsec += (tm.tm_sec - 59) * 1_000_000_000;
         tm.tm_sec = 59;
     }
 
-    let date = NaiveDate::from_ymd(tm.tm_year + 1900, tm.tm_mon as u32 + 1, tm.tm_mday as u32);
+    let date = NaiveDate::from_ymd(tm.tm_year + 1900, tm.tm_mon as u32 + 1, tm.tm_mday as u32)?;
     let time = NaiveTime::from_hms_nano(
         tm.tm_hour as u32,
         tm.tm_min as u32,
         tm.tm_sec as u32,
         tm.tm_nsec as u32,
-    );
+    )?;
 
-    let offset = FixedOffset::east(tm.tm_utcoff);
-    DateTime::from_utc(date.and_time(time) - offset, offset)
+    let offset = FixedOffset::east(tm.tm_utcoff)?;
+    Ok(DateTime::from_utc(date.and_time(time) - offset, offset))
 }
 
 /// A record specifying a time value in seconds and nanoseconds, where
@@ -89,14 +94,15 @@ struct Timespec {
 
 impl Timespec {
     /// Constructs a timespec representing the current time in UTC.
-    fn now() -> Timespec {
-        let st =
-            SystemTime::now().duration_since(UNIX_EPOCH).expect("system time before Unix epoch");
-        Timespec { sec: st.as_secs() as i64, nsec: st.subsec_nanos() as i32 }
+    fn now() -> Result<Timespec, ChronoError> {
+        let st = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| ChronoErrorKind::SystemTimeBeforeEpoch)?;
+        Ok(Timespec { sec: st.as_secs() as i64, nsec: st.subsec_nanos() as i32 })
     }
 
     /// Converts this timespec into the system's local time.
-    fn local(self) -> Tm {
+    fn local(self) -> Result<Tm, ChronoError> {
         let mut tm = Tm {
             tm_sec: 0,
             tm_min: 0,
@@ -110,9 +116,9 @@ impl Timespec {
             tm_utcoff: 0,
             tm_nsec: 0,
         };
-        time_to_local_tm(self.sec, &mut tm);
+        time_to_local_tm(self.sec, &mut tm)?;
         tm.tm_nsec = self.nsec;
-        tm
+        Ok(tm)
     }
 }
 
@@ -228,13 +234,12 @@ fn system_time_to_tm(sys: &SYSTEMTIME, tm: &mut Tm) {
 macro_rules! call {
     ($name:ident($($arg:expr),*)) => {
         if $name($($arg),*) == 0 {
-            panic!(concat!(stringify!($name), " failed with: {}"),
-                    io::Error::last_os_error());
+            return Err(ChronoError::new(ChronoErrorKind::SystemError(io::Error::last_os_error())))
         }
     }
 }
 
-fn time_to_local_tm(sec: i64, tm: &mut Tm) {
+fn time_to_local_tm(sec: i64, tm: &mut Tm) -> Result<(), ChronoError> {
     let ft = time_to_file_time(sec);
     unsafe {
         let mut utc = mem::zeroed();
@@ -253,25 +258,26 @@ fn time_to_local_tm(sec: i64, tm: &mut Tm) {
         // check if it non standard
         tm.tm_utcoff = (local_sec - sec) as i32;
         tm.tm_isdst = if tm.tm_utcoff == -60 * (tz.Bias + tz.StandardBias) { 0 } else { 1 };
+        Ok(())
     }
 }
 
-fn utc_tm_to_time(tm: &Tm) -> i64 {
+fn utc_tm_to_time(tm: &Tm) -> Result<i64, ChronoError> {
     unsafe {
         let mut ft = mem::zeroed();
         let sys_time = tm_to_system_time(tm);
         call!(SystemTimeToFileTime(&sys_time, &mut ft));
-        file_time_to_unix_seconds(&ft)
+        Ok(file_time_to_unix_seconds(&ft))
     }
 }
 
-fn local_tm_to_time(tm: &Tm) -> i64 {
+fn local_tm_to_time(tm: &Tm) -> Result<i64, ChronoError> {
     unsafe {
         let mut ft = mem::zeroed();
         let mut utc = mem::zeroed();
         let mut sys_time = tm_to_system_time(tm);
         call!(TzSpecificLocalTimeToSystemTime(0 as *mut _, &mut sys_time, &mut utc));
         call!(SystemTimeToFileTime(&utc, &mut ft));
-        file_time_to_unix_seconds(&ft)
+        Ok(file_time_to_unix_seconds(&ft))
     }
 }

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -399,7 +399,7 @@ pub trait TimeZone: Sized + Clone {
 /// A time zone that is fixed. It is distinguished from [TimeZone] by allowing
 /// for infallible operations since there is no need to access system
 /// information to figure out which timezone is being used.
-pub trait FixedTimeZone: TimeZone {
+pub(crate) trait FixedTimeZone: TimeZone {
     /// Creates the offset for given UTC `NaiveDate`. This cannot fail.
     fn offset_from_utc_date_fixed(&self, utc: &NaiveDate) -> Self::Offset;
 

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -20,10 +20,10 @@
 
 use core::fmt;
 
+use crate::error::ChronoErrorKind;
 use crate::format::{parse, ParseResult, Parsed, StrftimeItems};
 use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
-use crate::Weekday;
-use crate::{Date, DateTime};
+use crate::{ChronoError, Date, DateTime, Weekday};
 
 mod fixed;
 pub use self::fixed::FixedOffset;
@@ -39,9 +39,6 @@ pub use self::utc::Utc;
 /// The conversion result from the local time to the timezone-aware datetime types.
 #[derive(Clone, PartialEq, Debug, Copy, Eq, Hash)]
 pub enum LocalResult<T> {
-    /// Given local time representation is invalid.
-    /// This can occur when, for example, the positive timezone transition.
-    None,
     /// Given local time representation has a single unique result.
     Single(T),
     /// Given local time representation has multiple results and thus ambiguous.
@@ -50,36 +47,48 @@ pub enum LocalResult<T> {
 }
 
 impl<T> LocalResult<T> {
-    /// Returns `Some` only when the conversion result is unique, or `None` otherwise.
-    pub fn single(self) -> Option<T> {
+    /// Returns the single value that this local result corresponds to or
+    /// `Err(ChronoError)` if the result is ambiguous.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(ChronoError)` in case the value is not
+    /// [LocalResult::Single].
+    pub fn single(self) -> Result<T, ChronoError> {
         match self {
-            LocalResult::Single(t) => Some(t),
-            _ => None,
+            LocalResult::Single(value) => Ok(value),
+            _ => Err(ChronoError::new(ChronoErrorKind::AmbiguousDate)),
         }
     }
 
-    /// Returns `Some` for the earliest possible conversion result, or `None` if none.
-    pub fn earliest(self) -> Option<T> {
+    /// Returns the date corresponding to the earliest date in the local result.
+    pub fn earliest(self) -> T {
         match self {
-            LocalResult::Single(t) | LocalResult::Ambiguous(t, _) => Some(t),
-            _ => None,
+            LocalResult::Single(t) | LocalResult::Ambiguous(t, _) => t,
         }
     }
 
-    /// Returns `Some` for the latest possible conversion result, or `None` if none.
-    pub fn latest(self) -> Option<T> {
+    /// Returns the date corresponding to the latest date in the local result.
+    pub fn latest(self) -> T {
         match self {
-            LocalResult::Single(t) | LocalResult::Ambiguous(_, t) => Some(t),
-            _ => None,
+            LocalResult::Single(t) | LocalResult::Ambiguous(_, t) => t,
         }
     }
 
     /// Maps a `LocalResult<T>` into `LocalResult<U>` with given function.
     pub fn map<U, F: FnMut(T) -> U>(self, mut f: F) -> LocalResult<U> {
         match self {
-            LocalResult::None => LocalResult::None,
             LocalResult::Single(v) => LocalResult::Single(f(v)),
             LocalResult::Ambiguous(min, max) => LocalResult::Ambiguous(f(min), f(max)),
+        }
+    }
+
+    /// Maps a `LocalResult<T>` into `LocalResult<U>` fallibly with given
+    /// function.
+    pub fn try_map<U, E, F: FnMut(T) -> Result<U, E>>(self, mut f: F) -> Result<LocalResult<U>, E> {
+        match self {
+            LocalResult::Single(v) => Ok(LocalResult::Single(f(v)?)),
+            LocalResult::Ambiguous(min, max) => Ok(LocalResult::Ambiguous(f(min)?, f(max)?)),
         }
     }
 }
@@ -90,13 +99,8 @@ impl<Tz: TimeZone> LocalResult<Date<Tz>> {
     ///
     /// Propagates any error. Ambiguous result would be discarded.
     #[inline]
-    pub fn and_time(self, time: NaiveTime) -> LocalResult<DateTime<Tz>> {
-        match self {
-            LocalResult::Single(d) => {
-                d.and_time(time).map_or(LocalResult::None, LocalResult::Single)
-            }
-            _ => LocalResult::None,
-        }
+    pub fn and_time(self, time: NaiveTime) -> Result<DateTime<Tz>, ChronoError> {
+        self.single()?.and_time(time)
     }
 
     /// Makes a new `DateTime` from the current date, hour, minute and second.
@@ -104,89 +108,64 @@ impl<Tz: TimeZone> LocalResult<Date<Tz>> {
     ///
     /// Propagates any error. Ambiguous result would be discarded.
     #[inline]
-    pub fn and_hms_opt(self, hour: u32, min: u32, sec: u32) -> LocalResult<DateTime<Tz>> {
-        match self {
-            LocalResult::Single(d) => {
-                d.and_hms_opt(hour, min, sec).map_or(LocalResult::None, LocalResult::Single)
-            }
-            _ => LocalResult::None,
-        }
+    pub fn and_hms(self, hour: u32, min: u32, sec: u32) -> Result<DateTime<Tz>, ChronoError> {
+        self.single()?.and_hms(hour, min, sec)
     }
 
     /// Makes a new `DateTime` from the current date, hour, minute, second and millisecond.
     /// The millisecond part can exceed 1,000 in order to represent the leap second.
     /// The offset in the current date is preserved.
     ///
-    /// Propagates any error. Ambiguous result would be discarded.
+    /// Propagates any error. Errors on ambiguous results.
     #[inline]
-    pub fn and_hms_milli_opt(
+    pub fn and_hms_milli(
         self,
         hour: u32,
         min: u32,
         sec: u32,
         milli: u32,
-    ) -> LocalResult<DateTime<Tz>> {
-        match self {
-            LocalResult::Single(d) => d
-                .and_hms_milli_opt(hour, min, sec, milli)
-                .map_or(LocalResult::None, LocalResult::Single),
-            _ => LocalResult::None,
-        }
+    ) -> Result<DateTime<Tz>, ChronoError> {
+        self.single()?.and_hms_milli(hour, min, sec, milli)
     }
 
     /// Makes a new `DateTime` from the current date, hour, minute, second and microsecond.
     /// The microsecond part can exceed 1,000,000 in order to represent the leap second.
     /// The offset in the current date is preserved.
     ///
-    /// Propagates any error. Ambiguous result would be discarded.
+    /// Propagates any error. Errors on ambiguous results.
     #[inline]
-    pub fn and_hms_micro_opt(
+    pub fn and_hms_micro(
         self,
         hour: u32,
         min: u32,
         sec: u32,
         micro: u32,
-    ) -> LocalResult<DateTime<Tz>> {
-        match self {
-            LocalResult::Single(d) => d
-                .and_hms_micro_opt(hour, min, sec, micro)
-                .map_or(LocalResult::None, LocalResult::Single),
-            _ => LocalResult::None,
-        }
+    ) -> Result<DateTime<Tz>, ChronoError> {
+        self.single()?.and_hms_micro(hour, min, sec, micro)
     }
 
     /// Makes a new `DateTime` from the current date, hour, minute, second and nanosecond.
     /// The nanosecond part can exceed 1,000,000,000 in order to represent the leap second.
     /// The offset in the current date is preserved.
     ///
-    /// Propagates any error. Ambiguous result would be discarded.
+    /// Propagates any error. Errors on ambiguous results.
     #[inline]
-    pub fn and_hms_nano_opt(
+    pub fn and_hms_nano(
         self,
         hour: u32,
         min: u32,
         sec: u32,
         nano: u32,
-    ) -> LocalResult<DateTime<Tz>> {
-        match self {
-            LocalResult::Single(d) => d
-                .and_hms_nano_opt(hour, min, sec, nano)
-                .map_or(LocalResult::None, LocalResult::Single),
-            _ => LocalResult::None,
-        }
+    ) -> Result<DateTime<Tz>, ChronoError> {
+        self.single()?.and_hms_nano(hour, min, sec, nano)
     }
 }
 
-impl<T: fmt::Debug> LocalResult<T> {
+#[cfg(test)]
+impl<T> LocalResult<T> {
     /// Returns the single unique conversion result, or panics accordingly.
     pub fn unwrap(self) -> T {
-        match self {
-            LocalResult::None => panic!("No such local time"),
-            LocalResult::Single(t) => t,
-            LocalResult::Ambiguous(t1, t2) => {
-                panic!("Ambiguous local time, ranging from {:?} to {:?}", t1, t2)
-            }
-        }
+        self.single().unwrap()
     }
 }
 
@@ -206,46 +185,29 @@ pub trait TimeZone: Sized + Clone {
     /// The original `TimeZone` value can be recovered via `TimeZone::from_offset`.
     type Offset: Offset;
 
-    /// Makes a new `Date` from year, month, day and the current time zone.
-    /// This assumes the proleptic Gregorian calendar, with the year 0 being 1 BCE.
+    /// Makes a new `Date` from year, month, day and the current time zone. This
+    /// assumes the proleptic Gregorian calendar, with the year 0 being 1 BCE.
     ///
-    /// The time zone normally does not affect the date (unless it is between UTC-24 and UTC+24),
-    /// but it will propagate to the `DateTime` values constructed via this date.
+    /// The time zone normally does not affect the date (unless it is between
+    /// UTC-24 and UTC+24), but it will propagate to the `DateTime` values
+    /// constructed via this date.
     ///
-    /// Panics on the out-of-range date, invalid month and/or day.
+    /// Returns `Err(ChronoError)` on the out-of-range date, invalid month
+    /// and/or day.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{Utc, TimeZone};
     ///
-    /// assert_eq!(Utc.ymd(2015, 5, 15).to_string(), "2015-05-15UTC");
+    /// assert_eq!(Utc.ymd(2015, 5, 15)?.single()?.to_string(), "2015-05-15UTC");
+    /// assert_eq!(Utc.ymd(2015, 5, 15)?.single()?.to_string(), "2015-05-15UTC");
+    /// assert!(Utc.ymd(2000, 0, 0).is_err());
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    fn ymd(&self, year: i32, month: u32, day: u32) -> Date<Self> {
-        self.ymd_opt(year, month, day).unwrap()
-    }
-
-    /// Makes a new `Date` from year, month, day and the current time zone.
-    /// This assumes the proleptic Gregorian calendar, with the year 0 being 1 BCE.
-    ///
-    /// The time zone normally does not affect the date (unless it is between UTC-24 and UTC+24),
-    /// but it will propagate to the `DateTime` values constructed via this date.
-    ///
-    /// Returns `None` on the out-of-range date, invalid month and/or day.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use chrono::{Utc, LocalResult, TimeZone};
-    ///
-    /// assert_eq!(Utc.ymd_opt(2015, 5, 15).unwrap().to_string(), "2015-05-15UTC");
-    /// assert_eq!(Utc.ymd_opt(2000, 0, 0), LocalResult::None);
-    /// ```
-    fn ymd_opt(&self, year: i32, month: u32, day: u32) -> LocalResult<Date<Self>> {
-        match NaiveDate::from_ymd_opt(year, month, day) {
-            Some(d) => self.from_local_date(&d),
-            None => LocalResult::None,
-        }
+    fn ymd(&self, year: i32, month: u32, day: u32) -> Result<LocalResult<Date<Self>>, ChronoError> {
+        let d = NaiveDate::from_ymd(year, month, day)?;
+        self.from_local_date(&d)
     }
 
     /// Makes a new `Date` from year, day of year (DOY or "ordinal") and the current time zone.
@@ -254,142 +216,91 @@ pub trait TimeZone: Sized + Clone {
     /// The time zone normally does not affect the date (unless it is between UTC-24 and UTC+24),
     /// but it will propagate to the `DateTime` values constructed via this date.
     ///
-    /// Panics on the out-of-range date and/or invalid DOY.
+    /// Returns `Err(ChronoError)` on the out-of-range date and/or invalid DOY.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::{Utc, TimeZone};
+    /// use chrono::{ChronoError, Utc, TimeZone};
     ///
-    /// assert_eq!(Utc.yo(2015, 135).to_string(), "2015-05-15UTC");
+    /// assert_eq!(Utc.yo(2015, 135)?.single()?.to_string(), "2015-05-15UTC");
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    fn yo(&self, year: i32, ordinal: u32) -> Date<Self> {
-        self.yo_opt(year, ordinal).unwrap()
+    fn yo(&self, year: i32, ordinal: u32) -> Result<LocalResult<Date<Self>>, ChronoError> {
+        let d = NaiveDate::from_yo(year, ordinal)?;
+        self.from_local_date(&d)
     }
 
-    /// Makes a new `Date` from year, day of year (DOY or "ordinal") and the current time zone.
-    /// This assumes the proleptic Gregorian calendar, with the year 0 being 1 BCE.
+    /// Makes a new `Date` from ISO week date (year and week number), day of the
+    /// week (DOW) and the current time zone. This assumes the proleptic
+    /// Gregorian calendar, with the year 0 being 1 BCE. The resulting `Date`
+    /// may have a different year from the input year.
     ///
-    /// The time zone normally does not affect the date (unless it is between UTC-24 and UTC+24),
-    /// but it will propagate to the `DateTime` values constructed via this date.
+    /// The time zone normally does not affect the date (unless it is between
+    /// UTC-24 and UTC+24), but it will propagate to the `DateTime` values
+    /// constructed via this date.
     ///
-    /// Returns `None` on the out-of-range date and/or invalid DOY.
-    fn yo_opt(&self, year: i32, ordinal: u32) -> LocalResult<Date<Self>> {
-        match NaiveDate::from_yo_opt(year, ordinal) {
-            Some(d) => self.from_local_date(&d),
-            None => LocalResult::None,
-        }
-    }
-
-    /// Makes a new `Date` from ISO week date (year and week number), day of the week (DOW) and
-    /// the current time zone.
-    /// This assumes the proleptic Gregorian calendar, with the year 0 being 1 BCE.
-    /// The resulting `Date` may have a different year from the input year.
-    ///
-    /// The time zone normally does not affect the date (unless it is between UTC-24 and UTC+24),
-    /// but it will propagate to the `DateTime` values constructed via this date.
-    ///
-    /// Panics on the out-of-range date and/or invalid week number.
+    /// Returns `Err(ChronoError)` on the out-of-range date and/or invalid week
+    /// number.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{Utc, Weekday, TimeZone};
     ///
-    /// assert_eq!(Utc.isoywd(2015, 20, Weekday::Fri).to_string(), "2015-05-15UTC");
+    /// assert_eq!(Utc.isoywd(2015, 20, Weekday::Fri)?.single()?.to_string(), "2015-05-15UTC");
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    fn isoywd(&self, year: i32, week: u32, weekday: Weekday) -> Date<Self> {
-        self.isoywd_opt(year, week, weekday).unwrap()
-    }
-
-    /// Makes a new `Date` from ISO week date (year and week number), day of the week (DOW) and
-    /// the current time zone.
-    /// This assumes the proleptic Gregorian calendar, with the year 0 being 1 BCE.
-    /// The resulting `Date` may have a different year from the input year.
-    ///
-    /// The time zone normally does not affect the date (unless it is between UTC-24 and UTC+24),
-    /// but it will propagate to the `DateTime` values constructed via this date.
-    ///
-    /// Returns `None` on the out-of-range date and/or invalid week number.
-    fn isoywd_opt(&self, year: i32, week: u32, weekday: Weekday) -> LocalResult<Date<Self>> {
-        match NaiveDate::from_isoywd_opt(year, week, weekday) {
-            Some(d) => self.from_local_date(&d),
-            None => LocalResult::None,
-        }
+    fn isoywd(
+        &self,
+        year: i32,
+        week: u32,
+        weekday: Weekday,
+    ) -> Result<LocalResult<Date<Self>>, ChronoError> {
+        let d = NaiveDate::from_isoywd(year, week, weekday)?;
+        self.from_local_date(&d)
     }
 
     /// Makes a new `DateTime` from the number of non-leap seconds
-    /// since January 1, 1970 0:00:00 UTC (aka "UNIX timestamp")
-    /// and the number of nanoseconds since the last whole non-leap second.
+    /// since January 1, 1970 0:00:00 UTC (aka "UNIX timestamp") and the number
+    /// of nanoseconds since the last whole non-leap second.
     ///
-    /// Panics on the out-of-range number of seconds and/or invalid nanosecond,
-    /// for a non-panicking version see [`timestamp_opt`](#method.timestamp_opt).
+    /// Returns `Err(ChronoError)` on out-of-range number of seconds and/or
+    /// invalid nanosecond, otherwise always returns [`LocalResult::Single`].
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{Utc, TimeZone};
     ///
-    /// assert_eq!(Utc.timestamp(1431648000, 0).to_string(), "2015-05-15 00:00:00 UTC");
+    /// assert_eq!(Utc.timestamp(1431648000, 0)?.to_string(), "2015-05-15 00:00:00 UTC");
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    fn timestamp(&self, secs: i64, nsecs: u32) -> DateTime<Self> {
-        self.timestamp_opt(secs, nsecs).unwrap()
+    fn timestamp(&self, secs: i64, nsecs: u32) -> Result<DateTime<Self>, ChronoError> {
+        let dt = NaiveDateTime::from_timestamp(secs, nsecs)?;
+        self.from_utc_datetime(&dt)
     }
 
-    /// Makes a new `DateTime` from the number of non-leap seconds
-    /// since January 1, 1970 0:00:00 UTC (aka "UNIX timestamp")
-    /// and the number of nanoseconds since the last whole non-leap second.
+    /// Makes a new `DateTime` from the number of non-leap milliseconds since
+    /// January 1, 1970 0:00:00 UTC (aka "UNIX timestamp").
     ///
-    /// Returns `LocalResult::None` on out-of-range number of seconds and/or
-    /// invalid nanosecond, otherwise always returns `LocalResult::Single`.
-    fn timestamp_opt(&self, secs: i64, nsecs: u32) -> LocalResult<DateTime<Self>> {
-        match NaiveDateTime::from_timestamp_opt(secs, nsecs) {
-            Some(dt) => LocalResult::Single(self.from_utc_datetime(&dt)),
-            None => LocalResult::None,
-        }
-    }
-
-    /// Makes a new `DateTime` from the number of non-leap milliseconds
-    /// since January 1, 1970 0:00:00 UTC (aka "UNIX timestamp").
-    ///
-    /// Panics on out-of-range number of milliseconds for a non-panicking
-    /// version see [`timestamp_millis_opt`](#method.timestamp_millis_opt).
+    /// Returns `Err(ChronoError)` on out-of-range number of milliseconds and/or
+    /// invalid nanosecond.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{Utc, TimeZone};
-    ///
-    /// assert_eq!(Utc.timestamp_millis(1431648000).timestamp(), 1431648);
+    /// assert_eq!(Utc.timestamp_millis(1431648000)?.timestamp(), 1431648);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    fn timestamp_millis(&self, millis: i64) -> DateTime<Self> {
-        self.timestamp_millis_opt(millis).unwrap()
-    }
-
-    /// Makes a new `DateTime` from the number of non-leap milliseconds
-    /// since January 1, 1970 0:00:00 UTC (aka "UNIX timestamp").
-    ///
-    ///
-    /// Returns `LocalResult::None` on out-of-range number of milliseconds
-    /// and/or invalid nanosecond, otherwise always returns
-    /// `LocalResult::Single`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use chrono::{Utc, TimeZone, LocalResult};
-    /// match Utc.timestamp_millis_opt(1431648000) {
-    ///     LocalResult::Single(dt) => assert_eq!(dt.timestamp(), 1431648),
-    ///     _ => panic!("Incorrect timestamp_millis"),
-    /// };
-    /// ```
-    fn timestamp_millis_opt(&self, millis: i64) -> LocalResult<DateTime<Self>> {
+    fn timestamp_millis(&self, millis: i64) -> Result<DateTime<Self>, ChronoError> {
         let (mut secs, mut millis) = (millis / 1000, millis % 1000);
         if millis < 0 {
             secs -= 1;
             millis += 1000;
         }
-        self.timestamp_opt(secs, millis as u32 * 1_000_000)
+        self.timestamp(secs, millis as u32 * 1_000_000)
     }
 
     /// Makes a new `DateTime` from the number of non-leap nanoseconds
@@ -403,15 +314,16 @@ pub trait TimeZone: Sized + Clone {
     /// ```
     /// use chrono::{Utc, TimeZone};
     ///
-    /// assert_eq!(Utc.timestamp_nanos(1431648000000000).timestamp(), 1431648);
+    /// assert_eq!(Utc.timestamp_nanos(1431648000000000)?.timestamp(), 1431648);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
-    fn timestamp_nanos(&self, nanos: i64) -> DateTime<Self> {
+    fn timestamp_nanos(&self, nanos: i64) -> Result<DateTime<Self>, ChronoError> {
         let (mut secs, mut nanos) = (nanos / 1_000_000_000, nanos % 1_000_000_000);
         if nanos < 0 {
             secs -= 1;
             nanos += 1_000_000_000;
         }
-        self.timestamp_opt(secs, nanos as u32).unwrap()
+        self.timestamp(secs, nanos as u32)
     }
 
     /// Parses a string with the specified format string and returns a
@@ -435,45 +347,79 @@ pub trait TimeZone: Sized + Clone {
     fn from_offset(offset: &Self::Offset) -> Self;
 
     /// Creates the offset(s) for given local `NaiveDate` if possible.
-    fn offset_from_local_date(&self, local: &NaiveDate) -> LocalResult<Self::Offset>;
+    fn offset_from_local_date(
+        &self,
+        local: &NaiveDate,
+    ) -> Result<LocalResult<Self::Offset>, ChronoError>;
 
     /// Creates the offset(s) for given local `NaiveDateTime` if possible.
-    fn offset_from_local_datetime(&self, local: &NaiveDateTime) -> LocalResult<Self::Offset>;
+    fn offset_from_local_datetime(
+        &self,
+        local: &NaiveDateTime,
+    ) -> Result<LocalResult<Self::Offset>, ChronoError>;
 
     /// Converts the local `NaiveDate` to the timezone-aware `Date` if possible.
     #[allow(clippy::wrong_self_convention)]
-    fn from_local_date(&self, local: &NaiveDate) -> LocalResult<Date<Self>> {
-        self.offset_from_local_date(local).map(|offset| {
-            // since FixedOffset is within +/- 1 day, the date is never affected
-            Date::from_utc(*local, offset)
-        })
+    fn from_local_date(&self, local: &NaiveDate) -> Result<LocalResult<Date<Self>>, ChronoError> {
+        let offset = self.offset_from_local_date(local)?;
+        let offset = offset.map(|offset| Date::from_utc(*local, offset));
+        Ok(offset)
     }
 
     /// Converts the local `NaiveDateTime` to the timezone-aware `DateTime` if possible.
     #[allow(clippy::wrong_self_convention)]
-    fn from_local_datetime(&self, local: &NaiveDateTime) -> LocalResult<DateTime<Self>> {
-        self.offset_from_local_datetime(local)
-            .map(|offset| DateTime::from_utc(*local - offset.fix(), offset))
+    fn from_local_datetime(
+        &self,
+        local: &NaiveDateTime,
+    ) -> Result<LocalResult<DateTime<Self>>, ChronoError> {
+        let offset = self.offset_from_local_datetime(local)?;
+        let offset = offset.map(|offset| DateTime::from_utc(*local - offset.fix(), offset));
+        Ok(offset)
     }
 
     /// Creates the offset for given UTC `NaiveDate`. This cannot fail.
-    fn offset_from_utc_date(&self, utc: &NaiveDate) -> Self::Offset;
+    fn offset_from_utc_date(&self, utc: &NaiveDate) -> Result<Self::Offset, ChronoError>;
 
     /// Creates the offset for given UTC `NaiveDateTime`. This cannot fail.
-    fn offset_from_utc_datetime(&self, utc: &NaiveDateTime) -> Self::Offset;
+    fn offset_from_utc_datetime(&self, utc: &NaiveDateTime) -> Result<Self::Offset, ChronoError>;
 
     /// Converts the UTC `NaiveDate` to the local time.
     /// The UTC is continuous and thus this cannot fail (but can give the duplicate local time).
     #[allow(clippy::wrong_self_convention)]
-    fn from_utc_date(&self, utc: &NaiveDate) -> Date<Self> {
-        Date::from_utc(*utc, self.offset_from_utc_date(utc))
+    fn from_utc_date(&self, utc: &NaiveDate) -> Result<Date<Self>, ChronoError> {
+        Ok(Date::from_utc(*utc, self.offset_from_utc_date(utc)?))
     }
 
     /// Converts the UTC `NaiveDateTime` to the local time.
     /// The UTC is continuous and thus this cannot fail (but can give the duplicate local time).
     #[allow(clippy::wrong_self_convention)]
-    fn from_utc_datetime(&self, utc: &NaiveDateTime) -> DateTime<Self> {
-        DateTime::from_utc(*utc, self.offset_from_utc_datetime(utc))
+    fn from_utc_datetime(&self, utc: &NaiveDateTime) -> Result<DateTime<Self>, ChronoError> {
+        Ok(DateTime::from_utc(*utc, self.offset_from_utc_datetime(utc)?))
+    }
+}
+
+/// A time zone that is fixed. It is distinguished from [TimeZone] by allowing
+/// for infallible operations since there is no need to access system
+/// information to figure out which timezone is being used.
+pub trait FixedTimeZone: TimeZone {
+    /// Creates the offset for given UTC `NaiveDate`. This cannot fail.
+    fn offset_from_utc_date_fixed(&self, utc: &NaiveDate) -> Self::Offset;
+
+    /// Creates the offset for given UTC `NaiveDateTime`. This cannot fail.
+    fn offset_from_utc_datetime_fixed(&self, utc: &NaiveDateTime) -> Self::Offset;
+
+    /// Converts the UTC `NaiveDate` to the local time.
+    /// The UTC is continuous and thus this cannot fail (but can give the duplicate local time).
+    #[allow(clippy::wrong_self_convention)]
+    fn from_utc_date_fixed(&self, utc: &NaiveDate) -> Date<Self> {
+        Date::from_utc(*utc, self.offset_from_utc_date_fixed(utc))
+    }
+
+    /// Converts the UTC `NaiveDateTime` to the local time.
+    /// The UTC is continuous and thus this cannot fail (but can give the duplicate local time).
+    #[allow(clippy::wrong_self_convention)]
+    fn from_utc_datetime_fixed(&self, utc: &NaiveDateTime) -> DateTime<Self> {
+        DateTime::from_utc(*utc, self.offset_from_utc_datetime_fixed(utc))
     }
 }
 
@@ -483,21 +429,21 @@ mod tests {
 
     #[test]
     fn test_negative_millis() {
-        let dt = Utc.timestamp_millis(-1000);
+        let dt = Utc.timestamp_millis(-1000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59 UTC");
-        let dt = Utc.timestamp_millis(-7000);
+        let dt = Utc.timestamp_millis(-7000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:53 UTC");
-        let dt = Utc.timestamp_millis(-7001);
+        let dt = Utc.timestamp_millis(-7001).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:52.999 UTC");
-        let dt = Utc.timestamp_millis(-7003);
+        let dt = Utc.timestamp_millis(-7003).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:52.997 UTC");
-        let dt = Utc.timestamp_millis(-999);
+        let dt = Utc.timestamp_millis(-999).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59.001 UTC");
-        let dt = Utc.timestamp_millis(-1);
+        let dt = Utc.timestamp_millis(-1).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59.999 UTC");
-        let dt = Utc.timestamp_millis(-60000);
+        let dt = Utc.timestamp_millis(-60000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:00 UTC");
-        let dt = Utc.timestamp_millis(-3600000);
+        let dt = Utc.timestamp_millis(-3600000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:00:00 UTC");
 
         for (millis, expected) in &[
@@ -505,33 +451,29 @@ mod tests {
             (-7001, "1969-12-31 23:59:52.999 UTC"),
             (-7003, "1969-12-31 23:59:52.997 UTC"),
         ] {
-            match Utc.timestamp_millis_opt(*millis) {
-                LocalResult::Single(dt) => {
-                    assert_eq!(dt.to_string(), *expected);
-                }
-                e => panic!("Got {:?} instead of an okay answer", e),
-            }
+            let dt = Utc.timestamp_millis(*millis).unwrap();
+            assert_eq!(dt.to_string(), *expected);
         }
     }
 
     #[test]
     fn test_negative_nanos() {
-        let dt = Utc.timestamp_nanos(-1_000_000_000);
+        let dt = Utc.timestamp_nanos(-1_000_000_000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59 UTC");
-        let dt = Utc.timestamp_nanos(-999_999_999);
+        let dt = Utc.timestamp_nanos(-999_999_999).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59.000000001 UTC");
-        let dt = Utc.timestamp_nanos(-1);
+        let dt = Utc.timestamp_nanos(-1).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59.999999999 UTC");
-        let dt = Utc.timestamp_nanos(-60_000_000_000);
+        let dt = Utc.timestamp_nanos(-60_000_000_000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:00 UTC");
-        let dt = Utc.timestamp_nanos(-3_600_000_000_000);
+        let dt = Utc.timestamp_nanos(-3_600_000_000_000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:00:00 UTC");
     }
 
     #[test]
     fn test_nanos_never_panics() {
-        Utc.timestamp_nanos(i64::max_value());
-        Utc.timestamp_nanos(i64::default());
-        Utc.timestamp_nanos(i64::min_value());
+        Utc.timestamp_nanos(i64::max_value()).unwrap();
+        Utc.timestamp_nanos(i64::default()).unwrap();
+        Utc.timestamp_nanos(i64::min_value()).unwrap();
     }
 }

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -19,8 +19,9 @@ use rkyv::{Archive, Deserialize, Serialize};
 
 use super::{FixedOffset, FixedTimeZone, Offset, TimeZone};
 use crate::naive::{NaiveDate, NaiveDateTime};
+use crate::{ChronoError, LocalResult};
 #[cfg(feature = "clock")]
-use crate::{ChronoError, Date, DateTime, LocalResult};
+use crate::{Date, DateTime};
 
 /// The UTC time zone. This is the most efficient time zone when you don't need the local time.
 /// It is also used as an offset (which is also a dummy type).

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -73,8 +73,10 @@ impl Utc {
         not(any(target_os = "emscripten", target_os = "wasi"))
     ))]
     pub fn now() -> Result<DateTime<Utc>, ChronoError> {
+        use std::convert::TryFrom;
+
         let now = js_sys::Date::new_0();
-        Ok(DateTime::<Utc>::from(now))
+        DateTime::<Utc>::try_from(now)
     }
 }
 

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -19,9 +19,9 @@ use rkyv::{Archive, Deserialize, Serialize};
 
 use super::{FixedOffset, FixedTimeZone, Offset, TimeZone};
 use crate::naive::{NaiveDate, NaiveDateTime};
-use crate::{ChronoError, LocalResult};
 #[cfg(feature = "clock")]
 use crate::{Date, DateTime};
+use crate::{Error, LocalResult};
 
 /// The UTC time zone. This is the most efficient time zone when you don't need the local time.
 /// It is also used as an offset (which is also a dummy type).
@@ -39,7 +39,7 @@ use crate::{Date, DateTime};
 ///
 /// assert_eq!(Utc.timestamp(61, 0)?, dt);
 /// assert_eq!(Utc.ymd(1970, 1, 1)?.and_hms(0, 1, 1)?, dt);
-/// # Ok::<_, chrono::ChronoError>(())
+/// # Ok::<_, chrono::Error>(())
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
@@ -49,7 +49,7 @@ pub struct Utc;
 #[cfg_attr(docsrs, doc(cfg(feature = "clock")))]
 impl Utc {
     /// Returns a `Date` which corresponds to the current date.
-    pub fn today() -> Result<Date<Utc>, ChronoError> {
+    pub fn today() -> Result<Date<Utc>, Error> {
         Ok(Utc::now()?.date())
     }
 
@@ -59,7 +59,7 @@ impl Utc {
         feature = "wasmbind",
         not(any(target_os = "emscripten", target_os = "wasi"))
     )))]
-    pub fn now() -> Result<DateTime<Utc>, ChronoError> {
+    pub fn now() -> Result<DateTime<Utc>, Error> {
         let now =
             SystemTime::now().duration_since(UNIX_EPOCH).expect("system time before Unix epoch");
         let naive = NaiveDateTime::from_timestamp(now.as_secs() as i64, now.subsec_nanos() as u32)?;
@@ -72,7 +72,7 @@ impl Utc {
         feature = "wasmbind",
         not(any(target_os = "emscripten", target_os = "wasi"))
     ))]
-    pub fn now() -> Result<DateTime<Utc>, ChronoError> {
+    pub fn now() -> Result<DateTime<Utc>, Error> {
         use std::convert::TryFrom;
 
         let now = js_sys::Date::new_0();
@@ -87,22 +87,19 @@ impl TimeZone for Utc {
         Self
     }
 
-    fn offset_from_local_date(&self, _: &NaiveDate) -> Result<LocalResult<Self>, ChronoError> {
+    fn offset_from_local_date(&self, _: &NaiveDate) -> Result<LocalResult<Self>, Error> {
         Ok(LocalResult::Single(Self))
     }
 
-    fn offset_from_local_datetime(
-        &self,
-        _: &NaiveDateTime,
-    ) -> Result<LocalResult<Self>, ChronoError> {
+    fn offset_from_local_datetime(&self, _: &NaiveDateTime) -> Result<LocalResult<Self>, Error> {
         Ok(LocalResult::Single(Self))
     }
 
-    fn offset_from_utc_date(&self, _: &NaiveDate) -> Result<Self, ChronoError> {
+    fn offset_from_utc_date(&self, _: &NaiveDate) -> Result<Self, Error> {
         Ok(Self)
     }
 
-    fn offset_from_utc_datetime(&self, _: &NaiveDateTime) -> Result<Self, ChronoError> {
+    fn offset_from_utc_datetime(&self, _: &NaiveDateTime) -> Result<Self, Error> {
         Ok(Self)
     }
 }

--- a/src/round.rs
+++ b/src/round.rs
@@ -25,9 +25,10 @@ pub trait SubsecRound {
     /// # Example
     /// ``` rust
     /// # use chrono::{DateTime, SubsecRound, Timelike, TimeZone, Utc};
-    /// let dt = Utc.ymd(2018, 1, 11).and_hms_milli(12, 0, 0, 154);
+    /// let dt = Utc.ymd(2018, 1, 11)?.and_hms_milli(12, 0, 0, 154)?;
     /// assert_eq!(dt.round_subsecs(2).nanosecond(), 150_000_000);
     /// assert_eq!(dt.round_subsecs(1).nanosecond(), 200_000_000);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     fn round_subsecs(self, digits: u16) -> Self;
 
@@ -37,9 +38,10 @@ pub trait SubsecRound {
     /// # Example
     /// ``` rust
     /// # use chrono::{DateTime, SubsecRound, Timelike, TimeZone, Utc};
-    /// let dt = Utc.ymd(2018, 1, 11).and_hms_milli(12, 0, 0, 154);
+    /// let dt = Utc.ymd(2018, 1, 11)?.and_hms_milli(12, 0, 0, 154)?;
     /// assert_eq!(dt.trunc_subsecs(2).nanosecond(), 150_000_000);
     /// assert_eq!(dt.trunc_subsecs(1).nanosecond(), 100_000_000);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     fn trunc_subsecs(self, digits: u16) -> Self;
 }
@@ -112,7 +114,7 @@ pub trait DurationRound: Sized {
     /// # Example
     /// ``` rust
     /// # use chrono::{DateTime, DurationRound, TimeDelta, TimeZone, Utc};
-    /// let dt = Utc.ymd(2018, 1, 11).and_hms_milli(12, 0, 0, 154);
+    /// let dt = Utc.ymd(2018, 1, 11)?.and_hms_milli(12, 0, 0, 154)?;
     /// assert_eq!(
     ///     dt.duration_round(TimeDelta::milliseconds(10)).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
@@ -121,6 +123,7 @@ pub trait DurationRound: Sized {
     ///     dt.duration_round(TimeDelta::days(1)).unwrap().to_string(),
     ///     "2018-01-12 00:00:00 UTC"
     /// );
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     fn duration_round(self, duration: TimeDelta) -> Result<Self, Self::Err>;
 
@@ -129,7 +132,7 @@ pub trait DurationRound: Sized {
     /// # Example
     /// ``` rust
     /// # use chrono::{DateTime, DurationRound, TimeDelta, TimeZone, Utc};
-    /// let dt = Utc.ymd(2018, 1, 11).and_hms_milli(12, 0, 0, 154);
+    /// let dt = Utc.ymd(2018, 1, 11)?.and_hms_milli(12, 0, 0, 154)?;
     /// assert_eq!(
     ///     dt.duration_trunc(TimeDelta::milliseconds(10)).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
@@ -138,6 +141,7 @@ pub trait DurationRound: Sized {
     ///     dt.duration_trunc(TimeDelta::days(1)).unwrap().to_string(),
     ///     "2018-01-11 00:00:00 UTC"
     /// );
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     fn duration_trunc(self, duration: TimeDelta) -> Result<Self, Self::Err>;
 }
@@ -244,12 +248,13 @@ pub enum RoundingError {
     ///
     /// ``` rust
     /// # use chrono::{DateTime, DurationRound, TimeDelta, RoundingError, TimeZone, Utc};
-    /// let dt = Utc.ymd(1970, 12, 12).and_hms(0, 0, 0);
+    /// let dt = Utc.ymd(1970, 12, 12)?.and_hms(0, 0, 0)?;
     ///
     /// assert_eq!(
     ///     dt.duration_round(TimeDelta::days(365)),
     ///     Err(RoundingError::DurationExceedsTimestamp),
     /// );
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     DurationExceedsTimestamp,
 
@@ -257,12 +262,13 @@ pub enum RoundingError {
     ///
     /// ``` rust
     /// # use chrono::{DateTime, DurationRound, TimeDelta, RoundingError, TimeZone, Utc};
-    /// let dt = Utc.ymd(2260, 12, 31).and_hms_nano(23, 59, 59, 1_75_500_000);
+    /// let dt = Utc.ymd(2260, 12, 31)?.and_hms_nano(23, 59, 59, 1_75_500_000)?;
     ///
     /// assert_eq!(
     ///     dt.duration_round(TimeDelta::days(300 * 365)),
     ///     Err(RoundingError::DurationExceedsLimit)
     /// );
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     DurationExceedsLimit,
 
@@ -270,9 +276,10 @@ pub enum RoundingError {
     ///
     /// ``` rust
     /// # use chrono::{DateTime, DurationRound, TimeDelta, RoundingError, TimeZone, Utc};
-    /// let dt = Utc.ymd(2300, 12, 12).and_hms(0, 0, 0);
+    /// let dt = Utc.ymd(2300, 12, 12)?.and_hms(0, 0, 0)?;
     ///
     /// assert_eq!(dt.duration_round(TimeDelta::days(1)), Err(RoundingError::TimestampExceedsLimit),);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     TimestampExceedsLimit,
 }
@@ -310,8 +317,8 @@ mod tests {
 
     #[test]
     fn test_round_subsecs() {
-        let pst = FixedOffset::east(8 * 60 * 60);
-        let dt = pst.ymd(2018, 1, 11).and_hms_nano(10, 5, 13, 84_660_684);
+        let pst = FixedOffset::east(8 * 60 * 60).unwrap();
+        let dt = pst.ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_684).unwrap();
 
         assert_eq!(dt.round_subsecs(10), dt);
         assert_eq!(dt.round_subsecs(9), dt);
@@ -327,7 +334,7 @@ mod tests {
         assert_eq!(dt.round_subsecs(0).nanosecond(), 0);
         assert_eq!(dt.round_subsecs(0).second(), 13);
 
-        let dt = Utc.ymd(2018, 1, 11).and_hms_nano(10, 5, 27, 750_500_000);
+        let dt = Utc.ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 27, 750_500_000).unwrap();
         assert_eq!(dt.round_subsecs(9), dt);
         assert_eq!(dt.round_subsecs(4), dt);
         assert_eq!(dt.round_subsecs(3).nanosecond(), 751_000_000);
@@ -340,7 +347,7 @@ mod tests {
 
     #[test]
     fn test_round_leap_nanos() {
-        let dt = Utc.ymd(2016, 12, 31).and_hms_nano(23, 59, 59, 1_750_500_000);
+        let dt = Utc.ymd(2016, 12, 31).unwrap().and_hms_nano(23, 59, 59, 1_750_500_000).unwrap();
         assert_eq!(dt.round_subsecs(9), dt);
         assert_eq!(dt.round_subsecs(4), dt);
         assert_eq!(dt.round_subsecs(2).nanosecond(), 1_750_000_000);
@@ -353,8 +360,8 @@ mod tests {
 
     #[test]
     fn test_trunc_subsecs() {
-        let pst = FixedOffset::east(8 * 60 * 60);
-        let dt = pst.ymd(2018, 1, 11).and_hms_nano(10, 5, 13, 84_660_684);
+        let pst = FixedOffset::east(8 * 60 * 60).unwrap();
+        let dt = pst.ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_684).unwrap();
 
         assert_eq!(dt.trunc_subsecs(10), dt);
         assert_eq!(dt.trunc_subsecs(9), dt);
@@ -370,7 +377,7 @@ mod tests {
         assert_eq!(dt.trunc_subsecs(0).nanosecond(), 0);
         assert_eq!(dt.trunc_subsecs(0).second(), 13);
 
-        let dt = pst.ymd(2018, 1, 11).and_hms_nano(10, 5, 27, 750_500_000);
+        let dt = pst.ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 27, 750_500_000).unwrap();
         assert_eq!(dt.trunc_subsecs(9), dt);
         assert_eq!(dt.trunc_subsecs(4), dt);
         assert_eq!(dt.trunc_subsecs(3).nanosecond(), 750_000_000);
@@ -383,7 +390,7 @@ mod tests {
 
     #[test]
     fn test_trunc_leap_nanos() {
-        let dt = Utc.ymd(2016, 12, 31).and_hms_nano(23, 59, 59, 1_750_500_000);
+        let dt = Utc.ymd(2016, 12, 31).unwrap().and_hms_nano(23, 59, 59, 1_750_500_000).unwrap();
         assert_eq!(dt.trunc_subsecs(9), dt);
         assert_eq!(dt.trunc_subsecs(4), dt);
         assert_eq!(dt.trunc_subsecs(2).nanosecond(), 1_750_000_000);
@@ -396,7 +403,7 @@ mod tests {
 
     #[test]
     fn test_duration_round() {
-        let dt = Utc.ymd(2016, 12, 31).and_hms_nano(23, 59, 59, 175_500_000);
+        let dt = Utc.ymd(2016, 12, 31).unwrap().and_hms_nano(23, 59, 59, 175_500_000).unwrap();
 
         assert_eq!(
             dt.duration_round(TimeDelta::zero()).unwrap().to_string(),
@@ -409,13 +416,13 @@ mod tests {
         );
 
         // round up
-        let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 30, 0);
+        let dt = Utc.ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap();
         assert_eq!(
             dt.duration_round(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:25:00 UTC"
         );
         // round down
-        let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 29, 999);
+        let dt = Utc.ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap();
         assert_eq!(
             dt.duration_round(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:20:00 UTC"
@@ -439,7 +446,8 @@ mod tests {
         );
 
         // timezone east
-        let dt = FixedOffset::east(3600).ymd(2020, 10, 27).and_hms(15, 0, 0);
+        let dt =
+            FixedOffset::east(3600).unwrap().ymd(2020, 10, 27).unwrap().and_hms(15, 0, 0).unwrap();
         assert_eq!(
             dt.duration_round(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-28 00:00:00 +01:00"
@@ -450,7 +458,8 @@ mod tests {
         );
 
         // timezone west
-        let dt = FixedOffset::west(3600).ymd(2020, 10, 27).and_hms(15, 0, 0);
+        let dt =
+            FixedOffset::west(3600).unwrap().ymd(2020, 10, 27).unwrap().and_hms(15, 0, 0).unwrap();
         assert_eq!(
             dt.duration_round(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-28 00:00:00 -01:00"
@@ -463,7 +472,12 @@ mod tests {
 
     #[test]
     fn test_duration_round_naive() {
-        let dt = Utc.ymd(2016, 12, 31).and_hms_nano(23, 59, 59, 175_500_000).naive_utc();
+        let dt = Utc
+            .ymd(2016, 12, 31)
+            .unwrap()
+            .and_hms_nano(23, 59, 59, 175_500_000)
+            .unwrap()
+            .naive_utc();
 
         assert_eq!(
             dt.duration_round(TimeDelta::zero()).unwrap().to_string(),
@@ -476,13 +490,13 @@ mod tests {
         );
 
         // round up
-        let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 30, 0).naive_utc();
+        let dt = Utc.ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap().naive_utc();
         assert_eq!(
             dt.duration_round(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:25:00"
         );
         // round down
-        let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 29, 999).naive_utc();
+        let dt = Utc.ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap().naive_utc();
         assert_eq!(
             dt.duration_round(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:20:00"
@@ -508,7 +522,7 @@ mod tests {
 
     #[test]
     fn test_duration_round_pre_epoch() {
-        let dt = Utc.ymd(1969, 12, 12).and_hms(12, 12, 12);
+        let dt = Utc.ymd(1969, 12, 12).unwrap().and_hms(12, 12, 12).unwrap();
         assert_eq!(
             dt.duration_round(TimeDelta::minutes(10)).unwrap().to_string(),
             "1969-12-12 12:10:00 UTC"
@@ -517,7 +531,7 @@ mod tests {
 
     #[test]
     fn test_duration_trunc() {
-        let dt = Utc.ymd(2016, 12, 31).and_hms_nano(23, 59, 59, 175_500_000);
+        let dt = Utc.ymd(2016, 12, 31).unwrap().and_hms_nano(23, 59, 59, 175_500_000).unwrap();
 
         assert_eq!(
             dt.duration_trunc(TimeDelta::milliseconds(10)).unwrap().to_string(),
@@ -525,13 +539,13 @@ mod tests {
         );
 
         // would round up
-        let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 30, 0);
+        let dt = Utc.ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap();
         assert_eq!(
             dt.duration_trunc(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:20:00 UTC"
         );
         // would round down
-        let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 29, 999);
+        let dt = Utc.ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap();
         assert_eq!(
             dt.duration_trunc(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:20:00 UTC"
@@ -554,7 +568,8 @@ mod tests {
         );
 
         // timezone east
-        let dt = FixedOffset::east(3600).ymd(2020, 10, 27).and_hms(15, 0, 0);
+        let dt =
+            FixedOffset::east(3600).and_then(|o| o.ymd(2020, 10, 27)?.and_hms(15, 0, 0)).unwrap();
         assert_eq!(
             dt.duration_trunc(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-27 00:00:00 +01:00"
@@ -565,7 +580,8 @@ mod tests {
         );
 
         // timezone west
-        let dt = FixedOffset::west(3600).ymd(2020, 10, 27).and_hms(15, 0, 0);
+        let dt =
+            FixedOffset::west(3600).and_then(|o| o.ymd(2020, 10, 27)?.and_hms(15, 0, 0)).unwrap();
         assert_eq!(
             dt.duration_trunc(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-27 00:00:00 -01:00"
@@ -578,7 +594,12 @@ mod tests {
 
     #[test]
     fn test_duration_trunc_naive() {
-        let dt = Utc.ymd(2016, 12, 31).and_hms_nano(23, 59, 59, 175_500_000).naive_utc();
+        let dt = Utc
+            .ymd(2016, 12, 31)
+            .unwrap()
+            .and_hms_nano(23, 59, 59, 175_500_000)
+            .unwrap()
+            .naive_utc();
 
         assert_eq!(
             dt.duration_trunc(TimeDelta::milliseconds(10)).unwrap().to_string(),
@@ -586,13 +607,13 @@ mod tests {
         );
 
         // would round up
-        let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 30, 0).naive_utc();
+        let dt = Utc.ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap().naive_utc();
         assert_eq!(
             dt.duration_trunc(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:20:00"
         );
         // would round down
-        let dt = Utc.ymd(2012, 12, 12).and_hms_milli(18, 22, 29, 999).naive_utc();
+        let dt = Utc.ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap().naive_utc();
         assert_eq!(
             dt.duration_trunc(TimeDelta::minutes(5)).unwrap().to_string(),
             "2012-12-12 18:20:00"
@@ -617,7 +638,7 @@ mod tests {
 
     #[test]
     fn test_duration_trunc_pre_epoch() {
-        let dt = Utc.ymd(1969, 12, 12).and_hms(12, 12, 12);
+        let dt = Utc.ymd(1969, 12, 12).unwrap().and_hms(12, 12, 12).unwrap();
         assert_eq!(
             dt.duration_trunc(TimeDelta::minutes(10)).unwrap().to_string(),
             "1969-12-12 12:10:00 UTC"

--- a/src/round.rs
+++ b/src/round.rs
@@ -116,14 +116,14 @@ pub trait DurationRound: Sized {
     /// # use chrono::{DateTime, DurationRound, TimeDelta, TimeZone, Utc};
     /// let dt = Utc.ymd(2018, 1, 11)?.and_hms_milli(12, 0, 0, 154)?;
     /// assert_eq!(
-    ///     dt.duration_round(TimeDelta::milliseconds(10)).unwrap().to_string(),
+    ///     dt.duration_round(TimeDelta::milliseconds(10))?.to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
     /// );
     /// assert_eq!(
-    ///     dt.duration_round(TimeDelta::days(1)).unwrap().to_string(),
+    ///     dt.duration_round(TimeDelta::days(1))?.to_string(),
     ///     "2018-01-12 00:00:00 UTC"
     /// );
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     fn duration_round(self, duration: TimeDelta) -> Result<Self, Self::Err>;
 
@@ -134,14 +134,14 @@ pub trait DurationRound: Sized {
     /// # use chrono::{DateTime, DurationRound, TimeDelta, TimeZone, Utc};
     /// let dt = Utc.ymd(2018, 1, 11)?.and_hms_milli(12, 0, 0, 154)?;
     /// assert_eq!(
-    ///     dt.duration_trunc(TimeDelta::milliseconds(10)).unwrap().to_string(),
+    ///     dt.duration_trunc(TimeDelta::milliseconds(10))?.to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
     /// );
     /// assert_eq!(
-    ///     dt.duration_trunc(TimeDelta::days(1)).unwrap().to_string(),
+    ///     dt.duration_trunc(TimeDelta::days(1))?.to_string(),
     ///     "2018-01-11 00:00:00 UTC"
     /// );
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     fn duration_trunc(self, duration: TimeDelta) -> Result<Self, Self::Err>;
 }

--- a/src/round.rs
+++ b/src/round.rs
@@ -28,7 +28,7 @@ pub trait SubsecRound {
     /// let dt = Utc.ymd(2018, 1, 11)?.and_hms_milli(12, 0, 0, 154)?;
     /// assert_eq!(dt.round_subsecs(2).nanosecond(), 150_000_000);
     /// assert_eq!(dt.round_subsecs(1).nanosecond(), 200_000_000);
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     fn round_subsecs(self, digits: u16) -> Self;
 
@@ -41,7 +41,7 @@ pub trait SubsecRound {
     /// let dt = Utc.ymd(2018, 1, 11)?.and_hms_milli(12, 0, 0, 154)?;
     /// assert_eq!(dt.trunc_subsecs(2).nanosecond(), 150_000_000);
     /// assert_eq!(dt.trunc_subsecs(1).nanosecond(), 100_000_000);
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     fn trunc_subsecs(self, digits: u16) -> Self;
 }
@@ -254,7 +254,7 @@ pub enum RoundingError {
     ///     dt.duration_round(TimeDelta::days(365)),
     ///     Err(RoundingError::DurationExceedsTimestamp),
     /// );
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     DurationExceedsTimestamp,
 
@@ -268,7 +268,7 @@ pub enum RoundingError {
     ///     dt.duration_round(TimeDelta::days(300 * 365)),
     ///     Err(RoundingError::DurationExceedsLimit)
     /// );
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     DurationExceedsLimit,
 
@@ -279,7 +279,7 @@ pub enum RoundingError {
     /// let dt = Utc.ymd(2300, 12, 12)?.and_hms(0, 0, 0)?;
     ///
     /// assert_eq!(dt.duration_round(TimeDelta::days(1)), Err(RoundingError::TimestampExceedsLimit),);
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     TimestampExceedsLimit,
 }

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -211,14 +211,14 @@ impl TimeDelta {
     }
 
     /// Add two durations, returning `None` if overflow occurred.
-    pub fn checked_add(&self, rhs: &TimeDelta) -> Option<TimeDelta> {
+    pub fn checked_add(&self, rhs: &TimeDelta) -> Option<Self> {
         let mut secs = try_opt!(self.secs.checked_add(rhs.secs));
         let mut nanos = self.nanos + rhs.nanos;
         if nanos >= NANOS_PER_SEC {
             nanos -= NANOS_PER_SEC;
             secs = try_opt!(secs.checked_add(1));
         }
-        let d = TimeDelta { secs, nanos };
+        let d = Self { secs, nanos };
         // Even if d is within the bounds of i64 seconds,
         // it might still overflow i64 milliseconds.
         if d < MIN || d > MAX {
@@ -229,14 +229,14 @@ impl TimeDelta {
     }
 
     /// Subtract two durations, returning `None` if overflow occurred.
-    pub fn checked_sub(&self, rhs: &TimeDelta) -> Option<TimeDelta> {
+    pub fn checked_sub(&self, rhs: &TimeDelta) -> Option<Self> {
         let mut secs = try_opt!(self.secs.checked_sub(rhs.secs));
         let mut nanos = self.nanos - rhs.nanos;
         if nanos < 0 {
             nanos += NANOS_PER_SEC;
             secs = try_opt!(secs.checked_sub(1));
         }
-        let d = TimeDelta { secs, nanos };
+        let d = Self { secs, nanos };
         // Even if d is within the bounds of i64 seconds,
         // it might still overflow i64 milliseconds.
         if d < MIN || d > MAX {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::{IsoWeek, Weekday};
+use crate::{ChronoError, IsoWeek, Weekday};
 
 /// The common set of methods for date component.
 pub trait Datelike: Sized {
@@ -56,37 +56,37 @@ pub trait Datelike: Sized {
     /// Makes a new value with the year number changed.
     ///
     /// Returns `None` when the resulting value would be invalid.
-    fn with_year(&self, year: i32) -> Option<Self>;
+    fn with_year(&self, year: i32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the month number (starting from 1) changed.
     ///
     /// Returns `None` when the resulting value would be invalid.
-    fn with_month(&self, month: u32) -> Option<Self>;
+    fn with_month(&self, month: u32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the month number (starting from 0) changed.
     ///
     /// Returns `None` when the resulting value would be invalid.
-    fn with_month0(&self, month0: u32) -> Option<Self>;
+    fn with_month0(&self, month0: u32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the day of month (starting from 1) changed.
     ///
     /// Returns `None` when the resulting value would be invalid.
-    fn with_day(&self, day: u32) -> Option<Self>;
+    fn with_day(&self, day: u32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the day of month (starting from 0) changed.
     ///
     /// Returns `None` when the resulting value would be invalid.
-    fn with_day0(&self, day0: u32) -> Option<Self>;
+    fn with_day0(&self, day0: u32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the day of year (starting from 1) changed.
     ///
     /// Returns `None` when the resulting value would be invalid.
-    fn with_ordinal(&self, ordinal: u32) -> Option<Self>;
+    fn with_ordinal(&self, ordinal: u32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the day of year (starting from 0) changed.
     ///
     /// Returns `None` when the resulting value would be invalid.
-    fn with_ordinal0(&self, ordinal0: u32) -> Option<Self>;
+    fn with_ordinal0(&self, ordinal0: u32) -> Result<Self, ChronoError>;
 
     /// Counts the days in the proleptic Gregorian calendar, with January 1, Year 1 (CE) as day 1.
     ///
@@ -95,10 +95,11 @@ pub trait Datelike: Sized {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(1970, 1, 1).num_days_from_ce(), 719_163);
-    /// assert_eq!(NaiveDate::from_ymd(2, 1, 1).num_days_from_ce(), 366);
-    /// assert_eq!(NaiveDate::from_ymd(1, 1, 1).num_days_from_ce(), 1);
-    /// assert_eq!(NaiveDate::from_ymd(0, 1, 1).num_days_from_ce(), -365);
+    /// assert_eq!(NaiveDate::from_ymd(1970, 1, 1)?.num_days_from_ce(), 719_163);
+    /// assert_eq!(NaiveDate::from_ymd(2, 1, 1)?.num_days_from_ce(), 366);
+    /// assert_eq!(NaiveDate::from_ymd(1, 1, 1)?.num_days_from_ce(), 1);
+    /// assert_eq!(NaiveDate::from_ymd(0, 1, 1)?.num_days_from_ce(), -365);
+    /// # Ok::<_, chrono::ChronoError>(())
     /// ```
     fn num_days_from_ce(&self) -> i32 {
         // See test_num_days_from_ce_against_alternative_impl below for a more straightforward
@@ -149,26 +150,26 @@ pub trait Timelike: Sized {
     /// Makes a new value with the hour number changed.
     ///
     /// Returns `None` when the resulting value would be invalid.
-    fn with_hour(&self, hour: u32) -> Option<Self>;
+    fn with_hour(&self, hour: u32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the minute number changed.
     ///
     /// Returns `None` when the resulting value would be invalid.
-    fn with_minute(&self, min: u32) -> Option<Self>;
+    fn with_minute(&self, min: u32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the second number changed.
     ///
     /// Returns `None` when the resulting value would be invalid.
     /// As with the [`second`](#tymethod.second) method,
     /// the input range is restricted to 0 through 59.
-    fn with_second(&self, sec: u32) -> Option<Self>;
+    fn with_second(&self, sec: u32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with nanoseconds since the whole non-leap second changed.
     ///
     /// Returns `None` when the resulting value would be invalid.
     /// As with the [`nanosecond`](#tymethod.nanosecond) method,
     /// the input range can exceed 1,000,000,000 for leap seconds.
-    fn with_nanosecond(&self, nano: u32) -> Option<Self>;
+    fn with_nanosecond(&self, nano: u32) -> Result<Self, ChronoError>;
 
     /// Returns the number of non-leap seconds past the last midnight.
     #[inline]
@@ -222,7 +223,7 @@ mod tests {
         use num_iter::range_inclusive;
 
         for year in range_inclusive(NaiveDate::MIN.year(), NaiveDate::MAX.year()) {
-            let jan1_year = NaiveDate::from_ymd(year, 1, 1);
+            let jan1_year = NaiveDate::from_ymd(year, 1, 1).unwrap();
             assert_eq!(
                 jan1_year.num_days_from_ce(),
                 num_days_from_ce(&jan1_year),

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::{ChronoError, IsoWeek, Weekday};
+use crate::{Error, IsoWeek, Weekday};
 
 /// The common set of methods for date component.
 pub trait Datelike: Sized {
@@ -55,38 +55,38 @@ pub trait Datelike: Sized {
 
     /// Makes a new value with the year number changed.
     ///
-    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
-    fn with_year(&self, year: i32) -> Result<Self, ChronoError>;
+    /// Returns `Err(Error)` when the resulting value would be invalid.
+    fn with_year(&self, year: i32) -> Result<Self, Error>;
 
     /// Makes a new value with the month number (starting from 1) changed.
     ///
-    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
-    fn with_month(&self, month: u32) -> Result<Self, ChronoError>;
+    /// Returns `Err(Error)` when the resulting value would be invalid.
+    fn with_month(&self, month: u32) -> Result<Self, Error>;
 
     /// Makes a new value with the month number (starting from 0) changed.
     ///
-    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
-    fn with_month0(&self, month0: u32) -> Result<Self, ChronoError>;
+    /// Returns `Err(Error)` when the resulting value would be invalid.
+    fn with_month0(&self, month0: u32) -> Result<Self, Error>;
 
     /// Makes a new value with the day of month (starting from 1) changed.
     ///
-    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
-    fn with_day(&self, day: u32) -> Result<Self, ChronoError>;
+    /// Returns `Err(Error)` when the resulting value would be invalid.
+    fn with_day(&self, day: u32) -> Result<Self, Error>;
 
     /// Makes a new value with the day of month (starting from 0) changed.
     ///
-    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
-    fn with_day0(&self, day0: u32) -> Result<Self, ChronoError>;
+    /// Returns `Err(Error)` when the resulting value would be invalid.
+    fn with_day0(&self, day0: u32) -> Result<Self, Error>;
 
     /// Makes a new value with the day of year (starting from 1) changed.
     ///
-    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
-    fn with_ordinal(&self, ordinal: u32) -> Result<Self, ChronoError>;
+    /// Returns `Err(Error)` when the resulting value would be invalid.
+    fn with_ordinal(&self, ordinal: u32) -> Result<Self, Error>;
 
     /// Makes a new value with the day of year (starting from 0) changed.
     ///
-    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
-    fn with_ordinal0(&self, ordinal0: u32) -> Result<Self, ChronoError>;
+    /// Returns `Err(Error)` when the resulting value would be invalid.
+    fn with_ordinal0(&self, ordinal0: u32) -> Result<Self, Error>;
 
     /// Counts the days in the proleptic Gregorian calendar, with January 1, Year 1 (CE) as day 1.
     ///
@@ -99,7 +99,7 @@ pub trait Datelike: Sized {
     /// assert_eq!(NaiveDate::from_ymd(2, 1, 1)?.num_days_from_ce(), 366);
     /// assert_eq!(NaiveDate::from_ymd(1, 1, 1)?.num_days_from_ce(), 1);
     /// assert_eq!(NaiveDate::from_ymd(0, 1, 1)?.num_days_from_ce(), -365);
-    /// # Ok::<_, chrono::ChronoError>(())
+    /// # Ok::<_, chrono::Error>(())
     /// ```
     fn num_days_from_ce(&self) -> i32 {
         // See test_num_days_from_ce_against_alternative_impl below for a more straightforward
@@ -149,28 +149,28 @@ pub trait Timelike: Sized {
 
     /// Makes a new value with the hour number changed.
     ///
-    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
-    fn with_hour(&self, hour: u32) -> Result<Self, ChronoError>;
+    /// Returns `Err(Error)` when the resulting value would be invalid.
+    fn with_hour(&self, hour: u32) -> Result<Self, Error>;
 
     /// Makes a new value with the minute number changed.
     ///
-    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
-    fn with_minute(&self, min: u32) -> Result<Self, ChronoError>;
+    /// Returns `Err(Error)` when the resulting value would be invalid.
+    fn with_minute(&self, min: u32) -> Result<Self, Error>;
 
     /// Makes a new value with the second number changed.
     ///
-    /// Returns `Err(ChronoError)` when the resulting value would be invalid. As
+    /// Returns `Err(Error)` when the resulting value would be invalid. As
     /// with the [`second`](#tymethod.second) method, the input range is
     /// restricted to 0 through 59.
-    fn with_second(&self, sec: u32) -> Result<Self, ChronoError>;
+    fn with_second(&self, sec: u32) -> Result<Self, Error>;
 
     /// Makes a new value with nanoseconds since the whole non-leap second
     /// changed.
     ///
-    /// Returns `Err(ChronoError)` when the resulting value would be invalid. As
+    /// Returns `Err(Error)` when the resulting value would be invalid. As
     /// with the [`nanosecond`](#tymethod.nanosecond) method, the input range
     /// can exceed 1,000,000,000 for leap seconds.
-    fn with_nanosecond(&self, nano: u32) -> Result<Self, ChronoError>;
+    fn with_nanosecond(&self, nano: u32) -> Result<Self, Error>;
 
     /// Returns the number of non-leap seconds past the last midnight.
     #[inline]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -55,37 +55,37 @@ pub trait Datelike: Sized {
 
     /// Makes a new value with the year number changed.
     ///
-    /// Returns `None` when the resulting value would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
     fn with_year(&self, year: i32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the month number (starting from 1) changed.
     ///
-    /// Returns `None` when the resulting value would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
     fn with_month(&self, month: u32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the month number (starting from 0) changed.
     ///
-    /// Returns `None` when the resulting value would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
     fn with_month0(&self, month0: u32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the day of month (starting from 1) changed.
     ///
-    /// Returns `None` when the resulting value would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
     fn with_day(&self, day: u32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the day of month (starting from 0) changed.
     ///
-    /// Returns `None` when the resulting value would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
     fn with_day0(&self, day0: u32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the day of year (starting from 1) changed.
     ///
-    /// Returns `None` when the resulting value would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
     fn with_ordinal(&self, ordinal: u32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the day of year (starting from 0) changed.
     ///
-    /// Returns `None` when the resulting value would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
     fn with_ordinal0(&self, ordinal0: u32) -> Result<Self, ChronoError>;
 
     /// Counts the days in the proleptic Gregorian calendar, with January 1, Year 1 (CE) as day 1.
@@ -149,26 +149,27 @@ pub trait Timelike: Sized {
 
     /// Makes a new value with the hour number changed.
     ///
-    /// Returns `None` when the resulting value would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
     fn with_hour(&self, hour: u32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the minute number changed.
     ///
-    /// Returns `None` when the resulting value would be invalid.
+    /// Returns `Err(ChronoError)` when the resulting value would be invalid.
     fn with_minute(&self, min: u32) -> Result<Self, ChronoError>;
 
     /// Makes a new value with the second number changed.
     ///
-    /// Returns `None` when the resulting value would be invalid.
-    /// As with the [`second`](#tymethod.second) method,
-    /// the input range is restricted to 0 through 59.
+    /// Returns `Err(ChronoError)` when the resulting value would be invalid. As
+    /// with the [`second`](#tymethod.second) method, the input range is
+    /// restricted to 0 through 59.
     fn with_second(&self, sec: u32) -> Result<Self, ChronoError>;
 
-    /// Makes a new value with nanoseconds since the whole non-leap second changed.
+    /// Makes a new value with nanoseconds since the whole non-leap second
+    /// changed.
     ///
-    /// Returns `None` when the resulting value would be invalid.
-    /// As with the [`nanosecond`](#tymethod.nanosecond) method,
-    /// the input range can exceed 1,000,000,000 for leap seconds.
+    /// Returns `Err(ChronoError)` when the resulting value would be invalid. As
+    /// with the [`nanosecond`](#tymethod.nanosecond) method, the input range
+    /// can exceed 1,000,000,000 for leap seconds.
     fn with_nanosecond(&self, nano: u32) -> Result<Self, ChronoError>;
 
     /// Returns the number of non-leap seconds past the last midnight.

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -10,7 +10,7 @@ use self::wasm_bindgen_test::*;
 #[wasm_bindgen_test]
 fn now() {
     let utc: DateTime<Utc> = Utc::now();
-    let local: DateTime<Local> = Local::now();
+    let local: DateTime<Local> = Local::now().unwrap();
 
     // Ensure time set by the test script is correct
     let now = env!("NOW");
@@ -57,7 +57,7 @@ fn from_is_exact() {
 
 #[wasm_bindgen_test]
 fn local_from_local_datetime() {
-    let now = Local::now();
+    let now = Local::now().unwrap();
     let ndt = now.naive_local();
     let res = match Local.from_local_datetime(&ndt).single() {
         Some(v) => v,


### PR DESCRIPTION
*most of this message is copied from [this comment](https://github.com/chronotope/chrono/issues/815#issuecomment-1242821829)*

This is just a suggestion for changes to accomplish what's being proposed in #815. Consider it heavily WIP and any naming is preliminary.

I've opted for a single `ChronoError` type which has a private `kind` field that determines the message presented to the user (but is not public). I initially started with one error type per kind of error, but eventually noticed that it would make propagating errors overly hard like how constructing a DateTime either raises an error because the date or the time was invalid.

I've opted to make loading the local timezone fallible instead of panicking. I think this is motivated because technically the underlying platform [might perform checks which might fail](https://docs.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-systemtimetofiletime#return-value) all though what these look like exactly is a bit unclear. These kind of errors are represented through `ChronoErrorKind::SystemError(std::io::Error)`.
This has the side effect of making a number of TimeZone methods fallible - which is unfortunate because a number of timezones can easily be interacted with without erroring (`Utc` and `FixedOffset`). To mitigate this I've introduced a separate `FixedTimeZone` trait that extends the TimeZone trait which has a number of non-fallible methods. Note that this could also in theory have a suite of methods which do not produce `LocalResult` values, because the time zone used is never ambiguous.

`FixedOffset::{east, west}` now returns an error if the provided values is outside of a 24-hour offset. This might legitimately be a case that we are OK with panicking for instead.

Making things fallible has the effect of clearly marking the standard trait implementations which might panic, these are:
* The `From<T>` implementations which interacts with the Local timezone, because this doesn't implement FixedTimeZone. Where appropriate these have been moved to be `TryFrom<Error = ChronoError> implementations.
* As mentioned above Add and Sub.

The last big change is that `LocalResult::None` has been removed in favor of handling the absent case as an error in the `unix` implementation. This has the nice side effect that `LocalResult::earlest` and `LocalResult::latest` are neither fallible nor needs to return an `Option<T>`.