### PR TITLE
Remove `iana-time-zone` dependency for `clock` feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,11 @@ edition = "2018"
 name = "chrono"
 
 [features]
-default = ["clock", "std", "wasmbind"]
+default = ["clock", "std", "wasmbind", "iana-time-zone"]
 alloc = []
 libc = []
 std = []
-clock = ["std", "windows-sys", "iana-time-zone"]
+clock = ["std", "windows-sys"]
 wasmbind = ["wasm-bindgen", "js-sys"]
 unstable-locales = ["pure-rust-locales", "alloc"]
 __internal_bench = ["criterion"]

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -78,10 +78,16 @@ const TZDB_LOCATION: &str = "/usr/share/lib/zoneinfo";
 #[cfg(not(any(target_os = "android", target_os = "aix")))]
 const TZDB_LOCATION: &str = "/usr/share/zoneinfo";
 
+#[cfg(feature = "iana-time-zone")]
 fn fallback_timezone() -> Option<TimeZone> {
     let tz_name = iana_time_zone::get_timezone().ok()?;
     let bytes = fs::read(format!("{}/{}", TZDB_LOCATION, tz_name)).ok()?;
     TimeZone::from_tz_data(&bytes).ok()
+}
+
+#[cfg(not(feature = "iana-time-zone"))]
+fn fallback_timezone() -> Option<TimeZone> {
+    None
 }
 
 impl Default for Cache {


### PR DESCRIPTION
### Background

I would like to bump `chrono`'s version in Android project. Unfortunately, `iana-time-zone` dependency of the `clock` feature doesn't allow me do it. In case of Android `iana-time-zone` uses `android_system_properties` crate to look up system properties (this is not a stable API). 

### Solution

Make `iana-time-zone` dependency default for the crate, but remove it from the `clock` feature requirements.

### Alternative

Use `libc`'s localtime functionality. This functionality was removed from the crate in pull #499 due to potential [`SEGFAULT`](https://rustsec.org/advisories/RUSTSEC-2020-0159).