### PR TITLE
Allow guaranteed-no-panic conversion from NaiveDate to DateTime

### DIFF
--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -25,7 +25,7 @@ use crate::format::{Item, Numeric, Pad};
 use crate::month::Months;
 use crate::naive::{IsoWeek, NaiveDateTime, NaiveTime};
 use crate::oldtime::Duration as OldDuration;
-use crate::{Datelike, Duration, Weekday};
+use crate::{DateTime, Datelike, Duration, TimeZone, Weekday};
 
 use super::internals::{self, DateImpl, Mdf, Of, YearFlags};
 use super::isoweek;
@@ -873,6 +873,12 @@ impl NaiveDate {
         nano: u32,
     ) -> Option<NaiveDateTime> {
         NaiveTime::from_hms_nano_opt(hour, min, sec, nano).map(|time| self.and_time(time))
+    }
+
+    /// Makes a DateTime for the first second of the day in the provided timezone.
+    #[inline]
+    pub fn and_first_second<Tz: TimeZone>(&self, tz: Tz) -> DateTime<Tz> {
+        self.and_hms_opt(0, 0, 0).unwrap().and_local_timezone(tz).unwrap()
     }
 
     /// Returns the packed month-day-flags.


### PR DESCRIPTION
Hello people,

First, thank you for making chrono! It's very helpful to write code that (hopefully) will work on any timezone.

However, this "make it work on any timezone" makes me scared about doing some stuff that still sounds really reasonable.

So I'm opening this PR to kill two birds with one stone: asking my question ("how can I make a DateTime at the first second of a day"), and providing an easy way for others to know and use the answer.

Basically, I'm wondering whether the implementation of this PR is correct. Is it possible for eg. a summer time change change to happen across midnight?

If the implementation of this PR is always correct, then I think it should land, because otherwise writing the code as an end-user of the library does not make it obvious that it is actually panic-free. And this leads to convoluted ways to work around it. For instance my current solution is I already have a DateTime, and add 86400-its number of seconds since the beginning of the day; and that gives me a very-approximated-during-summer-time-changes but guaranteed no-panic solution.

If the implementation of this PR is incorrect, how would you go about solving the problem at hand, and do you think it would be possible to integrate it into chrono itself?

Either way, have a good end-of-year holiday!
