### PR TITLE
Add tests/issues.rs, test Issue #1096 (branch 0.4.x)

### DIFF
--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -1,0 +1,17 @@
+// issues.rs
+//
+// Regressions tests of specific issues.
+
+#[cfg(test)]
+use chrono::NaiveDateTime;
+
+#[test]
+#[should_panic]
+/// When Issue #1096 is fixed then `#[should_panic]` should be removed.
+/// See https://github.com/chronotope/chrono/issues/1096
+fn issue_1096() {
+    let test = NaiveDateTime::from_timestamp_millis(0).unwrap();
+    let tf = test.format("%+");
+    let output = tf.to_string();
+    assert_eq!(output, "1970-01-01T00:00:00.00000+00:00");
+}


### PR DESCRIPTION
- Add new file `tests/issues.rs` for regression tests specific to issues.
- add test for Issue #1096

---

If this PR is accepted, I will add another PR that moves all issue-specific tests into `tests/issues.rs`.

IMO, the issue-specific tests just make better sense in their own file. Since they cover niche topics it's often hard to know where to put issue-specific tests or what to title them. This code organization, placing them in `tests/issues.rs`, makes it easier to quickly add useful user-provided regression tests in a more organized manner.
User-provided issue-specific tests provide valuable certainty that a particular issue has been fixed.
They also exercise often niche behaviors that is too specific for "regular tests" to cover. Users spend a fair amount of time discovering then isolating an issue. Why not put that hard-won knowledge to use as another assurance of quality?
Issue-specific tests also demonstrate code-use for other users running into similar problems or with related questions.

I don't plan to add a test for all issues from the Issue backlog. But maybe going forward it can be made into a project practice that every fixed Issue gets a new test case in `tests/issues.rs` when that issue has reasonably simple reproduction steps provided,
e.g. a commit pattern like
1. add test to `tests/issues.rs` demonstrating failure (add test attribute `#[should_panic]` if the issue causes a panic)
2. code change with fix, adjust the test case for the fix

Issue-specific tests are not meant to replace "regular tests" or "general tests". Those should also be updated and augmented as necessary.