### PR TITLE
Enforce `FixedOffset` is a multiple of 60

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1241,13 +1241,6 @@ where
         .ok(),
         Some(r#""2014-07-24T12:34:06+01:01""#.into())
     );
-    assert_eq!(
-        to_string_fixed(
-            &FixedOffset::east_opt(3650).unwrap().with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
-        )
-        .ok(),
-        Some(r#""2014-07-24T12:34:06+01:00:50""#.into())
-    );
 }
 
 #[cfg(all(test, feature = "clock", any(feature = "rustc-serialize", feature = "serde")))]

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -172,7 +172,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// use chrono::prelude::*;
     ///
     /// let date: DateTime<Utc> = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
-    /// let other: DateTime<FixedOffset> = FixedOffset::east_opt(23).unwrap().with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+    /// let other: DateTime<FixedOffset> = FixedOffset::east_opt(13 * 60 * 60).unwrap().with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
     /// assert_eq!(date.date_naive(), other.date_naive());
     /// ```
     #[inline]

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -1209,8 +1209,8 @@ mod tests {
         );
         assert_eq!(
             parse!(year: 2014, ordinal: 365, hour_div_12: 0, hour_mod_12: 1,
-                          minute: 42, second: 4, nanosecond: 12_345_678, offset: -9876),
-            ymdhmsn(2014, 12, 31, 1, 42, 4, 12_345_678, -9876)
+                          minute: 42, second: 4, nanosecond: 12_345_678, offset: -9900),
+            ymdhmsn(2014, 12, 31, 1, 42, 4, 12_345_678, -9900)
         );
         assert_eq!(
             parse!(year: 2015, ordinal: 1, hour_div_12: 0, hour_mod_12: 4,

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -71,7 +71,7 @@ The following specifiers are available both to formatting and parsing.
 | `%Z`  | `ACST`   | Local time zone name. Skips all non-whitespace characters during parsing. [^8] |
 | `%z`  | `+0930`  | Offset from the local time to UTC (with UTC being `+0000`).                |
 | `%:z` | `+09:30` | Same as `%z` but with a colon.                                             |
-|`%::z`|`+09:30:00`| Offset from the local time to UTC with seconds.                            |
+|`%::z`|`+09:30:00`| Offset from the local time to UTC with seconds. Seconds must always be `00`. |
 |`%:::z`| `+09`    | Offset from the local time to UTC without minutes.                         |
 | `%#z` | `+09`    | *Parsing only:* Same as `%z` but allows minutes to be missing or present.  |
 |       |          |                                                                            |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -525,3 +525,20 @@ macro_rules! matches {
         }
     }
 }
+
+#[test]
+#[allow(deprecated)]
+fn test_type_sizes() {
+    use core::mem::size_of;
+    assert_eq!(size_of::<NaiveDate>(), 4);
+    assert_eq!(size_of::<NaiveTime>(), 8);
+    assert_eq!(size_of::<NaiveDateTime>(), 12);
+
+    assert_eq!(size_of::<DateTime<Utc>>(), 12);
+    assert_eq!(size_of::<DateTime<FixedOffset>>(), 16);
+    assert_eq!(size_of::<DateTime<Local>>(), 16);
+    assert_eq!(size_of::<Option<DateTime<FixedOffset>>>(), 16);
+
+    assert_eq!(size_of::<Date<Utc>>(), 4);
+    assert_eq!(size_of::<Date<FixedOffset>>(), 8);
+}


### PR DESCRIPTION
Offsets from UTC are defined in whole hours and minutes, never with seconds.
`FixedOffset` stores the offset from UTC in seconds, which makes sense because it allows for fast calculations.

I propose to enforce the value of `FixedOffset` is always a multiple of 60.
This prevents a number of existing or potential problems:
- RFC 2822 and RFC 3339 don't allow seconds. Chrono currently can create invalid strings with offset formatted as `hh::mm::ss`.
- The resulting string can not be parsed by chrono.
- This also effects serialization with serde.
- Leap seconds should always occur after the 59th second. Having an offset with seconds can place it after any other second, making a mess.

I mainly want to make this change because it prevents those problems.
Enforcing `FixedOffset` is always a multiple of 60 enables a nice possibility: it can fit inside an `i16` if we shift the value 2 bits (which we can, 60 is divisable by 4). This creates room for niche optimization: `<Option<DateTime<FixedOffset>>>` now only requires 16 bytes instead of 20.

Could this effect users of chrono?
It is pretty much a rule that whenever you start checking something you didn't before, it catches some problems. Because Unix, Windows and the IANA timezone database don't allow seconds to define offsets, and because chrono can barely parse them (only with the `%::z` specifier), I don't expect any issues in real-world uses. But it may trip up some artificial test.