### PR TITLE
Update deprecated methods in `from_utc` example

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -107,8 +107,8 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     /// use chrono::{DateTime, TimeZone, NaiveDateTime, Utc};
     ///
-    /// let dt = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(61, 0), Utc);
-    /// assert_eq!(Utc.timestamp(61, 0), dt);
+    /// let dt = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp_opt(61, 0).unwrap(), Utc);
+    /// assert_eq!(Utc.timestamp_opt(61, 0).unwrap(), dt);
     /// ```
     //
     // note: this constructor is purposely not named to `new` to discourage the direct usage.


### PR DESCRIPTION
`from_timestamp` and `Utc.timestamp` are deprecated, and have been replaced with `from_timestamp_opt` and `Utc.timestamp_opt` respectively, with unwrapping.

Related to https://github.com/chronotope/chrono/issues/931