### PR TITLE
Fix warnings when running tests on Windows

### DIFF
--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -1,7 +1,11 @@
+#[cfg(unix)]
 use chrono::offset::TimeZone;
+#[cfg(unix)]
 use chrono::Local;
+#[cfg(unix)]
 use chrono::{Datelike, NaiveDate, NaiveDateTime, Timelike};
 
+#[cfg(unix)]
 use std::{path, process};
 
 #[cfg(unix)]


### PR DESCRIPTION
On every test run on Windows I get a few warnings about unused code.
It is about the imports used when testing against the date command on Unix.