### PR TITLE
`(overflowing|checked)_(add|sub)_offset` implementations

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1247,22 +1247,13 @@ impl<Tz: TimeZone> AddAssign<Duration> for DateTime<Tz> {
     }
 }
 
-fn add_with_leapsecond<T>(lhs: &T, rhs: i32) -> T
-where
-    T: Timelike + Add<OldDuration, Output = T>,
-{
-    // extract and temporarily remove the fractional part and later recover it
-    let nanos = lhs.nanosecond();
-    let lhs = lhs.with_nanosecond(0).unwrap();
-    (lhs + OldDuration::seconds(i64::from(rhs))).with_nanosecond(nanos).unwrap()
-}
-
 impl<Tz: TimeZone> Add<FixedOffset> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
     #[inline]
-    fn add(self, rhs: FixedOffset) -> DateTime<Tz> {
-        add_with_leapsecond(&self, rhs.local_minus_utc())
+    fn add(mut self, rhs: FixedOffset) -> DateTime<Tz> {
+        self.datetime = self.naive_utc().checked_add_offset(rhs).unwrap();
+        self
     }
 }
 
@@ -1317,8 +1308,9 @@ impl<Tz: TimeZone> Sub<FixedOffset> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
     #[inline]
-    fn sub(self, rhs: FixedOffset) -> DateTime<Tz> {
-        add_with_leapsecond(&self, -rhs.local_minus_utc())
+    fn sub(mut self, rhs: FixedOffset) -> DateTime<Tz> {
+        self.datetime = self.naive_utc().checked_sub_offset(rhs).unwrap();
+        self
     }
 }
 

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -4,17 +4,14 @@
 //! The time zone which has a fixed offset from UTC.
 
 use core::fmt;
-use core::ops::{Add, Sub};
 use core::str::FromStr;
 
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
 
 use super::{LocalResult, Offset, TimeZone};
-use crate::duration::Duration as OldDuration;
-use crate::format::{scan, OUT_OF_RANGE};
+use crate::format::{scan, ParseError, OUT_OF_RANGE};
 use crate::naive::{NaiveDate, NaiveDateTime};
-use crate::{DateTime, ParseError, Timelike};
 
 /// The time zone with fixed offset, from UTC-23:59:59 to UTC+23:59:59.
 ///
@@ -181,39 +178,6 @@ impl arbitrary::Arbitrary<'_> for FixedOffset {
         let fixed_offset = FixedOffset::east_opt(secs)
             .expect("Could not generate a valid chrono::FixedOffset. It looks like implementation of Arbitrary for FixedOffset is erroneous.");
         Ok(fixed_offset)
-    }
-}
-
-// addition or subtraction of FixedOffset to/from Timelike values is the same as
-// adding or subtracting the offset's local_minus_utc value
-// but keep keeps the leap second information.
-// this should be implemented more efficiently, but for the time being, this is generic right now.
-
-fn add_with_leapsecond<T>(lhs: &T, rhs: i32) -> T
-where
-    T: Timelike + Add<OldDuration, Output = T>,
-{
-    // extract and temporarily remove the fractional part and later recover it
-    let nanos = lhs.nanosecond();
-    let lhs = lhs.with_nanosecond(0).unwrap();
-    (lhs + OldDuration::seconds(i64::from(rhs))).with_nanosecond(nanos).unwrap()
-}
-
-impl<Tz: TimeZone> Add<FixedOffset> for DateTime<Tz> {
-    type Output = DateTime<Tz>;
-
-    #[inline]
-    fn add(self, rhs: FixedOffset) -> DateTime<Tz> {
-        add_with_leapsecond(&self, rhs.local_minus_utc)
-    }
-}
-
-impl<Tz: TimeZone> Sub<FixedOffset> for DateTime<Tz> {
-    type Output = DateTime<Tz>;
-
-    #[inline]
-    fn sub(self, rhs: FixedOffset) -> DateTime<Tz> {
-        add_with_leapsecond(&self, -rhs.local_minus_utc)
     }
 }
 


### PR DESCRIPTION
Split out from https://github.com/chronotope/chrono/pull/1048.

The main goal is to add `NaiveDateTime::checked_(add|sub)_offset` methods. To quote from https://github.com/chronotope/chrono/pull/1048:

Instead of panicking in the `Add` or `Sub` implementation of `NaiveDateTime` with `FixedOffset`, we need a way to be informed of out-of-range result.

I added the following methods ~(not public for now)~:
- `NaiveTime::overflowing_add_offset` and `NaiveTime::overflowing_sub_offset`
- `NaiveDateTime::checked_add_offset` and `NaiveDateTime::checked_sub_offset`

The `Add` and `Sub` implementations of `FixedOffset` with `NaiveTime`, `NaiveDateTime` and `DateTime` are reimplemented using of these methods. This fixes a code comment:
> this should be implemented more efficiently, but for the time being, this is generic right now.

The best place to put the `Add` and `Sub` implementations for `DateTime` is in the module of `DateTime`, because there they have access to its private fields. I have moved all implementations to the module of their output type for consistency.

-------


Adding an offset works differently from adding a duration. Adding a duration tries to do something smart—but still rudimentary—with leap seconds. Adding an offset should not touch the leap seconds at all. So the methods that operate on `NaiveTime` should be different.

I extracted the part that operates on the `NaiveDate` that could be shared into an `add_days` methods. Previously `NaiveDate::checked_add_days` would convert the days to a `Duration` in seconds, and later devide them to get the value in days again. This now works in a less roundabout way. ~Might~ This would also help with the const implementation later.