### PR TITLE
Preserve `-00:00` offset

### DIFF
--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -518,7 +518,7 @@ fn test_datetime_rfc2822() {
     );
     assert_eq!(
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 -0000"),
-        Ok(FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
+        Ok(FixedOffset::OFFSET_UNKNOWN.with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
     );
     assert_eq!(
         ymdhms_micro(&edt, 2015, 2, 18, 23, 59, 59, 1_234_567).to_rfc2822(),

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -425,13 +425,13 @@ fn format_inner(
 #[cfg(any(feature = "alloc", feature = "serde", feature = "rustc-serialize"))]
 impl OffsetFormat {
     /// Writes an offset from UTC with the format defined by `self`.
-    fn format(&self, w: &mut impl Write, off: FixedOffset) -> fmt::Result {
-        let off = off.local_minus_utc();
+    fn format(&self, w: &mut impl Write, offset: FixedOffset) -> fmt::Result {
+        let off = offset.local_minus_utc();
         if self.allow_zulu && off == 0 {
             w.write_char('Z')?;
             return Ok(());
         }
-        let (sign, off) = if off < 0 { ('-', -off) } else { ('+', off) };
+        let (sign, off) = if off < 0 || offset.no_offset_info() { ('-', -off) } else { ('+', off) };
 
         let hours;
         let mut mins = 0;

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -66,7 +66,7 @@ pub use formatting::{format, format_item, DelayedFormat};
 pub use locales::Locale;
 pub(crate) use parse::parse_rfc3339;
 pub use parse::{parse, parse_and_remainder};
-pub use parsed::Parsed;
+pub use parsed::{Parsed, NO_OFFSET_INFO};
 pub use strftime::StrftimeItems;
 
 /// An uninhabited type used for `InternalNumeric` and `InternalFixed` below.

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -1645,8 +1645,9 @@ mod tests {
             ("Tue, 20 Jan 2015 17:35:20 PDT", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -7))),
             ("Tue, 20 Jan 2015 17:35:20 PST", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -8))),
             ("Tue, 20 Jan 2015 17:35:20 pst", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -8))),
-            // named single-letter military timezones must fallback to +0000
+            // Z is the only single-letter military timezones that maps to +0000
             ("Tue, 20 Jan 2015 17:35:20 Z", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, 0))),
+            // named single-letter military timezones must fallback to -0000
             ("Tue, 20 Jan 2015 17:35:20 A", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, 0))),
             ("Tue, 20 Jan 2015 17:35:20 a", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, 0))),
             ("Tue, 20 Jan 2015 17:35:20 K", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, 0))),
@@ -1682,6 +1683,22 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_rfc2822_no_offset_info() {
+        fn rfc2822_to_offset(date: &str) -> FixedOffset {
+            let mut parsed = Parsed::new();
+            parse(&mut parsed, date, [Item::Fixed(Fixed::RFC2822)].iter()).unwrap();
+            parsed.to_fixed_offset().unwrap()
+        }
+        assert_eq!(
+            rfc2822_to_offset("Tue, 20 Jan 2015 17:35:20 -0000"),
+            FixedOffset::OFFSET_UNKNOWN
+        );
+        assert_eq!(rfc2822_to_offset("Tue, 20 Jan 2015 17:35:20 A"), FixedOffset::OFFSET_UNKNOWN);
+        assert_eq!(rfc2822_to_offset("Tue, 20 Jan 2015 17:35:20 a"), FixedOffset::OFFSET_UNKNOWN);
+        assert_eq!(rfc2822_to_offset("Tue, 20 Jan 2015 17:35:20 K"), FixedOffset::OFFSET_UNKNOWN);
     }
 
     #[test]

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -17,12 +17,46 @@ use crate::naive::{NaiveDate, NaiveDateTime};
 const OFFSET_NORMAL: i32 = 1;
 const OFFSET_UNKNOWN: i32 = 2;
 
-/// The time zone with fixed offset, from UTC-23:59:59 to UTC+23:59:59.
+/// A fixed offset of clock time from [Coordinated Universal Time] (UTC) stored to seconds granularity.
+/// A `FixedOffset` can be used to indicate a time zone.
 ///
