### PR TITLE
Specify licenses in SPDX format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/chronotope/chrono"
 keywords = ["date", "time", "calendar"]
 categories = ["date-and-time"]
 readme = "README.md"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 exclude = ["/ci/*"]
 edition = "2018"
 


### PR DESCRIPTION
The use of `/` as a separator is deprecated.