### PR TITLE
Extract timezone info from tzdata file on Android

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,7 +99,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        target: [wasm32-unknown-unknown, wasm32-wasi, wasm32-unknown-emscripten, aarch64-apple-ios, aarch64-linux-android]
+        target:
+          [
+            wasm32-unknown-unknown,
+            wasm32-wasi,
+            wasm32-unknown-emscripten,
+            aarch64-apple-ios,
+            aarch64-linux-android,
+          ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ winapi = { version = "0.3.0", features = ["std", "minwinbase", "minwindef", "tim
 [target.'cfg(unix)'.dependencies]
 iana-time-zone = { version = "0.1.45", optional = true, features = ["fallback"] }
 
+[target.'cfg(target_os = "android")'.dependencies]
+android-tzdata = "0.1.1"
+
 [dev-dependencies]
 serde_json = { version = "1" }
 serde_derive = { version = "1", default-features = false }

--- a/src/offset/local/tz_info/timezone.rs
+++ b/src/offset/local/tz_info/timezone.rs
@@ -52,6 +52,14 @@ impl TimeZone {
             return Self::from_file(&mut file);
         }
 
+        // attributes are not allowed on if blocks in Rust 1.38
+        #[cfg(target_os = "android")]
+        {
+            if let Ok(bytes) = android_tzdata::find_tz_data(tz_string) {
+                return Self::from_tz_data(&bytes);
+            }
+        }
+
         // TZ string extensions are not allowed
         let tz_string = tz_string.trim_matches(|c: char| c.is_ascii_whitespace());
         let rule = TransitionRule::from_tz_string(tz_string.as_bytes(), false)?;

--- a/src/offset/local/tz_info/timezone.rs
+++ b/src/offset/local/tz_info/timezone.rs
@@ -43,6 +43,14 @@ impl TimeZone {
             return Self::from_tz_data(&fs::read("/etc/localtime")?);
         }
 
+        // attributes are not allowed on if blocks in Rust 1.38
+        #[cfg(target_os = "android")]
+        {
+            if let Ok(bytes) = android_tzdata::find_tz_data(tz_string) {
+                return Self::from_tz_data(&bytes);
+            }
+        }
+
         let mut chars = tz_string.chars();
         if chars.next() == Some(':') {
             return Self::from_file(&mut find_tz_file(chars.as_str())?);
@@ -50,14 +58,6 @@ impl TimeZone {
 
         if let Ok(mut file) = find_tz_file(tz_string) {
             return Self::from_file(&mut file);
-        }
-
-        // attributes are not allowed on if blocks in Rust 1.38
-        #[cfg(target_os = "android")]
-        {
-            if let Ok(bytes) = android_tzdata::find_tz_data(tz_string) {
-                return Self::from_tz_data(&bytes);
-            }
         }
 
         // TZ string extensions are not allowed

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -68,19 +68,18 @@ struct Cache {
     last_checked: SystemTime,
 }
 
-#[cfg(target_os = "android")]
-const TZDB_LOCATION: &str = " /system/usr/share/zoneinfo";
-
 #[cfg(target_os = "aix")]
 const TZDB_LOCATION: &str = "/usr/share/lib/zoneinfo";
 
-#[allow(dead_code)] // keeps the cfg simpler
 #[cfg(not(any(target_os = "android", target_os = "aix")))]
 const TZDB_LOCATION: &str = "/usr/share/zoneinfo";
 
 fn fallback_timezone() -> Option<TimeZone> {
     let tz_name = iana_time_zone::get_timezone().ok()?;
+    #[cfg(not(target_os = "android"))]
     let bytes = fs::read(format!("{}/{}", TZDB_LOCATION, tz_name)).ok()?;
+    #[cfg(target_os = "android")]
+    let bytes = android_tzdata::find_tz_data(&tz_name).ok()?;
     TimeZone::from_tz_data(&bytes).ok()
 }
 


### PR DESCRIPTION
Replacement for #975. As per @djc's suggestion, the tzdata parser now resides in its own crate.

Closes #922.