### PR TITLE
Revert "Add with_timezone to NaiveDateTime"

### DIFF
--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -554,28 +554,6 @@ impl NaiveDateTime {
         self.time.nanosecond()
     }
 
-    /// Associated this `NaiveDateTime` with a [`TimeZone`], turning it into a [`DateTime`].
-    ///
-    /// Note that not all datetimes may be valid in the target timezone, or a datetime may be
-    /// ambiguous. Use the methods on [`LocalResult`] to handle such cases.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use chrono::{Local, NaiveDate};
-    ///
-    /// let d = NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_opt(3, 5, 7).unwrap();
-    /// let timezone = Local;
-    /// let d_local = d.with_timezone(&timezone).latest().unwrap();
-    ///
-    /// assert_eq!(d_local.naive_local(), d)
-    /// ```
-    #[inline]
-    #[must_use]
-    pub fn with_timezone<Tz: TimeZone>(&self, tz: &Tz) -> LocalResult<DateTime<Tz>> {
-        tz.from_local_datetime(self)
-    }
-
     /// Adds given `Duration` to the current date and time.
     ///
     /// As a part of Chrono's [leap second handling](./struct.NaiveTime.html#leap-second-handling),


### PR DESCRIPTION
I honestly didn't notice the existing [`and_local_timezone`](https://docs.rs/chrono/latest/chrono/naive/struct.NaiveDateTime.html#method.and_local_timezone) method. Sorry!