### PR TITLE
Make StrftimeItems::new return Result

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -21,6 +21,7 @@ use crate::naive::{IsoWeek, NaiveDate, NaiveTime};
 use crate::offset::{TimeZone, Utc};
 use crate::time_delta::TimeDelta;
 use crate::DateTime;
+use crate::ParseError;
 use crate::{Datelike, Weekday};
 
 /// ISO 8601 calendar date with time zone.
@@ -353,9 +354,8 @@ where
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
-    #[must_use]
-    pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
-        self.format_with_items(StrftimeItems::new(fmt))
+    pub fn format<'a>(&self, fmt: &'a str) -> Result<DelayedFormat<StrftimeItems<'a>>, ParseError> {
+        Ok(self.format_with_items(StrftimeItems::new(fmt)?))
     }
 
     /// Formats the date with the specified formatting items and locale.
@@ -392,8 +392,8 @@ where
         &self,
         fmt: &'a str,
         locale: Locale,
-    ) -> DelayedFormat<StrftimeItems<'a>> {
-        self.format_localized_with_items(StrftimeItems::new_with_locale(fmt, locale), locale)
+    ) -> Result<DelayedFormat<StrftimeItems<'a>>, ParseError> {
+        Ok(self.format_localized_with_items(StrftimeItems::new_with_locale(fmt, locale)?, locale))
     }
 }
 
