### PR TITLE
test: explicitly set `LANG` to `c` in gnu `date`

### DIFF
--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -98,6 +98,7 @@ fn verify_against_date_command_format_local(path: &'static str, dt: NaiveDateTim
     // Z%Z - too many ways to represent it, will most likely fail
 
     let output = process::Command::new(path)
+        .env("LANG", "c")
         .arg("-d")
         .arg(format!(
             "{}-{:02}-{:02} {:02}:{:02}:{:02}",


### PR DESCRIPTION
- fixes #1060 

```
 ~/r/chrono   explicit-gnu-date …  echo $LA
NG
ko_KR.UTF-8
 ~/r/chrono   explicit-gnu-date …  cargo te
st --package chrono --test dateutils --feature
s unstable-locales -- try_verify_against_date_
command_format --exact --nocapture
    Finished test [unoptimized + debuginfo] target(s) in 0.03s
     Running tests/dateutils.rs (target/debug/deps/dateutils-917f84c226dfcdb1)

running 1 test
test try_verify_against_date_command_format ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.13s
```