### PR TITLE
Allow for changing TZ vairable and cache it for Local timezone

### DIFF
--- a/benches/chrono.rs
+++ b/benches/chrono.rs
@@ -4,7 +4,7 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use chrono::prelude::*;
-use chrono::{DateTime, FixedOffset, Utc, __BenchYearFlags};
+use chrono::{DateTime, FixedOffset, Local, Utc, __BenchYearFlags};
 
 fn bench_datetime_parse_from_rfc2822(c: &mut Criterion) {
     c.bench_function("bench_datetime_parse_from_rfc2822", |b| {
@@ -52,6 +52,14 @@ fn bench_year_flags_from_year(c: &mut Criterion) {
             for year in -999i32..1000 {
                 __BenchYearFlags::from_year(year);
             }
+        })
+    });
+}
+
+fn bench_get_local_time(c: &mut Criterion) {
+    c.bench_function("bench_get_local_time", |b| {
+        b.iter(|| {
+            let _ = Local::now();
         })
     });
 }
@@ -109,6 +117,7 @@ criterion_group!(
     bench_datetime_to_rfc3339,
     bench_year_flags_from_year,
     bench_num_days_from_ce,
+    bench_get_local_time,
 );
 
 criterion_main!(benches);

--- a/src/offset/local/tz_info/timezone.rs
+++ b/src/offset/local/tz_info/timezone.rs
@@ -26,11 +26,10 @@ impl TimeZone {
     ///
     /// This method in not supported on non-UNIX platforms, and returns the UTC time zone instead.
     ///
-    pub(crate) fn local() -> Result<Self, Error> {
-        if let Ok(tz) = std::env::var("TZ") {
-            Self::from_posix_tz(&tz)
-        } else {
-            Self::from_posix_tz("localtime")
+    pub(crate) fn local(env_tz: Option<&str>) -> Result<Self, Error> {
+        match env_tz {
+            Some(tz) => Self::from_posix_tz(tz),
+            None => Self::from_posix_tz("localtime"),
         }
     }
 
@@ -813,7 +812,7 @@ mod tests {
             // so just ensure that ::local() acts as expected
             // in this case
             if let Ok(tz) = std::env::var("TZ") {
-                let time_zone_local = TimeZone::local()?;
+                let time_zone_local = TimeZone::local(Some(tz.as_str()))?;
                 let time_zone_local_1 = TimeZone::from_posix_tz(&tz)?;
                 assert_eq!(time_zone_local, time_zone_local_1);
             }


### PR DESCRIPTION
This should solve https://github.com/chronotope/chrono/issues/834.

As discussed, I've done some basic benchmarks, and it seems that this has minimal effect on the standard `/etc/localtime` case, while being around 3% more expensive in the TZ variable case. However this seems justified as this now allows for the TZ variable to change.

### empty TZ variable, timezone is a symlink at `/etc/localtime`

Before (e0b16e9c…):
```
bench_get_local_time    time:   [79.480 ns 79.692 ns 79.923 ns]
```

After (360478ce…):
```
bench_get_local_time    time:   [79.232 ns 79.383 ns 79.556 ns]
```

### with TZ variable


Before (e0b16e9c…):
```
bench_get_local_time    time:   [77.322 ns 77.664 ns 78.002 ns]
```

After (360478ce…):
```
bench_get_local_time    time:   [79.711 ns 79.921 ns 80.155 ns]
```