### PR TITLE
Fix panic in `TimeZone::from_local_datetime`

### DIFF
--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -634,11 +634,6 @@ impl Parsed {
         let datetime = self.to_naive_datetime_with_offset(offset)?;
         let offset = FixedOffset::east_opt(offset).ok_or(OUT_OF_RANGE)?;
 
-        // this is used to prevent an overflow when calling FixedOffset::from_local_datetime
-        datetime
-            .checked_sub_signed(OldDuration::seconds(i64::from(offset.local_minus_utc())))
-            .ok_or(OUT_OF_RANGE)?;
-
         match offset.from_local_datetime(&datetime) {
             LocalResult::None => Err(IMPOSSIBLE),
             LocalResult::Single(t) => Ok(t),

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -1,7 +1,6 @@
 use super::NaiveDateTime;
 use crate::duration::Duration as OldDuration;
-use crate::NaiveDate;
-use crate::{Datelike, FixedOffset, Utc};
+use crate::{Datelike, FixedOffset, LocalResult, NaiveDate, Utc};
 
 #[test]
 fn test_datetime_from_timestamp_millis() {
@@ -489,4 +488,25 @@ fn test_checked_sub_offset() {
 
     assert_eq!(dt.checked_add_offset(positive_offset), Some(dt + positive_offset));
     assert_eq!(dt.checked_sub_offset(positive_offset), Some(dt - positive_offset));
+}
+
+#[test]
+fn test_and_timezone_min_max_dates() {
+    for offset_hour in -23..=23 {
+        dbg!(offset_hour);
+        let offset = FixedOffset::east_opt(offset_hour * 60 * 60).unwrap();
+
+        let local_max = NaiveDateTime::MAX.and_local_timezone(offset);
+        if offset_hour >= 0 {
+            assert_eq!(local_max.unwrap().naive_local(), NaiveDateTime::MAX);
+        } else {
+            assert_eq!(local_max, LocalResult::None);
+        }
+        let local_min = NaiveDateTime::MIN.and_local_timezone(offset);
+        if offset_hour <= 0 {
+            assert_eq!(local_min.unwrap().naive_local(), NaiveDateTime::MIN);
+        } else {
+            assert_eq!(local_min, LocalResult::None);
+        }
+    }
 }


### PR DESCRIPTION
Split out from https://github.com/chronotope/chrono/pull/1048. Depends on https://github.com/chronotope/chrono/pull/1069 for `NaiveDateTime::checked_sub_offset`, only the last commit is new.

The change is that `TimeZone::from_local_datetime` should check for overflow instead of blindly subtracting the offset. But you can't do so easily in `LocalResult::map`, so this adds a helper method.

Note that this PR only fixes the default implementation. But the implementations of `TimeZone` for `Local` don't use the default implementation, and are not fixed yet.

The last commit in https://github.com/chronotope/chrono/pull/1017#issuecomment-1536104845 refactors `Local` to pick up this fix. ~@djc do you want me to split out that commit and try to apply it to 0.4.x?~ Edit: Split it out to https://github.com/chronotope/chrono/pull/1072.