### PR TITLE
Fix DateTime out-of-range panics

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -974,7 +974,9 @@ impl<Tz: TimeZone> Datelike for DateTime<Tz> {
     /// - The local time at the resulting date does not exist or is ambiguous, for example during a
     ///   daylight saving time transition.
     fn with_year(&self, year: i32) -> Option<DateTime<Tz>> {
-        map_local(self, |datetime| datetime.with_year(year))
+        map_local(self, |dt| {
+            dt.date().overflowing_with_year(year).map(|d| NaiveDateTime::new(d, dt.time()))
+        })
     }
 
     /// Makes a new `DateTime` with the month number (starting from 1) changed.

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -431,8 +431,9 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///   daylight saving time transition.
     #[must_use]
     pub fn checked_add_days(self, days: Days) -> Option<Self> {
-        self.naive_local()
-            .checked_add_days(days)?
+        self.overflowing_naive_local()
+            .checked_add_days(days)
+            .filter(|d| d.date() <= NaiveDate::AFTER_MAX)?
             .and_local_timezone(TimeZone::from_offset(&self.offset))
             .single()
     }
@@ -447,8 +448,9 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///   daylight saving time transition.
     #[must_use]
     pub fn checked_sub_days(self, days: Days) -> Option<Self> {
-        self.naive_local()
-            .checked_sub_days(days)?
+        self.overflowing_naive_local()
+            .checked_sub_days(days)
+            .filter(|d| d.date() >= NaiveDate::BEFORE_MIN)?
             .and_local_timezone(TimeZone::from_offset(&self.offset))
             .single()
     }

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -382,7 +382,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///   daylight saving time transition.
     #[must_use]
     pub fn checked_add_months(self, rhs: Months) -> Option<DateTime<Tz>> {
-        self.naive_local()
+        self.overflowing_naive_local()
             .checked_add_months(rhs)?
             .and_local_timezone(Tz::from_offset(&self.offset))
             .single()
@@ -415,7 +415,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///   daylight saving time transition.
     #[must_use]
     pub fn checked_sub_months(self, rhs: Months) -> Option<DateTime<Tz>> {
-        self.naive_local()
+        self.overflowing_naive_local()
             .checked_sub_months(rhs)?
             .and_local_timezone(Tz::from_offset(&self.offset))
             .single()

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1458,6 +1458,19 @@ impl NaiveDate {
         self.of().weekday()
     }
 
+    // Similar to `Datelike::with_year()`, but allows creating a `NaiveDate` beyond `MIN` or `MAX`.
+    // Only used by `DateTime::with_year`.
+    pub(crate) fn overflowing_with_year(&self, year: i32) -> Option<NaiveDate> {
+        // we need to operate with `mdf` since we should keep the month and day number as is
+        let mdf = self.mdf();
+
+        // adjust the flags as needed
+        let flags = YearFlags::from_year(year);
+        let mdf = mdf.with_flags(flags);
+
+        mdf.to_of().map(|of| NaiveDate { ymdf: (year << 13) | (of.inner() as DateImpl) })
+    }
+
     /// The minimum possible `NaiveDate` (January 1, 262144 BCE).
     pub const MIN: NaiveDate = NaiveDate { ymdf: (MIN_YEAR << 13) | (1 << 4) | 0o12 /*D*/ };
     /// The maximum possible `NaiveDate` (December 31, 262142 CE).


### PR DESCRIPTION
If the timestamp of a `DateTime` is near the end of the range of `NaiveDateTime` and the offset pushes the timestamp beyond that range, all kinds of methods currently panic. About 40 methods that are part of the public API. With the `Debug` implementation panicking being the most fun. See https://github.com/chronotope/chrono/issues/1047.

Most of these methods fall in two categories:
- They panic on an intermediate value, but should be able to return a meaningful result. Examples are formatting, `year()`, `hour()`.
- They can return `None`. Examples are `checked_add_days`, `with_month`.

A somewhat easy fix is to slightly restrict the range of `NaiveDate`, so that we have some buffer space to represent the out-of-range datetimes. Everything that needs just the intermediate value will be fixed by this. But care should be taken to never let an invalid intermediate value escape to the library user.

-------

This PR grew larger than hoped. I'll describe the various commits to hopefully help review.

## Adjust MIN_YEAR and MAX_YEAR

I made `MIN_YEAR` and `MAX_YEAR` smaller, so that we have 1 year of buffer space. 1 day would have been enough, but having the minimum date be January 2 and the maximum date December 30 is just strange.

`NaiveDate::MIN` and `NaiveDate::MAX` are derived from these. There is a very helpful `test_date_bounds` to confirm the flags and oridinal are correct.

There is something subtly wrong in the calculation of `MIN_DAYS_FROM_YEAR_0`, which is only used in tests. It was only correct if `MIN_YEAR` was a leap year. I changed it to a correct formula that tries to be less smart, but couldn't figure out the problem in the derivation yet. Added a comment.

## checked_add_offset and unchecked_add_offset

Instead of panicking in the `Add` or `Sub` implementation of `NaiveDateTime` with `FixedOffset`, we need a way to be informed of out-of-range result. Or in other cases we need to be able to construct a value in the buffer space for intermediate use.

I added the following methods (not public for now):
- `NaiveTime::overflowing_add_offset` and `NaiveTime::overflowing_sub_offset`
- `NaiveDateTime::checked_add_offset` and `NaiveDateTime::checked_sub_offset`
- `NaiveDateTime::unchecked_add_offset` (in a later commit)

The `Add` and `Sub` implementations of `FixedOffset` with `NaiveTime`, `NaiveDateTime` and `DateTime` are reimplemented using of these methods. This fixes a code comment:
> this should be implemented more efficiently, but for the time being, this is generic right now.

The best place to put the `Add` and `Sub` implementations for `DateTime` where in the module of `DateTime`, because there they have access to its private fields. I have moved all implementations to the module of their output type for consistency.

## Simplify implementation

Adding an offset works differently from adding a duration. Adding a duration tries to do something smart—but still rudimentary—with leap seconds. Adding an offset should not touch the leap seconds at all. So the methods that operate on `NaiveTime` should be different.

I extracted the part that operates on the `NaiveDate` that could be shared into an `add_days` methods. Previously `NaiveDate::checked_add_days` would convert the days to a `Duration` in seconds, and later devide them to get the value in days again. This now works in a less roundabout way. Might also help with the const implementation later.

## Fix creating a DateTime with NaiveDateTime::{MIN, MAX}

The creation of a `DateTime` in `TimeZone::from_local_datetime` should use `checked_sub_offset`, and return `LocalResult::None` on overflow.

The implementation of `Local` had grown into a mess (sorry, that is the best word for it). With the last commit in https://github.com/chronotope/chrono/pull/1017 they should just use the provided implementation and pick up this fix.

## The actual fixes

The new method `DateTime::overflowing_naive_local` is not public, and can be used to create an out-of-bounds `NaiveDateTime` for use as an intermediate value.

Most of the problematic methods on `DateTime` simply work when converted to use `overflowing_naive_local`. If they don't return a `DateTime`, `NaiveDateTime` or `NaiveDate` there is also no worry the intermediate value may be exposed outside chrono.

The `DateTime::with_*` methods that are part of the `Datelike` trait have an interesting property: if the local `NaiveDateTime` would be out-of-range, there is only exactly one year/month/day/ordinal they can be set to that would result in a valid `DateTime`: the one that is already there. This is thanks to the restriction that offset is always less then 24h. To prevent creating an out-of-range `NaiveDateTime` all these methods short-circuit when possible.

The only two methods on `NaiveDate` (note: not `DateTime`) that had to change are `checked_add_months` and `checked_sub_months`. Both had a short-circuiting behaviour that with the changes in this PR could return invalid dates. When the input is out of range and `months == 0`, `checked_*_months` didn't check whether the result would be valid.

## Not fixed: parsing

All the relevant methods on `Parsed` are public.

Methods in there like `Parsed::to_naive_date`, `Parsed::to_naive_datetime_with_offset` and `NaiveDateTime::from_timestamp_opt` can't be converted to return an intermediate out-of-range value.

I have left it as is. Parsing doesn't panic, it just can't round-trip some `DateTime`'s.

## Tests
About 275 lines in this PR are tests, so its size may not be as bad as it looks. @jtmoon79 I tried to behave :innocent:

`test_min_max_datetimes` is in my opinion the interesting one, testing all methods that would previously panic.