### PR TITLE
When compared to "date" program, the week numbers are off

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -521,10 +521,10 @@ fn format_inner<'a>(
             use self::Numeric::*;
 
             let week_from_sun = |d: &NaiveDate| {
-                (d.ordinal() as i32 - d.weekday().num_days_from_sunday() as i32 + 7) / 7
+                (d.ordinal() as i32 - d.weekday().num_days_from_sunday() as i32 + 6) / 7
             };
             let week_from_mon = |d: &NaiveDate| {
-                (d.ordinal() as i32 - d.weekday().num_days_from_monday() as i32 + 7) / 7
+                (d.ordinal() as i32 - d.weekday().num_days_from_monday() as i32 + 6) / 7
             };
 
             let (width, v) = match *spec {

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -74,3 +74,52 @@ fn try_verify_against_date_command() {
         date += chrono::TimeDelta::hours(1);
     }
 }
+
+#[cfg(unix)]
+fn verify_against_date_command_format_local(path: &'static str, dt: NaiveDateTime) {
+    let required_format = "d%d D%D F%F H%H I%I j%j k%k l%l m%m M%M S%S T%T u%u U%U w%w W%W X%X y%y Y%Y z%:z";
+    // a%a - depends from localization
+    // A%A - depends from localization
+    // b%b - depends from localization
+    // B%B - depends from localization
+    // h%h - depends from localization
+    // c%c - depends from localization
+    // p%p - depends from localization
+    // r%r - depends from localization
+    // x%x - fails, date is dd/mm/yyyy, chrono is dd/mm/yy, same as %D
+    // Z%Z - too many ways to represent it, will most likely fail
+
+
+    let output = process::Command::new(path)
+        .arg("-d")
+        .arg(format!("{}-{:02}-{:02} {:02}:{:02}:{:02}", dt.year(), dt.month(), dt.day(), dt.hour(), dt.minute(), dt.second()))
+        .arg(format!("+{}", required_format))
+        .output()
+        .unwrap();
+
+    let date_command_str = String::from_utf8(output.stdout).unwrap();
+    let date = NaiveDate::from_ymd_opt(dt.year(), dt.month(), dt.day()).unwrap();
+    let ldt = Local.from_local_datetime(&date.and_hms_opt(dt.hour(), dt.minute(), dt.second()).unwrap()).unwrap();
+    let formated_date = format!("{}\n", ldt.format(required_format));
+    assert_eq!(date_command_str, formated_date);
+}
+
+#[test]
+#[cfg(unix)]
+fn try_verify_against_date_command_format() {
+    let date_path = "/usr/bin/date";
+
+    if !path::Path::new(date_path).exists() {
+        // date command not found, skipping
+        // avoid running this on macOS, which has path /bin/date
+        // as the required CLI arguments are not present in the
+        // macOS build.
+        return;
+    }
+    let mut date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_opt(12, 11, 13).unwrap();
+    while date.year() < 2078 {
+        verify_against_date_command_format_local(date_path, date);
+        date += chrono::Duration::days(1);
+    }
+}
+

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -119,7 +119,7 @@ fn try_verify_against_date_command_format() {
     let mut date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_opt(12, 11, 13).unwrap();
     while date.year() < 2078 {
         verify_against_date_command_format_local(date_path, date);
-        date += chrono::Duration::days(1);
+        date += chrono::TimeDelta::days(1);
     }
 }
 


### PR DESCRIPTION
Hello,

I have been learning rust recently and started a project which would help me practice several features. For doing so I have been writing an equivalent of the "find" command. Goal is to have same API and same output. I have been using "chrono" for the date handling.
When testing it extensively with random dates, I found out discrepancies, which I expected, but by looking deeper, the discrepancy are in the %U and %W format in chrono crate.

When checking the code in findutils-4.9.0/gl/lib/nstrftime.c, one can find the following code for %W:
`(tp->tm_yday        - (tp->tm_wday - 1 + 7) % 7                 + 7) / 7`
The equivalent in chrono is chrono-0.4.23/src/format/mod.rs, one can find the following code for %W:
`(d.ordinal() as i32 - d.weekday().num_days_from_monday() as i32 + 7) / 7`
with num_days_from_monday() being between 0 and 6 so it does match the modulo 7.

Nothing puzzling, math formula seems right except there are dates where it does not match.
Here is why:
the C version is 0 based, the rust version is 1 based, but have same formula !

Pull Request contains:
- as many formats as possible that could be compared and tested extensively against the "date" command,
- the 1 is substracted from calculation (and thus we end up with +6 instead of +7)