### PR TITLE
Implement generic assign operations for various types

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -912,16 +912,6 @@ impl<Tz: TimeZone> Add<OldDuration> for DateTime<Tz> {
     }
 }
 
-impl<Tz: TimeZone> AddAssign<OldDuration> for DateTime<Tz> {
-    #[inline]
-    fn add_assign(&mut self, rhs: OldDuration) {
-        let datetime =
-            self.datetime.checked_add_signed(rhs).expect("`DateTime + Duration` overflowed");
-        let tz = self.timezone();
-        *self = tz.from_utc_datetime(&datetime);
-    }
-}
-
 impl<Tz: TimeZone> Add<Months> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
@@ -936,16 +926,6 @@ impl<Tz: TimeZone> Sub<OldDuration> for DateTime<Tz> {
     #[inline]
     fn sub(self, rhs: OldDuration) -> DateTime<Tz> {
         self.checked_sub_signed(rhs).expect("`DateTime - Duration` overflowed")
-    }
-}
-
-impl<Tz: TimeZone> SubAssign<OldDuration> for DateTime<Tz> {
-    #[inline]
-    fn sub_assign(&mut self, rhs: OldDuration) {
-        let datetime =
-            self.datetime.checked_sub_signed(rhs).expect("`DateTime - Duration` overflowed");
-        let tz = self.timezone();
-        *self = tz.from_utc_datetime(&datetime)
     }
 }
 
@@ -979,6 +959,30 @@ impl<Tz: TimeZone> Sub<Days> for DateTime<Tz> {
 
     fn sub(self, days: Days) -> Self::Output {
         self.checked_sub_days(days).unwrap()
+    }
+}
+
+impl<T, Tz: TimeZone> AddAssign<T> for DateTime<Tz>
+where
+    NaiveDateTime: Add<T, Output = NaiveDateTime>,
+{
+    #[inline]
+    fn add_assign(&mut self, rhs: T) {
+        let datetime = self.datetime + rhs;
+        let tz = self.timezone();
+        *self = tz.from_utc_datetime(&datetime);
+    }
+}
+
+impl<T, Tz: TimeZone> SubAssign<T> for DateTime<Tz>
+where
+    NaiveDateTime: Sub<T, Output = NaiveDateTime>,
+{
+    #[inline]
+    fn sub_assign(&mut self, rhs: T) {
+        let datetime = self.datetime - rhs;
+        let tz = self.timezone();
+        *self = tz.from_utc_datetime(&datetime);
     }
 }
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1627,13 +1627,6 @@ impl Add<OldDuration> for NaiveDate {
     }
 }
 
-impl AddAssign<OldDuration> for NaiveDate {
-    #[inline]
-    fn add_assign(&mut self, rhs: OldDuration) {
-        *self = self.add(rhs);
-    }
-}
-
 impl Add<Months> for NaiveDate {
     type Output = NaiveDate;
 
@@ -1735,13 +1728,6 @@ impl Sub<OldDuration> for NaiveDate {
     }
 }
 
-impl SubAssign<OldDuration> for NaiveDate {
-    #[inline]
-    fn sub_assign(&mut self, rhs: OldDuration) {
-        *self = self.sub(rhs);
-    }
-}
-
 /// Subtracts another `NaiveDate` from the current date.
 /// Returns a `Duration` of integral numbers.
 ///
@@ -1772,6 +1758,26 @@ impl Sub<NaiveDate> for NaiveDate {
     #[inline]
     fn sub(self, rhs: NaiveDate) -> OldDuration {
         self.signed_duration_since(rhs)
+    }
+}
+
+impl<T> AddAssign<T> for NaiveDate
+where
+    Self: Add<T, Output = Self>,
+{
+    #[inline]
+    fn add_assign(&mut self, rhs: T) {
+        *self = *self + rhs;
+    }
+}
+
+impl<T> SubAssign<T> for NaiveDate
+where
+    Self: Sub<T, Output = Self>,
+{
+    #[inline]
+    fn sub_assign(&mut self, rhs: T) {
+        *self = *self - rhs;
     }
 }
 

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -1461,13 +1461,6 @@ impl Add<OldDuration> for NaiveDateTime {
     }
 }
 
-impl AddAssign<OldDuration> for NaiveDateTime {
-    #[inline]
-    fn add_assign(&mut self, rhs: OldDuration) {
-        *self = self.add(rhs);
-    }
-}
-
 impl Add<Months> for NaiveDateTime {
     type Output = NaiveDateTime;
 
@@ -1570,13 +1563,6 @@ impl Sub<OldDuration> for NaiveDateTime {
     }
 }
 