-/// Using the [`TimeZone`](./trait.TimeZone.html) methods
-/// on a `FixedOffset` struct is the preferred way to construct
-/// `DateTime<FixedOffset>` instances. See the [`east_opt`](#method.east_opt) and
-/// [`west_opt`](#method.west_opt) methods for examples.
+/// This type implements the [`TimeZone`] trait.
+///
+/// The valid range of offsets is UTC-23:59:59 to UTC+23:59:59.
+///
+/// ## Creating a `FixedOffset`
+///
+/// - Use [`FixedOffset::east_opt`] with a value in _seconds_ to create a new [`FixedOffset`].
+///   The offset is to be given as local time minus UTC time.
+/// - Use [`FixedOffset::west_opt`] with a value in _seconds_ to create the value from an offset
+///   given as UTC time minus local time.
+///
+/// See the [`east_opt`](#method.east_opt) and [`west_opt`](#method.west_opt) methods for examples.
+///
+/// ## Encoding an unknown offset
+///
+/// RFC 3339 and RFC 2822 make a distinction between an offset of `+00:00` and `-00:00`.
+///
+/// [RFC 2822]:
+/// > The form "+0000" SHOULD be used to indicate a time zone at Universal Time. Though "-0000"
+/// > also indicates Universal Time, it is used to indicate that the time was generated on a system
+/// > that may be in a local time zone other than Universal Time and therefore indicates that the
+/// > date-time contains no information about the local time zone.
+///
+/// [RFC 3339]:
+/// > If the time in UTC is known, but the offset to local time is unknown, this can be represented
+/// > with an offset of "-00:00". This differs semantically from an offset of "Z" or "+00:00",
+/// > which imply that UTC is the preferred reference point for the specified time.
+///
+/// An offset of `00:00` that indicates there is no information about the local timezone can be
+/// created with [`FixedOffset::OFFSET_UNKNOWN`]. Use [`no_offset_info()`](#method.no_offset_info)
+/// to inspect whether `00:00` carries the extra annotation.
+///
+/// Besides formatting `-00:00` is not treated any differently in chrono from `+00:00`.
+///
+/// [Coordinated Universal Time]: https://en.wikipedia.org/wiki/Coordinated_Universal_Time
+/// [RFC 2822]: https://www.rfc-editor.org/rfc/rfc2822.html#section-3.3
+/// [RFC 3339]: https://www.rfc-editor.org/rfc/rfc3339.html#section-4.3
 #[derive(Eq, Copy, Clone)]
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -4,6 +4,7 @@
 //! The time zone which has a fixed offset from UTC.
 
 use core::fmt;
+use core::num::NonZeroI32;
 use core::str::FromStr;
 
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
@@ -13,13 +14,16 @@ use super::{LocalResult, Offset, TimeZone};
 use crate::format::{scan, ParseError, OUT_OF_RANGE};
 use crate::naive::{NaiveDate, NaiveDateTime};
 
+const OFFSET_NORMAL: i32 = 1;
+const OFFSET_UNKNOWN: i32 = 2;
+
 /// The time zone with fixed offset, from UTC-23:59:59 to UTC+23:59:59.
 ///
 /// Using the [`TimeZone`](./trait.TimeZone.html) methods
 /// on a `FixedOffset` struct is the preferred way to construct
 /// `DateTime<FixedOffset>` instances. See the [`east_opt`](#method.east_opt) and
 /// [`west_opt`](#method.west_opt) methods for examples.
