### PR TITLE
README badge github commits-since

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Chrono on crates.io][cratesio-image]][cratesio]
 [![Chrono on docs.rs][docsrs-image]][docsrs]
 [![Join the chat at https://gitter.im/chrono-rs/chrono][gitter-image]][gitter]
+[![Commits since][commits-since]][commits-since-history]
 
 [gh-image]: https://github.com/chronotope/chrono/actions/workflows/test.yml/badge.svg
 [gh-checks]: https://github.com/chronotope/chrono/actions?query=workflow%3Atest
@@ -14,6 +15,8 @@
 [docsrs]: https://docs.rs/chrono
 [gitter-image]: https://badges.gitter.im/chrono-rs/chrono.svg
 [gitter]: https://gitter.im/chrono-rs/chrono
+[commits-since]: https://img.shields.io/github/commits-since/chronotope/chrono/latest/0.4.x
+[commits-since-history]: https://github.com/chronotope/chrono/commits/0.4.x
 
 It aims to be a feature-complete superset of
 the [time](https://github.com/rust-lang-deprecated/time) library.


### PR DESCRIPTION
The github label `latest` is currently pointing to release `0.4.23` so shields.io badge generator believes that is the latest (the latest is `0.4.24`).

Example at https://github.com/jtmoon79/super-speedy-syslog-searcher/#super-speedy-syslog-searcher-s4-

Why? Badges are grokkable and just fun eye candy.