### PR TITLE
Flexible offset parsing [2/3]

### DIFF
--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -803,6 +803,17 @@ fn test_datetime_from_str() {
             )
             .unwrap())
     );
+    assert_eq!(
+        "2015-2-18T13:16:9.15-10:00:00".parse::<DateTime<Utc>>(),
+        Ok(Utc
+            .from_local_datetime(
+                &NaiveDate::from_ymd_opt(2015, 2, 18)
+                    .unwrap()
+                    .and_hms_milli_opt(23, 16, 9, 150)
+                    .unwrap()
+            )
+            .unwrap())
+    );
     assert!("2015-2-18T23:16:9.15".parse::<DateTime<Utc>>().is_err());
 
     // no test for `DateTime<Local>`, we cannot verify that much.

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1024,9 +1024,9 @@ fn test_datetime_parse_from_str() {
     // %z
     //
     assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09 00", "%b %d %Y %H:%M:%S %z"), Ok(dt));
+    assert!(parse("Aug 09 2013 23:54:35 -09 00", "%b %d %Y %H:%M:%S %z").is_err());
     assert_eq!(parse("Aug 09 2013 23:54:35 -09:00", "%b %d %Y %H:%M:%S %z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09 : 00", "%b %d %Y %H:%M:%S %z"), Ok(dt));
+    assert!(parse("Aug 09 2013 23:54:35 -09 : 00", "%b %d %Y %H:%M:%S %z").is_err());
     assert_eq!(parse("Aug 09 2013 23:54:35 --0900", "%b %d %Y %H:%M:%S -%z"), Ok(dt));
     assert_eq!(parse("Aug 09 2013 23:54:35 +-0900", "%b %d %Y %H:%M:%S +%z"), Ok(dt));
     assert_eq!(parse("Aug 09 2013 23:54:35 -09:00 ", "%b %d %Y %H:%M:%S %z "), Ok(dt));
@@ -1041,7 +1041,7 @@ fn test_datetime_parse_from_str() {
     assert!(parse("Aug 09 2013 23:54:35 -09:00:", "%b %d %Y %H:%M:%S %z ").is_err());
     // wrong timezone data
     assert!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %z").is_err());
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %z"), Ok(dt));
+    assert!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %z").is_err());
     assert_eq!(parse("Aug 09 2013 23:54:35 -0900::", "%b %d %Y %H:%M:%S %z::"), Ok(dt));
     assert_eq!(parse("Aug 09 2013 23:54:35 -09:00:00", "%b %d %Y %H:%M:%S %z:00"), Ok(dt));
     assert_eq!(parse("Aug 09 2013 23:54:35 -09:00:00 ", "%b %d %Y %H:%M:%S %z:00 "), Ok(dt));
@@ -1050,13 +1050,13 @@ fn test_datetime_parse_from_str() {
     // %:z
     //
     assert_eq!(parse("Aug 09 2013 23:54:35  -09:00", "%b %d %Y %H:%M:%S  %:z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %:z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09 00", "%b %d %Y %H:%M:%S %:z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09 : 00", "%b %d %Y %H:%M:%S %:z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09 : 00:", "%b %d %Y %H:%M:%S %:z:"), Ok(dt));
+    assert!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %:z").is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09 00", "%b %d %Y %H:%M:%S %:z").is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09 : 00", "%b %d %Y %H:%M:%S %:z").is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09 : 00:", "%b %d %Y %H:%M:%S %:z:").is_err());
     // wrong timezone data
     assert!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %:z").is_err());
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %:z"), Ok(dt));
+    assert!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %:z").is_err());
     // timezone data hs too many colons
     assert!(parse("Aug 09 2013 23:54:35 -09:00:", "%b %d %Y %H:%M:%S %:z").is_err());
     // timezone data hs too many colons
@@ -1066,40 +1066,39 @@ fn test_datetime_parse_from_str() {
     //
     // %::z
     //
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %::z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00", "%b %d %Y %H:%M:%S %::z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09 : 00", "%b %d %Y %H:%M:%S %::z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00:00", "%b %d %Y %H:%M:%S %::z"), Ok(dt));
+    assert!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %::z").is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09:00", "%b %d %Y %H:%M:%S %::z").is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09 : 00", "%b %d %Y %H:%M:%S %::z").is_err());
     // mismatching colon expectations
