### PR TITLE
yamllint cleanup lint.yml test.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,16 +18,20 @@ jobs:
       - run: cargo fmt --check -- --color=always
       - run: cargo fmt --check --manifest-path fuzz/Cargo.toml
       - run: cargo clippy --color=always -- -D warnings
-      - run: cargo clippy --color=always --target x86_64-pc-windows-msvc -- -D warnings
-      - run: cargo clippy --manifest-path fuzz/Cargo.toml --color=always -- -D warnings
+      - run: |
+          cargo clippy --color=always --target x86_64-pc-windows-msvc \
+            -- -D warnings
+      - run: |
+          cargo clippy --manifest-path fuzz/Cargo.toml --color=always \
+            -- -D warnings
         env:
           RUSTFLAGS: "-Dwarnings"
 
   cargo-deny:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: actions/checkout@v3
+      - uses: EmbarkStudios/cargo-deny-action@v1
 
   check-doc:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,9 +45,18 @@ jobs:
         with:
           toolchain: 1.56.1
       - uses: Swatinem/rust-cache@v2
-      # run --lib and --doc to avoid the long running integration tests which are run elsewhere
-      - run: cargo test --lib --features unstable-locales,wasmbind,oldtime,clock,rustc-serialize,winapi,serde --color=always -- --color=always
-      - run: cargo test --doc --features unstable-locales,wasmbind,oldtime,clock,rustc-serialize,winapi,serde --color=always -- --color=always
+      # run --lib and --doc to avoid the long running integration tests
+      # which are run elsewhere
+      - run: |
+          cargo test --lib \
+            --features \
+            unstable-locales,wasmbind,oldtime,clock,rustc-serialize,winapi,serde \
+            --color=always -- --color=always
+      - run: |
+          cargo test --doc \
+            --features \
+            unstable-locales,wasmbind,oldtime,clock,rustc-serialize,winapi,serde \
+            --color=always -- --color=always
 
   rust_versions:
     strategy:
@@ -63,7 +72,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --benches
       - run: cargo check --manifest-path fuzz/Cargo.toml --all-targets
-      # run --lib and --doc to avoid the long running integration tests which are run elsewhere
+      # run --lib and --doc to avoid the long running integration tests
+      # which are run elsewhere
       - run: cargo test --lib --all-features --color=always -- --color=always
       - run: cargo test --doc --all-features --color=always -- --color=always
 
@@ -77,7 +87,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
-      - run: cargo hack check --feature-powerset --optional-deps serde,rkyv --skip default --skip __internal_bench --skip __doctest --skip iana-time-zone --skip pure-rust-locales
+      - run: |
+          cargo hack check --feature-powerset --optional-deps serde,rkyv \
+            --skip default --skip __internal_bench --skip __doctest \
+            --skip iana-time-zone --skip pure-rust-locales
+        # run using `bash` on all platforms for consistent
+        # line-continuation marks
+        shell: bash
       - run: cargo test --lib --no-default-features
       - run: cargo test --doc --no-default-features
 
@@ -136,7 +152,10 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
-      - run: cargo hack check --feature-powerset --optional-deps serde,rkyv --skip default --skip __internal_bench --skip __doctest --skip iana-time-zone --skip pure-rust-locales
+      - run: |
+          cargo hack check --feature-powerset --optional-deps serde,rkyv \
+            --skip default --skip __internal_bench --skip __doctest \
+            --skip iana-time-zone --skip pure-rust-locales
 
   cross-targets:
     strategy:


### PR DESCRIPTION
Apply recommendations from [`yamllint`](https://pypi.org/project/yamllint/) to the github YAML files, along with Document markers.

Document Start marker and Document End marker described at https://www.yaml.info/learn/document.html#start