### PR TITLE
Fix military timezones in RFC 2822 parsing

### DIFF
--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -854,6 +854,20 @@ fn test_rfc2822() {
         ("Tue, 20 Jan 2015 17:35:20 -0890", Err(OUT_OF_RANGE)), // bad offset
         ("6 Jun 1944 04:00:00Z", Err(INVALID)),            // bad offset (zulu not allowed)
         ("Tue, 20 Jan 2015 17:35:20 HAS", Err(NOT_ENOUGH)), // bad named time zone
+        // named timezones
+        ("Tue, 20 Jan 2015 17:35:20 GMT", Ok("Tue, 20 Jan 2015 17:35:20 +0000")),
+        ("Tue, 20 Jan 2015 17:35:20 UT", Ok("Tue, 20 Jan 2015 17:35:20 +0000")),
+        ("Tue, 20 Jan 2015 17:35:20 EDT", Ok("Tue, 20 Jan 2015 17:35:20 -0400")),
+        ("Tue, 20 Jan 2015 17:35:20 EST", Ok("Tue, 20 Jan 2015 17:35:20 -0500")),
+        ("Tue, 20 Jan 2015 17:35:20 CDT", Ok("Tue, 20 Jan 2015 17:35:20 -0500")),
+        ("Tue, 20 Jan 2015 17:35:20 CST", Ok("Tue, 20 Jan 2015 17:35:20 -0600")),
+        ("Tue, 20 Jan 2015 17:35:20 MDT", Ok("Tue, 20 Jan 2015 17:35:20 -0600")),
+        ("Tue, 20 Jan 2015 17:35:20 MST", Ok("Tue, 20 Jan 2015 17:35:20 -0700")),
+        ("Tue, 20 Jan 2015 17:35:20 PDT", Ok("Tue, 20 Jan 2015 17:35:20 -0700")),
+        ("Tue, 20 Jan 2015 17:35:20 PST", Ok("Tue, 20 Jan 2015 17:35:20 -0800")),
+        ("Tue, 20 Jan 2015 17:35:20 Z", Ok("Tue, 20 Jan 2015 17:35:20 +0000")),
+        ("Tue, 20 Jan 2015 17:35:20 A", Ok("Tue, 20 Jan 2015 17:35:20 +0000")),
+        ("Tue, 20 Jan 2015 17:35:20 K", Ok("Tue, 20 Jan 2015 17:35:20 +0000")),
     ];
 
     fn rfc2822_to_datetime(date: &str) -> ParseResult<DateTime<FixedOffset>> {

--- a/src/format/scan.rs
+++ b/src/format/scan.rs
@@ -334,8 +334,14 @@ pub(super) fn timezone_offset_2822(s: &str) -> ParseResult<(&str, Option<i32>)> 
             offset_hours(-7)
         } else if equals(name, "pst") {
             offset_hours(-8)
+        } else if name.len() == 1 {
+            match name.as_bytes()[0] {
+                // recommended by RFC 2822: consume but treat it as -0000
+                b'a'..=b'i' | b'k'..=b'z' | b'A'..=b'I' | b'K'..=b'Z' => offset_hours(0),
+                _ => Ok((s, None)),
+            }
         } else {
-            Ok((s, None)) // recommended by RFC 2822: consume but treat it as -0000
+            Ok((s, None))
         }
     } else {
         let (s_, offset) = timezone_offset(s, |s| Ok(s))?;


### PR DESCRIPTION
Currently RFC 2822 formatted datetimes with a single letter as timezone fail to parse, like `Tue, 20 Jan 2015 17:35:20 Z`.

The existing code had a comment `recommended by RFC 2822: consume but treat it as -0000`.
But then it would do the opposite and return an error.

I changed it to allow all acceptable military timezones (A-I and K-Z), but keep failing on other input.