### PR TITLE
tests: date path consolidate (branch 0.4.x)

### DIFF
--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -63,6 +63,23 @@ const DATE_PATH: &'static str = "/usr/bin/date";
 #[cfg(target_os = "aix")]
 const DATE_PATH: &'static str = "/opt/freeware/bin/date";
 
+#[cfg(test)]
+/// test helper to sanity check the date command behaves as expected
+/// asserts the command succeeded
+fn assert_run_date_version() {
+    // note environment variable `LANG`
+    match std::env::var_os("LANG") {
+        Some(lang) => eprintln!("LANG: {:?}", lang),
+        None => eprintln!("LANG not set"),
+    }
+    let out = process::Command::new(DATE_PATH).arg("--version").output().unwrap();
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    // note the `date` binary version
+    eprintln!("command: {:?} --version\nstdout: {:?}\nstderr: {:?}", DATE_PATH, stdout, stderr);
+    assert!(out.status.success(), "command failed: {:?} --version", DATE_PATH);
+}
+
 #[test]
 #[cfg(unix)]
 fn try_verify_against_date_command() {
@@ -71,6 +88,7 @@ fn try_verify_against_date_command() {
         eprintln!("date command {:?} not found, skipping", DATE_PATH);
         return;
     }
+    assert_run_date_version();
 
     let mut date = NaiveDate::from_ymd_opt(1975, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
 
@@ -132,6 +150,8 @@ fn try_verify_against_date_command_format() {
         eprintln!("date command {:?} not found, skipping", DATE_PATH);
         return;
     }
+    assert_run_date_version();
+
     let mut date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_opt(12, 11, 13).unwrap();
     while date.year() < 2008 {
         verify_against_date_command_format_local(DATE_PATH, date);

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -83,7 +83,6 @@ fn assert_run_date_version() {
 #[test]
 #[cfg(unix)]
 fn try_verify_against_date_command() {
-
     if !path::Path::new(DATE_PATH).exists() {
         eprintln!("date command {:?} not found, skipping", DATE_PATH);
         return;
@@ -92,16 +91,29 @@ fn try_verify_against_date_command() {
 
     let mut date = NaiveDate::from_ymd_opt(1975, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
 
+    eprintln!(
+        "Run command {:?} for every hour from {} to 2077, skipping some years...",
+        DATE_PATH,
+        date.year()
+    );
+    let mut count: u64 = 0;
+    let mut year_at = date.year();
     while date.year() < 2078 {
         if (1975..=1977).contains(&date.year())
             || (2020..=2022).contains(&date.year())
             || (2073..=2077).contains(&date.year())
         {
+            if date.year() != year_at {
+                eprintln!("at year {}...", date.year());
+                year_at = date.year();
+            }
             verify_against_date_command_local(DATE_PATH, date);
+            count += 1;
         }
 
         date += chrono::Duration::hours(1);
     }
+    eprintln!("Command {:?} was run {} times", DATE_PATH, count);
 }
 
 #[cfg(target_os = "linux")]

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -52,19 +52,23 @@ fn verify_against_date_command_local(path: &'static str, dt: NaiveDateTime) {
     }
 }
 
+/// path to Unix `date` command. Should work on most Linux and Unixes. Not the
+/// path for MacOS (/bin/date) which uses a different version of `date` with
+/// different arguments (so it won't run which is okay).
+/// for testing only
+#[allow(dead_code)]
+#[cfg(not(target_os = "aix"))]
+const DATE_PATH: &'static str = "/usr/bin/date";
+#[allow(dead_code)]
+#[cfg(target_os = "aix")]
+const DATE_PATH: &'static str = "/opt/freeware/bin/date";
+
 #[test]
 #[cfg(unix)]
 fn try_verify_against_date_command() {
-    #[cfg(not(target_os = "aix"))]
-    let date_path = "/usr/bin/date";
-    #[cfg(target_os = "aix")]
-    let date_path = "/opt/freeware/bin/date";
 
-    if !path::Path::new(date_path).exists() {
-        // date command not found, skipping
-        // avoid running this on macOS, which has path /bin/date
-        // as the required CLI arguments are not present in the
-        // macOS build.
+    if !path::Path::new(DATE_PATH).exists() {
+        eprintln!("date command {:?} not found, skipping", DATE_PATH);
         return;
     }
 
@@ -75,7 +79,7 @@ fn try_verify_against_date_command() {
             || (2020..=2022).contains(&date.year())
             || (2073..=2077).contains(&date.year())
         {
-            verify_against_date_command_local(date_path, date);
+            verify_against_date_command_local(DATE_PATH, date);
         }
 
         date += chrono::Duration::hours(1);
@@ -124,15 +128,13 @@ fn verify_against_date_command_format_local(path: &'static str, dt: NaiveDateTim
 #[test]
 #[cfg(target_os = "linux")]
 fn try_verify_against_date_command_format() {
-    let date_path = "/usr/bin/date";
-
-    if !path::Path::new(date_path).exists() {
-        // date command not found, skipping
+    if !path::Path::new(DATE_PATH).exists() {
+        eprintln!("date command {:?} not found, skipping", DATE_PATH);
         return;
     }
     let mut date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_opt(12, 11, 13).unwrap();
     while date.year() < 2008 {
-        verify_against_date_command_format_local(date_path, date);
+        verify_against_date_command_format_local(DATE_PATH, date);
         date += chrono::Duration::days(55);
     }
 }


### PR DESCRIPTION
- Consolidate `date_path`.
- Sanity check `date` can run `date --version` before attempting to use it.
- Print test progress messages.