### PR TITLE
Update CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ cff-version: 1.2.0
 message: Please cite this crate using these information.
 
 # Version information.
-date-released: 2023-03-12
-version: 0.4.24
+date-released: 2023-05-29
+version: 0.4.25
 
 # Project information.
 abstract: Date and time library for Rust


### PR DESCRIPTION
Thank you for your new version v0.4.25!

After updating the Rust manifest, I also tried to grab the updated citation data but noticed that the new version information is not entered there, yet.  Hence, I would like to suggest you these changes to the CITATION.cff to update the version and release date.