### PR TITLE
fix benches - plug in datetime type parameter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust_version }}
       - uses: Swatinem/rust-cache@v1
+      - run: cargo check --benches
       # run --lib and --doc to avoid the long running integration tests which are run elsewhere
       - run: cargo test --lib --all-features --color=always -- --color=always
       - run: cargo test --doc --all-features --color=always -- --color=always

--- a/benches/chrono.rs
+++ b/benches/chrono.rs
@@ -10,7 +10,7 @@ fn bench_datetime_parse_from_rfc2822(c: &mut Criterion) {
     c.bench_function("bench_datetime_parse_from_rfc2822", |b| {
         b.iter(|| {
             let str = black_box("Wed, 18 Feb 2015 23:16:09 +0000");
-            DateTime::parse_from_rfc2822(str).unwrap()
+            DateTime::<FixedOffset>::parse_from_rfc2822(str).unwrap()
         })
     });
 }
@@ -19,7 +19,7 @@ fn bench_datetime_parse_from_rfc3339(c: &mut Criterion) {
     c.bench_function("bench_datetime_parse_from_rfc3339", |b| {
         b.iter(|| {
             let str = black_box("2015-02-18T23:59:60.234567+05:00");
-            DateTime::parse_from_rfc3339(str).unwrap()
+            DateTime::<FixedOffset>::parse_from_rfc3339(str).unwrap()
         })
     });
 }


### PR DESCRIPTION
The benches are currently not compiling due to this. Potentially they should be added to the tests, or just a `cargo check --benches`. Happy to add in this PR but will wait until #836 is merged first and rebase.