### PR TITLE
add backticks in docs

### DIFF
--- a/src/datetime/rustc_serialize.rs
+++ b/src/datetime/rustc_serialize.rs
@@ -58,7 +58,7 @@ pub struct TsSeconds<Tz: TimeZone>(DateTime<Tz>);
 
 #[allow(deprecated)]
 impl<Tz: TimeZone> From<TsSeconds<Tz>> for DateTime<Tz> {
-    /// Pull the inner DateTime<Tz> out
+    /// Pull the inner `DateTime<Tz>` out
     #[allow(deprecated)]
     fn from(obj: TsSeconds<Tz>) -> DateTime<Tz> {
         obj.0

--- a/src/month.rs
+++ b/src/month.rs
@@ -153,7 +153,7 @@ impl Month {
 }
 
 impl num_traits::FromPrimitive for Month {
-    /// Returns an Option<Month> from a i64, assuming a 1-index, January = 1.
+    /// Returns an `Option<Month>` from a i64, assuming a 1-index, January = 1.
     ///
     /// `Month::from_i64(n: i64)`: | `1`                  | `2`                   | ... | `12`
     /// ---------------------------| -------------------- | --------------------- | ... | -----


### PR DESCRIPTION
This is causing CI failures in a few PRs. One of the open PRs may choose to just fix this, but otherwise this could be merged and they can rebase 