@@ -668,5 +668,11 @@ mod tests {
 
         date_sub -= TimeDelta::days(5);
         assert_eq!(date_sub, date - TimeDelta::days(5));
+    }
+
+    #[test]
+    fn test_invalid_format() {
+        let result = Utc::now().format("%");
+        assert!(result.is_err(), "Invalid format string should be format error")
     }
 }

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1156,7 +1156,10 @@ fn test_to_string_round_trip_with_local() {
 fn test_datetime_format_with_local() {
     // if we are not around the year boundary, local and UTC date should have the same year
     let dt = Local::now().with_month(5).unwrap();
-    assert_eq!(dt.format("%Y").to_string(), dt.with_timezone(&Utc).format("%Y").to_string());
+    assert_eq!(
+        dt.format("%Y").unwrap().to_string(),
+        dt.with_timezone(&Utc).format("%Y").unwrap().to_string()
+    );
 }
 
 #[test]
@@ -1347,25 +1350,25 @@ fn test_datetime_format_alignment() {
     let datetime = Utc.with_ymd_and_hms(2007, 1, 2, 0, 0, 0).unwrap();
 
     // Item::Literal
-    let percent = datetime.format("%%");
+    let percent = datetime.format("%%").unwrap();
     assert_eq!("  %", format!("{:>3}", percent));
     assert_eq!("%  ", format!("{:<3}", percent));
     assert_eq!(" % ", format!("{:^3}", percent));
 
     // Item::Numeric
-    let year = datetime.format("%Y");
+    let year = datetime.format("%Y").unwrap();
     assert_eq!("  2007", format!("{:>6}", year));
     assert_eq!("2007  ", format!("{:<6}", year));
     assert_eq!(" 2007 ", format!("{:^6}", year));
 
     // Item::Fixed
-    let tz = datetime.format("%Z");
+    let tz = datetime.format("%Z").unwrap();
     assert_eq!("  UTC", format!("{:>5}", tz));
     assert_eq!("UTC  ", format!("{:<5}", tz));
     assert_eq!(" UTC ", format!("{:^5}", tz));
 
     // [Item::Numeric, Item::Space, Item::Literal, Item::Space, Item::Numeric]
-    let ymd = datetime.format("%Y %B %d");
+    let ymd = datetime.format("%Y %B %d").unwrap();
     let ymd_formatted = "2007 January 02";
     assert_eq!(format!("  {}", ymd_formatted), format!("{:>17}", ymd));
     assert_eq!(format!("{}  ", ymd_formatted), format!("{:<17}", ymd));

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -22,7 +22,7 @@
 //!
 //! let date_time = Utc.with_ymd_and_hms(2020, 11, 10, 0, 1, 32).unwrap();
 //!
-//! let formatted = format!("{}", date_time.format("%Y-%m-%d %H:%M:%S"));
+//! let formatted = format!("{}", date_time.format("%Y-%m-%d %H:%M:%S").unwrap());
 //! assert_eq!(formatted, "2020-11-10 00:01:32");
 //!
 //! let parsed = Utc.datetime_from_str(&formatted, "%Y-%m-%d %H:%M:%S")?;

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -1472,7 +1472,7 @@ fn parse_rfc850() {
     let dt = Utc.with_ymd_and_hms(1994, 11, 6, 8, 49, 37).unwrap();
 
     // Check that the format is what we expect
-    assert_eq!(dt.format(RFC850_FMT).to_string(), dt_str);
+    assert_eq!(dt.format(RFC850_FMT).unwrap().to_string(), dt_str);
 
     // Check that it parses correctly
     assert_eq!(Ok(dt), Utc.datetime_from_str("Sunday, 06-Nov-94 08:49:37 GMT", RFC850_FMT));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,11 +218,11 @@
 //! # #[cfg(feature = "unstable-locales")]
 //! # fn test() {
 //! let dt = Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap();
-//! assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2014-11-28 12:00:09");
-//! assert_eq!(dt.format("%a %b %e %T %Y").to_string(), "Fri Nov 28 12:00:09 2014");
-//! assert_eq!(dt.format_localized("%A %e %B %Y, %T", Locale::fr_BE).to_string(), "vendredi 28 novembre 2014, 12:00:09");
+//! assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").unwrap().to_string(), "2014-11-28 12:00:09");
+//! assert_eq!(dt.format("%a %b %e %T %Y").unwrap().to_string(), "Fri Nov 28 12:00:09 2014");
+//! assert_eq!(dt.format_localized("%A %e %B %Y, %T", Locale::fr_BE).unwrap().to_string(), "vendredi 28 novembre 2014, 12:00:09");
 //!
-//! assert_eq!(dt.format("%a %b %e %T %Y").to_string(), dt.format("%c").to_string());
+//! assert_eq!(dt.format("%a %b %e %T %Y").unwrap().to_string(), dt.format("%c").unwrap().to_string());
 //! assert_eq!(dt.to_string(), "2014-11-28 12:00:09 UTC");
 //! assert_eq!(dt.to_rfc2822(), "Fri, 28 Nov 2014 12:00:09 +0000");
 //! assert_eq!(dt.to_rfc3339(), "2014-11-28T12:00:09+00:00");

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -20,7 +20,7 @@ fn test_datetime_from_timestamp_millis() {
     for (timestamp_millis, formatted) in valid_map.iter().copied() {
         let naive_datetime = NaiveDateTime::from_timestamp_millis(timestamp_millis);
         assert_eq!(timestamp_millis, naive_datetime.unwrap().timestamp_millis());
-        assert_eq!(naive_datetime.unwrap().format("%F %T%.9f").to_string(), formatted);
+        assert_eq!(naive_datetime.unwrap().format("%F %T%.9f").unwrap().to_string(), formatted);
     }
 
     let invalid = [i64::MAX, i64::MIN];
@@ -57,7 +57,7 @@ fn test_datetime_from_timestamp_micros() {
     for (timestamp_micros, formatted) in valid_map.iter().copied() {
         let naive_datetime = NaiveDateTime::from_timestamp_micros(timestamp_micros);
         assert_eq!(timestamp_micros, naive_datetime.unwrap().timestamp_micros());
-        assert_eq!(naive_datetime.unwrap().format("%F %T%.9f").to_string(), formatted);
+        assert_eq!(naive_datetime.unwrap().format("%F %T%.9f").unwrap().to_string(), formatted);
     }
 
     let invalid = [i64::MAX, i64::MIN];
@@ -329,15 +329,15 @@ fn test_datetime_parse_from_str() {
 #[test]
 fn test_datetime_format() {
     let dt = NaiveDate::from_ymd_opt(2010, 9, 8).unwrap().and_hms_milli_opt(7, 6, 54, 321).unwrap();
-    assert_eq!(dt.format("%c").to_string(), "Wed Sep  8 07:06:54 2010");
-    assert_eq!(dt.format("%s").to_string(), "1283929614");
-    assert_eq!(dt.format("%t%n%%%n%t").to_string(), "\t\n%\n\t");
+    assert_eq!(dt.format("%c").unwrap().to_string(), "Wed Sep  8 07:06:54 2010");
+    assert_eq!(dt.format("%s").unwrap().to_string(), "1283929614");
+    assert_eq!(dt.format("%t%n%%%n%t").unwrap().to_string(), "\t\n%\n\t");
 
     // a horror of leap second: coming near to you.
     let dt =
         NaiveDate::from_ymd_opt(2012, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_000).unwrap();
-    assert_eq!(dt.format("%c").to_string(), "Sat Jun 30 23:59:60 2012");
-    assert_eq!(dt.format("%s").to_string(), "1341100799"); // not 1341100800, it's intentional.
+    assert_eq!(dt.format("%c").unwrap().to_string(), "Sat Jun 30 23:59:60 2012");
+    assert_eq!(dt.format("%s").unwrap().to_string(), "1341100799"); // not 1341100800, it's intentional.
 }
 
 #[test]

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -158,12 +158,12 @@ mod tests {
         assert_eq!(minweek.year(), internals::MIN_YEAR);
         assert_eq!(minweek.week(), 1);
         assert_eq!(minweek.week0(), 0);
-        assert_eq!(format!("{:?}", minweek), NaiveDate::MIN.format("%G-W%V").to_string());
+        assert_eq!(format!("{:?}", minweek), NaiveDate::MIN.format("%G-W%V").unwrap().to_string());
 
         assert_eq!(maxweek.year(), internals::MAX_YEAR + 1);
         assert_eq!(maxweek.week(), 1);
         assert_eq!(maxweek.week0(), 0);
-        assert_eq!(format!("{:?}", maxweek), NaiveDate::MAX.format("%G-W%V").to_string());
+        assert_eq!(format!("{:?}", maxweek), NaiveDate::MAX.format("%G-W%V").unwrap().to_string());
     }
 
     #[test]

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -348,31 +348,34 @@ fn test_time_parse_from_str() {
 #[test]
 fn test_time_format() {
     let t = NaiveTime::from_hms_nano_opt(3, 5, 7, 98765432).unwrap();
-    assert_eq!(t.format("%H,%k,%I,%l,%P,%p").to_string(), "03, 3,03, 3,am,AM");
-    assert_eq!(t.format("%M").to_string(), "05");
-    assert_eq!(t.format("%S,%f,%.f").to_string(), "07,098765432,.098765432");
-    assert_eq!(t.format("%.3f,%.6f,%.9f").to_string(), ".098,.098765,.098765432");
-    assert_eq!(t.format("%R").to_string(), "03:05");
-    assert_eq!(t.format("%T,%X").to_string(), "03:05:07,03:05:07");
-    assert_eq!(t.format("%r").to_string(), "03:05:07 AM");
-    assert_eq!(t.format("%t%n%%%n%t").to_string(), "\t\n%\n\t");
+    assert_eq!(t.format("%H,%k,%I,%l,%P,%p").unwrap().to_string(), "03, 3,03, 3,am,AM");
+    assert_eq!(t.format("%M").unwrap().to_string(), "05");
+    assert_eq!(t.format("%S,%f,%.f").unwrap().to_string(), "07,098765432,.098765432");
+    assert_eq!(t.format("%.3f,%.6f,%.9f").unwrap().to_string(), ".098,.098765,.098765432");
+    assert_eq!(t.format("%R").unwrap().to_string(), "03:05");
+    assert_eq!(t.format("%T,%X").unwrap().to_string(), "03:05:07,03:05:07");
+    assert_eq!(t.format("%r").unwrap().to_string(), "03:05:07 AM");
+    assert_eq!(t.format("%t%n%%%n%t").unwrap().to_string(), "\t\n%\n\t");
 
     let t = NaiveTime::from_hms_micro_opt(3, 5, 7, 432100).unwrap();
-    assert_eq!(t.format("%S,%f,%.f").to_string(), "07,432100000,.432100");
-    assert_eq!(t.format("%.3f,%.6f,%.9f").to_string(), ".432,.432100,.432100000");
+    assert_eq!(t.format("%S,%f,%.f").unwrap().to_string(), "07,432100000,.432100");
+    assert_eq!(t.format("%.3f,%.6f,%.9f").unwrap().to_string(), ".432,.432100,.432100000");
 
     let t = NaiveTime::from_hms_milli_opt(3, 5, 7, 210).unwrap();
-    assert_eq!(t.format("%S,%f,%.f").to_string(), "07,210000000,.210");
-    assert_eq!(t.format("%.3f,%.6f,%.9f").to_string(), ".210,.210000,.210000000");
+    assert_eq!(t.format("%S,%f,%.f").unwrap().to_string(), "07,210000000,.210");
+    assert_eq!(t.format("%.3f,%.6f,%.9f").unwrap().to_string(), ".210,.210000,.210000000");
 
     let t = NaiveTime::from_hms_opt(3, 5, 7).unwrap();
-    assert_eq!(t.format("%S,%f,%.f").to_string(), "07,000000000,");
-    assert_eq!(t.format("%.3f,%.6f,%.9f").to_string(), ".000,.000000,.000000000");
+    assert_eq!(t.format("%S,%f,%.f").unwrap().to_string(), "07,000000000,");
+    assert_eq!(t.format("%.3f,%.6f,%.9f").unwrap().to_string(), ".000,.000000,.000000000");
 
     // corner cases
-    assert_eq!(NaiveTime::from_hms_opt(13, 57, 9).unwrap().format("%r").to_string(), "01:57:09 PM");
     assert_eq!(
-        NaiveTime::from_hms_milli_opt(23, 59, 59, 1_000).unwrap().format("%X").to_string(),
+        NaiveTime::from_hms_opt(13, 57, 9).unwrap().format("%r").unwrap().to_string(),
+        "01:57:09 PM"
+    );
+    assert_eq!(
+        NaiveTime::from_hms_milli_opt(23, 59, 59, 1_000).unwrap().format("%X").unwrap().to_string(),
         "23:59:60"
     );
 }

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -446,7 +446,7 @@ pub trait TimeZone: Sized + Clone {
     /// parsed [`FixedOffset`].
     fn datetime_from_str(&self, s: &str, fmt: &str) -> ParseResult<DateTime<Self>> {
         let mut parsed = Parsed::new();
-        parse(&mut parsed, s, StrftimeItems::new(fmt))?;
+        parse(&mut parsed, s, StrftimeItems::new(fmt)?)?;
         parsed.to_datetime_with_timezone(self)
     }
 

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -117,7 +117,7 @@ fn verify_against_date_command_format_local(path: &'static str, dt: NaiveDateTim
     let ldt = Local
         .from_local_datetime(&date.and_hms_opt(dt.hour(), dt.minute(), dt.second()).unwrap())
         .unwrap();
-    let formated_date = format!("{}\n", ldt.format(required_format));
+    let formated_date = format!("{}\n", ldt.format(required_format).unwrap());
     assert_eq!(date_command_str, formated_date);
 }
 


### PR DESCRIPTION
This makes the `date_time.format()` function return a `Result` instead of panicking when passed an invalid format string. If any part of the format string is invalid an error is returned.
This is a breaking change for the api.

Fixes #623 
closes #614 
