### PR TITLE
Naive utc

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -31,6 +31,7 @@ John Nagle <nagle@sitetruth.com>
 Jonas mg <jonasmg@yepmail.net>
 János Illés <ijanos@gmail.com>
 Ken Tossell <ken@tossell.net>
+Kurtis Nusbaum <kcommiter@gmail.com>
 Martin Risell Lilja <martin.risell.lilja@gmail.com>
 Richard Petrie <rap1011@ksu.edu>
 Ryan Lewis <ryansname@gmail.com>

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -18,6 +18,7 @@ use crate::format::DelayedFormat;
 use crate::format::{parse, ParseError, ParseResult, Parsed, StrftimeItems};
 use crate::format::{Fixed, Item, Numeric, Pad};
 use crate::naive::{Days, IsoWeek, NaiveDate, NaiveTime};
+use crate::offset::Utc;
 use crate::oldtime::Duration as OldDuration;
 use crate::{DateTime, Datelike, LocalResult, Months, TimeZone, Timelike, Weekday};
 
@@ -887,12 +888,29 @@ impl NaiveDateTime {
     /// # Example
     ///
     /// ```
-    /// use chrono::{NaiveDate, Utc};
-    /// let dt = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap().and_local_timezone(Utc).unwrap();
-    /// assert_eq!(dt.timezone(), Utc);
+    /// use chrono::{NaiveDate, FixedOffset};
+    /// let hour = 3600;
+    /// let tz = FixedOffset::east_opt(5 * hour).unwrap();
+    /// let dt = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap().and_local_timezone(tz).unwrap();
+    /// assert_eq!(dt.timezone(), tz);
+    /// ```
     #[must_use]
     pub fn and_local_timezone<Tz: TimeZone>(&self, tz: Tz) -> LocalResult<DateTime<Tz>> {
         tz.from_local_datetime(self)
+    }
+
+    /// Converts the `NaiveDateTime` into the timezone-aware `DateTime<Utc>`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use chrono::{NaiveDate, NaiveTime, Utc};
+    /// let dt = NaiveDate::from_ymd_opt(2023, 1, 30).unwrap().and_hms_opt(19, 32, 33).unwrap().and_utc();
+    /// assert_eq!(dt.timezone(), Utc);
+    /// ```
+    #[must_use]
+    pub fn and_utc(&self) -> DateTime<Utc> {
+        Utc.from_utc_datetime(self)
     }
 
     /// The minimum possible `NaiveDateTime`.

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -370,7 +370,7 @@ fn test_nanosecond_range() {
 }
 
 #[test]
-fn test_and_timezone() {
+fn test_and_local_timezone() {
     let ndt = NaiveDate::from_ymd_opt(2022, 6, 15).unwrap().and_hms_opt(18, 59, 36).unwrap();
     let dt_utc = ndt.and_local_timezone(Utc).unwrap();
     assert_eq!(dt_utc.naive_local(), ndt);
@@ -380,4 +380,12 @@ fn test_and_timezone() {
     let dt_offset = ndt.and_local_timezone(offset_tz).unwrap();
     assert_eq!(dt_offset.naive_local(), ndt);
     assert_eq!(dt_offset.timezone(), offset_tz);
+}
+
+#[test]
+fn test_and_utc() {
+    let ndt = NaiveDate::from_ymd_opt(2023, 1, 30).unwrap().and_hms_opt(19, 32, 33).unwrap();
+    let dt_utc = ndt.and_utc();
+    assert_eq!(dt_utc.naive_local(), ndt);
+    assert_eq!(dt_utc.timezone(), Utc);
 }


### PR DESCRIPTION
It seems common to use `DateTime<FixedOffset>` as a kind of canonical representation of any given instant. With that said, the following code almost works:

```Rust
fn parse_date(date: &str) -> Result<DateTime<FixedOffset>> {
    let parsed = date
        .parse::<NaiveDate>()?
        .and_time(NaiveTime::default())
        .and_local_timezone(Utc)
        .into()
    Ok(parsed)
}
```

However, `and_local_timezone` returns a `LocalResult` which is kind of irksome in this case. I know the converting to `Utc` won't produce multiple results, but I still either have to call `unwrap` or do something more complicated with the `LocalResult`.

For the case where I know I'm going to Utc, could we just have a special function specifically for Utc? Would folks be opposed to adding the convenience?