### PR TITLE
make NaiveTime::MIN public

### DIFF
--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -752,7 +752,8 @@ impl NaiveTime {
         (hour, min, sec)
     }
 
-    pub(super) const MIN: Self = Self { secs: 0, frac: 0 };
+    /// The earliest possible `NaiveTime`
+    pub const MIN: Self = Self { secs: 0, frac: 0 };
     pub(super) const MAX: Self = Self { secs: 23 * 3600 + 59 * 60 + 59, frac: 999_999_999 };
 }
 


### PR DESCRIPTION
This will be useful in `NaiveDateTime::new` and `NaiveDate::and_time` in reducing the amount of times that users have to use the fallible APIs.

This could potentially be extended with:
* More consts, eg `NaiveTime::H1` thru `NaiveTime::H23`
* An infallible `NaiveTime` constructor that takes an enum `Hour` and enum `Minute` potentially enum `Second`.