### PR TITLE
Clarify out of range value for from_timestamp_opt

### DIFF
--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -174,7 +174,8 @@ impl NaiveDateTime {
     /// in order to represent the [leap second](./struct.NaiveTime.html#leap-second-handling).
     /// (The true "UNIX timestamp" cannot represent a leap second unambiguously.)
     ///
-    /// Returns `None` on the out-of-range number of seconds and/or invalid nanosecond.
+    /// Returns `None` on the out-of-range number of seconds (more than 262 000 years away
+    /// from common era) and/or invalid nanosecond (2 seconds or more).
     ///
     /// # Example
     ///


### PR DESCRIPTION
The limits on the secs count has to be hunted down to the bottom of the readme / root document, which is a bit annoying when e.g. migrating from the deprecated `from_timestamp` and wondering why `from_timestamp_opt` is fallible.

The nsecs limits can be inferred from the rest of the text but explicit is better than implicit.