-    assert!(parse("Aug 09 2013 23:54:35 -09:00:00", "%b %d %Y %H:%M:%S %::z").is_err());
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %::z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %:z"), Ok(dt));
+    assert!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %::z").is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %:z").is_err());
     // wrong timezone data
     assert!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %::z").is_err());
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09001234", "%b %d %Y %H:%M:%S %::z1234"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09:001234", "%b %d %Y %H:%M:%S %::z1234"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900 ", "%b %d %Y %H:%M:%S %::z "), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900\t\n", "%b %d %Y %H:%M:%S %::z\t\n"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900:", "%b %d %Y %H:%M:%S %::z:"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 :-0900:0", "%b %d %Y %H:%M:%S :%::z:0"), Ok(dt));
+    assert!(parse("Aug 09 2013 23:54:35 -09001234", "%b %d %Y %H:%M:%S %::z1234").is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09:001234", "%b %d %Y %H:%M:%S %::z1234").is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -0900 ", "%b %d %Y %H:%M:%S %::z ").is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -0900\t\n", "%b %d %Y %H:%M:%S %::z\t\n").is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -0900:", "%b %d %Y %H:%M:%S %::z:").is_err());
+    assert!(parse("Aug 09 2013 23:54:35 :-0900:0", "%b %d %Y %H:%M:%S :%::z:0").is_err());
     // mismatching colons and spaces
     assert!(parse("Aug 09 2013 23:54:35 :-0900: ", "%b %d %Y %H:%M:%S :%::z::").is_err());
     // mismatching colons expectations
-    assert!(parse("Aug 09 2013 23:54:35 -09:00:00", "%b %d %Y %H:%M:%S %::z").is_err());
-    assert_eq!(parse("Aug 09 2013 -0900: 23:54:35", "%b %d %Y %::z: %H:%M:%S"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 :-0900:0 23:54:35", "%b %d %Y :%::z:0 %H:%M:%S"), Ok(dt));
+    assert!(parse("Aug 09 2013 -0900: 23:54:35", "%b %d %Y %::z: %H:%M:%S").is_err());
+    assert!(parse("Aug 09 2013 :-0900:0 23:54:35", "%b %d %Y :%::z:0 %H:%M:%S").is_err());
     // mismatching colons expectations mid-string
     assert!(parse("Aug 09 2013 :-0900: 23:54:35", "%b %d %Y :%::z  %H:%M:%S").is_err());
-    // mismatching colons expectations, before end
-    assert!(parse("Aug 09 2013 23:54:35 -09:00:00 ", "%b %d %Y %H:%M:%S %::z ").is_err());
+    // trailing space
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00:00 ", "%b %d %Y %H:%M:%S %::z "), Ok(dt));
 
     //
     // %:::z
     //
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00", "%b %d %Y %H:%M:%S %:::z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %:::z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900  ", "%b %d %Y %H:%M:%S %:::z  "), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %:::z"), Ok(dt));
     // wrong timezone data
-    assert!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %:::z").is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09:00", "%b %d %Y %H:%M:%S %:::z").is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %:::z").is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -0900  ", "%b %d %Y %H:%M:%S %:::z  ").is_err());
 
     //
     // %::::z
