### PR TITLE
move more code into internals

### DIFF
--- a/src/datetime/rustc_serialize.rs
+++ b/src/datetime/rustc_serialize.rs
@@ -58,7 +58,7 @@ pub struct TsSeconds<Tz: TimeZone>(DateTime<Tz>);
 
 #[allow(deprecated)]
 impl<Tz: TimeZone> From<TsSeconds<Tz>> for DateTime<Tz> {
-    /// Pull the inner DateTime<Tz> out
+    /// Pull the inner `DateTime<Tz>` out
     #[allow(deprecated)]
     fn from(obj: TsSeconds<Tz>) -> DateTime<Tz> {
         obj.0

--- a/src/month.rs
+++ b/src/month.rs
@@ -153,7 +153,7 @@ impl Month {
 }
 
 impl num_traits::FromPrimitive for Month {
-    /// Returns an Option<Month> from a i64, assuming a 1-index, January = 1.
+    /// Returns an `Option<Month>` from a i64, assuming a 1-index, January = 1.
     ///
     /// `Month::from_i64(n: i64)`: | `1`                  | `2`                   | ... | `12`
     /// ---------------------------| -------------------- | --------------------- | ... | -----

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -301,7 +301,7 @@ impl NaiveDate {
     /// ```
     pub fn from_yo_opt(year: i32, ordinal: u32) -> Option<NaiveDate> {
         let flags = YearFlags::from_year(year);
-        NaiveDate::from_of(year, Of::new(ordinal, flags))
+        NaiveDate::from_of(year, Of::new(ordinal, flags)?)
     }
 
     /// Makes a new `NaiveDate` from the [ISO week date](#week-date)
@@ -370,18 +370,18 @@ impl NaiveDate {
                 let prevflags = YearFlags::from_year(year - 1);
                 NaiveDate::from_of(
                     year - 1,
-                    Of::new(weekord + prevflags.ndays() - delta, prevflags),
+                    Of::new(weekord + prevflags.ndays() - delta, prevflags)?,
                 )
             } else {
                 let ordinal = weekord - delta;
                 let ndays = flags.ndays();
                 if ordinal <= ndays {
                     // this year
-                    NaiveDate::from_of(year, Of::new(ordinal, flags))
+                    NaiveDate::from_of(year, Of::new(ordinal, flags)?)
                 } else {
                     // ordinal > ndays, next year
                     let nextflags = YearFlags::from_year(year + 1);
-                    NaiveDate::from_of(year + 1, Of::new(ordinal - ndays, nextflags))
+                    NaiveDate::from_of(year + 1, Of::new(ordinal - ndays, nextflags)?)
                 }
             }
         } else {
@@ -424,7 +424,7 @@ impl NaiveDate {
         let (year_div_400, cycle) = div_mod_floor(days, 146_097);
         let (year_mod_400, ordinal) = internals::cycle_to_yo(cycle as u32);
         let flags = YearFlags::from_year_mod_400(year_mod_400 as i32);
-        NaiveDate::from_of(year_div_400 * 400 + year_mod_400 as i32, Of::new(ordinal, flags))
+        NaiveDate::from_of(year_div_400 * 400 + year_mod_400 as i32, Of::new(ordinal, flags)?)
     }
 
     /// Makes a new `NaiveDate` by counting the number of occurrences of a particular day-of-week
@@ -976,7 +976,7 @@ impl NaiveDate {
 
         let (year_mod_400, ordinal) = internals::cycle_to_yo(cycle as u32);
         let flags = YearFlags::from_year_mod_400(year_mod_400 as i32);
-        NaiveDate::from_of(year_div_400 * 400 + year_mod_400 as i32, Of::new(ordinal, flags))
+        NaiveDate::from_of(year_div_400 * 400 + year_mod_400 as i32, Of::new(ordinal, flags)?)
     }
 
     /// Subtracts the `days` part of given `Duration` from the current date.
@@ -1007,7 +1007,7 @@ impl NaiveDate {
 
         let (year_mod_400, ordinal) = internals::cycle_to_yo(cycle as u32);
         let flags = YearFlags::from_year_mod_400(year_mod_400 as i32);
-        NaiveDate::from_of(year_div_400 * 400 + year_mod_400 as i32, Of::new(ordinal, flags))
+        NaiveDate::from_of(year_div_400 * 400 + year_mod_400 as i32, Of::new(ordinal, flags)?)
     }
 
     /// Subtracts another `NaiveDate` from the current date.
@@ -1510,7 +1510,7 @@ impl Datelike for NaiveDate {
     /// ```
     #[inline]
     fn with_ordinal(&self, ordinal: u32) -> Option<NaiveDate> {
-        self.with_of(self.of().with_ordinal(ordinal))
+        self.with_of(self.of().with_ordinal(ordinal)?)
     }
 
     /// Makes a new `NaiveDate` with the day of year (starting from 0) changed.
@@ -1534,7 +1534,7 @@ impl Datelike for NaiveDate {
     /// ```
     #[inline]
     fn with_ordinal0(&self, ordinal0: u32) -> Option<NaiveDate> {
-        self.with_of(self.of().with_ordinal(ordinal0 + 1))
+        self.with_of(self.of().with_ordinal(ordinal0 + 1)?)
     }
 }
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -267,7 +267,7 @@ impl NaiveDate {
     /// ```
     pub fn from_ymd_opt(year: i32, month: u32, day: u32) -> Option<NaiveDate> {
         let flags = YearFlags::from_year(year);
-        NaiveDate::from_mdf(year, Mdf::new(month, day, flags))
+        NaiveDate::from_mdf(year, Mdf::new(month, day, flags)?)
     }
 
     /// Makes a new `NaiveDate` from the [ordinal date](#ordinal-date)
@@ -615,7 +615,7 @@ impl NaiveDate {
         let days = [31, feb_days, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
         let day = Ord::min(self.day(), days[(month - 1) as usize]);
 
-        NaiveDate::from_mdf(year, Mdf::new(month as u32, day, flags))
+        NaiveDate::from_mdf(year, Mdf::new(month as u32, day, flags)?)
     }
 
     /// Add a duration in [`Days`] to the date
@@ -1429,7 +1429,7 @@ impl Datelike for NaiveDate {
     /// ```
     #[inline]
     fn with_month(&self, month: u32) -> Option<NaiveDate> {
-        self.with_mdf(self.mdf().with_month(month))
+        self.with_mdf(self.mdf().with_month(month)?)
     }
 
     /// Makes a new `NaiveDate` with the month number (starting from 0) changed.
@@ -1448,7 +1448,7 @@ impl Datelike for NaiveDate {
     /// ```
     #[inline]
     fn with_month0(&self, month0: u32) -> Option<NaiveDate> {
-        self.with_mdf(self.mdf().with_month(month0 + 1))
+        self.with_mdf(self.mdf().with_month(month0 + 1)?)
     }
 
     /// Makes a new `NaiveDate` with the day of month (starting from 1) changed.
@@ -1467,7 +1467,7 @@ impl Datelike for NaiveDate {
     /// ```
     #[inline]
     fn with_day(&self, day: u32) -> Option<NaiveDate> {
-        self.with_mdf(self.mdf().with_day(day))
+        self.with_mdf(self.mdf().with_day(day)?)
     }
 
     /// Makes a new `NaiveDate` with the day of month (starting from 0) changed.
@@ -1486,7 +1486,7 @@ impl Datelike for NaiveDate {
     /// ```
     #[inline]
     fn with_day0(&self, day0: u32) -> Option<NaiveDate> {
-        self.with_mdf(self.mdf().with_day(day0 + 1))
+        self.with_mdf(self.mdf().with_day(day0 + 1)?)
     }
 
     /// Makes a new `NaiveDate` with the day of year (starting from 1) changed.

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -371,28 +371,11 @@ pub(super) struct Mdf(pub(super) u32);
 
 impl Mdf {
     #[inline]
-    fn clamp_month(month: u32) -> u32 {
-        if month > 12 {
-            0
-        } else {
-            month
+    pub(super) fn new(month: u32, day: u32, YearFlags(flags): YearFlags) -> Option<Mdf> {
+        match month <= 12 && day <= 31 {
+            true => Some(Mdf((month << 9) | (day << 4) | u32::from(flags))),
+            false => None,
         }
-    }
-
-    #[inline]
-    fn clamp_day(day: u32) -> u32 {
-        if day > 31 {
-            0
-        } else {
-            day
-        }
-    }
-
-    #[inline]
-    pub(super) fn new(month: u32, day: u32, YearFlags(flags): YearFlags) -> Mdf {
-        let month = Mdf::clamp_month(month);
-        let day = Mdf::clamp_day(day);
-        Mdf((month << 9) | (day << 4) | u32::from(flags))
     }
 
     #[inline]
@@ -421,10 +404,13 @@ impl Mdf {
     }
 
     #[inline]
-    pub(super) fn with_month(&self, month: u32) -> Mdf {
-        let month = Mdf::clamp_month(month);
+    pub(super) fn with_month(&self, month: u32) -> Option<Mdf> {
+        if month > 12 {
+            return None;
+        }
+
         let Mdf(mdf) = *self;
-        Mdf((mdf & 0b1_1111_1111) | (month << 9))
+        Some(Mdf((mdf & 0b1_1111_1111) | (month << 9)))
     }
 
     #[inline]
@@ -434,10 +420,13 @@ impl Mdf {
     }
 
     #[inline]
-    pub(super) fn with_day(&self, day: u32) -> Mdf {
-        let day = Mdf::clamp_day(day);
+    pub(super) fn with_day(&self, day: u32) -> Option<Mdf> {
+        if day > 31 {
+            return None;
+        }
+
         let Mdf(mdf) = *self;
-        Mdf((mdf & !0b1_1111_0000) | (day << 4))
+        Some(Mdf((mdf & !0b1_1111_0000) | (day << 4)))
     }
 
     #[inline]
@@ -556,7 +545,12 @@ mod tests {
         fn check(expected: bool, flags: YearFlags, month1: u32, day1: u32, month2: u32, day2: u32) {
             for month in range_inclusive(month1, month2) {
                 for day in range_inclusive(day1, day2) {
-                    let mdf = Mdf::new(month, day, flags);
+                    let mdf = match Mdf::new(month, day, flags) {
+                        Some(mdf) => mdf,
+                        None if !expected => continue,
+                        None => panic!("Mdf::new({}, {}, {:?}) returned None", month, day, flags),
+                    };
+
                     assert!(
                         mdf.valid() == expected,
                         "month {} day {} = {:?} should be {} for dominical year {:?}",
@@ -711,7 +705,11 @@ mod tests {
         for &flags in FLAGS.iter() {
             for month in range_inclusive(1u32, 12) {
                 for day in range_inclusive(1u32, 31) {
-                    let mdf = Mdf::new(month, day, flags);
+                    let mdf = match Mdf::new(month, day, flags) {
+                        Some(mdf) => mdf,
+                        None => continue,
+                    };
+
                     if mdf.valid() {
                         assert_eq!(mdf.month(), month);
                         assert_eq!(mdf.day(), day);
@@ -724,11 +722,15 @@ mod tests {
     #[test]
     fn test_mdf_with_fields() {
         fn check(flags: YearFlags, month: u32, day: u32) {
-            let mdf = Mdf::new(month, day, flags);
+            let mdf = Mdf::new(month, day, flags).unwrap();
 
             for month in range_inclusive(0u32, 16) {
-                let mdf = mdf.with_month(month);
-                assert_eq!(mdf.valid(), Mdf::new(month, day, flags).valid());
+                let mdf = match mdf.with_month(month) {
+                    Some(mdf) => mdf,
+                    None if month > 12 => continue,
+                    None => panic!("failed to create Mdf with month {}", month),
+                };
+
                 if mdf.valid() {
                     assert_eq!(mdf.month(), month);
                     assert_eq!(mdf.day(), day);
@@ -736,8 +738,12 @@ mod tests {
             }
 
             for day in range_inclusive(0u32, 1024) {
-                let mdf = mdf.with_day(day);
-                assert_eq!(mdf.valid(), Mdf::new(month, day, flags).valid());
+                let mdf = match mdf.with_day(day) {
+                    Some(mdf) => mdf,
+                    None if day > 31 => continue,
+                    None => panic!("failed to create Mdf with month {}", month),
+                };
+
                 if mdf.valid() {
                     assert_eq!(mdf.month(), month);
                     assert_eq!(mdf.day(), day);

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -14,17 +14,105 @@
 //! so that the user-facing `NaiveDate` can validate the input as late as possible.
 
 #![cfg_attr(feature = "__internal_bench", allow(missing_docs))]
+#![allow(unreachable_pub)]
 
 use crate::Weekday;
+use core::convert::TryFrom;
 use core::{fmt, i32};
 use num_integer::{div_rem, mod_floor};
 use num_traits::FromPrimitive;
 
-/// The internal date representation. This also includes the packed `Mdf` value.
-pub(super) type DateImpl = i32;
+#[cfg(feature = "rkyv")]
+use rkyv::{Archive, Deserialize, Serialize};
 
-pub(super) const MAX_YEAR: DateImpl = i32::MAX >> 13;
-pub(super) const MIN_YEAR: DateImpl = i32::MIN >> 13;
+/// The internal date representation. This also includes the packed `Mdf` value.
+#[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone, Debug)]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+pub struct DateImpl(i32); // (year << 13) | of
+
+impl DateImpl {
+    pub(super) fn from_parts(year: i32, of: Of) -> Option<DateImpl> {
+        if !(MIN_YEAR..=MAX_YEAR).contains(&year) {
+            return None;
+        }
+
+        let of = i32::try_from(of.0).ok()?;
+        Some(DateImpl(year << 13 | of))
+    }
+
+    // should this return an Option ?
+    pub(super) fn of(&self) -> Of {
+        Of((self.0 & 0b1_1111_1111_1111) as u32)
+    }
+
+    pub(super) fn year(&self) -> i32 {
+        // self.0 & !0b1_1111_1111_1111
+
+        self.0 >> 13
+    }
+
+    #[inline]
+    pub(super) fn succ_opt(&self) -> Option<DateImpl> {
+        let of = self.of();
+        let current_year = self.year();
+        if of.ordinal() == of.flags().ndays() {
+            let next_year = current_year.checked_add(1)?;
+            if next_year > MAX_YEAR {
+                return None;
+            }
+            let new_flags = YearFlags::from_year(next_year);
+            DateImpl::from_parts(next_year, Of::new(1, new_flags)?)
+        } else {
+            DateImpl::from_parts(current_year, Of::new(of.ordinal() + 1, of.flags())?)
+        }
+    }
+
+    #[inline]
+    pub(super) fn pred_opt(&self) -> Option<DateImpl> {
+        let of = self.of();
+        let current_year = self.year();
+        if of.ordinal() == 1 {
+            let prev_year = current_year.checked_sub(1)?;
+            if prev_year < MIN_YEAR {
+                return None;
+            }
+            let new_flags = YearFlags::from_year(prev_year);
+            DateImpl::from_parts(prev_year, Of::new(new_flags.ndays(), new_flags)?)
+        } else {
+            DateImpl::from_parts(current_year, Of::new(of.ordinal() - 1, of.flags())?)
+        }
+    }
+
+    /// The minimum possible `Date` (January 1, 262145 BCE).
+    pub(super) const MIN: DateImpl = DateImpl((MIN_YEAR << 13) | (1 << 4) | 0o07 /*FE*/);
+    /// The maximum possible `Date` (December 31, 262143 CE).
+    pub(super) const MAX: DateImpl = DateImpl((MAX_YEAR << 13) | (365 << 4) | 0o17 /*F*/);
+}
+
+// note that this allows for larger year range than `NaiveDate`.
+// this is crucial because we have an edge case for the first and last week supported,
+// which year number might not match the calendar year number.#[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone)]
+#[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone, Debug)]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+pub struct WeekImpl(i32); // (year << 10) | (week << 4) | flag
+
+impl WeekImpl {
+    pub(super) fn from_parts(year: i32, week: u16, flags: YearFlags) -> Option<WeekImpl> {
+        let week_part = i32::try_from(week << 4).ok()?;
+        let flags_part = i32::from(flags.0);
+        Some(WeekImpl((year << 10) | week_part | flags_part))
+    }
+
+    pub(super) fn year(&self) -> i32 {
+        self.0 >> 10
+    }
+    pub(super) fn week(&self) -> u32 {
+        u32::try_from((self.0 >> 4) & 0x3f).unwrap()
+    }
+}
+
+pub(super) const MAX_YEAR: i32 = i32::MAX >> 13;
+pub(super) const MIN_YEAR: i32 = i32::MIN >> 13;
 
 /// The year flags (aka the dominical letter).
 ///
@@ -266,31 +354,34 @@ static OL_TO_MDL: [u8; MAX_OL as usize + 1] = [
 /// The whole bits except for the least 3 bits are referred as `Ol` (ordinal and leap flag),
 /// which is an index to the `OL_TO_MDL` lookup table.
 #[derive(PartialEq, PartialOrd, Copy, Clone)]
-pub(super) struct Of(pub(crate) u32);
+pub(super) struct Of(u32);
 
 impl Of {
+    // this function should only allow creation of valid Of.
+    // otherwise it will return None.
     #[inline]
-    pub(super) fn new(ordinal: u32, YearFlags(flags): YearFlags) -> Option<Of> {
-        match ordinal <= 366 {
-            true => Some(Of((ordinal << 4) | u32::from(flags))),
+    pub(super) fn new(ordinal: u32, yf: YearFlags) -> Option<Of> {
+        match (1_u32..=yf.ndays()).contains(&ordinal) {
+            true => {
+                let raw = (ordinal << 4) | u32::from(yf.0);
+                if (MIN_OL..=MAX_OL).contains(&(raw >> 3)) {
+                    Some(Of(raw))
+                } else {
+                    None
+                }
+            }
             false => None,
         }
     }
 
     #[inline]
-    pub(super) fn from_mdf(Mdf(mdf): Mdf) -> Of {
+    pub(super) fn from_mdf(Mdf(mdf): Mdf) -> Option<Of> {
         let mdl = mdf >> 3;
-        match MDL_TO_OL.get(mdl as usize) {
-            Some(&v) => Of(mdf.wrapping_sub((i32::from(v) as u32 & 0x3ff) << 3)),
-            None => Of(0),
+        let proposed_ol = *MDL_TO_OL.get(mdl as usize)?;
+        if proposed_ol < 1 {
+            return None;
         }
-    }
-
-    #[inline]
-    pub(super) fn valid(&self) -> bool {
-        let Of(of) = *self;
-        let ol = of >> 3;
-        (MIN_OL..=MAX_OL).contains(&ol)
+        Some(Of(mdf.wrapping_sub((i32::from(proposed_ol) as u32 & 0x3ff) << 3)))
     }
 
     #[inline]
@@ -301,12 +392,7 @@ impl Of {
 
     #[inline]
     pub(super) fn with_ordinal(&self, ordinal: u32) -> Option<Of> {
-        if ordinal > 366 {
-            return None;
-        }
-
-        let Of(of) = *self;
-        Some(Of((of & 0b1111) | (ordinal << 4)))
+        Of::new(ordinal, self.flags())
     }
 
     #[inline]
@@ -329,22 +415,9 @@ impl Of {
         (weekord / 7, Weekday::from_u32(weekord % 7).unwrap())
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::wrong_self_convention))]
     #[inline]
-    pub(super) fn to_mdf(&self) -> Mdf {
-        Mdf::from_of(*self)
-    }
-
-    #[inline]
-    pub(super) fn succ(&self) -> Of {
-        let Of(of) = *self;
-        Of(of + (1 << 4))
-    }
-
-    #[inline]
-    pub(super) fn pred(&self) -> Of {
-        let Of(of) = *self;
-        Of(of - (1 << 4))
+    pub(super) fn to_mdf(self) -> Mdf {
+        Mdf::from_of(self)
     }
 }
 
@@ -367,14 +440,22 @@ impl fmt::Debug for Of {
 /// (month, day of month and leap flag),
 /// which is an index to the `MDL_TO_OL` lookup table.
 #[derive(PartialEq, PartialOrd, Copy, Clone)]
-pub(super) struct Mdf(pub(super) u32);
+pub(super) struct Mdf(u32);
 
 impl Mdf {
+    // this function should only allow creation of valid Mdf.
+    // otherwise it will return None.
     #[inline]
     pub(super) fn new(month: u32, day: u32, YearFlags(flags): YearFlags) -> Option<Mdf> {
-        match month <= 12 && day <= 31 {
-            true => Some(Mdf((month << 9) | (day << 4) | u32::from(flags))),
-            false => None,
+        if !(1..=12).contains(&month) || !(1..=31).contains(&day) {
+            return None;
+        }
+        let raw = (month << 9) | (day << 4) | u32::from(flags);
+
+        let mdl = raw >> 3;
+        match MDL_TO_OL.get(mdl as usize) {
+            Some(&v) if v >= 0 => Some(Mdf(raw)),
+            Some(_) | None => None,
         }
     }
 
@@ -384,16 +465,6 @@ impl Mdf {
         match OL_TO_MDL.get(ol as usize) {
             Some(&v) => Mdf(of + (u32::from(v) << 3)),
             None => Mdf(0),
-        }
-    }
-
-    #[cfg(test)]
-    pub(super) fn valid(&self) -> bool {
-        let Mdf(mdf) = *self;
-        let mdl = mdf >> 3;
-        match MDL_TO_OL.get(mdl as usize) {
-            Some(&v) => v >= 0,
-            None => false,
         }
     }
 
@@ -435,10 +506,9 @@ impl Mdf {
         Mdf((mdf & !0b1111) | u32::from(flags))
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::wrong_self_convention))]
     #[inline]
-    pub(super) fn to_of(&self) -> Of {
-        Of::from_mdf(*self)
+    pub(super) fn to_of(self) -> Option<Of> {
+        Of::from_mdf(self)
     }
 }
 
@@ -508,20 +578,24 @@ mod tests {
     fn test_of() {
         fn check(expected: bool, flags: YearFlags, ordinal1: u32, ordinal2: u32) {
             for ordinal in range_inclusive(ordinal1, ordinal2) {
-                let of = match Of::new(ordinal, flags) {
-                    Some(of) => of,
-                    None if !expected => continue,
-                    None => panic!("Of::new({}, {:?}) returned None", ordinal, flags),
+                match Of::new(ordinal, flags) {
+                    Some(of) => assert!(
+                        expected,
+                        "ordinal {} = {:?} should be {} for dominical year {:?}",
+                        ordinal,
+                        Some(of),
+                        if expected { "valid" } else { "invalid" },
+                        flags
+                    ),
+                    None => assert!(
+                        !expected,
+                        "ordinal {} = {:?} should be {} for dominical year {:?}",
+                        ordinal,
+                        None::<Of>,
+                        if expected { "valid" } else { "invalid" },
+                        flags
+                    ),
                 };
-
-                assert!(
-                    of.valid() == expected,
-                    "ordinal {} = {:?} should be {} for dominical year {:?}",
-                    ordinal,
-                    of,
-                    if expected { "valid" } else { "invalid" },
-                    flags
-                );
             }
         }
 
@@ -545,21 +619,26 @@ mod tests {
         fn check(expected: bool, flags: YearFlags, month1: u32, day1: u32, month2: u32, day2: u32) {
             for month in range_inclusive(month1, month2) {
                 for day in range_inclusive(day1, day2) {
-                    let mdf = match Mdf::new(month, day, flags) {
-                        Some(mdf) => mdf,
-                        None if !expected => continue,
-                        None => panic!("Mdf::new({}, {}, {:?}) returned None", month, day, flags),
+                    match Mdf::new(month, day, flags) {
+                        Some(mdf) => assert!(
+                            expected,
+                            "month {} day {} = {:?} should be {} for dominical year {:?}",
+                            month,
+                            day,
+                            Some(mdf),
+                            if expected { "valid" } else { "invalid" },
+                            flags
+                        ),
+                        None => assert!(
+                            !expected,
+                            "month {} day {} = {:?} should be {} for dominical year {:?}",
+                            month,
+                            day,
+                            None::<Mdf>,
+                            if expected { "valid" } else { "invalid" },
+                            flags
+                        ),
                     };
-
-                    assert!(
-                        mdf.valid() == expected,
-                        "month {} day {} = {:?} should be {} for dominical year {:?}",
-                        month,
-                        day,
-                        mdf,
-                        if expected { "valid" } else { "invalid" },
-                        flags
-                    );
                 }
             }
         }
@@ -635,9 +714,14 @@ mod tests {
     fn test_of_fields() {
         for &flags in FLAGS.iter() {
             for ordinal in range_inclusive(1u32, 366) {
-                let of = Of::new(ordinal, flags).unwrap();
-                if of.valid() {
-                    assert_eq!(of.ordinal(), ordinal);
+                match Of::new(ordinal, flags) {
+                    Some(of) => {
+                        assert_eq!(of.ordinal(), ordinal)
+                    }
+                    None => {
+                        assert_eq!(flags.ndays(), 365);
+                        assert_eq!(ordinal, 366);
+                    }
                 }
             }
         }
@@ -649,16 +733,17 @@ mod tests {
             let of = Of::new(ordinal, flags).unwrap();
 
             for ordinal in range_inclusive(0u32, 1024) {
-                let of = match of.with_ordinal(ordinal) {
-                    Some(of) => of,
-                    None if ordinal > 366 => continue,
-                    None => panic!("failed to create Of with ordinal {}", ordinal),
+                match of.with_ordinal(ordinal) {
+                    Some(of) => {
+                        assert_eq!(Of::new(ordinal, flags), Some(of));
+                        assert_eq!(of.ordinal(), ordinal);
+                    }
+                    // this should always succeed so it's a bug if not
+                    None if (1..=flags.ndays()).contains(&ordinal) => {
+                        panic!("failed to create Of with ordinal {}", ordinal);
+                    }
+                    None => continue,
                 };
-
-                assert_eq!(of.valid(), Of::new(ordinal, flags).unwrap().valid());
-                if of.valid() {
-                    assert_eq!(of.ordinal(), ordinal);
-                }
             }
         }
 
@@ -705,15 +790,13 @@ mod tests {
         for &flags in FLAGS.iter() {
             for month in range_inclusive(1u32, 12) {
                 for day in range_inclusive(1u32, 31) {
-                    let mdf = match Mdf::new(month, day, flags) {
-                        Some(mdf) => mdf,
+                    match Mdf::new(month, day, flags) {
+                        Some(mdf) => {
+                            assert_eq!(mdf.month(), month);
+                            assert_eq!(mdf.day(), day);
+                        }
                         None => continue,
                     };
-
-                    if mdf.valid() {
-                        assert_eq!(mdf.month(), month);
-                        assert_eq!(mdf.day(), day);
-                    }
                 }
             }
         }
@@ -721,51 +804,52 @@ mod tests {
 
     #[test]
     fn test_mdf_with_fields() {
-        fn check(flags: YearFlags, month: u32, day: u32) {
-            let mdf = Mdf::new(month, day, flags).unwrap();
-
-            for month in range_inclusive(0u32, 16) {
-                let mdf = match mdf.with_month(month) {
-                    Some(mdf) => mdf,
-                    None if month > 12 => continue,
-                    None => panic!("failed to create Mdf with month {}", month),
-                };
-
-                if mdf.valid() {
-                    assert_eq!(mdf.month(), month);
-                    assert_eq!(mdf.day(), day);
+        fn check(should_succeed: bool, flags: YearFlags, month: u32, day: u32) {
+            if let Some(mdf) = Mdf::new(month, day, flags) {
+                if !should_succeed {
+                    panic!("Mdf invalidly created from {:?} month {} day {}", flags, month, day)
                 }
-            }
-
-            for day in range_inclusive(0u32, 1024) {
-                let mdf = match mdf.with_day(day) {
-                    Some(mdf) => mdf,
-                    None if day > 31 => continue,
-                    None => panic!("failed to create Mdf with month {}", month),
-                };
-
-                if mdf.valid() {
-                    assert_eq!(mdf.month(), month);
-                    assert_eq!(mdf.day(), day);
+                for month in range_inclusive(0u32, 16) {
+                    match mdf.with_month(month) {
+                        Some(mdf) => {
+                            assert_eq!(mdf.month(), month);
+                            assert_eq!(mdf.day(), day);
+                        }
+                        None if month > 12 => continue,
+                        None => panic!("failed to create Mdf with month {}", month),
+                    };
                 }
+
+                for day in range_inclusive(0u32, 1024) {
+                    match mdf.with_day(day) {
+                        Some(mdf) => {
+                            assert_eq!(mdf.month(), month);
+                            assert_eq!(mdf.day(), day);
+                        }
+                        None if day > 31 => continue,
+                        None => panic!("failed to create Mdf with month {}", month),
+                    };
+                }
+            } else if should_succeed {
+                panic!("Mdf creation should have succeed but instead failed from: {:?} month {} day {}", flags, month, day);
             }
         }
 
         for &flags in NONLEAP_FLAGS.iter() {
-            check(flags, 1, 1);
-            check(flags, 1, 31);
-            check(flags, 2, 1);
-            check(flags, 2, 28);
-            check(flags, 2, 29);
-            check(flags, 12, 31);
+            check(true, flags, 1, 1);
+            check(true, flags, 1, 31);
+            check(true, flags, 2, 1);
+            check(true, flags, 2, 28);
+            check(false, flags, 2, 29);
+            check(true, flags, 12, 31);
         }
         for &flags in LEAP_FLAGS.iter() {
-            check(flags, 1, 1);
-            check(flags, 1, 31);
-            check(flags, 2, 1);
-            check(flags, 2, 29);
-            check(flags, 2, 30);
-            check(flags, 12, 31);
+            check(true, flags, 1, 1);
+            check(true, flags, 1, 31);
+            check(true, flags, 2, 1);
+            check(true, flags, 2, 29);
+            check(false, flags, 2, 30);
+            check(true, flags, 12, 31);
         }
     }
 
@@ -779,37 +863,27 @@ mod tests {
     }
 
     #[test]
-    fn test_of_to_mdf() {
-        for i in range_inclusive(0u32, 8192) {
-            let of = Of(i);
-            assert_eq!(of.valid(), of.to_mdf().valid());
-        }
-    }
-
-    #[test]
-    fn test_mdf_to_of() {
-        for i in range_inclusive(0u32, 8192) {
-            let mdf = Mdf(i);
-            assert_eq!(mdf.valid(), mdf.to_of().valid());
-        }
-    }
-
-    #[test]
-    fn test_of_to_mdf_to_of() {
-        for i in range_inclusive(0u32, 8192) {
-            let of = Of(i);
-            if of.valid() {
-                assert_eq!(of, of.to_mdf().to_of());
+    fn test_of_to_mdf_roundtrip() {
+        for flags in FLAGS.iter() {
+            for ordinal in 1..=366 {
+                assert_eq!(
+                    Of::new(ordinal, *flags).map(Of::to_mdf).and_then(Mdf::to_of),
+                    Of::new(ordinal, *flags),
+                );
             }
         }
     }
 
     #[test]
-    fn test_mdf_to_of_to_mdf() {
-        for i in range_inclusive(0u32, 8192) {
-            let mdf = Mdf(i);
-            if mdf.valid() {
-                assert_eq!(mdf, mdf.to_of().to_mdf());
+    fn test_mdf_to_of_roundtrip() {
+        for flags in FLAGS.iter() {
+            for month in 1..=12 {
+                for day in 1..=31 {
+                    assert_eq!(
+                        Mdf::new(month, day, *flags).and_then(Mdf::to_of).map(Of::to_mdf),
+                        Mdf::new(month, day, *flags),
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
My goals here are:
* Move any bitwise and other "internal" style operations into internals.rs (this could be split to modules later)
* Use only methods on the types from internals in naive/date.rs and naive/week.rs
* Given the Mdf::new and Of::new functions return an option, do the validation in the constructor