### PR TITLE
Add DateTime::fix_offset

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -325,6 +325,14 @@ impl<Tz: TimeZone> DateTime<Tz> {
         tz.from_utc_datetime(&self.datetime)
     }
 
+    /// Fix the offset from UTC to its current value, dropping the associated timezone information.
+    /// This it useful for converting a generic `DateTime<Tz: Timezone>` to `DateTime<FixedOffset>`.
+    #[inline]
+    #[must_use]
+    pub fn fixed_offset(&self) -> DateTime<FixedOffset> {
+        self.with_timezone(&self.offset().fix())
+    }
+
     /// Adds given `Duration` to the current date and time.
     ///
     /// Returns `None` when it will result in overflow.

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1920,4 +1920,18 @@ fn test_datetime_local_from_preserves_offset() {
 
     let datetime_fixed: DateTime<FixedOffset> = datetime.into();
     assert_eq!(&offset, datetime_fixed.offset());
+    assert_eq!(datetime.fixed_offset(), datetime_fixed);
+}
+
+#[test]
+fn test_datetime_fixed_offset() {
+    let naivedatetime = NaiveDate::from_ymd_opt(2023, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+
+    let datetime = Utc.from_utc_datetime(&naivedatetime);
+    let fixed_utc = FixedOffset::east_opt(0).unwrap();
+    assert_eq!(datetime.fixed_offset(), fixed_utc.from_local_datetime(&naivedatetime).unwrap());
+
+    let fixed_offset = FixedOffset::east_opt(3600).unwrap();
+    let datetime_fixed = fixed_offset.from_local_datetime(&naivedatetime).unwrap();
+    assert_eq!(datetime_fixed.fixed_offset(), datetime_fixed);
 }


### PR DESCRIPTION
As an anecdote, I was stumped for days how to let a hobby project handle timestamps with timezones. Entries could come from various sources, with different associated timezones. So I had generic `DateTime<Tz: Timezone>` objects. How to collect those in a data structure?

Finally it 'clicked' that the full timezone didn't matter in my case, just the offset from UTC of an entry should be preserved.

Converting a generic `DateTime` to `DateTime<FixedOffset>` is trivial when you know the innards of chrono. But if there was a `Datetime::fix_offset` method it probably would have set me on the right track. (Then this took me quite a while because the [`fix()`](https://docs.rs/chrono/latest/chrono/offset/trait.Offset.html#tymethod.fix) method is somewhat hidden in the `Offset` trait, and I saw a similar story in one of the issues.) 

Note that a generic `From` implementation is not possible:
```rust
impl<Tz: TimeZone> From<DateTime<Tz>> for DateTime<FixedOffset> {
    fn from(src: DateTime<Tz>) -> Self {
        src.with_timezone(&src.offset().fix())
    }
}
```
That fails with `conflicting implementation in crate 'core': impl<T> From<T> for T`.

I also remember one of my naive tries was `with_timezone(&FixedOffset)`, comparable to `with_timezone(&Utc)`. But that doesn't just work, the `FixedOffset` must be derived from the `DateTime` first.

What a `fix_offset` method would also be an alternative to is the unfortunate implementation of 
[`From<DateTime<Local>> for DateTime<FixedOffset>`](https://docs.rs/chrono/latest/chrono/struct.DateTime.html#method.from-2), that says: "Note that the converted value returned by this will be created with a fixed timezone offset of 0."

I am curious about your opinions. Can converting a generic `DateTime` to `DateTime<FixedOffset>` be considered a fundamental enough thing to do to add this method?