### PR TITLE
Fix inconsistent documentation for chrono::naive::Days::new

### DIFF
--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -124,7 +124,7 @@ impl NaiveWeek {
 pub struct Days(pub(crate) u64);
 
 impl Days {
-    /// Construct a new `Days` from a number of months
+    /// Construct a new `Days` from a number of days
     pub fn new(num: u64) -> Self {
         Self(num)
     }


### PR DESCRIPTION
A very simple change to the docs of [chrono::naive::Days::new](https://github.com/chronotope/chrono/blob/2aa222112999df57d063b60510f02cc0e7ee4e7f/src/naive/date.rs#L128) to avoid confusion

While this is a semver compatible change, there seems to be a regression in the docs, as the 4.x branch correctly states that the number refers to days, therefore this targets the main branch.

Closes #891 