### PR TITLE
Add #[must_use] to some methods

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -77,6 +77,7 @@ impl<Tz: TimeZone> Date<Tz> {
     //
     // note: this constructor is purposely not named to `new` to discourage the direct usage.
     #[inline]
+    #[must_use]
     pub fn from_utc(date: NaiveDate, offset: Tz::Offset) -> Date<Tz> {
         Date { date, offset }
     }
@@ -86,6 +87,7 @@ impl<Tz: TimeZone> Date<Tz> {
     ///
     /// Panics on invalid datetime.
     #[inline]
+    #[must_use]
     pub fn and_time(&self, time: NaiveTime) -> Option<DateTime<Tz>> {
         let localdt = self.naive_local().and_time(time);
         self.timezone().from_local_datetime(&localdt).single()
@@ -97,6 +99,7 @@ impl<Tz: TimeZone> Date<Tz> {
     /// Panics on invalid hour, minute and/or second.
     #[deprecated(since = "0.4.23", note = "Use and_hms_opt() instead")]
     #[inline]
+    #[must_use]
     pub fn and_hms(&self, hour: u32, min: u32, sec: u32) -> DateTime<Tz> {
         self.and_hms_opt(hour, min, sec).expect("invalid time")
     }
@@ -106,6 +109,7 @@ impl<Tz: TimeZone> Date<Tz> {
     ///
     /// Returns `None` on invalid hour, minute and/or second.
     #[inline]
+    #[must_use]
     pub fn and_hms_opt(&self, hour: u32, min: u32, sec: u32) -> Option<DateTime<Tz>> {
         NaiveTime::from_hms_opt(hour, min, sec).and_then(|time| self.and_time(time))
     }
@@ -117,6 +121,7 @@ impl<Tz: TimeZone> Date<Tz> {
     /// Panics on invalid hour, minute, second and/or millisecond.
     #[deprecated(since = "0.4.23", note = "Use and_hms_milli_opt() instead")]
     #[inline]
+    #[must_use]
     pub fn and_hms_milli(&self, hour: u32, min: u32, sec: u32, milli: u32) -> DateTime<Tz> {
         self.and_hms_milli_opt(hour, min, sec, milli).expect("invalid time")
     }
@@ -127,6 +132,7 @@ impl<Tz: TimeZone> Date<Tz> {
     ///
     /// Returns `None` on invalid hour, minute, second and/or millisecond.
     #[inline]
+    #[must_use]
     pub fn and_hms_milli_opt(
         &self,
         hour: u32,
@@ -144,6 +150,7 @@ impl<Tz: TimeZone> Date<Tz> {
     /// Panics on invalid hour, minute, second and/or microsecond.
     #[deprecated(since = "0.4.23", note = "Use and_hms_micro_opt() instead")]
     #[inline]
+    #[must_use]
     pub fn and_hms_micro(&self, hour: u32, min: u32, sec: u32, micro: u32) -> DateTime<Tz> {
         self.and_hms_micro_opt(hour, min, sec, micro).expect("invalid time")
     }
@@ -154,6 +161,7 @@ impl<Tz: TimeZone> Date<Tz> {
     ///
     /// Returns `None` on invalid hour, minute, second and/or microsecond.
     #[inline]
+    #[must_use]
     pub fn and_hms_micro_opt(
         &self,
         hour: u32,
@@ -171,6 +179,7 @@ impl<Tz: TimeZone> Date<Tz> {
     /// Panics on invalid hour, minute, second and/or nanosecond.
     #[deprecated(since = "0.4.23", note = "Use and_hms_nano_opt() instead")]
     #[inline]
+    #[must_use]
     pub fn and_hms_nano(&self, hour: u32, min: u32, sec: u32, nano: u32) -> DateTime<Tz> {
         self.and_hms_nano_opt(hour, min, sec, nano).expect("invalid time")
     }
@@ -181,6 +190,7 @@ impl<Tz: TimeZone> Date<Tz> {
     ///
     /// Returns `None` on invalid hour, minute, second and/or nanosecond.
     #[inline]
+    #[must_use]
     pub fn and_hms_nano_opt(
         &self,
         hour: u32,
@@ -196,6 +206,7 @@ impl<Tz: TimeZone> Date<Tz> {
     /// Panics when `self` is the last representable date.
     #[deprecated(since = "0.4.23", note = "Use succ_opt() instead")]
     #[inline]
+    #[must_use]
     pub fn succ(&self) -> Date<Tz> {
         self.succ_opt().expect("out of bound")
     }
@@ -204,6 +215,7 @@ impl<Tz: TimeZone> Date<Tz> {
     ///
     /// Returns `None` when `self` is the last representable date.
     #[inline]
+    #[must_use]
     pub fn succ_opt(&self) -> Option<Date<Tz>> {
         self.date.succ_opt().map(|date| Date::from_utc(date, self.offset.clone()))
     }
@@ -213,6 +225,7 @@ impl<Tz: TimeZone> Date<Tz> {
     /// Panics when `self` is the first representable date.
     #[deprecated(since = "0.4.23", note = "Use pred_opt() instead")]
     #[inline]
+    #[must_use]
     pub fn pred(&self) -> Date<Tz> {
         self.pred_opt().expect("out of bound")
     }
@@ -221,18 +234,21 @@ impl<Tz: TimeZone> Date<Tz> {
     ///
     /// Returns `None` when `self` is the first representable date.
     #[inline]
+    #[must_use]
     pub fn pred_opt(&self) -> Option<Date<Tz>> {
         self.date.pred_opt().map(|date| Date::from_utc(date, self.offset.clone()))
     }
 
     /// Retrieves an associated offset from UTC.
     #[inline]
+    #[must_use]
     pub fn offset(&self) -> &Tz::Offset {
         &self.offset
     }
 
     /// Retrieves an associated time zone.
     #[inline]
+    #[must_use]
     pub fn timezone(&self) -> Tz {
         TimeZone::from_offset(&self.offset)
     }
@@ -240,6 +256,7 @@ impl<Tz: TimeZone> Date<Tz> {
     /// Changes the associated time zone.
     /// This does not change the actual `Date` (but will change the string representation).
     #[inline]
+    #[must_use]
     pub fn with_timezone<Tz2: TimeZone>(&self, tz: &Tz2) -> Date<Tz2> {
         tz.from_utc_date(&self.date)
     }
@@ -248,6 +265,7 @@ impl<Tz: TimeZone> Date<Tz> {
     ///
     /// Returns `None` when it will result in overflow.
     #[inline]
+    #[must_use]
     pub fn checked_add_signed(self, rhs: OldDuration) -> Option<Date<Tz>> {
         let date = self.date.checked_add_signed(rhs)?;
         Some(Date { date, offset: self.offset })
@@ -257,6 +275,7 @@ impl<Tz: TimeZone> Date<Tz> {
     ///
     /// Returns `None` when it will result in overflow.
     #[inline]
+    #[must_use]
     pub fn checked_sub_signed(self, rhs: OldDuration) -> Option<Date<Tz>> {
         let date = self.date.checked_sub_signed(rhs)?;
         Some(Date { date, offset: self.offset })
@@ -268,12 +287,14 @@ impl<Tz: TimeZone> Date<Tz> {
     /// This does not overflow or underflow at all,
     /// as all possible output fits in the range of `Duration`.
     #[inline]
+    #[must_use]
     pub fn signed_duration_since<Tz2: TimeZone>(self, rhs: Date<Tz2>) -> OldDuration {
         self.date.signed_duration_since(rhs.date)
     }
 
     /// Returns a view to the naive UTC date.
     #[inline]
+    #[must_use]
     pub fn naive_utc(&self) -> NaiveDate {
         self.date
     }
@@ -284,11 +305,13 @@ impl<Tz: TimeZone> Date<Tz> {
     /// because the offset is restricted to never exceed one day,
     /// but provided for the consistency.
     #[inline]
+    #[must_use]
     pub fn naive_local(&self) -> NaiveDate {
         self.date
     }
 
     /// Returns the number of whole years from the given `base` until `self`.
+    #[must_use]
     pub fn years_since(&self, base: Self) -> Option<u32> {
         self.date.years_since(base.date)
     }
@@ -315,6 +338,7 @@ where
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
+    #[must_use]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
     where
         I: Iterator<Item = B> + Clone,
@@ -329,6 +353,7 @@ where
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
+    #[must_use]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
         self.format_with_items(StrftimeItems::new(fmt))
     }
@@ -337,6 +362,7 @@ where
     #[cfg(feature = "unstable-locales")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
     #[inline]
+    #[must_use]
     pub fn format_localized_with_items<'a, I, B>(
         &self,
         items: I,
@@ -361,6 +387,7 @@ where
     #[cfg(feature = "unstable-locales")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
     #[inline]
+    #[must_use]
     pub fn format_localized<'a>(
         &self,
         fmt: &'a str,

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -113,6 +113,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     //
     // note: this constructor is purposely not named to `new` to discourage the direct usage.
     #[inline]
+    #[must_use]
     pub fn from_utc(datetime: NaiveDateTime, offset: Tz::Offset) -> DateTime<Tz> {
         DateTime { datetime, offset }
     }
@@ -142,6 +143,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// assert_eq!(datetime_west, datetime_utc.with_timezone(&timezone_west));
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_local(datetime: NaiveDateTime, offset: Tz::Offset) -> DateTime<Tz> {
         let datetime_utc = datetime - offset.fix();
 
@@ -156,6 +158,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     #[inline]
     #[deprecated(since = "0.4.23", note = "Use `date_naive()` instead")]
     #[allow(deprecated)]
+    #[must_use]
     pub fn date(&self) -> Date<Tz> {
         Date::from_utc(self.naive_local().date(), self.offset.clone())
     }
@@ -173,6 +176,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// assert_eq!(date.date_naive(), other.date_naive());
     /// ```
     #[inline]
+    #[must_use]
     pub fn date_naive(&self) -> NaiveDate {
         let local = self.naive_local();
         NaiveDate::from_ymd_opt(local.year(), local.month(), local.day()).unwrap()
@@ -181,6 +185,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// Retrieves a time component.
     /// Unlike `date`, this is not associated to the time zone.
     #[inline]
+    #[must_use]
     pub fn time(&self) -> NaiveTime {
         self.datetime.time() + self.offset.fix()
     }
@@ -188,6 +193,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// Returns the number of non-leap seconds since January 1, 1970 0:00:00 UTC
     /// (aka "UNIX timestamp").
     #[inline]
+    #[must_use]
     pub fn timestamp(&self) -> i64 {
         self.datetime.timestamp()
     }
@@ -211,6 +217,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// assert_eq!(dt.timestamp_millis(), 1_000_000_000_555);
     /// ```
     #[inline]
+    #[must_use]
     pub fn timestamp_millis(&self) -> i64 {
         self.datetime.timestamp_millis()
     }
@@ -234,6 +241,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// assert_eq!(dt.timestamp_micros(), 1_000_000_000_000_555);
     /// ```
     #[inline]
+    #[must_use]
     pub fn timestamp_micros(&self) -> i64 {
         self.datetime.timestamp_micros()
     }
@@ -257,6 +265,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// assert_eq!(dt.timestamp_nanos(), 1_000_000_000_000_000_555);
     /// ```
     #[inline]
+    #[must_use]
     pub fn timestamp_nanos(&self) -> i64 {
         self.datetime.timestamp_nanos()
     }
@@ -267,6 +276,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// note: this is not the number of milliseconds since January 1, 1970 0:00:00 UTC
     #[inline]
+    #[must_use]
     pub fn timestamp_subsec_millis(&self) -> u32 {
         self.datetime.timestamp_subsec_millis()
     }
@@ -277,6 +287,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// note: this is not the number of microseconds since January 1, 1970 0:00:00 UTC
     #[inline]
+    #[must_use]
     pub fn timestamp_subsec_micros(&self) -> u32 {
         self.datetime.timestamp_subsec_micros()
     }
@@ -287,18 +298,21 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// note: this is not the number of nanoseconds since January 1, 1970 0:00:00 UTC
     #[inline]
+    #[must_use]
     pub fn timestamp_subsec_nanos(&self) -> u32 {
         self.datetime.timestamp_subsec_nanos()
     }
 
     /// Retrieves an associated offset from UTC.
     #[inline]
+    #[must_use]
     pub fn offset(&self) -> &Tz::Offset {
         &self.offset
     }
 
     /// Retrieves an associated time zone.
     #[inline]
+    #[must_use]
     pub fn timezone(&self) -> Tz {
         TimeZone::from_offset(&self.offset)
     }
@@ -306,6 +320,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// Changes the associated time zone.
     /// The returned `DateTime` references the same instant of time from the perspective of the provided time zone.
     #[inline]
+    #[must_use]
     pub fn with_timezone<Tz2: TimeZone>(&self, tz: &Tz2) -> DateTime<Tz2> {
         tz.from_utc_datetime(&self.datetime)
     }
@@ -314,6 +329,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// Returns `None` when it will result in overflow.
     #[inline]
+    #[must_use]
     pub fn checked_add_signed(self, rhs: OldDuration) -> Option<DateTime<Tz>> {
         let datetime = self.datetime.checked_add_signed(rhs)?;
         let tz = self.timezone();
@@ -326,6 +342,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// local time is not valid on the newly calculated date.
     ///
     /// See [`NaiveDate::checked_add_months`] for more details on behavior
+    #[must_use]
     pub fn checked_add_months(self, rhs: Months) -> Option<DateTime<Tz>> {
         self.naive_local()
             .checked_add_months(rhs)?
@@ -337,6 +354,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// Returns `None` when it will result in overflow.
     #[inline]
+    #[must_use]
     pub fn checked_sub_signed(self, rhs: OldDuration) -> Option<DateTime<Tz>> {
         let datetime = self.datetime.checked_sub_signed(rhs)?;
         let tz = self.timezone();
@@ -349,6 +367,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// local time is not valid on the newly calculated date.
     ///
     /// See [`NaiveDate::checked_sub_months`] for more details on behavior
+    #[must_use]
     pub fn checked_sub_months(self, rhs: Months) -> Option<DateTime<Tz>> {
         self.naive_local()
             .checked_sub_months(rhs)?
@@ -359,6 +378,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// Add a duration in [`Days`] to the date part of the `DateTime`
     ///
     /// Returns `None` if the resulting date would be out of range.
+    #[must_use]
     pub fn checked_add_days(self, days: Days) -> Option<Self> {
         self.naive_local()
             .checked_add_days(days)?
@@ -369,6 +389,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// Subtract a duration in [`Days`] from the date part of the `DateTime`
     ///
     /// Returns `None` if the resulting date would be out of range.
+    #[must_use]
     pub fn checked_sub_days(self, days: Days) -> Option<Self> {
         self.naive_local()
             .checked_sub_days(days)?
@@ -379,23 +400,27 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// Subtracts another `DateTime` from the current date and time.
     /// This does not overflow or underflow at all.
     #[inline]
+    #[must_use]
     pub fn signed_duration_since<Tz2: TimeZone>(self, rhs: DateTime<Tz2>) -> OldDuration {
         self.datetime.signed_duration_since(rhs.datetime)
     }
 
     /// Returns a view to the naive UTC datetime.
     #[inline]
+    #[must_use]
     pub fn naive_utc(&self) -> NaiveDateTime {
         self.datetime
     }
 
     /// Returns a view to the naive local datetime.
     #[inline]
+    #[must_use]
     pub fn naive_local(&self) -> NaiveDateTime {
         self.datetime + self.offset.fix()
     }
 
     /// Retrieve the elapsed years from now to the given [`DateTime`].
+    #[must_use]
     pub fn years_since(&self, base: Self) -> Option<u32> {
         let mut years = self.year() - base.year();
         let earlier_time =
@@ -588,6 +613,7 @@ where
     /// Returns an RFC 2822 date and time string such as `Tue, 1 Jul 2003 10:52:37 +0200`.
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
+    #[must_use]
     pub fn to_rfc2822(&self) -> String {
         let mut result = String::with_capacity(32);
         crate::format::write_rfc2822(&mut result, self.naive_local(), self.offset.fix())
@@ -598,6 +624,7 @@ where
     /// Returns an RFC 3339 and ISO 8601 date and time string such as `1996-12-19T16:39:57-08:00`.
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
+    #[must_use]
     pub fn to_rfc3339(&self) -> String {
         let mut result = String::with_capacity(32);
         crate::format::write_rfc3339(&mut result, self.naive_local(), self.offset.fix())
@@ -631,6 +658,7 @@ where
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
+    #[must_use]
     pub fn to_rfc3339_opts(&self, secform: SecondsFormat, use_z: bool) -> String {
         use crate::format::Numeric::*;
         use crate::format::Pad::Zero;
@@ -677,6 +705,7 @@ where
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
+    #[must_use]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
     where
         I: Iterator<Item = B> + Clone,
@@ -701,6 +730,7 @@ where
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
+    #[must_use]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
         self.format_with_items(StrftimeItems::new(fmt))
     }
@@ -709,6 +739,7 @@ where
     #[cfg(feature = "unstable-locales")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
     #[inline]
+    #[must_use]
     pub fn format_localized_with_items<'a, I, B>(
         &self,
         items: I,
@@ -736,6 +767,7 @@ where
     #[cfg(feature = "unstable-locales")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
     #[inline]
+    #[must_use]
     pub fn format_localized<'a>(
         &self,
         fmt: &'a str,

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -174,6 +174,7 @@ pub mod ts_nanoseconds {
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -200,6 +201,7 @@ pub mod ts_nanoseconds {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -296,6 +298,7 @@ pub mod ts_nanoseconds_option {
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -325,6 +328,7 @@ pub mod ts_nanoseconds_option {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -425,6 +429,7 @@ pub mod ts_microseconds {
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -451,6 +456,7 @@ pub mod ts_microseconds {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -546,6 +552,7 @@ pub mod ts_microseconds_option {
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -575,6 +582,7 @@ pub mod ts_microseconds_option {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -675,6 +683,7 @@ pub mod ts_milliseconds {
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -701,6 +710,7 @@ pub mod ts_milliseconds {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -793,6 +803,7 @@ pub mod ts_milliseconds_option {
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -834,6 +845,7 @@ pub mod ts_milliseconds_option {
     /// assert_eq!(t, E::V(S { time: None }));
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -935,6 +947,7 @@ pub mod ts_seconds {
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -961,6 +974,7 @@ pub mod ts_seconds {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -1050,6 +1064,7 @@ pub mod ts_seconds_option {
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -1079,6 +1094,7 @@ pub mod ts_seconds_option {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where
         D: de::Deserializer<'de>,

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -472,7 +472,7 @@ fn test_rfc3339_opts() {
 fn test_rfc3339_opts_nonexhaustive() {
     use crate::SecondsFormat;
     let dt = Utc.with_ymd_and_hms(1999, 10, 9, 1, 2, 3).unwrap();
-    dt.to_rfc3339_opts(SecondsFormat::__NonExhaustive, true);
+    let _ = dt.to_rfc3339_opts(SecondsFormat::__NonExhaustive, true);
 }
 
 #[test]

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -867,6 +867,7 @@ pub struct DelayedFormat<I> {
 #[cfg(any(feature = "alloc", feature = "std", test))]
 impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
     /// Makes a new `DelayedFormat` value out of local date and time.
+    #[must_use]
     pub fn new(date: Option<NaiveDate>, time: Option<NaiveTime>, items: I) -> DelayedFormat<I> {
         DelayedFormat {
             date,
@@ -879,6 +880,7 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
     }
 
     /// Makes a new `DelayedFormat` value out of local date and time and UTC offset.
+    #[must_use]
     pub fn new_with_offset<Off>(
         date: Option<NaiveDate>,
         time: Option<NaiveTime>,
@@ -902,6 +904,7 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
     /// Makes a new `DelayedFormat` value out of local date and time and locale.
     #[cfg(feature = "unstable-locales")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
+    #[must_use]
     pub fn new_with_locale(
         date: Option<NaiveDate>,
         time: Option<NaiveTime>,
@@ -914,6 +917,7 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
     /// Makes a new `DelayedFormat` value out of local date and time, UTC offset and locale.
     #[cfg(feature = "unstable-locales")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
+    #[must_use]
     pub fn new_with_offset_and_locale<Off>(
         date: Option<NaiveDate>,
         time: Option<NaiveTime>,

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -127,6 +127,7 @@ fn set_if_consistent<T: PartialEq>(old: &mut Option<T>, new: T) -> ParseResult<(
 
 impl Parsed {
     /// Returns the initial value of parsed parts.
+    #[must_use]
     pub fn new() -> Parsed {
         Parsed::default()
     }

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -227,6 +227,7 @@ pub struct StrftimeItems<'a> {
 
 impl<'a> StrftimeItems<'a> {
     /// Creates a new parsing iterator from the `strftime`-like format string.
+    #[must_use]
     pub fn new(s: &'a str) -> StrftimeItems<'a> {
         Self::with_remainer(s)
     }
@@ -234,6 +235,7 @@ impl<'a> StrftimeItems<'a> {
     /// Creates a new parsing iterator from the `strftime`-like format string.
     #[cfg(feature = "unstable-locales")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
+    #[must_use]
     pub fn new_with_locale(s: &'a str, locale: Locale) -> StrftimeItems<'a> {
         let d_fmt = StrftimeItems::new(locales::d_fmt(locale)).collect();
         let d_t_fmt = StrftimeItems::new(locales::d_t_fmt(locale)).collect();

--- a/src/month.rs
+++ b/src/month.rs
@@ -65,6 +65,7 @@ impl Month {
     /// ----------- | ---------  | ---------- | --- | ---------
     /// `m.succ()`: | `February` | `March`    | `...` | `January`
     #[inline]
+    #[must_use]
     pub fn succ(&self) -> Month {
         match *self {
             Month::January => Month::February,
@@ -88,6 +89,7 @@ impl Month {
     /// ----------- | ---------  | ---------- | --- | ---------
     /// `m.pred()`: | `December` | `January`  | `...` | `November`
     #[inline]
+    #[must_use]
     pub fn pred(&self) -> Month {
         match *self {
             Month::January => Month::December,
@@ -111,6 +113,7 @@ impl Month {
     /// -------------------------| --------- | ---------- | --- | -----
     /// `m.number_from_month()`: | 1         | 2          | `...` | 12
     #[inline]
+    #[must_use]
     pub fn number_from_month(&self) -> u32 {
         match *self {
             Month::January => 1,
@@ -135,6 +138,7 @@ impl Month {
     ///
     /// assert_eq!(Month::January.name(), "January")
     /// ```
+    #[must_use]
     pub fn name(&self) -> &'static str {
         match *self {
             Month::January => "January",

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -77,6 +77,7 @@ impl NaiveWeek {
     /// assert!(week.first_day() <= date);
     /// ```
     #[inline]
+    #[must_use]
     pub fn first_day(&self) -> NaiveDate {
         let start = self.start.num_days_from_monday();
         let end = self.date.weekday().num_days_from_monday();
@@ -96,6 +97,7 @@ impl NaiveWeek {
     /// assert!(week.last_day() >= date);
     /// ```
     #[inline]
+    #[must_use]
     pub fn last_day(&self) -> NaiveDate {
         self.first_day() + Duration::days(6)
     }
@@ -115,6 +117,7 @@ impl NaiveWeek {
     /// assert!(days.contains(&date));
     /// ```
     #[inline]
+    #[must_use]
     pub fn days(&self) -> RangeInclusive<NaiveDate> {
         self.first_day()..=self.last_day()
     }
@@ -259,6 +262,7 @@ impl NaiveDate {
     ///
     /// Panics on the out-of-range date, invalid month and/or day.
     #[deprecated(since = "0.4.23", note = "use `from_ymd_opt()` instead")]
+    #[must_use]
     pub fn from_ymd(year: i32, month: u32, day: u32) -> NaiveDate {
         NaiveDate::from_ymd_opt(year, month, day).expect("invalid or out-of-range date")
     }
@@ -282,6 +286,7 @@ impl NaiveDate {
     /// assert!(from_ymd_opt(400000, 1, 1).is_none());
     /// assert!(from_ymd_opt(-400000, 1, 1).is_none());
     /// ```
+    #[must_use]
     pub fn from_ymd_opt(year: i32, month: u32, day: u32) -> Option<NaiveDate> {
         let flags = YearFlags::from_year(year);
         NaiveDate::from_mdf(year, Mdf::new(month, day, flags)?)
@@ -292,6 +297,7 @@ impl NaiveDate {
     ///
     /// Panics on the out-of-range date and/or invalid day of year.
     #[deprecated(since = "0.4.23", note = "use `from_yo_opt()` instead")]
+    #[must_use]
     pub fn from_yo(year: i32, ordinal: u32) -> NaiveDate {
         NaiveDate::from_yo_opt(year, ordinal).expect("invalid or out-of-range date")
     }
@@ -316,6 +322,7 @@ impl NaiveDate {
     /// assert!(from_yo_opt(400000, 1).is_none());
     /// assert!(from_yo_opt(-400000, 1).is_none());
     /// ```
+    #[must_use]
     pub fn from_yo_opt(year: i32, ordinal: u32) -> Option<NaiveDate> {
         let flags = YearFlags::from_year(year);
         NaiveDate::from_of(year, Of::new(ordinal, flags)?)
@@ -327,6 +334,7 @@ impl NaiveDate {
     ///
     /// Panics on the out-of-range date and/or invalid week number.
     #[deprecated(since = "0.4.23", note = "use `from_isoywd_opt()` instead")]
+    #[must_use]
     pub fn from_isoywd(year: i32, week: u32, weekday: Weekday) -> NaiveDate {
         NaiveDate::from_isoywd_opt(year, week, weekday).expect("invalid or out-of-range date")
     }
@@ -375,6 +383,7 @@ impl NaiveDate {
     /// assert_eq!(from_isoywd_opt(2015, 54, Weekday::Mon), None);
     /// assert_eq!(from_isoywd_opt(2016, 1, Weekday::Mon), Some(from_ymd(2016, 1, 4)));
     /// ```
+    #[must_use]
     pub fn from_isoywd_opt(year: i32, week: u32, weekday: Weekday) -> Option<NaiveDate> {
         let flags = YearFlags::from_year(year);
         let nweeks = flags.nisoweeks();
@@ -412,6 +421,7 @@ impl NaiveDate {
     /// Panics if the date is out of range.
     #[deprecated(since = "0.4.23", note = "use `from_num_days_from_ce_opt()` instead")]
     #[inline]
+    #[must_use]
     pub fn from_num_days_from_ce(days: i32) -> NaiveDate {
         NaiveDate::from_num_days_from_ce_opt(days).expect("out-of-range date")
     }
@@ -436,6 +446,7 @@ impl NaiveDate {
     /// assert_eq!(from_ndays_opt(100_000_000),  None);
     /// assert_eq!(from_ndays_opt(-100_000_000), None);
     /// ```
+    #[must_use]
     pub fn from_num_days_from_ce_opt(days: i32) -> Option<NaiveDate> {
         let days = days + 365; // make December 31, 1 BCE equal to day 0
         let (year_div_400, cycle) = div_mod_floor(days, 146_097);
@@ -455,6 +466,7 @@ impl NaiveDate {
     ///
     /// `n` is 1-indexed.  Passing `n=0` will cause a panic.
     #[deprecated(since = "0.4.23", note = "use `from_weekday_of_month_opt()` instead")]
+    #[must_use]
     pub fn from_weekday_of_month(year: i32, month: u32, weekday: Weekday, n: u8) -> NaiveDate {
         NaiveDate::from_weekday_of_month_opt(year, month, weekday, n).expect("out-of-range date")
     }
@@ -471,6 +483,7 @@ impl NaiveDate {
     ///
     /// Returns `None` if `n` out-of-range; ie. if `n` is larger than the number of `weekday` in
     /// `month` (eg. the 6th Friday of March 2017), or if `n == 0`.
+    #[must_use]
     pub fn from_weekday_of_month_opt(
         year: i32,
         month: u32,
@@ -551,6 +564,7 @@ impl NaiveDate {
     ///     Some(NaiveDate::from_ymd_opt(2022, 9, 30).unwrap())
     /// );
     /// ```
+    #[must_use]
     pub fn checked_add_months(self, months: Months) -> Option<Self> {
         if months.0 == 0 {
             return Some(self);
@@ -581,6 +595,7 @@ impl NaiveDate {
     ///     None
     /// );
     /// ```
+    #[must_use]
     pub fn checked_sub_months(self, months: Months) -> Option<Self> {
         if months.0 == 0 {
             return Some(self);
@@ -654,6 +669,7 @@ impl NaiveDate {
     ///     None
     /// );
     /// ```
+    #[must_use]
     pub fn checked_add_days(self, days: Days) -> Option<Self> {
         if days.0 == 0 {
             return Some(self);
@@ -677,6 +693,7 @@ impl NaiveDate {
     ///     None
     /// );
     /// ```
+    #[must_use]
     pub fn checked_sub_days(self, days: Days) -> Option<Self> {
         if days.0 == 0 {
             return Some(self);
@@ -708,6 +725,7 @@ impl NaiveDate {
     /// assert_eq!(dt.time(), t);
     /// ```
     #[inline]
+    #[must_use]
     pub const fn and_time(&self, time: NaiveTime) -> NaiveDateTime {
         NaiveDateTime::new(*self, time)
     }
@@ -720,6 +738,7 @@ impl NaiveDate {
     /// Panics on invalid hour, minute and/or second.
     #[deprecated(since = "0.4.23", note = "use `and_hms_opt()` instead")]
     #[inline]
+    #[must_use]
     pub fn and_hms(&self, hour: u32, min: u32, sec: u32) -> NaiveDateTime {
         self.and_hms_opt(hour, min, sec).expect("invalid time")
     }
@@ -743,6 +762,7 @@ impl NaiveDate {
     /// assert!(d.and_hms_opt(24, 34, 56).is_none());
     /// ```
     #[inline]
+    #[must_use]
     pub fn and_hms_opt(&self, hour: u32, min: u32, sec: u32) -> Option<NaiveDateTime> {
         NaiveTime::from_hms_opt(hour, min, sec).map(|time| self.and_time(time))
     }
@@ -755,6 +775,7 @@ impl NaiveDate {
     /// Panics on invalid hour, minute, second and/or millisecond.
     #[deprecated(since = "0.4.23", note = "use `and_hms_milli_opt()` instead")]
     #[inline]
+    #[must_use]
     pub fn and_hms_milli(&self, hour: u32, min: u32, sec: u32, milli: u32) -> NaiveDateTime {
         self.and_hms_milli_opt(hour, min, sec, milli).expect("invalid time")
     }
@@ -780,6 +801,7 @@ impl NaiveDate {
     /// assert!(d.and_hms_milli_opt(24, 34, 56,   789).is_none());
     /// ```
     #[inline]
+    #[must_use]
     pub fn and_hms_milli_opt(
         &self,
         hour: u32,
@@ -812,6 +834,7 @@ impl NaiveDate {
     /// ```
     #[deprecated(since = "0.4.23", note = "use `and_hms_micro_opt()` instead")]
     #[inline]
+    #[must_use]
     pub fn and_hms_micro(&self, hour: u32, min: u32, sec: u32, micro: u32) -> NaiveDateTime {
         self.and_hms_micro_opt(hour, min, sec, micro).expect("invalid time")
     }
@@ -837,6 +860,7 @@ impl NaiveDate {
     /// assert!(d.and_hms_micro_opt(24, 34, 56,   789_012).is_none());
     /// ```
     #[inline]
+    #[must_use]
     pub fn and_hms_micro_opt(
         &self,
         hour: u32,
@@ -855,6 +879,7 @@ impl NaiveDate {
     /// Panics on invalid hour, minute, second and/or nanosecond.
     #[deprecated(since = "0.4.23", note = "use `and_hms_nano_opt()` instead")]
     #[inline]
+    #[must_use]
     pub fn and_hms_nano(&self, hour: u32, min: u32, sec: u32, nano: u32) -> NaiveDateTime {
         self.and_hms_nano_opt(hour, min, sec, nano).expect("invalid time")
     }
@@ -880,6 +905,7 @@ impl NaiveDate {
     /// assert!(d.and_hms_nano_opt(24, 34, 56,   789_012_345).is_none());
     /// ```
     #[inline]
+    #[must_use]
     pub fn and_hms_nano_opt(
         &self,
         hour: u32,
@@ -928,6 +954,7 @@ impl NaiveDate {
     /// Panics when `self` is the last representable date.
     #[deprecated(since = "0.4.23", note = "use `succ_opt()` instead")]
     #[inline]
+    #[must_use]
     pub fn succ(&self) -> NaiveDate {
         self.succ_opt().expect("out of bound")
     }
@@ -946,6 +973,7 @@ impl NaiveDate {
     /// assert_eq!(NaiveDate::MAX.succ_opt(), None);
     /// ```
     #[inline]
+    #[must_use]
     pub fn succ_opt(&self) -> Option<NaiveDate> {
         self.with_of(self.of().succ()).or_else(|| NaiveDate::from_ymd_opt(self.year() + 1, 1, 1))
     }
@@ -955,6 +983,7 @@ impl NaiveDate {
     /// Panics when `self` is the first representable date.
     #[deprecated(since = "0.4.23", note = "use `pred_opt()` instead")]
     #[inline]
+    #[must_use]
     pub fn pred(&self) -> NaiveDate {
         self.pred_opt().expect("out of bound")
     }
@@ -973,6 +1002,7 @@ impl NaiveDate {
     /// assert_eq!(NaiveDate::MIN.pred_opt(), None);
     /// ```
     #[inline]
+    #[must_use]
     pub fn pred_opt(&self) -> Option<NaiveDate> {
         self.with_of(self.of().pred()).or_else(|| NaiveDate::from_ymd_opt(self.year() - 1, 12, 31))
     }
@@ -995,6 +1025,7 @@ impl NaiveDate {
     /// assert_eq!(d.checked_add_signed(Duration::days(-1_000_000_000)), None);
     /// assert_eq!(NaiveDate::MAX.checked_add_signed(Duration::days(1)), None);
     /// ```
+    #[must_use]
     pub fn checked_add_signed(self, rhs: OldDuration) -> Option<NaiveDate> {
         let year = self.year();
         let (mut year_div_400, year_mod_400) = div_mod_floor(year, 400);
@@ -1026,6 +1057,7 @@ impl NaiveDate {
     /// assert_eq!(d.checked_sub_signed(Duration::days(-1_000_000_000)), None);
     /// assert_eq!(NaiveDate::MIN.checked_sub_signed(Duration::days(1)), None);
     /// ```
+    #[must_use]
     pub fn checked_sub_signed(self, rhs: OldDuration) -> Option<NaiveDate> {
         let year = self.year();
         let (mut year_div_400, year_mod_400) = div_mod_floor(year, 400);
@@ -1061,6 +1093,7 @@ impl NaiveDate {
     /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2010, 1, 1)), Duration::days(365*4 + 1));
     /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(1614, 1, 1)), Duration::days(365*400 + 97));
     /// ```
+    #[must_use]
     pub fn signed_duration_since(self, rhs: NaiveDate) -> OldDuration {
         let year1 = self.year();
         let year2 = rhs.year();
@@ -1074,6 +1107,7 @@ impl NaiveDate {
     }
 
     /// Returns the number of whole years from the given `base` until `self`.
+    #[must_use]
     pub fn years_since(&self, base: Self) -> Option<u32> {
         let mut years = self.year() - base.year();
         if (self.month(), self.day()) < (base.month(), base.day()) {
@@ -1116,6 +1150,7 @@ impl NaiveDate {
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
+    #[must_use]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
     where
         I: Iterator<Item = B> + Clone,
@@ -1159,6 +1194,7 @@ impl NaiveDate {
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
+    #[must_use]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
         self.format_with_items(StrftimeItems::new(fmt))
     }
@@ -1167,6 +1203,7 @@ impl NaiveDate {
     #[cfg(feature = "unstable-locales")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
     #[inline]
+    #[must_use]
     pub fn format_localized_with_items<'a, I, B>(
         &self,
         items: I,
@@ -1186,6 +1223,7 @@ impl NaiveDate {
     #[cfg(feature = "unstable-locales")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
     #[inline]
+    #[must_use]
     pub fn format_localized<'a>(
         &self,
         fmt: &'a str,

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -150,6 +150,7 @@ impl NaiveDateTime {
     /// Panics on the out-of-range number of seconds and/or invalid nanosecond.
     #[deprecated(since = "0.4.23", note = "use `from_timestamp_opt()` instead")]
     #[inline]
+    #[must_use]
     pub fn from_timestamp(secs: i64, nsecs: u32) -> NaiveDateTime {
         let datetime = NaiveDateTime::from_timestamp_opt(secs, nsecs);
         datetime.expect("invalid or out-of-range datetime")
@@ -177,6 +178,7 @@ impl NaiveDateTime {
     /// assert_eq!(timestamp_millis, naive_datetime.unwrap().timestamp_millis());
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_timestamp_millis(millis: i64) -> Option<NaiveDateTime> {
         Self::from_timestamp_unit(millis, TimestampUnit::Millis)
     }
@@ -203,6 +205,7 @@ impl NaiveDateTime {
     /// assert_eq!(timestamp_micros, naive_datetime.unwrap().timestamp_micros());
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_timestamp_micros(micros: i64) -> Option<NaiveDateTime> {
         Self::from_timestamp_unit(micros, TimestampUnit::Micros)
     }
@@ -234,6 +237,7 @@ impl NaiveDateTime {
     /// assert!(from_timestamp_opt(i64::MAX, 0).is_none());
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_timestamp_opt(secs: i64, nsecs: u32) -> Option<NaiveDateTime> {
         let (days, secs) = div_mod_floor(secs, 86_400);
         let date = days
@@ -317,7 +321,7 @@ impl NaiveDateTime {
     /// let fmt = "%Y-%m-%d %H:%M:%S";
     /// assert!(parse_from_str("10000-09-09 01:46:39", fmt).is_err());
     /// assert!(parse_from_str("+10000-09-09 01:46:39", fmt).is_ok());
-    ///```     
+    ///```
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<NaiveDateTime> {
         let mut parsed = Parsed::new();
         parse(&mut parsed, s, StrftimeItems::new(fmt))?;
@@ -377,6 +381,7 @@ impl NaiveDateTime {
     /// assert_eq!(dt.timestamp(), -62198755200);
     /// ```
     #[inline]
+    #[must_use]
     pub fn timestamp(&self) -> i64 {
         const UNIX_EPOCH_DAY: i64 = 719_163;
         let gregorian_day = i64::from(self.date.num_days_from_ce());
@@ -409,6 +414,7 @@ impl NaiveDateTime {
     /// assert_eq!(dt.timestamp_millis(), -900);
     /// ```
     #[inline]
+    #[must_use]
     pub fn timestamp_millis(&self) -> i64 {
         let as_ms = self.timestamp() * 1000;
         as_ms + i64::from(self.timestamp_subsec_millis())
@@ -436,6 +442,7 @@ impl NaiveDateTime {
     /// assert_eq!(dt.timestamp_micros(), 1_000_000_000_000_555);
     /// ```
     #[inline]
+    #[must_use]
     pub fn timestamp_micros(&self) -> i64 {
         let as_us = self.timestamp() * 1_000_000;
         as_us + i64::from(self.timestamp_subsec_micros())
@@ -475,6 +482,7 @@ impl NaiveDateTime {
     /// );
     /// ```
     #[inline]
+    #[must_use]
     pub fn timestamp_nanos(&self) -> i64 {
         let as_ns = self.timestamp() * 1_000_000_000;
         as_ns + i64::from(self.timestamp_subsec_nanos())
@@ -497,6 +505,7 @@ impl NaiveDateTime {
     /// assert_eq!(dt.timestamp_subsec_millis(), 1_234);
     /// ```
     #[inline]
+    #[must_use]
     pub fn timestamp_subsec_millis(&self) -> u32 {
         self.timestamp_subsec_nanos() / 1_000_000
     }
@@ -518,6 +527,7 @@ impl NaiveDateTime {
     /// assert_eq!(dt.timestamp_subsec_micros(), 1_234_567);
     /// ```
     #[inline]
+    #[must_use]
     pub fn timestamp_subsec_micros(&self) -> u32 {
         self.timestamp_subsec_nanos() / 1_000
     }
@@ -539,6 +549,7 @@ impl NaiveDateTime {
     /// assert_eq!(dt.timestamp_subsec_nanos(), 1_234_567_890);
     /// ```
     #[inline]
+    #[must_use]
     pub fn timestamp_subsec_nanos(&self) -> u32 {
         self.time.nanosecond()
     }
@@ -608,6 +619,7 @@ impl NaiveDateTime {
     /// assert_eq!(leap.checked_add_signed(Duration::days(1)),
     ///            Some(from_ymd(2016, 7, 9).and_hms_milli_opt(3, 5, 59, 300).unwrap()));
     /// ```
+    #[must_use]
     pub fn checked_add_signed(self, rhs: OldDuration) -> Option<NaiveDateTime> {
         let (time, rhs) = self.time.overflowing_add_signed(rhs);
 
@@ -644,6 +656,7 @@ impl NaiveDateTime {
     ///     None
     /// );
     /// ```
+    #[must_use]
     pub fn checked_add_months(self, rhs: Months) -> Option<NaiveDateTime> {
         Some(Self { date: self.date.checked_add_months(rhs)?, time: self.time })
     }
@@ -709,6 +722,7 @@ impl NaiveDateTime {
     /// assert_eq!(leap.checked_sub_signed(Duration::days(1)),
     ///            Some(from_ymd(2016, 7, 7).and_hms_milli_opt(3, 6, 0, 300).unwrap()));
     /// ```
+    #[must_use]
     pub fn checked_sub_signed(self, rhs: OldDuration) -> Option<NaiveDateTime> {
         let (time, rhs) = self.time.overflowing_sub_signed(rhs);
 
@@ -745,6 +759,7 @@ impl NaiveDateTime {
     ///     None
     /// );
     /// ```
+    #[must_use]
     pub fn checked_sub_months(self, rhs: Months) -> Option<NaiveDateTime> {
         Some(Self { date: self.date.checked_sub_months(rhs)?, time: self.time })
     }
@@ -752,6 +767,7 @@ impl NaiveDateTime {
     /// Add a duration in [`Days`] to the date part of the `NaiveDateTime`
     ///
     /// Returns `None` if the resulting date would be out of range.
+    #[must_use]
     pub fn checked_add_days(self, days: Days) -> Option<Self> {
         Some(Self { date: self.date.checked_add_days(days)?, ..self })
     }
@@ -759,6 +775,7 @@ impl NaiveDateTime {
     /// Subtract a duration in [`Days`] from the date part of the `NaiveDateTime`
     ///
     /// Returns `None` if the resulting date would be out of range.
+    #[must_use]
     pub fn checked_sub_days(self, days: Days) -> Option<Self> {
         Some(Self { date: self.date.checked_sub_days(days)?, ..self })
     }
@@ -801,6 +818,7 @@ impl NaiveDateTime {
     /// assert_eq!(from_ymd(2015, 7, 1).and_hms_opt(1, 0, 0).unwrap().signed_duration_since(leap),
     ///            Duration::seconds(3600) - Duration::milliseconds(500));
     /// ```
+    #[must_use]
     pub fn signed_duration_since(self, rhs: NaiveDateTime) -> OldDuration {
         self.date.signed_duration_since(rhs.date) + self.time.signed_duration_since(rhs.time)
     }
@@ -835,6 +853,7 @@ impl NaiveDateTime {
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
+    #[must_use]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
     where
         I: Iterator<Item = B> + Clone,
@@ -878,6 +897,7 @@ impl NaiveDateTime {
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
+    #[must_use]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
         self.format_with_items(StrftimeItems::new(fmt))
     }
@@ -899,6 +919,7 @@ impl NaiveDateTime {
     /// use chrono::{NaiveDate, Utc};
     /// let dt = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timezone(), Utc);
+    #[must_use]
     pub fn and_local_timezone<Tz: TimeZone>(&self, tz: Tz) -> LocalResult<DateTime<Tz>> {
         tz.from_local_datetime(self)
     }

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -110,6 +110,7 @@ pub mod ts_nanoseconds {
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -136,6 +137,7 @@ pub mod ts_nanoseconds {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -230,6 +232,7 @@ pub mod ts_nanoseconds_option {
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(opt: &Option<NaiveDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -259,6 +262,7 @@ pub mod ts_nanoseconds_option {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -356,6 +360,7 @@ pub mod ts_microseconds {
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -382,6 +387,7 @@ pub mod ts_microseconds {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -479,6 +485,7 @@ pub mod ts_microseconds_option {
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(opt: &Option<NaiveDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -508,6 +515,7 @@ pub mod ts_microseconds_option {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -605,6 +613,7 @@ pub mod ts_milliseconds {
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -631,6 +640,7 @@ pub mod ts_milliseconds {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -725,6 +735,7 @@ pub mod ts_milliseconds_option {
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(opt: &Option<NaiveDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -754,6 +765,7 @@ pub mod ts_milliseconds_option {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -851,6 +863,7 @@ pub mod ts_seconds {
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -877,6 +890,7 @@ pub mod ts_seconds {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -968,6 +982,7 @@ pub mod ts_seconds_option {
     /// assert_eq!(as_string, r#"{"time":1526522699}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn serialize<S>(opt: &Option<NaiveDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -997,6 +1012,7 @@ pub mod ts_seconds_option {
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
     /// # Ok::<(), serde_json::Error>(())
     /// ```
+    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
     where
         D: de::Deserializer<'de>,

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -114,6 +114,7 @@ impl YearFlags {
     #[allow(unreachable_pub)] // public as an alias for benchmarks only
     #[doc(hidden)] // for benchmarks only
     #[inline]
+    #[must_use]
     pub fn from_year(year: i32) -> YearFlags {
         let year = mod_floor(year, 400);
         YearFlags::from_year_mod_400(year)

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -214,6 +214,7 @@ impl NaiveTime {
     /// Panics on invalid hour, minute and/or second.
     #[deprecated(since = "0.4.23", note = "use `from_hms_opt()` instead")]
     #[inline]
+    #[must_use]
     pub fn from_hms(hour: u32, min: u32, sec: u32) -> NaiveTime {
         NaiveTime::from_hms_opt(hour, min, sec).expect("invalid time")
     }
@@ -239,6 +240,7 @@ impl NaiveTime {
     /// assert!(from_hms_opt(23, 59, 60).is_none());
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_hms_opt(hour: u32, min: u32, sec: u32) -> Option<NaiveTime> {
         NaiveTime::from_hms_nano_opt(hour, min, sec, 0)
     }
@@ -251,6 +253,7 @@ impl NaiveTime {
     /// Panics on invalid hour, minute, second and/or millisecond.
     #[deprecated(since = "0.4.23", note = "use `from_hms_milli_opt()` instead")]
     #[inline]
+    #[must_use]
     pub fn from_hms_milli(hour: u32, min: u32, sec: u32, milli: u32) -> NaiveTime {
         NaiveTime::from_hms_milli_opt(hour, min, sec, milli).expect("invalid time")
     }
@@ -278,6 +281,7 @@ impl NaiveTime {
     /// assert!(from_hmsm_opt(23, 59, 59, 2_000).is_none());
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_hms_milli_opt(hour: u32, min: u32, sec: u32, milli: u32) -> Option<NaiveTime> {
         milli
             .checked_mul(1_000_000)
@@ -292,6 +296,7 @@ impl NaiveTime {
     /// Panics on invalid hour, minute, second and/or microsecond.
     #[deprecated(since = "0.4.23", note = "use `from_hms_micro_opt()` instead")]
     #[inline]
+    #[must_use]
     pub fn from_hms_micro(hour: u32, min: u32, sec: u32, micro: u32) -> NaiveTime {
         NaiveTime::from_hms_micro_opt(hour, min, sec, micro).expect("invalid time")
     }
@@ -319,6 +324,7 @@ impl NaiveTime {
     /// assert!(from_hmsu_opt(23, 59, 59, 2_000_000).is_none());
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_hms_micro_opt(hour: u32, min: u32, sec: u32, micro: u32) -> Option<NaiveTime> {
         micro.checked_mul(1_000).and_then(|nano| NaiveTime::from_hms_nano_opt(hour, min, sec, nano))
     }
@@ -331,6 +337,7 @@ impl NaiveTime {
     /// Panics on invalid hour, minute, second and/or nanosecond.
     #[deprecated(since = "0.4.23", note = "use `from_hms_nano_opt()` instead")]
     #[inline]
+    #[must_use]
     pub fn from_hms_nano(hour: u32, min: u32, sec: u32, nano: u32) -> NaiveTime {
         NaiveTime::from_hms_nano_opt(hour, min, sec, nano).expect("invalid time")
     }
@@ -358,6 +365,7 @@ impl NaiveTime {
     /// assert!(from_hmsn_opt(23, 59, 59, 2_000_000_000).is_none());
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_hms_nano_opt(hour: u32, min: u32, sec: u32, nano: u32) -> Option<NaiveTime> {
         if hour >= 24 || min >= 60 || sec >= 60 || nano >= 2_000_000_000 {
             return None;
@@ -374,6 +382,7 @@ impl NaiveTime {
     /// Panics on invalid number of seconds and/or nanosecond.
     #[deprecated(since = "0.4.23", note = "use `from_num_seconds_from_midnight_opt()` instead")]
     #[inline]
+    #[must_use]
     pub fn from_num_seconds_from_midnight(secs: u32, nano: u32) -> NaiveTime {
         NaiveTime::from_num_seconds_from_midnight_opt(secs, nano).expect("invalid time")
     }
@@ -399,6 +408,7 @@ impl NaiveTime {
     /// assert!(from_nsecs_opt(86399, 2_000_000_000).is_none());
     /// ```
     #[inline]
+    #[must_use]
     pub fn from_num_seconds_from_midnight_opt(secs: u32, nano: u32) -> Option<NaiveTime> {
         if secs >= 86_400 || nano >= 2_000_000_000 {
             return None;
@@ -492,6 +502,7 @@ impl NaiveTime {
     /// assert_eq!(from_hms(3, 4, 5).overflowing_add_signed(Duration::hours(-7)),
     ///            (from_hms(20, 4, 5), -86_400));
     /// ```
+    #[must_use]
     pub fn overflowing_add_signed(&self, mut rhs: OldDuration) -> (NaiveTime, i64) {
         let mut secs = self.secs;
         let mut frac = self.frac;
@@ -575,6 +586,7 @@ impl NaiveTime {
     ///            (from_hms(1, 4, 5), -86_400));
     /// ```
     #[inline]
+    #[must_use]
     pub fn overflowing_sub_signed(&self, rhs: OldDuration) -> (NaiveTime, i64) {
         let (time, rhs) = self.overflowing_add_signed(-rhs);
         (time, -rhs) // safe to negate, rhs is within +/- (2^63 / 1000)
@@ -634,6 +646,7 @@ impl NaiveTime {
     /// assert_eq!(since(from_hmsm(3, 0, 59, 1_000), from_hmsm(2, 59, 59, 1_000)),
     ///            Duration::seconds(61));
     /// ```
+    #[must_use]
     pub fn signed_duration_since(self, rhs: NaiveTime) -> OldDuration {
         //     |    |    :leap|    |    |    |    |    |    |    :leap|    |
         //     |    |    :    |    |    |    |    |    |    |    :    |    |
@@ -696,6 +709,7 @@ impl NaiveTime {
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
+    #[must_use]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
     where
         I: Iterator<Item = B> + Clone,
@@ -741,6 +755,7 @@ impl NaiveTime {
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
+    #[must_use]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
         self.format_with_items(StrftimeItems::new(fmt))
     }

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -34,6 +34,7 @@ impl FixedOffset {
     ///
     /// Panics on the out-of-bound `secs`.
     #[deprecated(since = "0.4.23", note = "use `east_opt()` instead")]
+    #[must_use]
     pub fn east(secs: i32) -> FixedOffset {
         FixedOffset::east_opt(secs).expect("FixedOffset::east out of bounds")
     }
@@ -52,6 +53,7 @@ impl FixedOffset {
     ///                                           .and_hms_opt(0, 0, 0).unwrap();
     /// assert_eq!(&datetime.to_rfc3339(), "2016-11-08T00:00:00+05:00")
     /// ```
+    #[must_use]
     pub fn east_opt(secs: i32) -> Option<FixedOffset> {
         if -86_400 < secs && secs < 86_400 {
             Some(FixedOffset { local_minus_utc: secs })
@@ -65,6 +67,7 @@ impl FixedOffset {
     ///
     /// Panics on the out-of-bound `secs`.
     #[deprecated(since = "0.4.23", note = "use `west_opt()` instead")]
+    #[must_use]
     pub fn west(secs: i32) -> FixedOffset {
         FixedOffset::west_opt(secs).expect("FixedOffset::west out of bounds")
     }
@@ -83,6 +86,7 @@ impl FixedOffset {
     ///                                           .and_hms_opt(0, 0, 0).unwrap();
     /// assert_eq!(&datetime.to_rfc3339(), "2016-11-08T00:00:00-05:00")
     /// ```
+    #[must_use]
     pub fn west_opt(secs: i32) -> Option<FixedOffset> {
         if -86_400 < secs && secs < 86_400 {
             Some(FixedOffset { local_minus_utc: -secs })

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -60,6 +60,7 @@ impl Local {
     /// Returns a `Date` which corresponds to the current date.
     #[deprecated(since = "0.4.23", note = "use `Local::now()` instead")]
     #[allow(deprecated)]
+    #[must_use]
     pub fn today() -> Date<Local> {
         Local::now().date()
     }
@@ -70,6 +71,7 @@ impl Local {
         feature = "wasmbind",
         not(any(target_os = "emscripten", target_os = "wasi"))
     )))]
+    #[must_use]
     pub fn now() -> DateTime<Local> {
         inner::now()
     }
@@ -80,6 +82,7 @@ impl Local {
         feature = "wasmbind",
         not(any(target_os = "emscripten", target_os = "wasi"))
     ))]
+    #[must_use]
     pub fn now() -> DateTime<Local> {
         use super::Utc;
         let now: DateTime<Utc> = super::Utc::now();

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -52,6 +52,7 @@ pub enum LocalResult<T> {
 
 impl<T> LocalResult<T> {
     /// Returns `Some` only when the conversion result is unique, or `None` otherwise.
+    #[must_use]
     pub fn single(self) -> Option<T> {
         match self {
             LocalResult::Single(t) => Some(t),
@@ -60,6 +61,7 @@ impl<T> LocalResult<T> {
     }
 
     /// Returns `Some` for the earliest possible conversion result, or `None` if none.
+    #[must_use]
     pub fn earliest(self) -> Option<T> {
         match self {
             LocalResult::Single(t) | LocalResult::Ambiguous(t, _) => Some(t),
@@ -68,6 +70,7 @@ impl<T> LocalResult<T> {
     }
 
     /// Returns `Some` for the latest possible conversion result, or `None` if none.
+    #[must_use]
     pub fn latest(self) -> Option<T> {
         match self {
             LocalResult::Single(t) | LocalResult::Ambiguous(_, t) => Some(t),
@@ -76,6 +79,7 @@ impl<T> LocalResult<T> {
     }
 
     /// Maps a `LocalResult<T>` into `LocalResult<U>` with given function.
+    #[must_use]
     pub fn map<U, F: FnMut(T) -> U>(self, mut f: F) -> LocalResult<U> {
         match self {
             LocalResult::None => LocalResult::None,
@@ -92,6 +96,7 @@ impl<Tz: TimeZone> LocalResult<Date<Tz>> {
     ///
     /// Propagates any error. Ambiguous result would be discarded.
     #[inline]
+    #[must_use]
     pub fn and_time(self, time: NaiveTime) -> LocalResult<DateTime<Tz>> {
         match self {
             LocalResult::Single(d) => {
@@ -106,6 +111,7 @@ impl<Tz: TimeZone> LocalResult<Date<Tz>> {
     ///
     /// Propagates any error. Ambiguous result would be discarded.
     #[inline]
+    #[must_use]
     pub fn and_hms_opt(self, hour: u32, min: u32, sec: u32) -> LocalResult<DateTime<Tz>> {
         match self {
             LocalResult::Single(d) => {
@@ -121,6 +127,7 @@ impl<Tz: TimeZone> LocalResult<Date<Tz>> {
     ///
     /// Propagates any error. Ambiguous result would be discarded.
     #[inline]
+    #[must_use]
     pub fn and_hms_milli_opt(
         self,
         hour: u32,
@@ -142,6 +149,7 @@ impl<Tz: TimeZone> LocalResult<Date<Tz>> {
     ///
     /// Propagates any error. Ambiguous result would be discarded.
     #[inline]
+    #[must_use]
     pub fn and_hms_micro_opt(
         self,
         hour: u32,
@@ -163,6 +171,7 @@ impl<Tz: TimeZone> LocalResult<Date<Tz>> {
     ///
     /// Propagates any error. Ambiguous result would be discarded.
     #[inline]
+    #[must_use]
     pub fn and_hms_nano_opt(
         self,
         hour: u32,
@@ -181,6 +190,7 @@ impl<Tz: TimeZone> LocalResult<Date<Tz>> {
 
 impl<T: fmt::Debug> LocalResult<T> {
     /// Returns the single unique conversion result, or panics accordingly.
+    #[must_use]
     pub fn unwrap(self) -> T {
         match self {
             LocalResult::None => panic!("No such local time"),

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -54,6 +54,7 @@ impl Utc {
         note = "use `Utc::now()` instead, potentially with `.date_naive()`"
     )]
     #[allow(deprecated)]
+    #[must_use]
     pub fn today() -> Date<Utc> {
         Utc::now().date()
     }
@@ -64,6 +65,7 @@ impl Utc {
         feature = "wasmbind",
         not(any(target_os = "emscripten", target_os = "wasi"))
     )))]
+    #[must_use]
     pub fn now() -> DateTime<Utc> {
         let now =
             SystemTime::now().duration_since(UNIX_EPOCH).expect("system time before Unix epoch");
@@ -78,6 +80,7 @@ impl Utc {
         feature = "wasmbind",
         not(any(target_os = "emscripten", target_os = "wasi"))
     ))]
+    #[must_use]
     pub fn now() -> DateTime<Utc> {
         let now = js_sys::Date::new_0();
         DateTime::<Utc>::from(now)

--- a/src/oldtime.rs
+++ b/src/oldtime.rs
@@ -74,6 +74,7 @@ impl Duration {
     /// Equivalent to `Duration::seconds(weeks * 7 * 24 * 60 * 60)` with overflow checks.
     /// Panics when the duration is out of bounds.
     #[inline]
+    #[must_use]
     pub fn weeks(weeks: i64) -> Duration {
         let secs = weeks.checked_mul(SECS_PER_WEEK).expect("Duration::weeks out of bounds");
         Duration::seconds(secs)
@@ -83,6 +84,7 @@ impl Duration {
     /// Equivalent to `Duration::seconds(days * 24 * 60 * 60)` with overflow checks.
     /// Panics when the duration is out of bounds.
     #[inline]
+    #[must_use]
     pub fn days(days: i64) -> Duration {
         let secs = days.checked_mul(SECS_PER_DAY).expect("Duration::days out of bounds");
         Duration::seconds(secs)
@@ -92,6 +94,7 @@ impl Duration {
     /// Equivalent to `Duration::seconds(hours * 60 * 60)` with overflow checks.
     /// Panics when the duration is out of bounds.
     #[inline]
+    #[must_use]
     pub fn hours(hours: i64) -> Duration {
         let secs = hours.checked_mul(SECS_PER_HOUR).expect("Duration::hours ouf of bounds");
         Duration::seconds(secs)
@@ -101,6 +104,7 @@ impl Duration {
     /// Equivalent to `Duration::seconds(minutes * 60)` with overflow checks.
     /// Panics when the duration is out of bounds.
     #[inline]
+    #[must_use]
     pub fn minutes(minutes: i64) -> Duration {
         let secs = minutes.checked_mul(SECS_PER_MINUTE).expect("Duration::minutes out of bounds");
         Duration::seconds(secs)
@@ -110,6 +114,7 @@ impl Duration {
     /// Panics when the duration is more than `i64::MAX` seconds
     /// or less than `i64::MIN` seconds.
     #[inline]
+    #[must_use]
     pub fn seconds(seconds: i64) -> Duration {
         let d = Duration { secs: seconds, nanos: 0 };
         if d < MIN || d > MAX {
@@ -211,6 +216,7 @@ impl Duration {
     }
 
     /// Add two durations, returning `None` if overflow occurred.
+    #[must_use]
     pub fn checked_add(&self, rhs: &Duration) -> Option<Duration> {
         let mut secs = try_opt!(self.secs.checked_add(rhs.secs));
         let mut nanos = self.nanos + rhs.nanos;
@@ -229,6 +235,7 @@ impl Duration {
     }
 
     /// Subtract two durations, returning `None` if overflow occurred.
+    #[must_use]
     pub fn checked_sub(&self, rhs: &Duration) -> Option<Duration> {
         let mut secs = try_opt!(self.secs.checked_sub(rhs.secs));
         let mut nanos = self.nanos - rhs.nanos;

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -36,6 +36,7 @@ impl Weekday {
     /// ----------- | ----- | ----- | ----- | ----- | ----- | ----- | -----
     /// `w.succ()`: | `Tue` | `Wed` | `Thu` | `Fri` | `Sat` | `Sun` | `Mon`
     #[inline]
+    #[must_use]
     pub fn succ(&self) -> Weekday {
         match *self {
             Weekday::Mon => Weekday::Tue,
@@ -54,6 +55,7 @@ impl Weekday {
     /// ----------- | ----- | ----- | ----- | ----- | ----- | ----- | -----
     /// `w.pred()`: | `Sun` | `Mon` | `Tue` | `Wed` | `Thu` | `Fri` | `Sat`
     #[inline]
+    #[must_use]
     pub fn pred(&self) -> Weekday {
         match *self {
             Weekday::Mon => Weekday::Sun,


### PR DESCRIPTION
## Problem:

```rust
some_date.checked_add_days(Days::new(1)).unwrap();
```

## Expected:

`some_date` to change by 1 day, or a warning to be thrown.
Currently neither happens.

## After:

```
warning: unused return value of `NaiveDate::checked_add_days` that must be used
   --> src/main.rs:10:9
    |
10  |         some_date.checked_add_days(Days::new(1));
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_must_use)]` on by default
```

Adding [`#[must_use]`](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute) indicates that the method does not change the original object and the return value has to be used.

As I am not using chrono too much, I only added must_use to some methods and not all that should have it