### PR TITLE
Use correct offset in conversion from `Local` to `FixedOffset`

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -529,10 +529,9 @@ impl From<DateTime<Local>> for DateTime<Utc> {
 impl From<DateTime<Local>> for DateTime<FixedOffset> {
     /// Convert this `DateTime<Local>` instance into a `DateTime<FixedOffset>` instance.
     ///
-    /// Conversion is performed via [`DateTime::with_timezone`]. Note that the converted value returned
-    /// by this will be created with a fixed timezone offset of 0.
+    /// Conversion is performed via [`DateTime::with_timezone`].
     fn from(src: DateTime<Local>) -> Self {
-        src.with_timezone(&FixedOffset::east_opt(0).unwrap())
+        src.with_timezone(&src.offset().fix())
     }
 }
 

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -4,7 +4,7 @@ use super::DateTime;
 use crate::naive::{NaiveDate, NaiveTime};
 #[cfg(feature = "clock")]
 use crate::offset::Local;
-use crate::offset::{FixedOffset, TimeZone, Utc};
+use crate::offset::{FixedOffset, Offset, TimeZone, Utc};
 use crate::oldtime::Duration;
 #[cfg(feature = "clock")]
 use crate::Datelike;
@@ -984,4 +984,15 @@ fn test_from_naive_date_time_windows() {
         Local.from_utc_datetime(&too_high_year);
     });
     assert!(err.is_err());
+}
+
+#[test]
+fn test_datetime_local_from_preserves_offset() {
+    let naivedatetime = NaiveDate::from_ymd_opt(2023, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+
+    let datetime = Local.from_utc_datetime(&naivedatetime);
+    let offset = datetime.offset().fix();
+
+    let datetime_fixed: DateTime<FixedOffset> = datetime.into();
+    assert_eq!(&offset, datetime_fixed.offset());
 }


### PR DESCRIPTION
I can't see any good reason to forget the local offset when converting from `DateTime<Local>` to `DateTime<FixedOffset>`.
Seems to be an oversight in the initial implementation https://github.com/chronotope/chrono/pull/271.