### PR TITLE
[Documentation] Create CITATION.cff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,7 @@ on:
       - .github/**
       - .ci/**
       - Cargo.toml
+      - CITATION.cff
       - deny.toml
 
 jobs:
@@ -29,3 +30,13 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: EmbarkStudios/cargo-deny-action@v1
+
+  cffconvert:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: citation-file-format/cffconvert-github-action@2.0.0
+        with:
+          args: --validate

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,17 +3,24 @@ cff-version: 1.2.0
 message: Please cite this crate using these information.
 
 # Version information.
-date-released: 2022-11-12
-version: 0.4.23
+date-released: 2023-03-12
+version: 0.4.24
 
 # Project information.
 abstract: Date and time library for Rust
 authors:
-  - alias: .
-    # email:
-    family-names: .
-    given-names: .
-    # website:
+  - alias: quodlibetor
+    family-names: Maister
+    given-names: Brandon W.
+  - alias: djc
+    family-names: Ochtman
+    given-names: Dirkjan
+  - alias: lifthrasiir
+    family-names: Seonghoon
+    given-names: Kang
+  - alias: esheppa
+    family-names: Sheppard
+    given-names: Eric
 license:
   - Apache-2.0
   - MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,23 @@
+# Parser settings.
+cff-version: 1.2.0
+message: Please cite this crate using these information.
+
+# Version information.
+date-released: 2022-11-12
+version: 0.4.23
+
+# Project information.
+abstract: Date and time library for Rust
+authors:
+  - alias: .
+    # email:
+    family-names: .
+    given-names: .
+    # website:
+license:
+  - Apache-2.0
+  - MIT
+repository-artifact: https://crates.io/crates/chrono
+repository-code: https://github.com/chronotope/chrono
+title: chrono
+url: https://docs.rs/chrono


### PR DESCRIPTION
This PR fixes #981.

As requested by @djc in #981, I submit this PR to add initial citation metadata to `chrono`.  The applied format is CFF, GitHub's default format for software citations.  GitHub will render a "Cite this repository" blob on the project's landing page from it, thus, I targeted the default branch such that you can make use of this feature immediately.

This is just a draft because I did not know who to add to the authors section.  I would like to discuss who should be named as authors and which further changes might be required to meet the requirements of this project.  I will submit a review explaining the functions of each section.