### PR TITLE
Fix doc on Days::new to refer to days, not months.

### DIFF
--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -124,7 +124,7 @@ impl NaiveWeek {
 pub struct Days(pub(crate) u64);
 
 impl Days {
-    /// Construct a new `Days` from a number of months
+    /// Construct a new `Days` from a number of days
     pub fn new(num: u64) -> Self {
         Self(num)
     }


### PR DESCRIPTION
This fixes chronotope/chrono#871

### Thanks for contributing to chrono!

If your feature is semver-compatible, please target the 0.4.x branch;
the main branch will be used for 0.5.0 development going forward.

Please consider adding a test to ensure your bug fix/feature will not break in the future.
