### PR TITLE
Adding now() functionality for FixedOffest and a Utc::fixed_now() for DateTime w/ TimeZone (set to 0)

### DIFF
--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -129,7 +129,7 @@ impl Offset for FixedOffset {
         *self
     }
     fn now(&self) -> DateTime<FixedOffset> {
-        Utc::now()
+        self.from_utc_datetime(&Utc::now().naive_utc())
     }
 }
 

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -13,7 +13,7 @@ use rkyv::{Archive, Deserialize, Serialize};
 use super::{LocalResult, Offset, TimeZone};
 use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
 use crate::time_delta::TimeDelta;
-use crate::DateTime;
+use crate::{DateTime, Utc};
 use crate::Timelike;
 
 /// The time zone with fixed offset, from UTC-23:59:59 to UTC+23:59:59.
@@ -127,6 +127,9 @@ impl TimeZone for FixedOffset {
 impl Offset for FixedOffset {
     fn fix(&self) -> FixedOffset {
         *self
+    }
+    fn now(&self) -> DateTime<FixedOffset> {
+        Utc::now()
     }
 }
 

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -9,12 +9,14 @@ use core::ops::{Add, Sub};
 use num_integer::div_mod_floor;
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::{LocalResult, Offset, TimeZone};
+use crate::DateTime;
 use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
 use crate::time_delta::TimeDelta;
-use crate::{DateTime, Utc};
 use crate::Timelike;
+
 
 /// The time zone with fixed offset, from UTC-23:59:59 to UTC+23:59:59.
 ///
@@ -129,7 +131,9 @@ impl Offset for FixedOffset {
         *self
     }
     fn now(&self) -> DateTime<FixedOffset> {
-        self.from_utc_datetime(&Utc::now().naive_utc())
+        let now =
+            SystemTime::now().duration_since(UNIX_EPOCH).expect("system time before Unix epoch");
+        self.timestamp_opt(now.as_secs() as i64, now.subsec_nanos() as u32).unwrap()
     }
 }
 

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -194,7 +194,7 @@ impl<T: fmt::Debug> LocalResult<T> {
 pub trait Offset: Sized + Clone + fmt::Debug {
     /// Returns the fixed offset from UTC to the local time stored.
     fn fix(&self) -> FixedOffset;
-    /// Returns a fixed offset DateTime with
+    /// Returns a fixed offset DateTime at the current date and time in self's timezone
     fn now(&self) -> DateTime<FixedOffset>;
 }
 

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -194,6 +194,7 @@ impl<T: fmt::Debug> LocalResult<T> {
 pub trait Offset: Sized + Clone + fmt::Debug {
     /// Returns the fixed offset from UTC to the local time stored.
     fn fix(&self) -> FixedOffset;
+    /// Returns a fixed offset DateTime with
     fn now(&self) -> DateTime<FixedOffset>;
 }
 

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -194,6 +194,7 @@ impl<T: fmt::Debug> LocalResult<T> {
 pub trait Offset: Sized + Clone + fmt::Debug {
     /// Returns the fixed offset from UTC to the local time stored.
     fn fix(&self) -> FixedOffset;
+    fn now(&self) -> DateTime<FixedOffset>;
 }
 
 /// The time zone.

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -64,6 +64,12 @@ impl Utc {
         DateTime::from_utc(naive, Utc)
     }
 
+    /// Returns a `DateTime<FixedOffset>` which corresponds to the current date and time
+    /// but with timezone offset set to zero
+    pub fn fixed_now() -> DateTime<FixedOffset> {
+        Offset::now(&Utc)
+    }
+
     /// Returns a `DateTime` which corresponds to the current date and time.
     #[cfg(all(
         target_arch = "wasm32",
@@ -103,7 +109,7 @@ impl Offset for Utc {
         FixedOffset::east(0)
     }
     fn now(&self) -> DateTime<FixedOffset>{
-        FixedOffset::east(0).from_utc_datetime(&Utc::now().naive_utc())
+        FixedOffset::east(0).now()
     }
 }
 

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -103,7 +103,7 @@ impl Offset for Utc {
         FixedOffset::east(0)
     }
     fn now(&self) -> DateTime<FixedOffset>{
-        FixedOffset::east(0).from_utc_datetime(self.naive())
+        FixedOffset::east(0).from_utc_datetime(Utc::now().naive_utc())
     }
 }
 

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -103,7 +103,7 @@ impl Offset for Utc {
         FixedOffset::east(0)
     }
     fn now(&self) -> DateTime<FixedOffset>{
-        FixedOffset::east(0).from_utc_datetime(Utc::now().naive_utc())
+        FixedOffset::east(0).from_utc_datetime(&Utc::now().naive_utc())
     }
 }
 

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -102,6 +102,9 @@ impl Offset for Utc {
     fn fix(&self) -> FixedOffset {
         FixedOffset::east(0)
     }
+    fn now(&self) -> DateTime<FixedOffset>{
+        FixedOffset::east(0).from_utc_datetime(self)
+    }
 }
 
 impl fmt::Debug for Utc {

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -103,7 +103,7 @@ impl Offset for Utc {
         FixedOffset::east(0)
     }
     fn now(&self) -> DateTime<FixedOffset>{
-        FixedOffset::east(0).from_utc_datetime(self)
+        FixedOffset::east(0).from_utc_datetime(self.naive())
     }
 }
 


### PR DESCRIPTION
I'm new to Rust so please review.  If this is an acceptable way of doing it I can clean it up and maybe add tests.

added a `now()` function to Offset trait and a `fixed_now()` function to Utc that calls the trait's now. FixedOffset's `now()` function get the duration from the system the same way Utc::now does but afterwards uses timestamp_opt to return DateTime<FixedOffset>. 

This was in response to related comment in #624 and #169 

(again I'm new to Rust so forgive any meandering commits, I can make a cleaner one if this is an acceptable set of changes.)