@@ -1122,8 +1121,8 @@ fn test_datetime_parse_from_str() {
     assert_eq!(parse("Aug 09 2013 23:54:35  -0900  ", "%b %d %Y %H:%M:%S  %#z  "), Ok(dt));
     assert_eq!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %#z"), Ok(dt));
     assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %#z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09:", "%b %d %Y %H:%M:%S %#z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09: ", "%b %d %Y %H:%M:%S %#z "), Ok(dt));
+    assert!(parse("Aug 09 2013 23:54:35 -09:", "%b %d %Y %H:%M:%S %#z").is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09: ", "%b %d %Y %H:%M:%S %#z ").is_err());
     assert_eq!(parse("Aug 09 2013 23:54:35+-09", "%b %d %Y %H:%M:%S+%#z"), Ok(dt));
     assert_eq!(parse("Aug 09 2013 23:54:35--09", "%b %d %Y %H:%M:%S-%#z"), Ok(dt));
     assert_eq!(parse("Aug 09 2013 -09:00 23:54:35", "%b %d %Y %#z%H:%M:%S"), Ok(dt));

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -227,7 +227,6 @@ pub enum Fixed {
     TimezoneOffsetDoubleColon,
     /// Offset from the local time to UTC without minutes (`+09` or `-04` or `+00`).
     ///
-    /// In the parser, the colon can be omitted and/or surrounded with any amount of whitespace.
     /// The offset is limited from `-24` to `+24`,
     /// which is the same as [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.
     TimezoneOffsetTripleColon,

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -215,7 +215,6 @@ pub enum Fixed {
     TimezoneName,
     /// Offset from the local time to UTC (`+09:00` or `-04:00` or `+00:00`).
     ///
-    /// In the parser, the colon can be omitted and/or surrounded with any amount of whitespace.
     /// The offset is limited from `-24:00` to `+24:00`,
     /// which is the same as [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.
     TimezoneOffsetColon,

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -221,7 +221,6 @@ pub enum Fixed {
     TimezoneOffsetColon,
     /// Offset from the local time to UTC with seconds (`+09:00:00` or `-04:00:00` or `+00:00:00`).
     ///
-    /// In the parser, the colon can be omitted and/or surrounded with any amount of whitespace.
     /// The offset is limited from `-24:00:00` to `+24:00:00`,
     /// which is the same as [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.
     TimezoneOffsetDoubleColon,

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -515,7 +515,14 @@ where
 /// A space or a 'T' are acepted as the separator between the date and time
 /// parts. Additional spaces are allowed between each component.
 ///
-/// All of these examples are equivalent:
+/// Differences with RFC3339:
+/// - A space or a 'T' are accepted as the separator between the date and time parts.
+/// - Values don't require padding to two digits.
+/// - `UTC` and `Z` are accepted as a valid timezone offset.
+/// - There can be a space between time and offset.
+/// - The colon in the offset may be missing.
+/// - The offset may optionally have seconds (compatible with the `Debug` format of `DateTime`).
+///
 /// ```
 /// # use chrono::{DateTime, offset::FixedOffset};
 /// "2012-12-12T12:12:12Z".parse::<DateTime<FixedOffset>>()?;
@@ -545,6 +552,7 @@ impl str::FromStr for DateTime<FixedOffset> {
 ///   `DateTime<Utc>`.
 /// - There can be spaces between any of the components.
 /// - The colon in the offset may be missing.
+/// - The offset may optionally have seconds (compatible with the `Debug` format of `DateTime`).
 fn parse_rfc3339_relaxed<'a>(parsed: &mut Parsed, mut s: &'a str) -> ParseResult<(&'a str, ())> {
     const DATE_ITEMS: &[Item<'static>] = &[
         Item::Numeric(Numeric::Year, Pad::Zero),
@@ -567,7 +575,7 @@ fn parse_rfc3339_relaxed<'a>(parsed: &mut Parsed, mut s: &'a str) -> ParseResult
         Item::Space(""),
     ];
     const OFFSET_FORMAT: OffsetFormat = OffsetFormat {
-        precision: OffsetPrecision::Minutes,
+        precision: OffsetPrecision::OptionalSeconds,
         colons: Colons::Maybe,
         allow_zulu: true,
         padding: Pad::Zero,

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -458,7 +458,6 @@ where
                     }
 
                     &TimezoneOffsetColon
-                    | &TimezoneOffsetDoubleColon
                     | &TimezoneOffset
                     | &TimezoneOffsetColonZ
                     | &TimezoneOffsetZ => {
@@ -466,6 +465,17 @@ where
                             precision: OffsetPrecision::Minutes,
                             colons: Colons::Maybe,
                             allow_zulu: spec == &TimezoneOffsetColonZ || spec == &TimezoneOffsetZ,
+                            padding: Pad::Zero,
+                        };
+                        let offset = try_consume!(scan::utc_offset(s.trim_start(), offset_format));
+                        parsed.set_offset(i64::from(offset)).map_err(|e| (s, e))?;
+                    }
+
+                    &TimezoneOffsetDoubleColon => {
+                        let offset_format = OffsetFormat {
+                            precision: OffsetPrecision::Seconds,
+                            colons: Colons::Colon,
+                            allow_zulu: false,
                             padding: Pad::Zero,
                         };
                         let offset = try_consume!(scan::utc_offset(s.trim_start(), offset_format));

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -11,7 +11,7 @@ use core::str::FromStr;
 use rkyv::{Archive, Deserialize, Serialize};
 
 use super::{LocalResult, Offset, TimeZone};
-use crate::format::{scan, OUT_OF_RANGE};
+use crate::format::{scan, Colons, OffsetFormat, OffsetPrecision, Pad, OUT_OF_RANGE};
 use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
 use crate::oldtime::Duration as OldDuration;
 use crate::{DateTime, ParseError, Timelike};
@@ -118,7 +118,13 @@ impl FixedOffset {
 impl FromStr for FixedOffset {
     type Err = ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (_, offset) = scan::timezone_offset(s, scan::colon_or_space, false, false, true)?;
+        let offset_format = OffsetFormat {
+            precision: OffsetPrecision::Minutes,
+            colons: Colons::Maybe,
+            allow_zulu: false,
+            padding: Pad::Zero,
+        };
+        let (_, offset) = scan::utc_offset(s, offset_format)?;
         Self::east_opt(offset).ok_or(OUT_OF_RANGE)
     }
 }

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -119,10 +119,10 @@ impl FromStr for FixedOffset {
     type Err = ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let offset_format = OffsetFormat {
-            precision: OffsetPrecision::Minutes,
+            precision: OffsetPrecision::OptionalMinutesAndSeconds,
             colons: Colons::Maybe,
-            allow_zulu: false,
-            padding: Pad::Zero,
+            allow_zulu: true,
+            padding: Pad::None,
         };
         let (_, offset) = scan::utc_offset(s, offset_format)?;
         Self::east_opt(offset).ok_or(OUT_OF_RANGE)


### PR DESCRIPTION
The first commit is shared with https://github.com/chronotope/chrono/pull/1082.
Then a couple of commits do some cleanup and add a new offset parser.
All the test keep passing, except some of those for `#z`. The difference is in the error causes, which have improved a bit.

Next are commits to make `%:z`, `%::z` and `%:::z` work as documented:
- `%:z` should require a colon (this is what makes it different from `%z`).
- `%::z` should also be able to parse, and even require, seconds.
- `%:::z` should only accept hours.

Finally the `FromStr` implementation of `DateTime<FixedOffset>` now accepts optional seconds in the offset, so that it can parse the `Debug` format of `DateTime`.

---

TODO: I still need to figure out some way to test all the code paths of the new offset parser.