### PR TITLE
Fixes RUSTSEC-2021-0127

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,14 +30,13 @@ __doctest = []
 num-integer = { version = "0.1.36", default-features = false }
 serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.5.2", optional = true }
-criterion = { version = "0.3", optional = true }
+criterion = { version = "0.4.0", optional = true }
 rkyv = {version = "0.7", optional = true}
 iana-time-zone = { version = "0.1.44", optional = true, features = ["fallback"] }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 wasm-bindgen = { version = "0.2", optional = true }
 js-sys = { version = "0.3", optional = true } # contains FFI bindings for the JS Date API
-
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.0", features = ["std", "minwinbase", "minwindef", "timezoneapi"], optional = true }


### PR DESCRIPTION
Fixes RUSTSEC-2021-0127
https://rustsec.org/advisories/RUSTSEC-2021-0127

Criterion v0.3 contained an unmaintained crate which seemed to contained another security issue that was fixed in v0.04.

All tests passed.

Please review. 

### Thanks for contributing to chrono!

If your feature is semver-compatible, please target the 0.4.x branch;
the main branch will be used for 0.5.0 development going forward.

Please consider adding a test to ensure your bug fix/feature will not break in the future.