-#[derive(PartialEq, Eq, Hash, Copy, Clone)]
+#[derive(Eq, Copy, Clone)]
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
@@ -28,7 +32,41 @@ use crate::naive::{NaiveDate, NaiveDateTime};
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub struct FixedOffset {
-    local_minus_utc: i32,
+    // Encodes an offset in seconds, with the value shifted two bits to the left.
+    // The remaining bits encode flags:
+    // - `OFFSET_NORMAL` sets one flag to a non-zero value, so we can encode it in a `NonZeroI32`
+    //   and get niche optimization.
+    // - `OFFSET_UNKNOWN` to preserve the difference RFC 2822 and RFC 3339 make between an offset
+    //    of +0:00 and -0:00.
+    // Advantage of this encoding is that it only takes a single shift right to get offset in
+    // seconds.
+    //
+    // Use `local_minus_utc()` to get the offset in seconds, and `no_offset_info()` to inspect the
+    // `OFFSET_UNKNOWN` flag.
+    local_minus_utc: NonZeroI32,
+}
+
+// Compare with only the offset. `-00:00` compares equal to `+00:00`
+impl PartialEq for FixedOffset {
+    fn eq(&self, other: &Self) -> bool {
+        self.local_minus_utc() == other.local_minus_utc()
+    }
+}
+
+// Hash only the offset. `-00:00` hashes equal to `+00:00`
+impl core::hash::Hash for FixedOffset {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.local_minus_utc().hash(state);
+    }
+}
+
+// Workaround because `unwrap` in `NonZeroI32::new(val).unwrap()` is not const.
+#[allow(unconditional_panic)]
+const fn nonzero_i32_new(val: i32) -> NonZeroI32 {
+    match NonZeroI32::new(val) {
+        Some(v) => v,
+        None => [][0],
+    }
 }
 
 impl FixedOffset {
@@ -60,7 +98,7 @@ impl FixedOffset {
     #[must_use]
     pub const fn east_opt(secs: i32) -> Option<FixedOffset> {
         if -86_400 < secs && secs < 86_400 {
-            Some(FixedOffset { local_minus_utc: secs })
+            Some(FixedOffset { local_minus_utc: nonzero_i32_new(secs << 2 | OFFSET_NORMAL) })
         } else {
             None
         }
@@ -94,7 +132,7 @@ impl FixedOffset {
     #[must_use]
     pub const fn west_opt(secs: i32) -> Option<FixedOffset> {
         if -86_400 < secs && secs < 86_400 {
-            Some(FixedOffset { local_minus_utc: -secs })
+            Some(FixedOffset { local_minus_utc: nonzero_i32_new(-secs << 2 | OFFSET_NORMAL) })
         } else {
             None
         }
@@ -103,7 +141,7 @@ impl FixedOffset {
     /// Returns the number of seconds to add to convert from UTC to the local time.
     #[inline]
     pub const fn local_minus_utc(&self) -> i32 {
-        self.local_minus_utc
+        self.local_minus_utc.get() >> 2
     }
 
     /// Returns the number of seconds to add to convert from the local time to UTC.
@@ -111,6 +149,21 @@ impl FixedOffset {
     pub const fn utc_minus_local(&self) -> i32 {
         -self.local_minus_utc()
     }
+
+    /// Returns true if this `FixedOffset` contains no offset data (in some formats encoded as
+    /// `-00:00`).
+    ///
+    /// In some formats, such as RFC 2822 and RFC 3339, `-00:00` can represent timestamps for which
+    /// only the time in UTC is known, and the relation to local time is not avaliable (anymore).
+    #[inline]
+    pub const fn no_offset_info(&self) -> bool {
+        self.local_minus_utc.get() == OFFSET_UNKNOWN
+    }
+
+    /// A special value to indicate no offset information is available.
+    /// The created offset will have the value `-00:00`.
+    pub const OFFSET_UNKNOWN: FixedOffset =
+        FixedOffset { local_minus_utc: nonzero_i32_new(OFFSET_UNKNOWN) };
 }
 
 /// Parsing a `str` into a `FixedOffset` uses the format [`%z`](crate::format::strftime).
@@ -152,6 +205,11 @@ impl Offset for FixedOffset {
 
 impl fmt::Debug for FixedOffset {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.no_offset_info() {
+            // In RFC 3339 `-00:00` can represent timestamps for which only the time in UTC is
+            // known, and the relation to local time is not avaliable (anymore).
+            return write!(f, "-00:00");
+        }
         let offset = self.local_minus_utc();
         let (sign, offset) = if offset < 0 { ('-', -offset) } else { ('+', offset) };
         let sec = offset.rem_euclid(60);

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -109,7 +109,7 @@ impl FixedOffset {
     /// Returns the number of seconds to add to convert from the local time to UTC.
     #[inline]
     pub const fn utc_minus_local(&self) -> i32 {
-        -self.local_minus_utc
+        -self.local_minus_utc()
     }
 }
 
@@ -152,7 +152,7 @@ impl Offset for FixedOffset {
 
 impl fmt::Debug for FixedOffset {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let offset = self.local_minus_utc;
+        let offset = self.local_minus_utc();
         let (sign, offset) = if offset < 0 { ('-', -offset) } else { ('+', offset) };
         let sec = offset.rem_euclid(60);
         let mins = offset.div_euclid(60);
@@ -217,11 +217,11 @@ mod tests {
     #[test]
     fn test_parse_offset() {
         let offset = FixedOffset::from_str("-0500").unwrap();
-        assert_eq!(offset.local_minus_utc, -5 * 3600);
+        assert_eq!(offset.local_minus_utc(), -5 * 3600);
         let offset = FixedOffset::from_str("-08:00").unwrap();
-        assert_eq!(offset.local_minus_utc, -8 * 3600);
+        assert_eq!(offset.local_minus_utc(), -8 * 3600);
         let offset = FixedOffset::from_str("+06:30").unwrap();
-        assert_eq!(offset.local_minus_utc, (6 * 3600) + 1800);
+        assert_eq!(offset.local_minus_utc(), (6 * 3600) + 1800);
     }
 
     #[test]

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -205,7 +205,10 @@ impl FromStr for FixedOffset {
     type Err = ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (_, offset) = scan::timezone_offset(s, scan::colon_or_space, false, false, true)?;
-        Self::east_opt(offset).ok_or(OUT_OF_RANGE)
+        match offset {
+            Some(offset) => Self::east_opt(offset).ok_or(OUT_OF_RANGE),
+            None => Ok(Self::OFFSET_UNKNOWN),
+        }
     }
 }
 
@@ -314,6 +317,8 @@ mod tests {
         assert_eq!(offset.local_minus_utc(), -8 * 3600);
         let offset = FixedOffset::from_str("+06:30").unwrap();
         assert_eq!(offset.local_minus_utc(), (6 * 3600) + 1800);
+        let offset = FixedOffset::from_str("-00:00").unwrap();
+        assert_eq!(offset, FixedOffset::OFFSET_UNKNOWN);
     }
 
     #[test]


### PR DESCRIPTION
RFC 3339 and RFC 2822 make a distinction between an offset of `+00:00` and `-00:00`.

RFC 2822:
> The form "+0000" SHOULD be used to indicate a time zone at Universal Time. Though "-0000" also indicates Universal Time, it is used to indicate that the time was generated on a system that may be in a local time zone other than Universal Time and therefore indicates that the date-time contains no information about the local time zone.

From RFC3339:
> If the time in UTC is known, but the offset to local time is unknown, this can be represented with an offset of "-00:00". This differs semantically from an offset of "Z" or "+00:00", which imply that UTC is the preferred reference point for the specified time.

Currently chrono drops the distinction, but I would like to preserve it.

- I noticed `format/scan.rs` was already written with the functionality of this RFCs in mind, but did not go all the way. It now follows the specs better and can sometimes give better parser errors.
- Modifying `Parsed` to preserve this information is a bit messy as all the methods are public. Adding a public constant `NO_OFFSET_INFO` seemed the cleanest solution. Parsing doesn't support more than two digits for the offset hours, limiting the values that are passed to `Parsed::set_offset` to `99 * 3600 + 59 * 60 = 359940`. The value of `NO_OFFSET_INFO` is way outside that range, so no chance for conflicts.
- `FixedOffset` can be modified in a reasonably clean way to encode `-0`: shift the value 2 bits left and encode this special state as an `OFFSET_UNKNOWN` flag in the rightmost bits. Advantage of this encoding is that it only takes a single shift right to get the offset in seconds, so this should not measurably impact performance.
- The same shifting trick enables using `NonZeroI32`, as long as we set one of the rightmost bits to something non-null with the `OFFSET_NORMAL` flag. This gives `FixedOffset` a niche. `Option<DateTime<FixedOffset>>` is now the same size as `DateTime<FixedOffset>`: 16 bytes instead of 20.
- For comparisons and hashing the flags are ignored. This way `-00:00` is treated as equal to `+00:00`, which is usually what is expected. Also this way we remain backwards compatible.
- `FixedOffset::no_offset_info` returns whether the offset is `-00:00`.
- `FixedOffset::OFFSET_UNKNOWN` can be used to initialize an offset to `-00:00`.