-impl SubAssign<OldDuration> for NaiveDateTime {
-    #[inline]
-    fn sub_assign(&mut self, rhs: OldDuration) {
-        *self = self.sub(rhs);
-    }
-}
-
 /// A subtraction of Months from `NaiveDateTime` clamped to valid days in resulting month.
 ///
 /// # Panics
@@ -1671,6 +1657,26 @@ impl Sub<Days> for NaiveDateTime {
 
     fn sub(self, days: Days) -> Self::Output {
         self.checked_sub_days(days).unwrap()
+    }
+}
+
+impl<T> AddAssign<T> for NaiveDateTime
+where
+    Self: Add<T, Output = Self>,
+{
+    #[inline]
+    fn add_assign(&mut self, rhs: T) {
+        *self = *self + rhs;
+    }
+}
+
+impl<T> SubAssign<T> for NaiveDateTime
+where
+    Self: Sub<T, Output = Self>,
+{
+    #[inline]
+    fn sub_assign(&mut self, rhs: T) {
+        *self = *self - rhs;
     }
 }
 

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -1024,13 +1024,6 @@ impl Add<OldDuration> for NaiveTime {
     }
 }
 
-impl AddAssign<OldDuration> for NaiveTime {
-    #[inline]
-    fn add_assign(&mut self, rhs: OldDuration) {
-        *self = self.add(rhs);
-    }
-}
-
 /// A subtraction of `Duration` from `NaiveTime` wraps around and never overflows or underflows.
 /// In particular the addition ignores integral number of days.
 /// It is the same as the addition with a negated `Duration`.
@@ -1085,13 +1078,6 @@ impl Sub<OldDuration> for NaiveTime {
     }
 }
 
-impl SubAssign<OldDuration> for NaiveTime {
-    #[inline]
-    fn sub_assign(&mut self, rhs: OldDuration) {
-        *self = self.sub(rhs);
-    }
-}
-
 /// Subtracts another `NaiveTime` from the current time.
 /// Returns a `Duration` within +/- 1 day.
 /// This does not overflow or underflow at all.
@@ -1143,6 +1129,26 @@ impl Sub<NaiveTime> for NaiveTime {
     #[inline]
     fn sub(self, rhs: NaiveTime) -> OldDuration {
         self.signed_duration_since(rhs)
+    }
+}
+
+impl<T> AddAssign<T> for NaiveTime
+where
+    Self: Add<T, Output = Self>,
+{
+    #[inline]
+    fn add_assign(&mut self, rhs: T) {
+        *self = *self + rhs;
+    }
+}
+
+impl<T> SubAssign<T> for NaiveTime
+where
+    Self: Sub<T, Output = Self>,
+{
+    #[inline]
+    fn sub_assign(&mut self, rhs: T) {
+        *self = *self - rhs;
     }
 }
 

--- a/src/oldtime.rs
+++ b/src/oldtime.rs
@@ -10,7 +10,7 @@
 
 //! Temporal quantification
 
-use core::ops::{Add, Div, Mul, Neg, Sub};
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use core::time::Duration as StdDuration;
 use core::{fmt, i64};
 #[cfg(any(feature = "std", test))]
@@ -378,6 +378,42 @@ impl Div<i32> for Duration {
             secs -= 1;
         }
         Duration { secs: secs, nanos: nanos }
+    }
+}
+
+impl<T> AddAssign<T> for Duration
+where
+    Self: Add<T, Output = Self>,
+{
+    fn add_assign(&mut self, rhs: T) {
+        *self = *self + rhs;
+    }
+}
+
+impl<T> SubAssign<T> for Duration
+where
+    Self: Sub<T, Output = Self>,
+{
+    fn sub_assign(&mut self, rhs: T) {
+        *self = *self - rhs;
+    }
+}
+
+impl<T> MulAssign<T> for Duration
+where
+    Self: Mul<T, Output = Self>,
+{
+    fn mul_assign(&mut self, rhs: T) {
+        *self = *self * rhs;
+    }
+}
+
+impl<T> DivAssign<T> for Duration
+where
+    Self: Div<T, Output = Self>,
+{
+    fn div_assign(&mut self, rhs: T) {
+        *self = *self / rhs;
     }
 }
 


### PR DESCRIPTION
Includes:
* `oldtime::Duration`
* `datetime::DateTime`
* `naive::date::NaiveDate`
* `naive::datetime::NaiveDateTime`
* `naive::time::NaiveTime`

Did not implement it for `date::Date`. This is because `Add` expects to be passed the owned object, but `AddAssign` only has access to a mutable reference. Since `Date` doesn't implement `Copy`, that makes it impossible to generically and safely implement `AddAssign` using `Add` without cloning. It might be possible with unsafe code, but that's probably over the top. `date::Date` is deprecated anyways.
