### PR TITLE
Impl Arbitrary for Naive{Date,Time,DateTime}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ pure-rust-locales = { version = "0.5.2", optional = true }
 criterion = { version = "0.4.0", optional = true }
 rkyv = {version = "0.7", optional = true}
 iana-time-zone = { version = "0.1.44", optional = true, features = ["fallback"] }
+arbitrary = { version = "1.0.0", features = ["derive"], optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 wasm-bindgen = { version = "0.2", optional = true }

--- a/ci/github.sh
+++ b/ci/github.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 source "${BASH_SOURCE[0]%/*}/_shlib.sh"
 
 TEST_TZS=(ACST-9:30 EST4 UTC0 Asia/Katmandu)
-FEATURES=(std serde clock "alloc serde" unstable-locales)
+FEATURES=(std serde clock "alloc serde" unstable-locales arbitrary)
 CHECK_FEATURES=(alloc "std unstable-locales" "serde clock" "clock unstable-locales")
 RUST_132_FEATURES=(serde)
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -191,6 +191,15 @@ pub const MIN_DATE: NaiveDate = NaiveDate::MIN;
 #[deprecated(since = "0.4.20", note = "Use NaiveDate::MAX instead")]
 pub const MAX_DATE: NaiveDate = NaiveDate::MAX;
 
+#[cfg(feature = "arbitrary")]
+impl arbitrary::Arbitrary<'_> for NaiveDate {
+    fn arbitrary(u: &mut arbitrary::Unstructured) -> arbitrary::Result<NaiveDate> {
+        let year = u.int_in_range(MIN_YEAR..=MAX_YEAR)?;
+        let ord = u.int_in_range(1..=366)?;
+        NaiveDate::from_yo_opt(year, ord).ok_or(arbitrary::Error::IncorrectFormat)
+    }
+}
+
 // as it is hard to verify year flags in `NaiveDate::MIN` and `NaiveDate::MAX`,
 // we use a separate run-time test.
 #[test]

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -195,7 +195,8 @@ pub const MAX_DATE: NaiveDate = NaiveDate::MAX;
 impl arbitrary::Arbitrary<'_> for NaiveDate {
     fn arbitrary(u: &mut arbitrary::Unstructured) -> arbitrary::Result<NaiveDate> {
         let year = u.int_in_range(MIN_YEAR..=MAX_YEAR)?;
-        let ord = u.int_in_range(1..=366)?;
+        let max_days = YearFlags::from_year(year).ndays();
+        let ord = u.int_in_range(1..=max_days)?;
         NaiveDate::from_yo_opt(year, ord).ok_or(arbitrary::Error::IncorrectFormat)
     }
 }

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -74,6 +74,7 @@ pub const MAX_DATETIME: NaiveDateTime = NaiveDateTime::MAX;
 /// ```
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone)]
 #[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct NaiveDateTime {
     date: NaiveDate,
     time: NaiveTime,

--- a/src/naive/time/arbitrary.rs
+++ b/src/naive/time/arbitrary.rs
@@ -1,0 +1,44 @@
+#![cfg_attr(docsrs, doc(cfg(feature = "arbitrary")))]
+
+use super::NaiveTime;
+use arbitrary::{Arbitrary, Unstructured};
+
+impl Arbitrary<'_> for NaiveTime {
+    fn arbitrary(u: &mut Unstructured) -> arbitrary::Result<NaiveTime> {
+        let secs = u.int_in_range(0..=86_399)?;
+        let nano = u.int_in_range(0..=1_999_999_999)?;
+        let time = NaiveTime::from_num_seconds_from_midnight_opt(secs, nano)
+            .expect("Could not generate a valid chrono::NaiveTime. It looks like implementation of Arbitrary for NaiveTime is erroneous.");
+        Ok(time)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const UNSTRCUTURED_BINARY1: [u8; 8] = [0x8f, 0xc2, 0x95, 0xdc, 0x3e, 0x45, 0xb2, 0x3e];
+    const UNSTRCUTURED_BINARY2: [u8; 8] = [0x8b, 0xad, 0x2c, 0xc9, 0xf0, 0x05, 0x75, 0x84];
+
+    #[test]
+    fn test_different_unstructured() {
+        let mut unstrctured1 = Unstructured::new(&UNSTRCUTURED_BINARY1);
+        let time1 = NaiveTime::arbitrary(&mut unstrctured1).unwrap();
+
+        let mut unstrctured2 = Unstructured::new(&UNSTRCUTURED_BINARY2);
+        let time2 = NaiveTime::arbitrary(&mut unstrctured2).unwrap();
+
+        assert_ne!(time1, time2);
+    }
+
+    #[test]
+    fn test_same_unstructured() {
+        let mut unstrctured1 = Unstructured::new(&UNSTRCUTURED_BINARY1);
+        let time1 = NaiveTime::arbitrary(&mut unstrctured1).unwrap();
+
+        let mut unstrctured2 = Unstructured::new(&UNSTRCUTURED_BINARY1);
+        let time2 = NaiveTime::arbitrary(&mut unstrctured2).unwrap();
+
+        assert_eq!(time1, time2);
+    }
+}

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -21,6 +21,9 @@ use crate::{TimeDelta, Timelike};
 #[cfg(feature = "serde")]
 mod serde;
 
