### PR TITLE
derive `Hash` for most pub types that also derive `PartialEq`

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -52,7 +52,7 @@ mod tests;
 /// future, so exhaustive matching in external code is not recommended.
 ///
 /// See the `TimeZone::to_rfc3339_opts` function for usage.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum SecondsFormat {
     /// Format whole seconds only, with no decimal point nor subseconds.
     Secs,

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -69,11 +69,11 @@ pub use strftime::StrftimeItems;
 struct Locale;
 
 /// An uninhabited type used for `InternalNumeric` and `InternalFixed` below.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 enum Void {}
 
 /// Padding characters for numeric items.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Pad {
     /// No padding.
     None,
@@ -96,7 +96,7 @@ pub enum Pad {
 /// It also trims the preceding whitespace if any.
 /// It cannot parse the negative number, so some date and time cannot be formatted then
 /// parsed with the same formatting items.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Numeric {
     /// Full Gregorian year (FW=4, PW=∞).
     /// May accept years before 1 BCE or after 9999 CE, given an initial sign.
@@ -152,23 +152,10 @@ pub enum Numeric {
 }
 
 /// An opaque type representing numeric item types for internal uses only.
+#[derive(Clone, Eq, Hash, PartialEq)]
 pub struct InternalNumeric {
     _dummy: Void,
 }
-
-impl Clone for InternalNumeric {
-    fn clone(&self) -> Self {
-        match self._dummy {}
-    }
-}
-
-impl PartialEq for InternalNumeric {
-    fn eq(&self, _other: &InternalNumeric) -> bool {
-        match self._dummy {}
-    }
-}
-
-impl Eq for InternalNumeric {}
 
 impl fmt::Debug for InternalNumeric {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -180,7 +167,7 @@ impl fmt::Debug for InternalNumeric {
 ///
 /// They have their own rules of formatting and parsing.
 /// Otherwise noted, they print in the specified cases but parse case-insensitively.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Fixed {
     /// Abbreviated month names.
     ///
@@ -264,12 +251,12 @@ pub enum Fixed {
 }
 
 /// An opaque type representing fixed-format item types for internal uses only.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct InternalFixed {
     val: InternalInternal,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum InternalInternal {
     /// Same as [`TimezoneOffsetColonZ`](#variant.TimezoneOffsetColonZ), but
     /// allows missing minutes (per [ISO 8601][iso8601]).
@@ -289,7 +276,7 @@ enum InternalInternal {
 }
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum Colons {
     None,
     Single,
@@ -298,7 +285,7 @@ enum Colons {
 }
 
 /// A single formatting item. This is used for both formatting and parsing.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Item<'a> {
     /// A literally printed and parsed text.
     Literal(&'a str),
@@ -358,7 +345,7 @@ macro_rules! internal_fix {
 }
 
 /// An error from the `parse` function.
-#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
 pub struct ParseError(ParseErrorKind);
 
 impl ParseError {
@@ -369,7 +356,7 @@ impl ParseError {
 }
 
 /// The category of parse error
-#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
 pub enum ParseErrorKind {
     /// Given field is out of permitted range.
     OutOfRange,

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -22,7 +22,7 @@ use crate::{Datelike, Timelike};
 ///
 /// - `to_*` methods try to make a concrete date and time value out of set fields.
 ///   It fully checks any remaining out-of-range conditions and inconsistent/impossible fields.
-#[derive(Clone, PartialEq, Eq, Debug, Default)]
+#[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
 pub struct Parsed {
     /// Year.
     ///

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -35,7 +35,7 @@ pub(super) const MIN_YEAR: DateImpl = i32::MIN >> 13;
 /// and `bbb` is a non-zero `Weekday` (mapping `Mon` to 7) of the last day in the past year
 /// (simplifies the day of week calculation from the 1-based ordinal).
 #[allow(unreachable_pub)] // public as an alias for benchmarks only
-#[derive(PartialEq, Eq, Copy, Clone)]
+#[derive(PartialEq, Eq, Copy, Clone, Hash)]
 pub struct YearFlags(pub(super) u8);
 
 pub(super) const A: YearFlags = YearFlags(0o15);

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -16,7 +16,7 @@ use rkyv::{Archive, Deserialize, Serialize};
 /// constitutes the ISO 8601 [week date](./struct.NaiveDate.html#week-date).
 /// One can retrieve this type from the existing [`Datelike`](../trait.Datelike.html) types
 /// via the [`Datelike::iso_week`](../trait.Datelike.html#tymethod.iso_week) method.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 #[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
 pub struct IsoWeek {
     // note that this allows for larger year range than `NaiveDate`.

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -40,7 +40,7 @@ use crate::{Date, DateTime};
 /// assert_eq!(Utc.timestamp(61, 0), dt);
 /// assert_eq!(Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(), dt);
 /// ```
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Utc;

--- a/src/oldtime.rs
+++ b/src/oldtime.rs
@@ -50,7 +50,7 @@ macro_rules! try_opt {
 /// ISO 8601 time duration with nanosecond precision.
 ///
 /// This also allows for the negative duration; see individual methods for details.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
 pub struct Duration {
     secs: i64,


### PR DESCRIPTION
We needed to store `Item` alongside other data in a hash set, which requires all of the contained data be hashable. While I was adding the derive for that type, I looked for other pub types that could use it.

This is a backport of #852 to the `0.4.x` branch.