### PR TITLE
Test no default features

### DIFF
--- a/ci/github.sh
+++ b/ci/github.sh
@@ -69,6 +69,7 @@ test_regular() {
     tz="$1" && shift
 
     runt env TZ="$tz" cargo test --features __doctest,unstable-locales --color=always -- --color=always
+    runt env TZ="$tz" cargo test --no-default-features --color=always -- --color=always
     for feature in "${FEATURES[@]}"; do
         runt env TZ="$tz" cargo test --no-default-features --features "$feature" --lib --color=always -- --color=always
     done

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -16,7 +16,8 @@
 //! C's `strftime` format. The available options can be found [here](./strftime/index.html).
 //!
 //! # Example
-//! ```rust
+#![cfg_attr(not(feature = "std"), doc = "```ignore")]
+#![cfg_attr(feature = "std", doc = "```rust")]
 //! # use std::error::Error;
 //! use chrono::prelude::*;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,8 @@
 //! or in the local time zone
 //! ([`Local::now()`](./offset/struct.Local.html#method.now)).
 //!
-//! ```rust
+#![cfg_attr(not(feature = "clock"), doc = "```ignore")]
+#![cfg_attr(feature = "clock", doc = "```rust")]
 //! use chrono::prelude::*;
 //!
 //! let utc: DateTime<Utc> = Utc::now();       // e.g. `2014-11-28T12:45:59.324310806Z`
@@ -108,7 +109,8 @@
 //! This is a bit verbose due to Rust's lack of function and method overloading,
 //! but in turn we get a rich combination of initialization methods.
 //!
-//! ```rust
+#![cfg_attr(not(feature = "std"), doc = "```ignore")]
+#![cfg_attr(feature = "std", doc = "```rust")]
 //! use chrono::prelude::*;
 //! use chrono::offset::LocalResult;
 //!
@@ -300,7 +302,8 @@
 //! [`DateTime.timestamp_subsec_nanos`](./struct.DateTime.html#method.timestamp_subsec_nanos)
 //! to get the number of additional number of nanoseconds.
 //!
-//! ```rust
+#![cfg_attr(not(feature = "std"), doc = "```ignore")]
+#![cfg_attr(feature = "std", doc = "```rust")]
 //! // We need the trait in scope to use Utc::timestamp().
 //! use chrono::{DateTime, FixedOffset, TimeZone, Utc};
 //!
@@ -319,7 +322,8 @@
 //! It also has time zones attached, and have to be constructed via time zones.
 //! Most operations available to `DateTime` are also available to `Date` whenever appropriate.
 //!
-//! ```rust
+#![cfg_attr(not(feature = "std"), doc = "```ignore")]
+#![cfg_attr(feature = "std", doc = "```rust")]
 //! use chrono::prelude::*;
 //! use chrono::offset::LocalResult;
 //!

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -848,7 +848,8 @@ impl Timelike for NaiveTime {
     /// ([Why?](#leap-second-handling))
     /// Use the proper [formatting method](#method.format) to get a human-readable representation.
     ///
-    /// ```
+    #[cfg_attr(not(feature = "std"), doc = "```ignore")]
+    #[cfg_attr(feature = "std", doc = "```")]
     /// # use chrono::{NaiveTime, Timelike};
     /// let leap = NaiveTime::from_hms_milli(23, 59, 59, 1_000);
     /// assert_eq!(leap.second(), 59);
@@ -876,7 +877,8 @@ impl Timelike for NaiveTime {
     /// You can reduce the range with `time.nanosecond() % 1_000_000_000`, or
     /// use the proper [formatting method](#method.format) to get a human-readable representation.
     ///
-    /// ```
+    #[cfg_attr(not(feature = "std"), doc = "```ignore")]
+    #[cfg_attr(feature = "std", doc = "```")]
     /// # use chrono::{NaiveTime, Timelike};
     /// let leap = NaiveTime::from_hms_milli(23, 59, 59, 1_000);
     /// assert_eq!(leap.nanosecond(), 1_000_000_000);

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -36,7 +36,8 @@ impl FixedOffset {
     ///
     /// # Example
     ///
-    /// ```
+    #[cfg_attr(not(feature = "std"), doc = "```ignore")]
+    #[cfg_attr(feature = "std", doc = "```")]
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
     /// let datetime = FixedOffset::east(5 * hour).ymd(2016, 11, 08)
@@ -66,7 +67,8 @@ impl FixedOffset {
     ///
     /// # Example
     ///
-    /// ```
+    #[cfg_attr(not(feature = "std"), doc = "```ignore")]
+    #[cfg_attr(feature = "std", doc = "```")]
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
     /// let datetime = FixedOffset::west(5 * hour).ymd(2016, 11, 08)


### PR DESCRIPTION
This patch configures CI to assert that `cargo test --no-default-features` also passes (in addition to the default combinatoric feature matrix). 

An additional commit is included that fixes the existing errors preventing `cargo test` from passing under `--no-default-features`. The commit message explains the approach taken.

This PR is target 0.5.x as some of the fixes were to 0.5.x-only impls; I'll file a separate PR for 0.4.x after this one lands in case any changes are needed or requested.