### PR TITLE
Fix tests on AIX

### DIFF
--- a/src/offset/local/tz_info/timezone.rs
+++ b/src/offset/local/tz_info/timezone.rs
@@ -620,8 +620,8 @@ fn saturating_abs(v: i32) -> i32 {
 
 // Possible system timezone directories
 #[cfg(unix)]
-const ZONE_INFO_DIRECTORIES: [&str; 3] =
-    ["/usr/share/zoneinfo", "/share/zoneinfo", "/etc/zoneinfo"];
+const ZONE_INFO_DIRECTORIES: [&str; 4] =
+    ["/usr/share/zoneinfo", "/share/zoneinfo", "/etc/zoneinfo", "/usr/share/lib/zoneinfo"];
 
 /// Number of seconds in one week
 pub(crate) const SECONDS_PER_WEEK: i64 = SECONDS_PER_DAY * DAYS_PER_WEEK;

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -51,7 +51,10 @@ fn verify_against_date_command_local(path: &'static str, dt: NaiveDateTime) {
 #[test]
 #[cfg(unix)]
 fn try_verify_against_date_command() {
+    #[cfg(not(target_os = "aix"))]
     let date_path = "/usr/bin/date";
+    #[cfg(target_os = "aix")]
+    let date_path = "/opt/freeware/bin/date";
 
     if !path::Path::new(date_path).exists() {
         // date command not found, skipping


### PR DESCRIPTION
- Add AIX timezone database path to search list.
- Use date program from freeware to do the testing.

Unfortunately AIX has not been supported by CI, but after this fix, all tests pass on AIX.