### PR TITLE
use #[non_exhaustive]

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -48,6 +48,7 @@ mod tests;
 ///
 /// See the `TimeZone::to_rfc3339_opts` function for usage.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[non_exhaustive]
 pub enum SecondsFormat {
     /// Format whole seconds only, with no decimal point nor subseconds.
     Secs,
@@ -68,10 +69,6 @@ pub enum SecondsFormat {
     /// display all available non-zero sub-second digits.  This corresponds to
     /// [Fixed::Nanosecond](format/enum.Fixed.html#variant.Nanosecond).
     AutoSi,
-
-    // Do not match against this.
-    #[doc(hidden)]
-    __NonExhaustive,
 }
 
 /// ISO 8601 combined date and time with time zone.
@@ -694,8 +691,6 @@ where
         use crate::format::Pad::Zero;
         use crate::SecondsFormat::*;
 
-        debug_assert!(secform != __NonExhaustive, "Do not use __NonExhaustive!");
-
         const PREFIX: &[Item<'static>] = &[
             Item::Numeric(Year, Zero),
             Item::Literal("-"),
@@ -716,7 +711,6 @@ where
             Micros => Some(Item::Fixed(Fixed::Nanosecond6)),
             Nanos => Some(Item::Fixed(Fixed::Nanosecond9)),
             AutoSi => Some(Item::Fixed(Fixed::Nanosecond)),
-            __NonExhaustive => unreachable!(),
         };
 
         let tzitem = Item::Fixed(if use_z {

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -470,14 +470,6 @@ fn test_rfc3339_opts() {
 }
 
 #[test]
-#[should_panic]
-fn test_rfc3339_opts_nonexhaustive() {
-    use crate::SecondsFormat;
-    let dt = Utc.with_ymd_and_hms(1999, 10, 9, 1, 2, 3).unwrap();
-    dt.to_rfc3339_opts(SecondsFormat::__NonExhaustive, true);
-}
-
-#[test]
 fn test_datetime_from_str() {
     assert_eq!(
         "2015-02-18T23:16:9.15Z".parse::<DateTime<FixedOffset>>(),

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -357,6 +357,7 @@ impl ParseError {
 
 /// The category of parse error
 #[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
+#[non_exhaustive]
 pub enum ParseErrorKind {
     /// Given field is out of permitted range.
     OutOfRange,
@@ -385,10 +386,6 @@ pub enum ParseErrorKind {
 
     /// There was an error on the formatting string, or there were non-supported formating items.
     BadFormat,
-
-    // TODO: Change this to `#[non_exhaustive]` (on the enum) when MSRV is increased
-    #[doc(hidden)]
-    __Nonexhaustive,
 }
 
 /// Same as `Result<T, ParseError>`.


### PR DESCRIPTION
### Thanks for contributing to chrono!

If your feature is semver-compatible, please target the 0.4.x branch;
the main branch will be used for 0.5.0 development going forward.

Please consider adding a test to ensure your bug fix/feature will not break in the future.

MSRV has been bumped at https://github.com/chronotope/chrono/commit/95532dbc99315ee17597e1fb43b783b94f2e9952, and `#[non_exhaustive]` is stabilized in 1.40. We can remove the tricks now.