### PR TITLE
Fix available range of datetime for `Local.from_utc_datetime` and `Local.from_local_datetime` functions

### DIFF
--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -954,21 +954,14 @@ fn test_datetime_sub_assign_local() {
 #[test]
 #[cfg(target_os = "windows")]
 fn test_from_naive_date_time_conversions() {
-    let min_year = NaiveDate::from_ymd_opt(1601, 1, 3)
-        .unwrap().and_hms_opt(0, 0, 0)
-        .unwrap();
+    let min_year = NaiveDate::from_ymd_opt(1601, 1, 3).unwrap().and_hms_opt(0, 0, 0).unwrap();
 
-    let max_year = NaiveDate::from_ymd_opt(30827, 12, 29)
-        .unwrap().and_hms_opt(23, 59, 59)
-        .unwrap();
+    let max_year = NaiveDate::from_ymd_opt(30827, 12, 29).unwrap().and_hms_opt(23, 59, 59).unwrap();
 
-    let too_low_year = NaiveDate::from_ymd_opt(1600, 12, 29)
-        .unwrap().and_hms_opt(23, 59, 59)
-        .unwrap();
+    let too_low_year =
+        NaiveDate::from_ymd_opt(1600, 12, 29).unwrap().and_hms_opt(23, 59, 59).unwrap();
 
-    let too_high_year = NaiveDate::from_ymd_opt(30829, 1, 3)
-        .unwrap().and_hms_opt(0, 0, 0)
-        .unwrap();
+    let too_high_year = NaiveDate::from_ymd_opt(30829, 1, 3).unwrap().and_hms_opt(0, 0, 0).unwrap();
 
     let _ = Local.from_utc_datetime(&min_year);
     let _ = Local.from_utc_datetime(&max_year);
@@ -976,15 +969,23 @@ fn test_from_naive_date_time_conversions() {
     let _ = Local.from_local_datetime(&min_year);
     let _ = Local.from_local_datetime(&max_year);
 
-    let err = std::panic::catch_unwind(|| {Local.from_utc_datetime(&too_low_year);});
+    let err = std::panic::catch_unwind(|| {
+        Local.from_utc_datetime(&too_low_year);
+    });
     assert!(err.is_err());
 
-    let err = std::panic::catch_unwind(|| {Local.from_local_datetime(&too_low_year);});
+    let err = std::panic::catch_unwind(|| {
+        Local.from_local_datetime(&too_low_year);
+    });
     assert!(err.is_err());
 
-    let err = std::panic::catch_unwind(|| {Local.from_utc_datetime(&too_high_year);});
+    let err = std::panic::catch_unwind(|| {
+        Local.from_utc_datetime(&too_high_year);
+    });
     assert!(err.is_err());
 
-    let err = std::panic::catch_unwind(|| {Local.from_local_datetime(&too_high_year);});
+    let err = std::panic::catch_unwind(|| {
+        Local.from_local_datetime(&too_high_year);
+    });
     assert!(err.is_err());
 }

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -950,3 +950,41 @@ fn test_datetime_sub_assign_local() {
         assert_eq!(datetime_sub, datetime - Duration::days(i))
     }
 }
+
+#[test]
+#[cfg(target_os = "windows")]
+fn test_from_naive_date_time_conversions() {
+    let min_year = NaiveDate::from_ymd_opt(1601, 1, 3)
+        .unwrap().and_hms_opt(0, 0, 0)
+        .unwrap();
+
+    let max_year = NaiveDate::from_ymd_opt(30827, 12, 29)
+        .unwrap().and_hms_opt(23, 59, 59)
+        .unwrap();
+
+    let too_low_year = NaiveDate::from_ymd_opt(1600, 12, 29)
+        .unwrap().and_hms_opt(23, 59, 59)
+        .unwrap();
+
+    let too_high_year = NaiveDate::from_ymd_opt(30829, 1, 3)
+        .unwrap().and_hms_opt(0, 0, 0)
+        .unwrap();
+
+    let _ = Local.from_utc_datetime(&min_year);
+    let _ = Local.from_utc_datetime(&max_year);
+
+    let _ = Local.from_local_datetime(&min_year);
+    let _ = Local.from_local_datetime(&max_year);
+
+    let err = std::panic::catch_unwind(|| {Local.from_utc_datetime(&too_low_year);});
+    assert!(err.is_err());
+
+    let err = std::panic::catch_unwind(|| {Local.from_local_datetime(&too_low_year);});
+    assert!(err.is_err());
+
+    let err = std::panic::catch_unwind(|| {Local.from_utc_datetime(&too_high_year);});
+    assert!(err.is_err());
+
+    let err = std::panic::catch_unwind(|| {Local.from_local_datetime(&too_high_year);});
+    assert!(err.is_err());
+}

--- a/src/offset/local/windows.rs
+++ b/src/offset/local/windows.rs
@@ -207,7 +207,7 @@ fn system_time_to_tm(sys: &SYSTEMTIME, tm: &mut Tm) {
     tm.tm_mday = sys.wDay as i32;
     tm.tm_wday = sys.wDayOfWeek as i32;
     tm.tm_mon = (sys.wMonth - 1) as i32;
-    tm.tm_year = (sys.wYear - 1900) as i32;
+    tm.tm_year = i32::from(sys.wYear) - 1900i32;
     tm.tm_yday = yday(tm.tm_year, tm.tm_mon + 1, tm.tm_mday);
 
     fn yday(year: i32, month: i32, day: i32) -> i32 {


### PR DESCRIPTION
fixes #977