### PR TITLE
move MIN_UTC, MAX_UTC to a specialized impl

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -406,7 +406,9 @@ impl<Tz: TimeZone> DateTime<Tz> {
             false => None,
         }
     }
+}
 
+impl DateTime<Utc> {
     /// The minimum possible `DateTime<Utc>`.
     pub const MIN_UTC: DateTime<Utc> = DateTime { datetime: NaiveDateTime::MIN, offset: Utc };
     /// The maximum possible `DateTime<Utc>`.


### PR DESCRIPTION
For more info visit the [issue](https://github.com/chronotope/chrono/issues/932)
This is a breaking change.