### PR TITLE
GitHub yml shell `set -eux`, use bash

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,7 +121,8 @@ jobs:
       - run: |
           set -euxo pipefail
           export RUST_BACKTRACE=1
-          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf \
+              | bash --noprofile --norc
           wasm-pack --version
         shell: bash
       - run: cargo build --target ${{ matrix.target }}  --color=always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,9 +119,11 @@ jobs:
         with:
           node-version: "12"
       - run: |
+          set -euxo pipefail
           export RUST_BACKTRACE=1
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
           wasm-pack --version
+        shell: bash
       - run: cargo build --target ${{ matrix.target }}  --color=always
 
   features_check_wasm:


### PR DESCRIPTION
Previously, a failure from `curl` or `sh` would be ignored (any failure before the final script statement would be ignored).

Use `bash`. Previously `sh` was emitting an error `sh: 139: [: x86_64: unexpected operator`
For example https://github.com/chronotope/chrono/actions/runs/5107217021/jobs/9179925191?pr=1087#step:6:12