### PR TITLE
Add method for computing ratio of two TimeDeltas

### DIFF
--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -706,7 +706,18 @@ mod tests {
         assert_eq!(TimeDelta::hours(5) / TimeDelta::minutes(15), 20.0);
         assert_eq!(TimeDelta::microseconds(20) / TimeDelta::microseconds(4), 5.0);
         assert_eq!(TimeDelta::hours(2) / TimeDelta::nanoseconds(3), 2.4e12);
-        assert_eq!(TimeDelta::nanoseconds(1) / TimeDelta::nanoseconds(1 << 30), 1.0 / (1024.0 * 1024.0 * 1024.0));
+        assert_eq!(
+            TimeDelta::days(2000) / TimeDelta::nanoseconds(3),
+            (2000.0 * 28800.0 * 1e9)
+        );
+        assert_eq!(
+            TimeDelta::weeks(-4000) / TimeDelta::nanoseconds(2),
+            (-4000.0 * 7.0 * 43200.0 * 1e9)
+        );
+        assert_eq!(
+            TimeDelta::nanoseconds(1) / TimeDelta::nanoseconds(1 << 30),
+            1.0 / (1024.0 * 1024.0 * 1024.0)
+        );
     }
 
     #[test]


### PR DESCRIPTION
This pull-request adds a method for dividing two TimeDeltas, returning the result as a floating point number. This can be useful for quantizing a DateTime instance relative to a given epoch, for example finding the nearest 45-second interval from a start time of 12:30. The method attempts to minimize round-off error by converting the TimeDelta into either seconds or nanoseconds using two new helper methods `as_seconds()` and `as_nanoseconds()` which also return `f64` types. Some basic unit-tests are also included.