### PR TITLE
archive derive of PartialEq for rkyv

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -32,12 +32,13 @@ Jonas mg <jonasmg@yepmail.net>
 János Illés <ijanos@gmail.com>
 Ken Tossell <ken@tossell.net>
 Martin Risell Lilja <martin.risell.lilja@gmail.com>
+Mikhail Katychev <mkatych@gmail.com>
 Richard Petrie <rap1011@ksu.edu>
 Ryan Lewis <ryansname@gmail.com>
-Sergey V. Shadoy <shadoysv@yandex.ru>
 Sergey V. Galtsev <sergey.v.galtsev@github.com>
+Sergey V. Shadoy <shadoysv@yandex.ru>
 Steve Klabnik <steve@steveklabnik.com>
 Tom Gallacher <tomgallacher23@gmail.com>
+Yohan Boogaert <yozhgoor@outlook.com>
 klutzy <klutzytheklutzy@gmail.com>
 kud1ing <github@kudling.de>
-Yohan Boogaert <yozhgoor@outlook.com>

--- a/src/date.rs
+++ b/src/date.rs
@@ -56,7 +56,7 @@ use crate::{Datelike, Weekday};
 ///   even though the raw calculation between `NaiveDate` and `Duration` may not.
 #[deprecated(since = "0.4.23", note = "Use `NaiveDate` or `DateTime<Tz>` instead")]
 #[derive(Clone)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize), archive(compare(PartialEq)))]
 pub struct Date<Tz: TimeZone> {
     date: NaiveDate,
     offset: Tz::Offset,

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -80,7 +80,7 @@ pub enum SecondsFormat {
 /// the general-purpose constructors are all via the methods on the
 /// [`TimeZone`](./offset/trait.TimeZone.html) implementations.
 #[derive(Clone)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize), archive(compare(PartialEq)))]
 pub struct DateTime<Tz: TimeZone> {
     datetime: NaiveDateTime,
     offset: Tz::Offset,

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -661,7 +661,7 @@ fn format_inner<'a>(
                             let nano = t.nanosecond() % 1_000_000_000;
                             write!(result, "{:09}", nano)
                         }),
-                    TimezoneName => off.map(|&(ref name, _)| {
+                    TimezoneName => off.map(|(name, _)| {
                         result.push_str(name);
                         Ok(())
                     }),

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -487,12 +487,12 @@ impl Locales {
 /// Formats single formatting item
 #[cfg(any(feature = "alloc", feature = "std", test))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
-pub fn format_item<'a>(
+pub fn format_item(
     w: &mut fmt::Formatter,
     date: Option<&NaiveDate>,
     time: Option<&NaiveTime>,
     off: Option<&(String, FixedOffset)>,
-    item: &Item<'a>,
+    item: &Item<'_>,
 ) -> fmt::Result {
     let mut result = String::new();
     format_inner(&mut result, date, time, off, item, None)?;
@@ -500,12 +500,12 @@ pub fn format_item<'a>(
 }
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
-fn format_inner<'a>(
+fn format_inner(
     result: &mut String,
     date: Option<&NaiveDate>,
     time: Option<&NaiveTime>,
     off: Option<&(String, FixedOffset)>,
-    item: &Item<'a>,
+    item: &Item<'_>,
     locale: Option<Locale>,
 ) -> fmt::Result {
     let locale = Locales::new(locale);

--- a/src/month.rs
+++ b/src/month.rs
@@ -30,7 +30,7 @@ use crate::OutOfRange;
 /// Can be Serialized/Deserialized with serde
 // Actual implementation is zero-indexed, API intended as 1-indexed for more intuitive behavior.
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize), archive(compare(PartialEq)))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Month {
     /// January

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -183,7 +183,7 @@ impl Days {
 ///
 /// This is currently the internal format of Chrono's date types.
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize), archive(compare(PartialEq)))]
 pub struct NaiveDate {
     ymdf: DateImpl, // (year << 13) | of
 }

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -75,7 +75,7 @@ pub const MAX_DATETIME: NaiveDateTime = NaiveDateTime::MAX;
 /// assert_eq!(dt.num_seconds_from_midnight(), 33011);
 /// ```
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize), archive(compare(PartialEq)))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct NaiveDateTime {
     date: NaiveDate,

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -17,7 +17,7 @@ use rkyv::{Archive, Deserialize, Serialize};
 /// One can retrieve this type from the existing [`Datelike`](../trait.Datelike.html) types
 /// via the [`Datelike::iso_week`](../trait.Datelike.html#tymethod.iso_week) method.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize), archive(compare(PartialEq)))]
 pub struct IsoWeek {
     // note that this allows for larger year range than `NaiveDate`.
     // this is crucial because we have an edge case for the first and last week supported,

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -184,7 +184,7 @@ mod tests;
 /// Since Chrono alone cannot determine any existence of leap seconds,
 /// **there is absolutely no guarantee that the leap second read has actually happened**.
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize), archive(compare(PartialEq)))]
 pub struct NaiveTime {
     secs: u32,
     frac: u32,

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -23,7 +23,7 @@ use crate::Timelike;
 /// `DateTime<FixedOffset>` instances. See the [`east`](#method.east) and
 /// [`west`](#method.west) methods for examples.
 #[derive(PartialEq, Eq, Hash, Copy, Clone)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize), archive(compare(PartialEq)))]
 pub struct FixedOffset {
     local_minus_utc: i32,
 }

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -52,7 +52,7 @@ mod tz_info;
 /// let dt: DateTime<Local> = Local.timestamp(0, 0);
 /// ```
 #[derive(Copy, Clone, Debug)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize), archive(compare(PartialEq)))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Local;
 

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -41,7 +41,7 @@ use crate::{Date, DateTime};
 /// assert_eq!(Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(), dt);
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize), archive(compare(PartialEq)))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Utc;
 

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -51,7 +51,7 @@ macro_rules! try_opt {
 ///
 /// This also allows for the negative duration; see individual methods for details.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize), archive(compare(PartialEq)))]
 pub struct TimeDelta {
     secs: i64,
     nanos: i32, // Always 0 <= nanos < NANOS_PER_SEC

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -11,7 +11,7 @@ use crate::OutOfRange;
 /// (This is why this type does *not* implement `PartialOrd` or `Ord` traits.)
 /// One should prefer `*_from_monday` or `*_from_sunday` methods to get the correct result.
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
-#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
+#[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize), archive(compare(PartialEq)))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Weekday {
     /// Monday.


### PR DESCRIPTION
This PR resolves `PartialEq` compilation errors for types that derive `rkyv::Archive`:

```
error[E0277]: can't compare `chrono::datetime::ArchivedDateTime<Utc>` with `DateTime<Utc>`
   --> common/src/transaction.rs:142:5
    |
142 |     rkyv::Archive,
    |     ^^^^^^^^^^^^^ no implementation for `chrono::datetime::ArchivedDateTime<Utc> == DateTime<Utc>`
    |
    = help: the trait `PartialEq<DateTime<Utc>>` is not implemented for `chrono::datetime::ArchivedDateTime<Utc>`
    = help: see issue #48214
    = note: this error originates in the derive macro `rkyv::Archive` (in Nightly builds, run with -Z macro-backtrace for more info)
```

This PR does not address https://github.com/chronotope/chrono/pull/762 since a new archived object is created, for example `ArchivedDateTime<Utc>` is derived from `DateTime<Utc>`, but does preserve feature inclusivity.

I don't think this change merits tests as the object created is not directly accessible for comparison as shown in the rkyv [basic example](https://github.com/rkyv/rkyv#example) but happy to discuss.