+#[cfg(feature = "arbitrary")]
+mod arbitrary;
+
 #[cfg(test)]
 mod tests;
 
@@ -188,17 +191,6 @@ mod tests;
 pub struct NaiveTime {
     secs: u32,
     frac: u32,
-}
-
-#[cfg(feature = "arbitrary")]
-impl arbitrary::Arbitrary<'_> for NaiveTime {
-    fn arbitrary(u: &mut arbitrary::Unstructured) -> arbitrary::Result<NaiveTime> {
-        let secs = u.int_in_range(0..=86_399)?;
-        let nano = u.int_in_range(0..=1_999_999_999)?;
-        let time = NaiveTime::from_num_seconds_from_midnight_opt(secs, nano)
-            .expect("Could not generate a valid chrono::NaiveTime. It looks like implementation of Arbitrary for NaiveTime is erroneous.");
-        Ok(time)
-    }
 }
 
 impl NaiveTime {

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -190,6 +190,15 @@ pub struct NaiveTime {
     frac: u32,
 }
 
+#[cfg(feature = "arbitrary")]
+impl arbitrary::Arbitrary<'_> for NaiveTime {
+    fn arbitrary(u: &mut arbitrary::Unstructured) -> arbitrary::Result<NaiveTime> {
+        let secs = u.int_in_range(0..=86_400)?;
+        let frac = u.int_in_range(0..=2_000_000_000)?;
+        Ok(NaiveTime { secs, frac })
+    }
+}
+
 impl NaiveTime {
     /// Makes a new `NaiveTime` from hour, minute and second.
     ///

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -193,9 +193,11 @@ pub struct NaiveTime {
 #[cfg(feature = "arbitrary")]
 impl arbitrary::Arbitrary<'_> for NaiveTime {
     fn arbitrary(u: &mut arbitrary::Unstructured) -> arbitrary::Result<NaiveTime> {
-        let secs = u.int_in_range(0..=86_400)?;
-        let frac = u.int_in_range(0..=2_000_000_000)?;
-        Ok(NaiveTime { secs, frac })
+        let secs = u.int_in_range(0..=86_399)?;
+        let nano = u.int_in_range(0..=1_999_999_999)?;
+        let time = NaiveTime::from_num_seconds_from_midnight_opt(secs, nano)
+            .expect("Could not generate a valid chrono::NaiveTime. It looks like implementation of Arbitrary for NaiveTime is erroneous.");
+        Ok(time)
     }
 }
 


### PR DESCRIPTION
I'd love to see https://github.com/chronotope/chrono/pull/559 moving forward, but looks like @asayers has no time to address the code review right now. 
Since I am very interested in the support of `Arbitrary` I've decided to cherry pick his commit and address the code review.

## What is in this PR:
* Implementation of `Arbitrary` behind feature flag for `NaiveDate`, `NaiveTime`, `NaiveDateTime`.
* Unit tests for `NaiveDate` and `NaiveTime` (no unit test for `NaiveDateTime`, since it's implementation of `Arbitrary` is derived)
* The implementation and tests are placed into `arbitrary` modules (in the same fashion like it's done with `serde`)

## Considerations

Despite 
```rust
let ord = u.int_in_range(1..=366)?;
```
 does not make large difference when constructing `NaiveDate` as @djc mentioned, I've decided to use `YearFlags`, so the both implementations for `NaiveDate` and `NaiveTime` are implemented in similar infallible fashion.