### PR TITLE
Serde serialize improvements

### DIFF
--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -2,7 +2,7 @@
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-use chrono::NaiveDateTime;
+use chrono::{NaiveDate, NaiveDateTime};
 
 fn bench_ser_naivedatetime_string(c: &mut Criterion) {
     c.bench_function("bench_ser_naivedatetime_string", |b| {
@@ -25,5 +25,32 @@ fn bench_ser_naivedatetime_writer(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_ser_naivedatetime_writer, bench_ser_naivedatetime_string);
+fn bench_ser_naivedate_string(c: &mut Criterion) {
+    c.bench_function("bench_ser_naivedate_string", |b| {
+        let dt: NaiveDate = "1999-11-11".parse().unwrap();
+        b.iter(|| {
+            black_box(serde_json::to_string(&dt)).unwrap();
+        });
+    });
+}
+
+fn bench_ser_naivedate_writer(c: &mut Criterion) {
+    c.bench_function("bench_ser_naivedate_writer", |b| {
+        let mut s: Vec<u8> = Vec::with_capacity(20);
+        let dt: NaiveDate = "1999-11-11".parse().unwrap();
+        b.iter(|| {
+            let s = &mut s;
+            s.clear();
+            black_box(serde_json::to_writer(s, &dt)).unwrap();
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_ser_naivedatetime_writer,
+    bench_ser_naivedatetime_string,
+    bench_ser_naivedate_writer,
+    bench_ser_naivedate_string
+);
 criterion_main!(benches);

--- a/src/month.rs
+++ b/src/month.rs
@@ -227,7 +227,7 @@ mod month_serde {
         where
             S: ser::Serializer,
         {
-            serializer.collect_str(self.name())
+            serializer.serialize_str(self.name())
         }
     }
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -2054,17 +2054,7 @@ mod serde {
         where
             S: ser::Serializer,
         {
-            struct FormatWrapped<'a, D: 'a> {
-                inner: &'a D,
-            }
-
-            impl<'a, D: fmt::Debug> fmt::Display for FormatWrapped<'a, D> {
-                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                    self.inner.fmt(f)
-                }
-            }
-
-            serializer.collect_str(&FormatWrapped { inner: &self })
+            serializer.serialize_str(&self.to_string())
         }
     }
 

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -15,17 +15,7 @@ impl ser::Serialize for NaiveDateTime {
     where
         S: ser::Serializer,
     {
-        struct FormatWrapped<'a, D: 'a> {
-            inner: &'a D,
-        }
-
-        impl<'a, D: fmt::Debug> fmt::Display for FormatWrapped<'a, D> {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                self.inner.fmt(f)
-            }
-        }
-
-        serializer.collect_str(&FormatWrapped { inner: &self })
+        serializer.serialize_str(&self.to_string())
     }
 }
 

--- a/src/naive/time/serde.rs
+++ b/src/naive/time/serde.rs
@@ -12,7 +12,7 @@ impl ser::Serialize for NaiveTime {
     where
         S: ser::Serializer,
     {
-        serializer.collect_str(&self)
+        serializer.serialize_str(&self.to_string())
     }
 }
 

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -222,7 +222,7 @@ mod weekday_serde {
         where
             S: ser::Serializer,
         {
-            serializer.collect_str(&self)
+            serializer.serialize_str(&self.to_string())
         }
     }
 


### PR DESCRIPTION
Noticed that this change made a significant improvement in serde::Serialize timings (on my machine at least). I'm surprised this worked so it might be good to see if this can be replicated elsewhere before it gets merged

After 431988f

```
    Finished bench [optimized] target(s) in 0.02s
     Running unittests src/lib.rs (target/release/deps/chrono-e1dcaaaa10e3f11a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 177 filtered out; finished in 0.00s

     Running benches/chrono.rs (target/release/deps/chrono-ca1f633a26e467d4)
     Running benches/serde.rs (target/release/deps/serde-5c35e4d9face791b)
bench_ser_naivedatetime_writer
                        time:   [101.42 ns 101.76 ns 102.11 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

bench_ser_naivedatetime_string
                        time:   [108.30 ns 108.59 ns 108.84 ns]

bench_ser_naivedate_writer
                        time:   [55.041 ns 55.269 ns 55.477 ns]

bench_ser_naivedate_string
                        time:   [60.872 ns 61.116 ns 61.352 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

After f26c2a9

```
   Compiling chrono v0.4.23 (/var/home/eric/Repos/chrono)
    Finished bench [optimized] target(s) in 3.53s
     Running unittests src/lib.rs (target/release/deps/chrono-e1dcaaaa10e3f11a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 177 filtered out; finished in 0.00s

     Running benches/chrono.rs (target/release/deps/chrono-ca1f633a26e467d4)
     Running benches/serde.rs (target/release/deps/serde-5c35e4d9face791b)
bench_ser_naivedatetime_writer
                        time:   [76.851 ns 77.143 ns 77.406 ns]
                        change: [-25.180% -24.792% -24.424%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

bench_ser_naivedatetime_string
                        time:   [86.622 ns 86.961 ns 87.260 ns]
                        change: [-20.409% -19.997% -19.609%] (p = 0.00 < 0.05)
                        Performance has improved.

bench_ser_naivedate_writer
                        time:   [42.930 ns 43.114 ns 43.292 ns]
                        change: [-22.248% -21.797% -21.343%] (p = 0.00 < 0.05)
                        Performance has improved.

bench_ser_naivedate_string
                        time:   [51.183 ns 51.308 ns 51.424 ns]
                        change: [-16.972% -16.516% -16.079%] (p = 0.00 < 0.05)
                        Performance has improved.
```
