### PR TITLE
Remove cargo ignoration `RUSTSEC-2020-0071` on `time`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,7 +4,6 @@ copyleft = "deny"
 
 [advisories]
 ignore = [
-    "RUSTSEC-2020-0071", # time 0.1, doesn't affect the API we use
     "RUSTSEC-2021-0145", # atty (dev-deps only, dependency of criterion)
     "RUSTSEC-2022-0004", # rustc_serialize, cannot remove due to compatibility
 ]


### PR DESCRIPTION
Now that dependency on `time` is complely removed in version 0.5 with [this commit](https://github.com/chronotope/chrono/commit/4c351b1e720a30a6e32068fe386293b36d0e86fd#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L21), we can remove this ignoration.
