### PR TITLE
Remove num-iter dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ android-tzdata = "0.1.1"
 serde_json = { version = "1" }
 serde_derive = { version = "1", default-features = false }
 bincode = { version = "1.3.0" }
-num-iter = { version = "0.1.35", default-features = false }
 doc-comment = { version = "0.3" }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -2376,9 +2376,7 @@ mod tests {
 
     #[test]
     fn test_readme_doomsday() {
-        use num_iter::range_inclusive;
-
-        for y in range_inclusive(NaiveDate::MIN.year(), NaiveDate::MAX.year()) {
+        for y in NaiveDate::MIN.year()..=NaiveDate::MAX.year() {
             // even months
             let d4 = NaiveDate::from_ymd_opt(y, 4, 4).unwrap();
             let d6 = NaiveDate::from_ymd_opt(y, 6, 6).unwrap();

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -504,7 +504,6 @@ const fn weekday_from_u32_mod7(n: u32) -> Weekday {
 
 #[cfg(test)]
 mod tests {
-    use num_iter::range_inclusive;
     use std::convert::TryFrom;
     use std::u32;
 
@@ -555,7 +554,7 @@ mod tests {
     #[test]
     fn test_of() {
         fn check(expected: bool, flags: YearFlags, ordinal1: u32, ordinal2: u32) {
-            for ordinal in range_inclusive(ordinal1, ordinal2) {
+            for ordinal in ordinal1..=ordinal2 {
                 let of = match Of::new(ordinal, flags) {
                     Some(of) => of,
                     None if !expected => continue,
@@ -591,8 +590,8 @@ mod tests {
     #[test]
     fn test_mdf_valid() {
         fn check(expected: bool, flags: YearFlags, month1: u32, day1: u32, month2: u32, day2: u32) {
-            for month in range_inclusive(month1, month2) {
-                for day in range_inclusive(day1, day2) {
+            for month in month1..=month2 {
+                for day in day1..=day2 {
                     let mdf = match Mdf::new(month, day, flags) {
                         Some(mdf) => mdf,
                         None if !expected => continue,
@@ -682,7 +681,7 @@ mod tests {
     #[test]
     fn test_of_fields() {
         for &flags in FLAGS.iter() {
-            for ordinal in range_inclusive(1u32, 366) {
+            for ordinal in 1u32..=366 {
                 if let Some(of) = Of::new(ordinal, flags) {
                     assert_eq!(of.ordinal(), ordinal);
                 }
@@ -695,7 +694,7 @@ mod tests {
         fn check(flags: YearFlags, ordinal: u32) {
             let of = Of::new(ordinal, flags).unwrap();
 
-            for ordinal in range_inclusive(0u32, 1024) {
+            for ordinal in 0u32..=1024 {
                 let of = of.with_ordinal(ordinal);
                 assert_eq!(of, Of::new(ordinal, flags));
                 if let Some(of) = of {
@@ -733,7 +732,7 @@ mod tests {
 
         for &flags in FLAGS.iter() {
             let mut prev = Of::new(1, flags).unwrap().weekday();
-            for ordinal in range_inclusive(2u32, flags.ndays()) {
+            for ordinal in 2u32..=flags.ndays() {
                 let of = Of::new(ordinal, flags).unwrap();
                 let expected = prev.succ();
                 assert_eq!(of.weekday(), expected);
@@ -745,8 +744,8 @@ mod tests {
     #[test]
     fn test_mdf_fields() {
         for &flags in FLAGS.iter() {
-            for month in range_inclusive(1u32, 12) {
-                for day in range_inclusive(1u32, 31) {
+            for month in 1u32..=12 {
+                for day in 1u32..31 {
                     let mdf = match Mdf::new(month, day, flags) {
                         Some(mdf) => mdf,
                         None => continue,
@@ -766,7 +765,7 @@ mod tests {
         fn check(flags: YearFlags, month: u32, day: u32) {
             let mdf = Mdf::new(month, day, flags).unwrap();
 
-            for month in range_inclusive(0u32, 16) {
+            for month in 0u32..=16 {
                 let mdf = match mdf.with_month(month) {
                     Some(mdf) => mdf,
                     None if month > 12 => continue,
@@ -779,7 +778,7 @@ mod tests {
                 }
             }
 
-            for day in range_inclusive(0u32, 1024) {
+            for day in 0u32..=1024 {
                 let mdf = match mdf.with_day(day) {
                     Some(mdf) => mdf,
                     None if day > 31 => continue,
@@ -822,7 +821,7 @@ mod tests {
 
     #[test]
     fn test_of_to_mdf() {
-        for i in range_inclusive(0u32, 8192) {
+        for i in 0u32..=8192 {
             if let Some(of) = Of(i).validate() {
                 assert!(of.to_mdf().valid());
             }
@@ -831,7 +830,7 @@ mod tests {
 
     #[test]
     fn test_mdf_to_of() {
-        for i in range_inclusive(0u32, 8192) {
+        for i in 0u32..=8192 {
             let mdf = Mdf(i);
             assert_eq!(mdf.valid(), mdf.to_of().is_some());
         }
@@ -839,7 +838,7 @@ mod tests {
 
     #[test]
     fn test_of_to_mdf_to_of() {
-        for i in range_inclusive(0u32, 8192) {
+        for i in 0u32..=8192 {
             if let Some(of) = Of(i).validate() {
                 assert_eq!(of, of.to_mdf().to_of().unwrap());
             }
@@ -848,7 +847,7 @@ mod tests {
 
     #[test]
     fn test_mdf_to_of_to_mdf() {
-        for i in range_inclusive(0u32, 8192) {
+        for i in 0u32..=8192 {
             let mdf = Mdf(i);
             if mdf.valid() {
                 assert_eq!(mdf, mdf.to_of().unwrap().to_mdf());

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -219,9 +219,7 @@ mod tests {
             date.ordinal() as i32 + 365 * diff(1) + diff(4) - diff(100) + diff(400)
         }
 
-        use num_iter::range_inclusive;
-
-        for year in range_inclusive(NaiveDate::MIN.year(), NaiveDate::MAX.year()) {
+        for year in NaiveDate::MIN.year()..=NaiveDate::MAX.year() {
             let jan1_year = NaiveDate::from_ymd_opt(year, 1, 1).unwrap();
             assert_eq!(
                 jan1_year.num_days_from_ce(),


### PR DESCRIPTION
We might be able to use `core::ops::RangeInclusive` instead of `num_iter::RangeInclusive`.