### PR TITLE
Make iana-time-zone a target specific dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.5.2", optional = true }
 criterion = { version = "0.4.0", optional = true }
 rkyv = {version = "0.7", optional = true}
-iana-time-zone = { version = "0.1.45", optional = true, features = ["fallback"] }
 arbitrary = { version = "1.0.0", features = ["derive"], optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
@@ -46,6 +45,9 @@ js-sys = { version = "0.3", optional = true } # contains FFI bindings for the JS
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.0", features = ["std", "minwinbase", "minwindef", "timezoneapi"], optional = true }
+
+[target.'cfg(unix)'.dependencies]
+iana-time-zone = { version = "0.1.45", optional = true, features = ["fallback"] }
 
 [dev-dependencies]
 serde_json = { version = "1" }


### PR DESCRIPTION
Currently, iana-tiime-zone is only used on cfg(unix). This crate, and its windows code in particular, contains a lot of unsafe, so it seems prudent to limit its scope to where it is actually needed.

# Geiger

## Before

```
Functions  Expressions  Impls  Traits  Methods  Dependency

0/0        2/48         2/2    0/0     0/0      ☢️  chrono 0.5.0-alpha.1
0/2        1/147        0/0    0/0     0/1      ☢️  ├── iana-time-zone 0.1.53
0/46       0/500        0/0    0/0     0/0      ❓ │   └── winapi 0.3.9
0/0        0/0          0/0    0/0     0/0      ❓ │       └── winapi-x86_64-pc-windows-gnu 0.4.0
0/0        0/0          0/0    0/0     0/0      ❓ ├── num-integer 0.1.45
0/0        6/12         0/0    0/0     0/0      ☢️  │   └── num-traits 0.2.15
0/0        0/5          0/0    0/0     0/0      ❓ ├── serde 1.0.152
0/0        0/0          0/0    0/0     0/0      ❓ │   └── serde_derive 1.0.152
0/0        0/15         0/0    0/0     0/3      ❓ │       ├── proc-macro2 1.0.51
0/0        0/4          0/0    0/0     0/0      ❓ │       │   └── unicode-ident 1.0.8
0/0        0/0          0/0    0/0     0/0      ❓ │       ├── quote 1.0.23
0/0        0/15         0/0    0/0     0/3      ❓ │       │   └── proc-macro2 1.0.51
0/0        0/69         0/3    0/0     0/2      ❓ │       └── syn 1.0.109
0/0        0/15         0/0    0/0     0/3      ❓ │           ├── proc-macro2 1.0.51
0/0        0/0          0/0    0/0     0/0      ❓ │           ├── quote 1.0.23
0/0        0/4          0/0    0/0     0/0      ❓ │           └── unicode-ident 1.0.8
0/0        0/0          0/0    0/0     0/0      ❓ └── windows-sys 0.45.0
0/0        0/0          0/0    0/0     0/0      ❓     └── windows-targets 0.42.1
0/0        0/0          0/0    0/0     0/0      ❓         └── windows_x86_64_gnu 0.42.1

0/48       9/800        2/5    0/0     0/6
```

## After

```
Functions  Expressions  Impls  Traits  Methods  Dependency

0/0        2/48         2/2    0/0     0/0      ☢️  chrono 0.5.0-alpha.1
0/0        0/0          0/0    0/0     0/0      ❓ ├── num-integer 0.1.45
0/0        6/12         0/0    0/0     0/0      ☢️  │   └── num-traits 0.2.15
0/0        0/5          0/0    0/0     0/0      ❓ ├── serde 1.0.152
0/0        0/0          0/0    0/0     0/0      ❓ │   └── serde_derive 1.0.152
0/0        0/15         0/0    0/0     0/3      ❓ │       ├── proc-macro2 1.0.51
0/0        0/4          0/0    0/0     0/0      ❓ │       │   └── unicode-ident 1.0.8
0/0        0/0          0/0    0/0     0/0      ❓ │       ├── quote 1.0.23
0/0        0/15         0/0    0/0     0/3      ❓ │       │   └── proc-macro2 1.0.51
0/0        0/69         0/3    0/0     0/2      ❓ │       └── syn 1.0.109
0/0        0/15         0/0    0/0     0/3      ❓ │           ├── proc-macro2 1.0.51
0/0        0/0          0/0    0/0     0/0      ❓ │           ├── quote 1.0.23
0/0        0/4          0/0    0/0     0/0      ❓ │           └── unicode-ident 1.0.8
0/0        0/0          0/0    0/0     0/0      ❓ └── windows-sys 0.45.0
0/0        0/0          0/0    0/0     0/0      ❓     └── windows-targets 0.42.1
0/0        0/0          0/0    0/0     0/0      ❓         └── windows_x86_64_gnu 0.42.1

0/0        8/153        2/5    0/0     0/5
```