### PR TITLE
Add ParseErrorKind::TooMany if format string contains too many directives for given type

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -575,7 +575,7 @@ impl DateTime<FixedOffset> {
     pub fn parse_from_rfc2822(s: &str) -> ParseResult<DateTime<FixedOffset>> {
         const ITEMS: &[Item<'static>] = &[Item::Fixed(Fixed::RFC2822)];
         let mut parsed = Parsed::new();
-        parse(&mut parsed, s, ITEMS.iter())?;
+        parse(&mut parsed, s, ITEMS.iter(), false, false)?;
         parsed.to_datetime()
     }
 
@@ -595,7 +595,7 @@ impl DateTime<FixedOffset> {
     pub fn parse_from_rfc3339(s: &str) -> ParseResult<DateTime<FixedOffset>> {
         const ITEMS: &[Item<'static>] = &[Item::Fixed(Fixed::RFC3339)];
         let mut parsed = Parsed::new();
-        parse(&mut parsed, s, ITEMS.iter())?;
+        parse(&mut parsed, s, ITEMS.iter(), false, false)?;
         parsed.to_datetime()
     }
 
@@ -620,7 +620,7 @@ impl DateTime<FixedOffset> {
     /// ```
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<DateTime<FixedOffset>> {
         let mut parsed = Parsed::new();
-        parse(&mut parsed, s, StrftimeItems::new(fmt))?;
+        parse(&mut parsed, s, StrftimeItems::new(fmt), false, false)?;
         parsed.to_datetime()
     }
 
@@ -654,7 +654,7 @@ impl DateTime<FixedOffset> {
         fmt: &str,
     ) -> ParseResult<(DateTime<FixedOffset>, &'a str)> {
         let mut parsed = Parsed::new();
-        let remainder = parse_and_remainder(&mut parsed, s, StrftimeItems::new(fmt))?;
+        let remainder = parse_and_remainder(&mut parsed, s, StrftimeItems::new(fmt), false, false)?;
         parsed.to_datetime().map(|d| (d, remainder))
     }
 }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -376,6 +376,10 @@ pub enum ParseErrorKind {
     /// most useful sets of fields however, as such constraint solving can be expensive.
     NotEnough,
 
+    /// The input string contains directives which aren't valid for the given type, e.g. "hour"
+    /// for NaiveDate.
+    TooMany,
+
     /// The input string has some invalid character sequence for given formatting items.
     Invalid,
 
@@ -424,6 +428,7 @@ impl Error for ParseError {
 const OUT_OF_RANGE: ParseError = ParseError(ParseErrorKind::OutOfRange);
 const IMPOSSIBLE: ParseError = ParseError(ParseErrorKind::Impossible);
 const NOT_ENOUGH: ParseError = ParseError(ParseErrorKind::NotEnough);
+const TOO_MANY: ParseError = ParseError(ParseErrorKind::TooMany);
 const INVALID: ParseError = ParseError(ParseErrorKind::Invalid);
 const TOO_SHORT: ParseError = ParseError(ParseErrorKind::TooShort);
 const TOO_LONG: ParseError = ParseError(ParseErrorKind::TooLong);

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -296,7 +296,7 @@ impl NaiveDateTime {
     ///```
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<NaiveDateTime> {
         let mut parsed = Parsed::new();
-        parse(&mut parsed, s, StrftimeItems::new(fmt))?;
+        parse(&mut parsed, s, StrftimeItems::new(fmt), false, false)?;
         parsed.to_naive_datetime_with_offset(0) // no offset adjustment
     }
 
@@ -321,7 +321,7 @@ impl NaiveDateTime {
     /// ```
     pub fn parse_and_remainder<'a>(s: &'a str, fmt: &str) -> ParseResult<(NaiveDateTime, &'a str)> {
         let mut parsed = Parsed::new();
-        let remainder = parse_and_remainder(&mut parsed, s, StrftimeItems::new(fmt))?;
+        let remainder = parse_and_remainder(&mut parsed, s, StrftimeItems::new(fmt), false, false)?;
         parsed.to_naive_datetime_with_offset(0).map(|d| (d, remainder)) // no offset adjustment
     }
 
@@ -1801,7 +1801,7 @@ impl str::FromStr for NaiveDateTime {
         ];
 
         let mut parsed = Parsed::new();
-        parse(&mut parsed, s, ITEMS.iter())?;
+        parse(&mut parsed, s, ITEMS.iter(), false, false)?;
         parsed.to_naive_datetime_with_offset(0)
     }
 }

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -434,13 +434,12 @@ impl NaiveTime {
     ///            Ok(NaiveTime::from_hms_micro_opt(13, 23, 45, 678_900).unwrap()));
     /// ```
     ///
-    /// Date and offset is ignored for the purpose of parsing.
+    /// Date and offset are errors.
     ///
     /// ```
     /// # use chrono::NaiveTime;
     /// # let parse_from_str = NaiveTime::parse_from_str;
-    /// assert_eq!(parse_from_str("2014-5-17T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
-    ///            Ok(NaiveTime::from_hms_opt(12, 34, 56).unwrap()));
+    /// assert!(parse_from_str("2014-5-17T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z").is_err());
     /// ```
     ///
     /// [Leap seconds](#leap-second-handling) are correctly handled by
@@ -480,7 +479,7 @@ impl NaiveTime {
     /// ```
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<NaiveTime> {
         let mut parsed = Parsed::new();
-        parse(&mut parsed, s, StrftimeItems::new(fmt))?;
+        parse(&mut parsed, s, StrftimeItems::new(fmt), false, true)?;
         parsed.to_naive_time()
     }
 
@@ -502,7 +501,7 @@ impl NaiveTime {
     /// ```
     pub fn parse_and_remainder<'a>(s: &'a str, fmt: &str) -> ParseResult<(NaiveTime, &'a str)> {
         let mut parsed = Parsed::new();
-        let remainder = parse_and_remainder(&mut parsed, s, StrftimeItems::new(fmt))?;
+        let remainder = parse_and_remainder(&mut parsed, s, StrftimeItems::new(fmt), false, true)?;
         parsed.to_naive_time().map(|t| (t, remainder))
     }
 
@@ -1313,7 +1312,7 @@ impl str::FromStr for NaiveTime {
         ];
 
         let mut parsed = Parsed::new();
-        parse(&mut parsed, s, ITEMS.iter())?;
+        parse(&mut parsed, s, ITEMS.iter(), false, true)?;
         parsed.to_naive_time()
     }
 }

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -328,10 +328,7 @@ fn test_date_from_str() {
 #[test]
 fn test_time_parse_from_str() {
     let hms = |h, m, s| NaiveTime::from_hms_opt(h, m, s).unwrap();
-    assert_eq!(
-        NaiveTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
-        Ok(hms(12, 34, 56))
-    ); // ignore date and offset
+    assert!(NaiveTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z").is_err()); // error on date and offset
     assert_eq!(NaiveTime::parse_from_str("PM 12:59", "%P %H:%M"), Ok(hms(12, 59, 0)));
     assert_eq!(NaiveTime::parse_from_str("12:59 \n\t PM", "%H:%M \n\t %P"), Ok(hms(12, 59, 0)));
     assert_eq!(NaiveTime::parse_from_str("\t\t12:59\tPM\t", "\t\t%H:%M\t%P\t"), Ok(hms(12, 59, 0)));

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -446,7 +446,7 @@ pub trait TimeZone: Sized + Clone {
     /// parsed [`FixedOffset`].
     fn datetime_from_str(&self, s: &str, fmt: &str) -> ParseResult<DateTime<Self>> {
         let mut parsed = Parsed::new();
-        parse(&mut parsed, s, StrftimeItems::new(fmt))?;
+        parse(&mut parsed, s, StrftimeItems::new(fmt), false, false)?;
         parsed.to_datetime_with_timezone(self)
     }
 


### PR DESCRIPTION
### Thanks for contributing to chrono!

If your feature is semver-compatible, please target the 0.4.x branch;
the main branch will be used for 0.5.0 development going forward.

Please consider adding a test to ensure your bug fix/feature will not break in the future.

---

Here's my attempt at adding ParseErrorKind::TooMany

closes #1075 