### PR TITLE
Apply comments from MSRV bump

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -386,7 +386,7 @@ pub enum ParseErrorKind {
     /// There was an error on the formatting string, or there were non-supported formating items.
     BadFormat,
 
-    // TODO: Change this to `#[non_exhaustive]` (on the enum) when MSRV is increased
+    // TODO: Change this to `#[non_exhaustive]` (on the enum) with the next breaking release.
     #[doc(hidden)]
     __Nonexhaustive,
 }

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -106,6 +106,7 @@ pub struct Parsed {
     pub offset: Option<i32>,
 
     /// A dummy field to make this type not fully destructible (required for API stability).
+    // TODO: Change this to `#[non_exhaustive]` (on the enum) with the next breaking release.
     _dummy: (),
 }
 

--- a/src/offset/local/tz_info/mod.rs
+++ b/src/offset/local/tz_info/mod.rs
@@ -100,21 +100,6 @@ impl From<Utf8Error> for Error {
     }
 }
 
-// MSRV: 1.38
-#[inline]
-fn rem_euclid(v: i64, rhs: i64) -> i64 {
-    let r = v % rhs;
-    if r < 0 {
-        if rhs < 0 {
-            r - rhs
-        } else {
-            r + rhs
-        }
-    } else {
-        r
-    }
-}
-
 /// Number of hours in one day
 const HOURS_PER_DAY: i64 = 24;
 /// Number of seconds in one hour

--- a/src/offset/local/tz_info/parser.rs
+++ b/src/offset/local/tz_info/parser.rs
@@ -7,7 +7,6 @@ use super::rule::TransitionRule;
 use super::timezone::{LeapSecond, LocalTimeType, TimeZone, Transition};
 use super::Error;
 
-#[allow(clippy::map_clone)] // MSRV: 1.36
 pub(super) fn parse(bytes: &[u8]) -> Result<TimeZone, Error> {
     let mut cursor = Cursor::new(bytes);
     let state = State::new(&mut cursor, true)?;
@@ -66,8 +65,8 @@ pub(super) fn parse(bytes: &[u8]) -> Result<TimeZone, Error> {
         leap_seconds.push(LeapSecond::new(unix_leap_time, correction));
     }
 
-    let std_walls_iter = state.std_walls.iter().map(|&i| i).chain(iter::repeat(0));
-    let ut_locals_iter = state.ut_locals.iter().map(|&i| i).chain(iter::repeat(0));
+    let std_walls_iter = state.std_walls.iter().copied().chain(iter::repeat(0));
+    let ut_locals_iter = state.ut_locals.iter().copied().chain(iter::repeat(0));
     if std_walls_iter.zip(ut_locals_iter).take(state.header.type_count).any(|pair| pair == (0, 1)) {
         return Err(Error::InvalidTzFile(
             "invalid couple of standard/wall and UT/local indicators",

--- a/src/offset/local/tz_info/rule.rs
+++ b/src/offset/local/tz_info/rule.rs
@@ -3,7 +3,7 @@ use std::cmp::Ordering;
 use super::parser::Cursor;
 use super::timezone::{LocalTimeType, SECONDS_PER_WEEK};
 use super::{
-    rem_euclid, Error, CUMUL_DAY_IN_MONTHS_NORMAL_YEAR, DAYS_PER_WEEK, DAY_IN_MONTHS_NORMAL_YEAR,
+    Error, CUMUL_DAY_IN_MONTHS_NORMAL_YEAR, DAYS_PER_WEEK, DAY_IN_MONTHS_NORMAL_YEAR,
     SECONDS_PER_DAY,
 };
 
@@ -589,9 +589,9 @@ impl RuleDay {
                 }
 
                 let week_day_of_first_month_day =
-                    rem_euclid(4 + days_since_unix_epoch(year, month, 1), DAYS_PER_WEEK);
+                    (4 + days_since_unix_epoch(year, month, 1)).rem_euclid(DAYS_PER_WEEK);
                 let first_week_day_occurence_in_month =
-                    1 + rem_euclid(week_day as i64 - week_day_of_first_month_day, DAYS_PER_WEEK);
+                    1 + (week_day as i64 - week_day_of_first_month_day).rem_euclid(DAYS_PER_WEEK);
 
                 let mut month_day =
                     first_week_day_occurence_in_month + (week as i64 - 1) * DAYS_PER_WEEK;


### PR DESCRIPTION
Apply three comments that could be done when the MSRV was increased to 1.48.

I am not sure about applying `#[non_exhaustive]` to `ParseErrorKind` instead of a `__Nonexhaustive` variant. Would that be a breaking change?

Or would this be the time to increase the MSRV further?