### PR TITLE
optimise rfc3339 (and rfc2822)

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -532,7 +532,8 @@ impl<Tz: TimeZone> Sub<Date<Tz>> for Date<Tz> {
 
 impl<Tz: TimeZone> fmt::Debug for Date<Tz> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}{:?}", self.naive_local(), self.offset)
+        self.naive_local().fmt(f)?;
+        self.offset.fmt(f)
     }
 }
 
@@ -541,7 +542,8 @@ where
     Tz::Offset: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}{}", self.naive_local(), self.offset)
+        self.naive_local().fmt(f)?;
+        self.offset.fmt(f)
     }
 }
 

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -11,6 +11,7 @@ use alloc::string::{String, ToString};
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::cmp::Ordering;
+use core::fmt::Write;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::{fmt, hash, str};
 #[cfg(feature = "std")]
@@ -990,7 +991,8 @@ impl<Tz: TimeZone> Sub<Days> for DateTime<Tz> {
 
 impl<Tz: TimeZone> fmt::Debug for DateTime<Tz> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}{:?}", self.naive_local(), self.offset)
+        self.naive_local().fmt(f)?;
+        self.offset.fmt(f)
     }
 }
 
@@ -999,7 +1001,9 @@ where
     Tz::Offset: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {}", self.naive_local(), self.offset)
+        self.naive_local().fmt(f)?;
+        f.write_char(' ')?;
+        self.offset.fmt(f)
     }
 }
 

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -608,8 +608,10 @@ where
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     pub fn to_rfc3339(&self) -> String {
-        const ITEMS: &[Item<'static>] = &[Item::Fixed(Fixed::RFC3339)];
-        self.format_with_items(ITEMS.iter()).to_string()
+        let mut result = String::with_capacity(32);
+        crate::format::write_rfc3339(&mut result, self.naive_local(), self.offset.fix())
+            .expect("writing rfc3339 datetime to string should never fail");
+        result
     }
 
     /// Return an RFC 3339 and ISO 8601 date and time string with subseconds

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -600,8 +600,10 @@ where
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     pub fn to_rfc2822(&self) -> String {
-        const ITEMS: &[Item<'static>] = &[Item::Fixed(Fixed::RFC2822)];
-        self.format_with_items(ITEMS.iter()).to_string()
+        let mut result = String::with_capacity(32);
+        crate::format::write_rfc2822(&mut result, self.naive_local(), self.offset.fix())
+            .expect("writing rfc2822 datetime to string should never fail");
+        result
     }
 
     /// Returns an RFC 3339 and ISO 8601 date and time string such as `1996-12-19T16:39:57-08:00`.

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -737,7 +737,7 @@ fn format_inner<'a>(
                         if let (Some(d), Some(t), Some(&(_, off))) = (date, time, off) {
                             // reuse `Debug` impls which already print ISO 8601 format.
                             // this is faster in this way.
-                            write!(result, "{:?}T{:?}", d, t)?;
+                            write!(result, "{:?}", crate::NaiveDateTime::new(*d, *t))?;
                             Some(write_local_minus_utc(result, off, false, Colons::Single))
                         } else {
                             None

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -6,6 +6,7 @@
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::convert::TryFrom;
+use core::fmt::Write;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::{fmt, str};
 
@@ -1629,7 +1630,9 @@ impl Sub<Days> for NaiveDateTime {
 /// ```
 impl fmt::Debug for NaiveDateTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}T{:?}", self.date, self.time)
+        self.date.fmt(f)?;
+        f.write_char('T')?;
+        self.time.fmt(f)
     }
 }
 
@@ -1660,7 +1663,9 @@ impl fmt::Debug for NaiveDateTime {
 /// ```
 impl fmt::Display for NaiveDateTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{} {}", self.date, self.time)
+        self.date.fmt(f)?;
+        f.write_char(' ')?;
+        self.time.fmt(f)
     }
 }
 

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -14,7 +14,7 @@ use rkyv::{Archive, Deserialize, Serialize};
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use crate::format::DelayedFormat;
-use crate::format::{parse, ParseError, ParseResult, Parsed, StrftimeItems};
+use crate::format::{parse, write_hundreds, ParseError, ParseResult, Parsed, StrftimeItems};
 use crate::format::{Fixed, Item, Numeric, Pad};
 use crate::oldtime::Duration as OldDuration;
 use crate::Timelike;
@@ -1188,7 +1188,13 @@ impl fmt::Debug for NaiveTime {
             (sec, self.frac)
         };
 
-        write!(f, "{:02}:{:02}:{:02}", hour, min, sec)?;
+        use core::fmt::Write;
+        write_hundreds(f, hour as u8)?;
+        f.write_char(':')?;
+        write_hundreds(f, min as u8)?;
+        f.write_char(':')?;
+        write_hundreds(f, sec as u8)?;
+
         if nano == 0 {
             Ok(())
         } else if nano % 1_000_000 == 0 {


### PR DESCRIPTION
We use `to_rfc3339()` a lot in our observability libraries at TrueLayer. Upon profiling, I noticed that it took up a large portion of time, so I looked into optimising it.

![Screenshot 2022-10-15 at 10 43 30](https://user-images.githubusercontent.com/6625462/195979919-f199c5da-6853-48e6-a050-c625ea6a79ea.png)

![Screenshot 2022-10-15 at 10 43 39](https://user-images.githubusercontent.com/6625462/195979921-937631c5-3c33-43f5-bad9-713f706d43cb.png)

I was able to do more optimisations but the requirement of the year formatting causes the code to be pretty tricky. I can attempt it in a later PR if this is accepted.

In our observability code I know that the year is 0..=9999 and the timezone is Utc so I had a bit more gains from cheating 😅 