### PR TITLE
Added reset_time() to Timelike traits

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -914,6 +914,26 @@ impl<Tz: TimeZone> Timelike for DateTime<Tz> {
     fn with_nanosecond(&self, nano: u32) -> Option<DateTime<Tz>> {
         map_local(self, |datetime| datetime.with_nanosecond(nano))
     }
+
+    /// Returns an instance of `DateTime<Tz>` with the same _date_ and _offset_ parts.
+    /// The time part gets reset to `00:00:00.0`.
+    ///
+    /// # Example
+    ///
+    /// * before reset: `2014-11-28T21:45:59.324310806+00:00`
+    /// * after reset:  `2014-11-28T00:00:00.0+00:00`
+    #[inline]
+    fn reset_time(&self) -> DateTime<Tz> {
+        self.clone()
+            .with_hour(0)
+            .unwrap()
+            .with_minute(0)
+            .unwrap()
+            .with_second(0)
+            .unwrap()
+            .with_nanosecond(0)
+            .unwrap()
+    }
 }
 
 // we need them as automatic impls cannot handle associated types

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -6,6 +6,7 @@ use crate::offset::Local;
 use crate::offset::{FixedOffset, TimeZone, Utc};
 #[cfg(feature = "clock")]
 use crate::Datelike;
+use crate::Timelike;
 use crate::{
     naive::{NaiveDate, NaiveTime},
     TimeDelta,
@@ -336,6 +337,28 @@ fn test_datetime_date_and_time() {
 
     let utc_d = Utc.with_ymd_and_hms(2017, 8, 9, 12, 34, 56).unwrap();
     assert!(utc_d < d);
+}
+
+#[test]
+fn test_datetime_reset_time() {
+    let tz = FixedOffset::east_opt(5 * 60 * 60).unwrap();
+    let d1 = tz
+        .with_ymd_and_hms(2014, 5, 6, 7, 8, 9)
+        .unwrap()
+        .with_nanosecond(12345)
+        .unwrap()
+        .reset_time();
+    let d2 = tz.with_ymd_and_hms(2014, 5, 6, 0, 0, 0).unwrap();
+    assert_eq!(d1, d2);
+
+    let d1 = Utc
+        .with_ymd_and_hms(2014, 5, 6, 7, 8, 9)
+        .unwrap()
+        .with_nanosecond(12345)
+        .unwrap()
+        .reset_time();
+    let d2 = Utc.with_ymd_and_hms(2014, 5, 6, 0, 0, 0).unwrap();
+    assert_eq!(d1, d2);
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,6 +167,7 @@
 //! assert_eq!(dt.with_day(29).unwrap().weekday(), Weekday::Sat); // 2014-11-29 is Saturday
 //! assert_eq!(dt.with_day(32), None);
 //! assert_eq!(dt.with_year(-300).unwrap().num_days_from_ce(), -109606); // November 29, 301 BCE
+//! println!("{}",Utc.with_ymd_and_hms(2014, 7, 8, 21, 15, 33).unwrap().reset_time()); // 2014-07-08 21:15:33 UTC -> 2014-07-08 00:00:00 UTC
 //!
 //! // arithmetic operations
 //! let dt1 = Utc.with_ymd_and_hms(2014, 11, 14, 8, 9, 10).unwrap();

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -1396,6 +1396,16 @@ impl Timelike for NaiveDateTime {
     fn with_nanosecond(&self, nano: u32) -> Option<NaiveDateTime> {
         self.time.with_nanosecond(nano).map(|t| NaiveDateTime { time: t, ..*self })
     }
+
+    /// Returns an instance of `NaiveDateTime` with the same _date_ part and the time part reset to `00:00:00.0`.
+    ///
+    /// # Example
+    ///
+    /// * before reset: `2014-11-28T21:45:59.324310806`
+    /// * after reset:  `2014-11-28T00:00:00.0`
+    fn reset_time(&self) -> Self {
+        Self { date: self.date.clone(), time: NaiveTime::MIN }
+    }
 }
 
 /// An addition of `TimeDelta` to `NaiveDateTime` yields another `NaiveDateTime`.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -1404,7 +1404,7 @@ impl Timelike for NaiveDateTime {
     /// * before reset: `2014-11-28T21:45:59.324310806`
     /// * after reset:  `2014-11-28T00:00:00.0`
     fn reset_time(&self) -> Self {
-        Self { date: self.date.clone(), time: NaiveTime::MIN }
+        Self { date: self.date, time: NaiveTime::MIN }
     }
 }
 

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -1,7 +1,7 @@
 use super::NaiveDateTime;
 use crate::time_delta::TimeDelta;
 use crate::NaiveDate;
-use crate::{Datelike, FixedOffset, Utc};
+use crate::{Datelike, FixedOffset, Timelike, Utc};
 use std::i64;
 
 #[test]
@@ -340,4 +340,17 @@ fn test_and_timezone() {
     let dt_offset = ndt.and_local_timezone(offset_tz).unwrap();
     assert_eq!(dt_offset.naive_local(), ndt);
     assert_eq!(dt_offset.timezone(), offset_tz);
+}
+
+#[test]
+fn test_reset_time() {
+    let d1 = NaiveDate::from_ymd_opt(2022, 6, 15)
+        .unwrap()
+        .and_hms_opt(18, 59, 36)
+        .unwrap()
+        .with_nanosecond(12345)
+        .unwrap()
+        .reset_time();
+    let d2 = NaiveDate::from_ymd_opt(2022, 6, 15).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    assert_eq!(d1, d2);
 }

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -960,6 +960,11 @@ impl Timelike for NaiveTime {
     fn num_seconds_from_midnight(&self) -> u32 {
         self.secs // do not repeat the calculation!
     }
+
+    /// Returns naive zero-time of 00:00:00.0 and is the equivalent of calling `NaiveTime::MIN`.
+    fn reset_time(&self) -> Self {
+        NaiveTime::MIN
+    }
 }
 
 /// An addition of `TimeDelta` to `NaiveTime` wraps around and never overflows or underflows.

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -196,6 +196,16 @@ fn test_time_sub() {
 }
 
 #[test]
+fn test_reset_time() {
+    let d1 = NaiveTime::from_hms_milli_opt(1, 2, 3, 4).unwrap().reset_time();
+    let d2 = NaiveTime::from_hms_milli_opt(0, 0, 0, 0).unwrap();
+    assert_eq!(d1, d2);
+    // since the function itself returns MIN value we need to be alerted if MIN changes
+    // expecting d1 == d2 == MIN
+    assert_eq!(d1, NaiveTime::MIN);
+}
+
+#[test]
 fn test_time_fmt() {
     assert_eq!(
         format!("{}", NaiveTime::from_hms_milli_opt(23, 59, 59, 999).unwrap()),

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -175,6 +175,14 @@ pub trait Timelike: Sized {
     fn num_seconds_from_midnight(&self) -> u32 {
         self.hour() * 3600 + self.minute() * 60 + self.second()
     }
+
+    /// Returns a clone of Self with the time portion reset to `00:00:00.0`. No other members of Self are affected.
+    ///
+    /// # Example
+    ///
+    /// * before reset: `2014-11-28T21:45:59.324310806+09:00`
+    /// * after reset:  `2014-11-28T00:00:00.0+09:00`
+    fn reset_time(&self) -> Self;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Comparing or sorting the date only part of timestamps is slow and difficult if the time part is present. It is often faster to reset the time part to `00:00:00.0` before adding to a list or a database.

This PR is an implementation of a shortcut function to reset time on DateTime and NaiveDateTime structures in a single step.

The added function seems to be infallible and does not need to be wrapped into _Option_ or _Result_.

Issue: #928

## Changes

* added the trait itself
* implemented the trait for DateTime, NaiveDateTime and NaiveTime
* implemented tests for all trait implementations

## ToDo

* [ ] Get someone to look at the draft
* [x] Update the docs to include an example
