### PR TITLE
Remove num-integer dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ __doctest = []
 
 [dependencies]
 time = { version = "0.1.43", optional = true }
-num-integer = { version = "0.1.36", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }
 serde = { version = "1.0.99", default-features = false, optional = true }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -512,8 +512,6 @@ fn format_inner(
 ) -> fmt::Result {
     let locale = Locales::new(locale);
 
-    use num_integer::{div_floor, mod_floor};
-
     match *item {
         Item::Literal(s) | Item::Space(s) => result.push_str(s),
         #[cfg(any(feature = "alloc", feature = "std", test))]
@@ -527,11 +525,11 @@ fn format_inner(
 
             let (width, v) = match *spec {
                 Year => (4, date.map(|d| i64::from(d.year()))),
-                YearDiv100 => (2, date.map(|d| div_floor(i64::from(d.year()), 100))),
-                YearMod100 => (2, date.map(|d| mod_floor(i64::from(d.year()), 100))),
+                YearDiv100 => (2, date.map(|d| i64::from(d.year()).div_euclid(100))),
+                YearMod100 => (2, date.map(|d| i64::from(d.year()).rem_euclid(100))),
                 IsoYear => (4, date.map(|d| i64::from(d.iso_week().year()))),
-                IsoYearDiv100 => (2, date.map(|d| div_floor(i64::from(d.iso_week().year()), 100))),
-                IsoYearMod100 => (2, date.map(|d| mod_floor(i64::from(d.iso_week().year()), 100))),
+                IsoYearDiv100 => (2, date.map(|d| i64::from(d.iso_week().year()).div_euclid(100))),
+                IsoYearMod100 => (2, date.map(|d| i64::from(d.iso_week().year()).rem_euclid(100))),
                 Month => (2, date.map(|d| i64::from(d.month()))),
                 Day => (2, date.map(|d| i64::from(d.day()))),
                 WeekFromSun => (2, date.map(|d| i64::from(week_from_sun(d)))),

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -4,7 +4,6 @@
 //! A collection of parsed date and time items.
 //! They can be constructed incrementally while being checked for consistency.
 
-use num_integer::div_rem;
 use num_traits::ToPrimitive;
 
 use super::{ParseResult, IMPOSSIBLE, NOT_ENOUGH, OUT_OF_RANGE};
@@ -311,7 +310,8 @@ impl Parsed {
                     if y < 0 {
                         return Err(OUT_OF_RANGE);
                     }
-                    let (q_, r_) = div_rem(y, 100);
+                    let q_ = y / 100;
+                    let r_ = y % 100;
                     if q.unwrap_or(q_) == q_ && r.unwrap_or(r_) == r_ {
                         Ok(Some(y))
                     } else {
@@ -346,8 +346,7 @@ impl Parsed {
         let verify_ymd = |date: NaiveDate| {
             let year = date.year();
             let (year_div_100, year_mod_100) = if year >= 0 {
-                let (q, r) = div_rem(year, 100);
-                (Some(q), Some(r))
+                (Some(year / 100), Some(year % 100))
             } else {
                 (None, None) // they should be empty to be consistent
             };
@@ -367,8 +366,7 @@ impl Parsed {
             let isoweek = week.week();
             let weekday = date.weekday();
             let (isoyear_div_100, isoyear_mod_100) = if isoyear >= 0 {
-                let (q, r) = div_rem(isoyear, 100);
-                (Some(q), Some(r))
+                (Some(isoyear / 100), Some(isoyear % 100))
             } else {
                 (None, None) // they should be empty to be consistent
             };

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -9,7 +9,6 @@ use core::convert::TryFrom;
 use core::ops::{Add, AddAssign, RangeInclusive, Sub, SubAssign};
 use core::{fmt, str};
 
-use num_integer::div_mod_floor;
 use num_traits::ToPrimitive;
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
@@ -2035,6 +2034,10 @@ impl Default for NaiveDate {
     fn default() -> Self {
         NaiveDate::from_ymd_opt(1970, 1, 1).unwrap()
     }
+}
+
+fn div_mod_floor(val: i32, div: i32) -> (i32, i32) {
+    (val.div_euclid(div), val.rem_euclid(div))
 }
 
 #[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -10,7 +10,6 @@ use core::fmt::Write;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::{fmt, str};
 
-use num_integer::div_mod_floor;
 use num_traits::ToPrimitive;
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
@@ -239,7 +238,8 @@ impl NaiveDateTime {
     #[inline]
     #[must_use]
     pub fn from_timestamp_opt(secs: i64, nsecs: u32) -> Option<NaiveDateTime> {
-        let (days, secs) = div_mod_floor(secs, 86_400);
+        let days = secs.div_euclid(86_400);
+        let secs = secs.rem_euclid(86_400);
         let date = days
             .to_i32()
             .and_then(|days| days.checked_add(719_163))

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -17,7 +17,6 @@
 
 use crate::Weekday;
 use core::{fmt, i32};
-use num_integer::{div_rem, mod_floor};
 use num_traits::FromPrimitive;
 
 /// The internal date representation. This also includes the packed `Mdf` value.
@@ -95,7 +94,8 @@ static YEAR_DELTAS: [u8; 401] = [
 ];
 
 pub(super) fn cycle_to_yo(cycle: u32) -> (u32, u32) {
-    let (mut year_mod_400, mut ordinal0) = div_rem(cycle, 365);
+    let mut year_mod_400 = cycle / 365;
+    let mut ordinal0 = cycle % 365;
     let delta = u32::from(YEAR_DELTAS[year_mod_400 as usize]);
     if ordinal0 < delta {
         year_mod_400 -= 1;
@@ -116,7 +116,7 @@ impl YearFlags {
     #[inline]
     #[must_use]
     pub fn from_year(year: i32) -> YearFlags {
-        let year = mod_floor(year, 400);
+        let year = year.rem_euclid(400);
         YearFlags::from_year_mod_400(year)
     }
 

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -8,7 +8,6 @@ use core::borrow::Borrow;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::{fmt, str};
 
-use num_integer::div_mod_floor;
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -762,8 +761,10 @@ impl NaiveTime {
 
     /// Returns a triple of the hour, minute and second numbers.
     fn hms(&self) -> (u32, u32, u32) {
-        let (mins, sec) = div_mod_floor(self.secs, 60);
-        let (hour, min) = div_mod_floor(mins, 60);
+        let sec = self.secs % 60;
+        let mins = self.secs / 60;
+        let min = mins % 60;
+        let hour = mins / 60;
         (hour, min, sec)
     }
 

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -6,7 +6,6 @@
 use core::fmt;
 use core::ops::{Add, Sub};
 
-use num_integer::div_mod_floor;
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -142,8 +141,10 @@ impl fmt::Debug for FixedOffset {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let offset = self.local_minus_utc;
         let (sign, offset) = if offset < 0 { ('-', -offset) } else { ('+', offset) };
-        let (mins, sec) = div_mod_floor(offset, 60);
-        let (hour, min) = div_mod_floor(mins, 60);
+        let sec = offset.rem_euclid(60);
+        let mins = offset.div_euclid(60);
+        let min = mins.rem_euclid(60);
+        let hour = mins.div_euclid(60);
         if sec == 0 {
             write!(f, "{}{:02}:{:02}", sign, hour, min)
         } else {

--- a/src/oldtime.rs
+++ b/src/oldtime.rs
@@ -462,31 +462,9 @@ impl Error for OutOfRangeError {
     }
 }
 
-// Copied from libnum
 #[inline]
 const fn div_mod_floor_64(this: i64, other: i64) -> (i64, i64) {
-    (div_floor_64(this, other), mod_floor_64(this, other))
-}
-
-#[inline]
-const fn div_floor_64(this: i64, other: i64) -> i64 {
-    match div_rem_64(this, other) {
-        (d, r) if (r > 0 && other < 0) || (r < 0 && other > 0) => d - 1,
-        (d, _) => d,
-    }
-}
-
-#[inline]
-const fn mod_floor_64(this: i64, other: i64) -> i64 {
-    match this % other {
-        r if (r > 0 && other < 0) || (r < 0 && other > 0) => r + other,
-        r => r,
-    }
-}
-
-#[inline]
-const fn div_rem_64(this: i64, other: i64) -> (i64, i64) {
-    (this / other, this % other)
+    (this.div_euclid(other), this.rem_euclid(other))
 }
 
 #[cfg(feature = "arbitrary")]


### PR DESCRIPTION
Some more uses for `div_euclid` and `rem_euclid`. These were basically the only reason for the `num-integer` dependency, which is now no longer necessary.

I have run the benchmarks numerous times, and also tried creating optimized combined `div_rem_euclid`-functions. LLVM should be able to combine the `div` and `rem` into a single instruction . But the difference seems to be nothing but noise.

```
     Running benches/chrono.rs (target/release/deps/chrono-d6d355f24635cdec)
bench_datetime_parse_from_rfc2822
                        time:   [195.32 ns 196.89 ns 198.69 ns]
                        change: [-0.8068% +0.2830% +1.4734%] (p = 0.64 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

bench_datetime_parse_from_rfc3339
                        time:   [168.97 ns 169.93 ns 170.86 ns]
                        change: [-7.2979% -6.5254% -5.7402%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild

bench_datetime_from_str time:   [279.07 ns 280.92 ns 283.04 ns]
                        change: [-2.6836% -1.7437% -0.8206%] (p = 0.00 < 0.05)
                        Change within noise threshold.

bench_datetime_to_rfc2822
                        time:   [97.445 ns 97.840 ns 98.286 ns]
                        change: [-6.4046% -5.6356% -4.8322%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

bench_datetime_to_rfc3339
                        time:   [174.69 ns 176.00 ns 177.14 ns]
                        change: [-1.6935% -0.8501% -0.0899%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low mild
  2 (2.00%) high mild

bench_year_flags_from_year
                        time:   [0.0000 ps 0.0000 ps 0.0000 ps]
                        change: [-29.311% +28.074% +138.77%] (p = 0.47 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  3 (3.00%) high mild
  9 (9.00%) high severe

num_days_from_ce/new/1  time:   [5.2447 ns 5.2753 ns 5.3099 ns]
                        change: [-1.7032% -1.0711% -0.3952%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
num_days_from_ce/classic/1
                        time:   [1.6623 ns 1.6662 ns 1.6704 ns]
                        change: [-3.3013% -2.6817% -2.0427%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
num_days_from_ce/new/500
                        time:   [5.4324 ns 5.4602 ns 5.4864 ns]
                        change: [+0.6683% +1.2929% +1.9432%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
num_days_from_ce/classic/500
                        time:   [1.7459 ns 1.7574 ns 1.7708 ns]
                        change: [+3.3119% +4.2201% +5.0321%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
num_days_from_ce/new/2000
                        time:   [5.4078 ns 5.4249 ns 5.4425 ns]
                        change: [-0.2753% +0.5890% +1.4985%] (p = 0.19 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
num_days_from_ce/classic/2000
                        time:   [1.7171 ns 1.7235 ns 1.7304 ns]
                        change: [+0.6090% +1.1668% +1.7379%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
num_days_from_ce/new/2019
                        time:   [5.3835 ns 5.4044 ns 5.4270 ns]
                        change: [-3.5537% -2.5228% -1.5619%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
num_days_from_ce/classic/2019
                        time:   [1.7406 ns 1.7523 ns 1.7641 ns]
                        change: [-2.7985% -1.8732% -0.9854%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

bench_get_local_time    time:   [107.79 ns 108.27 ns 108.78 ns]
                        change: [+5.1082% +5.8630% +6.5985%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```
