### PR TITLE
Revert backport of #807

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -560,9 +560,6 @@ impl DateTime<FixedOffset> {
     /// RFC 2822 is the internet message standard that specifies the representation of times in HTTP
     /// and email headers.
     ///
-    /// The RFC 2822 standard allows arbitrary intermixed whitespace.
-    /// See [RFC 2822 Appendix A.5]
-    ///
     /// ```
     /// # use chrono::{DateTime, FixedOffset, TimeZone};
     /// assert_eq!(
@@ -570,8 +567,6 @@ impl DateTime<FixedOffset> {
     ///     FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap()
     /// );
     /// ```
-    ///
-    /// [RFC 2822 Appendix A.5]: https://www.rfc-editor.org/rfc/rfc2822#appendix-A.5
     pub fn parse_from_rfc2822(s: &str) -> ParseResult<DateTime<FixedOffset>> {
         const ITEMS: &[Item<'static>] = &[Item::Fixed(Fixed::RFC2822)];
         let mut parsed = Parsed::new();

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -240,94 +240,6 @@ fn test_datetime_sub_months() {
     );
 }
 
-// local helper function to easily create a DateTime<FixedOffset>
-fn ymdhms(
-    fixedoffset: &FixedOffset,
-    year: i32,
-    month: u32,
-    day: u32,
-    hour: u32,
-    min: u32,
-    sec: u32,
-) -> DateTime<FixedOffset> {
-    fixedoffset.with_ymd_and_hms(year, month, day, hour, min, sec).unwrap()
-}
-
-// local helper function to easily create a DateTime<FixedOffset>
-fn ymdhms_milli(
-    fixedoffset: &FixedOffset,
-    year: i32,
-    month: u32,
-    day: u32,
-    hour: u32,
-    min: u32,
-    sec: u32,
-    milli: i64,
-) -> DateTime<FixedOffset> {
-    fixedoffset
-        .with_ymd_and_hms(year, month, day, hour, min, sec)
-        .unwrap()
-        .checked_add_signed(Duration::milliseconds(milli))
-        .unwrap()
-}
-
-// local helper function to easily create a DateTime<FixedOffset>
-fn ymdhms_micro(
-    fixedoffset: &FixedOffset,
-    year: i32,
-    month: u32,
-    day: u32,
-    hour: u32,
-    min: u32,
-    sec: u32,
-    micro: i64,
-) -> DateTime<FixedOffset> {
-    fixedoffset
-        .with_ymd_and_hms(year, month, day, hour, min, sec)
-        .unwrap()
-        .checked_add_signed(Duration::microseconds(micro))
-        .unwrap()
-}
-
-// local helper function to easily create a DateTime<FixedOffset>
-fn ymdhms_nano(
-    fixedoffset: &FixedOffset,
-    year: i32,
-    month: u32,
-    day: u32,
-    hour: u32,
-    min: u32,
-    sec: u32,
-    nano: i64,
-) -> DateTime<FixedOffset> {
-    fixedoffset
-        .with_ymd_and_hms(year, month, day, hour, min, sec)
-        .unwrap()
-        .checked_add_signed(Duration::nanoseconds(nano))
-        .unwrap()
-}
-
-// local helper function to easily create a DateTime<Utc>
-fn ymdhms_utc(year: i32, month: u32, day: u32, hour: u32, min: u32, sec: u32) -> DateTime<Utc> {
-    Utc.with_ymd_and_hms(year, month, day, hour, min, sec).unwrap()
-}
-
-// local helper function to easily create a DateTime<Utc>
-fn ymdhms_milli_utc(
-    year: i32,
-    month: u32,
-    day: u32,
-    hour: u32,
-    min: u32,
-    sec: u32,
-    milli: i64,
-) -> DateTime<Utc> {
-    Utc.with_ymd_and_hms(year, month, day, hour, min, sec)
-        .unwrap()
-        .checked_add_signed(Duration::milliseconds(milli))
-        .unwrap()
-}
-
 #[test]
 fn test_datetime_offset() {
     let est = FixedOffset::west_opt(5 * 60 * 60).unwrap();
@@ -432,15 +344,16 @@ fn test_datetime_with_timezone() {
 }
 
 #[test]
-fn test_datetime_rfc2822() {
+fn test_datetime_rfc2822_and_rfc3339() {
     let edt = FixedOffset::east_opt(5 * 60 * 60).unwrap();
-
-    // timezone 0
     assert_eq!(
         Utc.with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap().to_rfc2822(),
         "Wed, 18 Feb 2015 23:16:09 +0000"
     );
-    // timezone +05
+    assert_eq!(
+        Utc.with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap().to_rfc3339(),
+        "2015-02-18T23:16:09+00:00"
+    );
     assert_eq!(
         edt.from_local_datetime(
             &NaiveDate::from_ymd_opt(2015, 2, 18)
@@ -452,7 +365,17 @@ fn test_datetime_rfc2822() {
         .to_rfc2822(),
         "Wed, 18 Feb 2015 23:16:09 +0500"
     );
-    // seconds 60
+    assert_eq!(
+        edt.from_local_datetime(
+            &NaiveDate::from_ymd_opt(2015, 2, 18)
+                .unwrap()
+                .and_hms_milli_opt(23, 16, 9, 150)
+                .unwrap()
+        )
+        .unwrap()
+        .to_rfc3339(),
+        "2015-02-18T23:16:09.150+05:00"
+    );
     assert_eq!(
         edt.from_local_datetime(
             &NaiveDate::from_ymd_opt(2015, 2, 18)
@@ -464,6 +387,17 @@ fn test_datetime_rfc2822() {
         .to_rfc2822(),
         "Wed, 18 Feb 2015 23:59:60 +0500"
     );
+    assert_eq!(
+        edt.from_local_datetime(
+            &NaiveDate::from_ymd_opt(2015, 2, 18)
+                .unwrap()
+                .and_hms_micro_opt(23, 59, 59, 1_234_567)
+                .unwrap()
+        )
+        .unwrap()
+        .to_rfc3339(),
+        "2015-02-18T23:59:60.234567+05:00"
+    );
 
     assert_eq!(
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +0000"),
@@ -474,135 +408,12 @@ fn test_datetime_rfc2822() {
         Ok(FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
     );
     assert_eq!(
-        ymdhms_milli(&edt, 2015, 2, 18, 23, 59, 58, 1_234_567).to_rfc2822(),
-        "Thu, 19 Feb 2015 00:20:32 +0500"
+        DateTime::parse_from_rfc3339("2015-02-18T23:16:09Z"),
+        Ok(FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:58 +0500"),
-        Ok(ymdhms(&edt, 2015, 2, 18, 23, 59, 58))
-    );
-    assert_ne!(
-        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:58 +0500"),
-        Ok(ymdhms_milli(&edt, 2015, 2, 18, 23, 59, 58, 500))
-    );
-
-    // many varying whitespace intermixed
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822(
-            "\t\t\tWed,\n\t\t18 \r\n\t\tFeb \u{3000} 2015\r\n\t\t\t23:59:58    \t+0500"
-        ),
-        Ok(ymdhms(&edt, 2015, 2, 18, 23, 59, 58))
-    );
-    // example from RFC 2822 Appendix A.5.
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822(
-            "Thu,\n\t13\n      Feb\n        1969\n    23:32\n             -0330 (Newfoundland Time)"
-        ),
-        Ok(
-            ymdhms(
-                &FixedOffset::east_opt(-3 * 60 * 60 - 30 * 60).unwrap(),
-                1969, 2, 13, 23, 32, 0,
-            )
-        )
-    );
-    // example from RFC 2822 Appendix A.5. without trailing " (Newfoundland Time)"
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822(
-            "Thu,\n\t13\n      Feb\n        1969\n    23:32\n             -0330"
-        ),
-        Ok(
-            ymdhms(&FixedOffset::east_opt(-3 * 60 * 60 - 30 * 60).unwrap(), 1969, 2, 13, 23, 32, 0,)
-        )
-    );
-
-    // bad year
-    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("31 DEC 262143 23:59 -2359").is_err());
-    // wrong format
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +00:00").is_err()
-    );
-    // full name day of week
-    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("Wednesday, 18 Feb 2015 23:16:09 +0000")
-        .is_err());
-    // full name day of week
-    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("Wednesday 18 Feb 2015 23:16:09 +0000")
-        .is_err());
-    // wrong day of week separator '.'
-    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("Wed. 18 Feb 2015 23:16:09 +0000").is_err());
-    // *trailing* space causes failure
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +0000   ").is_err()
-    );
-}
-
-#[test]
-fn test_datetime_rfc3339() {
-    let edt5 = FixedOffset::east_opt(5 * 60 * 60).unwrap();
-    let edt0 = FixedOffset::east_opt(0).unwrap();
-
-    // timezone 0
-    assert_eq!(
-        Utc.with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap().to_rfc3339(),
-        "2015-02-18T23:16:09+00:00"
-    );
-    // timezone +05
-    assert_eq!(
-        edt5.from_local_datetime(
-            &NaiveDate::from_ymd_opt(2015, 2, 18)
-                .unwrap()
-                .and_hms_milli_opt(23, 16, 9, 150)
-                .unwrap()
-        )
-        .unwrap()
-        .to_rfc3339(),
-        "2015-02-18T23:16:09.150+05:00"
-    );
-
-    assert_eq!(ymdhms_utc(2015, 2, 18, 23, 16, 9).to_rfc3339(), "2015-02-18T23:16:09+00:00");
-    assert_eq!(
-        ymdhms_milli(&edt5, 2015, 2, 18, 23, 16, 9, 150).to_rfc3339(),
-        "2015-02-18T23:16:09.150+05:00"
-    );
-    assert_eq!(
-        ymdhms_micro(&edt5, 2015, 2, 18, 23, 59, 59, 1_234_567).to_rfc3339(),
-        "2015-02-19T00:00:00.234567+05:00"
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:59.123+05:00"),
-        Ok(ymdhms_micro(&edt5, 2015, 2, 18, 23, 59, 59, 123_000))
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:59.123456+05:00"),
-        Ok(ymdhms_micro(&edt5, 2015, 2, 18, 23, 59, 59, 123_456))
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:59.123456789+05:00"),
-        Ok(ymdhms_nano(&edt5, 2015, 2, 18, 23, 59, 59, 123_456_789))
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:16:09Z"),
-        Ok(ymdhms(&edt0, 2015, 2, 18, 23, 16, 9))
-    );
-
-    assert_eq!(
-        ymdhms_micro(&edt5, 2015, 2, 18, 23, 59, 59, 1_234_567).to_rfc3339(),
-        "2015-02-19T00:00:00.234567+05:00"
-    );
-    assert_eq!(
-        ymdhms_milli(&edt5, 2015, 2, 18, 23, 16, 9, 150).to_rfc3339(),
-        "2015-02-18T23:16:09.150+05:00"
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T00:00:00.234567+05:00"),
-        Ok(ymdhms_micro(&edt5, 2015, 2, 18, 0, 0, 0, 234_567))
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:16:09Z"),
-        Ok(ymdhms(&edt0, 2015, 2, 18, 23, 16, 9))
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:60 +0500"),
-        Ok(edt5
+        DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:60 +0500"),
+        Ok(edt
             .from_local_datetime(
                 &NaiveDate::from_ymd_opt(2015, 2, 18)
                     .unwrap()
@@ -613,8 +424,8 @@ fn test_datetime_rfc3339() {
     );
     assert!(DateTime::parse_from_rfc2822("31 DEC 262143 23:59 -2359").is_err());
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00"),
-        Ok(edt5
+        DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00"),
+        Ok(edt
             .from_local_datetime(
                 &NaiveDate::from_ymd_opt(2015, 2, 18)
                     .unwrap()
@@ -622,41 +433,6 @@ fn test_datetime_rfc3339() {
                     .unwrap()
             )
             .unwrap())
-    );
-    assert_eq!(ymdhms_utc(2015, 2, 18, 23, 16, 9).to_rfc3339(), "2015-02-18T23:16:09+00:00");
-
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567 +05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:059:60.234567+05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00PST").is_err()
-    );
-    assert!(DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+PST").is_err());
-    assert!(DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567PST").is_err());
-    assert!(DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+0500").is_err());
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18 23:59:60.234567+05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567:+05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00 ").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339(" 2015-02-18T23:59:60.234567+05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015- 02-18T23:59:60.234567+05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567A+05:00").is_err()
     );
 }
 
@@ -799,106 +575,13 @@ fn test_datetime_from_str() {
 }
 
 #[test]
-fn test_parse_datetime_utc() {
-    // valid cases
-    let valid = [
-        "2001-02-03T04:05:06Z",
-        "2001-02-03T04:05:06+0000",
-        "2001-02-03T04:05:06-00:00",
-        "2001-02-03T04:05:06-01:00",
-        "2012-12-12T12:12:12Z",
-        "2015-02-18T23:16:09.153Z",
-        "2015-2-18T23:16:09.153Z",
-        "+2015-2-18T23:16:09.153Z",
-        "-77-02-18T23:16:09Z",
-        "+82701-05-6T15:9:60.898989898989Z",
-    ];
-    for &s in &valid {
-        eprintln!("test_parse_datetime_utc valid {:?}", s);
-        let d = match s.parse::<DateTime<Utc>>() {
-            Ok(d) => d,
-            Err(e) => panic!("parsing `{}` has failed: {}", s, e),
-        };
-        let s_ = format!("{:?}", d);
-        // `s` and `s_` may differ, but `s.parse()` and `s_.parse()` must be same
-        let d_ = match s_.parse::<DateTime<Utc>>() {
-            Ok(d) => d,
-            Err(e) => {
-                panic!("`{}` is parsed into `{:?}`, but reparsing that has failed: {}", s, d, e)
-            }
-        };
-        assert!(
-            d == d_,
-            "`{}` is parsed into `{:?}`, but reparsed result \
-                              `{:?}` does not match",
-            s,
-            d,
-            d_
-        );
-    }
-
-    // some invalid cases
-    // since `ParseErrorKind` is private, all we can do is to check if there was an error
-    let invalid = [
-        "",                                                          // empty
-        "Z",                                                         // missing data
-        "15Z",                                                       // missing data
-        "15:8:9Z",                                                   // missing date
-        "15-8-9Z",                                                   // missing time or date
-        "Fri, 09 Aug 2013 23:54:35 GMT",                             // valid datetime, wrong format
-        "Sat Jun 30 23:59:60 2012",                                  // valid datetime, wrong format
-        "1441497364.649",                                            // valid datetime, wrong format
-        "+1441497364.649",                                           // valid datetime, wrong format
-        "+1441497364",                                               // valid datetime, wrong format
-        "+1441497364Z",                                              // valid datetime, wrong format
-        "2014/02/03 04:05:06Z",                                      // valid datetime, wrong format
-        "2001-02-03T04:05:0600:00",   // valid datetime, timezone too close
-        "2015-15-15T15:15:15Z",       // invalid datetime
-        "2012-12-12T12:12:12x",       // invalid timezone
-        "2012-123-12T12:12:12Z",      // invalid month
-        "2012-12-77T12:12:12Z",       // invalid day
-        "2012-12-12T26:12:12Z",       // invalid hour
-        "2012-12-12T12:61:12Z",       // invalid minute
-        "2012-12-12T12:12:62Z",       // invalid second
-        "2012-12-12 T12:12:12Z",      // space after date
-        "2012-12-12t12:12:12Z",       // wrong divider 't'
-        "2012-12-12T12:12:12ZZ",      // trailing literal 'Z'
-        "+802701-12-12T12:12:12Z",    // invalid year (out of bounds)
-        "+ 2012-12-12T12:12:12Z",     // invalid space before year
-        "2012 -12-12T12:12:12Z",      // space after year
-        "2012  -12-12T12:12:12Z",     // multi space after year
-        "2012- 12-12T12:12:12Z",      // space after year divider
-        "2012-  12-12T12:12:12Z",     // multi space after year divider
-        "2012-12-12T 12:12:12Z",      // space after date-time divider
-        "2012-12-12T12 :12:12Z",      // space after hour
-        "2012-12-12T12  :12:12Z",     // multi space after hour
-        "2012-12-12T12: 12:12Z",      // space before minute
-        "2012-12-12T12:  12:12Z",     // multi space before minute
-        "2012-12-12T12 : 12:12Z",     // space space before and after hour-minute divider
-        "2012-12-12T12:12:12Z ",      // trailing space
-        " 2012-12-12T12:12:12Z",      // leading space
-        "2001-02-03T04:05:06-00 00",  // invalid timezone spacing
-        "2001-02-03T04:05:06-01: 00", // invalid timezone spacing
-        "2001-02-03T04:05:06-01 :00", // invalid timezone spacing
-        "2001-02-03T04:05:06-01 : 00", // invalid timezone spacing
-        "2001-02-03T04:05:06-01 :     00", // invalid timezone spacing
-        "2001-02-03T04:05:06-01 :    :00", // invalid timezone spacing
-        "  +82701  -  05  -  6  T  15  :  9  : 60.898989898989   Z", // valid datetime, wrong format
-    ];
-    for &s in invalid.iter() {
-        eprintln!("test_parse_datetime_utc invalid {:?}", s);
-        assert!(s.parse::<DateTime<Utc>>().is_err());
-    }
-}
-
-#[test]
-fn test_utc_datetime_from_str() {
-    let edt = FixedOffset::east_opt(570 * 60).unwrap();
-    let edt0 = FixedOffset::east_opt(0).unwrap();
-    let wdt = FixedOffset::west_opt(10 * 3600).unwrap();
+fn test_datetime_parse_from_str() {
+    let ymdhms = |y, m, d, h, n, s, off| {
+        FixedOffset::east_opt(off).unwrap().with_ymd_and_hms(y, m, d, h, n, s).unwrap()
+    };
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
-        Ok(ymdhms(&edt, 2014, 5, 7, 12, 34, 56))
+        DateTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
+        Ok(ymdhms(2014, 5, 7, 12, 34, 56, 570 * 60))
     ); // ignore offset
     assert!(DateTime::parse_from_str("20140507000000", "%Y%m%d%H%M%S").is_err()); // no offset
     assert!(DateTime::parse_from_str("Fri, 09 Aug 2013 23:54:35 GMT", "%a, %d %b %Y %H:%M:%S GMT")
@@ -907,235 +590,6 @@ fn test_utc_datetime_from_str() {
         Utc.datetime_from_str("Fri, 09 Aug 2013 23:54:35 GMT", "%a, %d %b %Y %H:%M:%S GMT"),
         Ok(Utc.with_ymd_and_hms(2013, 8, 9, 23, 54, 35).unwrap())
     );
-
-    assert_eq!(
-        "2015-02-18T23:16:9.15Z".parse::<DateTime<FixedOffset>>(),
-        Ok(ymdhms_milli(&edt0, 2015, 2, 18, 23, 16, 9, 150))
-    );
-    assert_eq!(
-        "2015-02-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
-        Ok(ymdhms_milli_utc(2015, 2, 18, 23, 16, 9, 150)),
-    );
-    assert_eq!(
-        "2015-02-18T23:16:9.15 UTC".parse::<DateTime<Utc>>(),
-        Ok(ymdhms_milli_utc(2015, 2, 18, 23, 16, 9, 150))
-    );
-    assert_eq!(
-        "2015-02-18T23:16:9.15UTC".parse::<DateTime<Utc>>(),
-        Ok(ymdhms_milli_utc(2015, 2, 18, 23, 16, 9, 150))
-    );
-
-    assert_eq!(
-        "2015-2-18T23:16:9.15Z".parse::<DateTime<FixedOffset>>(),
-        Ok(ymdhms_milli(&edt0, 2015, 2, 18, 23, 16, 9, 150))
-    );
-    assert_eq!(
-        "2015-2-18T13:16:9.15-10:00".parse::<DateTime<FixedOffset>>(),
-        Ok(ymdhms_milli(&wdt, 2015, 2, 18, 13, 16, 9, 150))
-    );
-    assert!("2015-2-18T23:16:9.15".parse::<DateTime<FixedOffset>>().is_err());
-
-    assert_eq!(
-        "2015-2-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
-        Ok(ymdhms_milli_utc(2015, 2, 18, 23, 16, 9, 150))
-    );
-    assert_eq!(
-        "2015-2-18T13:16:9.15-10:00".parse::<DateTime<Utc>>(),
-        Ok(ymdhms_milli_utc(2015, 2, 18, 23, 16, 9, 150))
-    );
-    assert!("2015-2-18T23:16:9.15".parse::<DateTime<Utc>>().is_err());
-
-    // no test for `DateTime<Local>`, we cannot verify that much.
-}
-
-#[test]
-fn test_utc_datetime_from_str_with_spaces() {
-    let dt = ymdhms_utc(2013, 8, 9, 23, 54, 35);
-    // with varying spaces - should succeed
-    assert_eq!(Utc.datetime_from_str(" Aug 09 2013 23:54:35", " %b %d %Y %H:%M:%S"), Ok(dt),);
-    assert_eq!(Utc.datetime_from_str("Aug 09 2013 23:54:35 ", "%b %d %Y %H:%M:%S "), Ok(dt),);
-    assert_eq!(Utc.datetime_from_str(" Aug 09 2013  23:54:35 ", " %b %d %Y  %H:%M:%S "), Ok(dt),);
-    assert_eq!(Utc.datetime_from_str("  Aug 09 2013 23:54:35", "  %b %d %Y %H:%M:%S"), Ok(dt),);
-    assert_eq!(Utc.datetime_from_str("   Aug 09 2013 23:54:35", "   %b %d %Y %H:%M:%S"), Ok(dt),);
-    assert_eq!(
-        Utc.datetime_from_str("\n\tAug 09 2013 23:54:35  ", "\n\t%b %d %Y %H:%M:%S  "),
-        Ok(dt),
-    );
-    assert_eq!(Utc.datetime_from_str("\tAug 09 2013 23:54:35\t", "\t%b %d %Y %H:%M:%S\t"), Ok(dt),);
-    assert_eq!(Utc.datetime_from_str("Aug  09 2013 23:54:35", "%b  %d %Y %H:%M:%S"), Ok(dt),);
-    assert_eq!(Utc.datetime_from_str("Aug    09 2013 23:54:35", "%b    %d %Y %H:%M:%S"), Ok(dt),);
-    assert_eq!(Utc.datetime_from_str("Aug  09 2013\t23:54:35", "%b  %d %Y\t%H:%M:%S"), Ok(dt),);
-    assert_eq!(Utc.datetime_from_str("Aug  09 2013\t\t23:54:35", "%b  %d %Y\t\t%H:%M:%S"), Ok(dt),);
-    // with varying spaces - should fail
-    // leading whitespace in format
-    assert!(Utc.datetime_from_str("Aug 09 2013 23:54:35", " %b %d %Y %H:%M:%S").is_err());
-    // trailing whitespace in format
-    assert!(Utc.datetime_from_str("Aug 09 2013 23:54:35", "%b %d %Y %H:%M:%S ").is_err());
-    // extra mid-string whitespace in format
-    assert!(Utc.datetime_from_str("Aug 09 2013 23:54:35", "%b %d %Y  %H:%M:%S").is_err());
-    // mismatched leading whitespace
-    assert!(Utc.datetime_from_str("\tAug 09 2013 23:54:35", "\n%b %d %Y %H:%M:%S").is_err());
-    // mismatched trailing whitespace
-    assert!(Utc.datetime_from_str("Aug 09 2013 23:54:35 ", "%b %d %Y %H:%M:%S\n").is_err());
-    // mismatched mid-string whitespace
-    assert!(Utc.datetime_from_str("Aug 09 2013 23:54:35", "%b %d %Y\t%H:%M:%S").is_err());
-    // trailing whitespace in format
-    assert!(Utc.datetime_from_str("Aug 09 2013 23:54:35", "%b %d %Y %H:%M:%S ").is_err());
-    // trailing whitespace (newline) in format
-    assert!(Utc.datetime_from_str("Aug 09 2013 23:54:35", "%b %d %Y %H:%M:%S\n").is_err());
-    // leading space in data
-    assert!(Utc.datetime_from_str(" Aug 09 2013 23:54:35", "%b %d %Y %H:%M:%S").is_err());
-    // trailing space in data
-    assert!(Utc.datetime_from_str("Aug 09 2013 23:54:35 ", "%b %d %Y %H:%M:%S").is_err());
-    // trailing tab in data
-    assert!(Utc.datetime_from_str("Aug 09 2013 23:54:35\t", "%b %d %Y %H:%M:%S").is_err());
-    // mismatched newlines
-    assert!(Utc.datetime_from_str("\nAug 09 2013 23:54:35", "%b %d %Y %H:%M:%S\n").is_err());
-    // trailing literal in data
-    assert!(Utc.datetime_from_str("Aug 09 2013 23:54:35 !!!", "%b %d %Y %H:%M:%S ").is_err());
-}
-
-#[test]
-fn test_datetime_parse_from_str() {
-    let dt = ymdhms(&FixedOffset::east_opt(-9 * 60 * 60).unwrap(), 2013, 8, 9, 23, 54, 35);
-    let parse = DateTime::<FixedOffset>::parse_from_str;
-
-    // timezone variations
-
-    //
-    // %Z
-    //
-    // wrong timezone format
-    assert!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %Z").is_err());
-    // bad timezone data?
-    assert!(parse("Aug 09 2013 23:54:35 PST", "%b %d %Y %H:%M:%S %Z").is_err());
-    // bad timezone data
-    assert!(parse("Aug 09 2013 23:54:35 XXXXX", "%b %d %Y %H:%M:%S %Z").is_err());
-
-    //
-    // %z
-    //
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %z"), Ok(dt));
-    assert!(parse("Aug 09 2013 23:54:35 -09 00", "%b %d %Y %H:%M:%S %z").is_err());
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00", "%b %d %Y %H:%M:%S %z"), Ok(dt));
-    assert!(parse("Aug 09 2013 23:54:35 -09 : 00", "%b %d %Y %H:%M:%S %z").is_err());
-    assert_eq!(parse("Aug 09 2013 23:54:35 --0900", "%b %d %Y %H:%M:%S -%z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 +-0900", "%b %d %Y %H:%M:%S +%z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00 ", "%b %d %Y %H:%M:%S %z "), Ok(dt));
-    // trailing newline after timezone
-    assert!(parse("Aug 09 2013 23:54:35 -09:00\n", "%b %d %Y %H:%M:%S %z").is_err());
-    assert!(parse("Aug 09 2013 23:54:35 -09:00\n", "%b %d %Y %H:%M:%S %z ").is_err());
-    // trailing colon
-    assert!(parse("Aug 09 2013 23:54:35 -09:00:", "%b %d %Y %H:%M:%S %z").is_err());
-    // trailing colon with space
-    assert!(parse("Aug 09 2013 23:54:35 -09:00: ", "%b %d %Y %H:%M:%S %z ").is_err());
-    // trailing colon, mismatch space
-    assert!(parse("Aug 09 2013 23:54:35 -09:00:", "%b %d %Y %H:%M:%S %z ").is_err());
-    // wrong timezone data
-    assert!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %z").is_err());
-    assert!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %z").is_err());
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900::", "%b %d %Y %H:%M:%S %z::"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00:00", "%b %d %Y %H:%M:%S %z:00"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00:00 ", "%b %d %Y %H:%M:%S %z:00 "), Ok(dt));
-
-    //
-    // %:z
-    //
-    assert_eq!(parse("Aug 09 2013 23:54:35  -09:00", "%b %d %Y %H:%M:%S  %:z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %:z"), Ok(dt));
-    assert!(parse("Aug 09 2013 23:54:35 -09 00", "%b %d %Y %H:%M:%S %:z").is_err());
-    assert!(parse("Aug 09 2013 23:54:35 -09 : 00", "%b %d %Y %H:%M:%S %:z").is_err());
-    assert!(parse("Aug 09 2013 23:54:35 -09 : 00:", "%b %d %Y %H:%M:%S %:z:").is_err());
-    // wrong timezone data
-    assert!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %:z").is_err());
-    assert!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %:z").is_err());
-    // timezone data hs too many colons
-    assert!(parse("Aug 09 2013 23:54:35 -09:00:", "%b %d %Y %H:%M:%S %:z").is_err());
-    // timezone data hs too many colons
-    assert!(parse("Aug 09 2013 23:54:35 -09:00::", "%b %d %Y %H:%M:%S %:z").is_err());
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00::", "%b %d %Y %H:%M:%S %:z::"), Ok(dt));
-
-    //
-    // %::z
-    //
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %::z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00", "%b %d %Y %H:%M:%S %::z"), Ok(dt));
-    assert!(parse("Aug 09 2013 23:54:35 -09 : 00", "%b %d %Y %H:%M:%S %::z").is_err());
-    // mismatching colon expectations
-    assert!(parse("Aug 09 2013 23:54:35 -09:00:00", "%b %d %Y %H:%M:%S %::z").is_err());
-    assert!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %::z").is_err());
-    assert!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %:z").is_err());
-    // wrong timezone data
-    assert!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %::z").is_err());
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09001234", "%b %d %Y %H:%M:%S %::z1234"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09:001234", "%b %d %Y %H:%M:%S %::z1234"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900 ", "%b %d %Y %H:%M:%S %::z "), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900\t\n", "%b %d %Y %H:%M:%S %::z\t\n"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900:", "%b %d %Y %H:%M:%S %::z:"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 :-0900:0", "%b %d %Y %H:%M:%S :%::z:0"), Ok(dt));
-    // mismatching colons and spaces
-    assert!(parse("Aug 09 2013 23:54:35 :-0900: ", "%b %d %Y %H:%M:%S :%::z::").is_err());
-    // mismatching colons expectations
-    assert!(parse("Aug 09 2013 23:54:35 -09:00:00", "%b %d %Y %H:%M:%S %::z").is_err());
-    assert_eq!(parse("Aug 09 2013 -0900: 23:54:35", "%b %d %Y %::z: %H:%M:%S"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 :-0900:0 23:54:35", "%b %d %Y :%::z:0 %H:%M:%S"), Ok(dt));
-    // mismatching colons expectations mid-string
-    assert!(parse("Aug 09 2013 :-0900: 23:54:35", "%b %d %Y :%::z  %H:%M:%S").is_err());
-    // mismatching colons expectations, before end
-    assert!(parse("Aug 09 2013 23:54:35 -09:00:00 ", "%b %d %Y %H:%M:%S %::z ").is_err());
-
-    //
-    // %:::z
-    //
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00", "%b %d %Y %H:%M:%S %:::z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %:::z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900  ", "%b %d %Y %H:%M:%S %:::z  "), Ok(dt));
-    // wrong timezone data
-    assert!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %:::z").is_err());
-
-    //
-    // %::::z
-    //
-    // too many colons
-    assert!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %::::z").is_err());
-    // too many colons
-    assert!(parse("Aug 09 2013 23:54:35 -09:00", "%b %d %Y %H:%M:%S %::::z").is_err());
-    // too many colons
-    assert!(parse("Aug 09 2013 23:54:35 -09:00:", "%b %d %Y %H:%M:%S %::::z").is_err());
-    // too many colons
-    assert!(parse("Aug 09 2013 23:54:35 -09:00:00", "%b %d %Y %H:%M:%S %::::z").is_err());
-
-    //
-    // %#z
-    //
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00", "%b %d %Y %H:%M:%S %#z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %#z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35  -09:00  ", "%b %d %Y %H:%M:%S  %#z  "), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35  -0900  ", "%b %d %Y %H:%M:%S  %#z  "), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %#z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %#z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35 -09:", "%b %d %Y %H:%M:%S %#z"), Ok(dt));
-    assert!(parse("Aug 09 2013 23:54:35 -09: ", "%b %d %Y %H:%M:%S %#z ").is_err());
-    assert_eq!(parse("Aug 09 2013 23:54:35+-09", "%b %d %Y %H:%M:%S+%#z"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 23:54:35--09", "%b %d %Y %H:%M:%S-%#z"), Ok(dt));
-    assert!(parse("Aug 09 2013 -09:00 23:54:35", "%b %d %Y %#z%H:%M:%S").is_err());
-    assert!(parse("Aug 09 2013 -0900 23:54:35", "%b %d %Y %#z%H:%M:%S").is_err());
-    assert_eq!(parse("Aug 09 2013 -090023:54:35", "%b %d %Y %#z%H:%M:%S"), Ok(dt));
-    assert_eq!(parse("Aug 09 2013 -09:0023:54:35", "%b %d %Y %#z%H:%M:%S"), Ok(dt));
-    // timezone with partial minutes adjacent hours
-    assert_ne!(parse("Aug 09 2013 -09023:54:35", "%b %d %Y %#z%H:%M:%S"), Ok(dt));
-    // bad timezone data
-    assert!(parse("Aug 09 2013 23:54:35 -09:00:00", "%b %d %Y %H:%M:%S %#z").is_err());
-    // bad timezone data (partial minutes)
-    assert!(parse("Aug 09 2013 23:54:35 -090", "%b %d %Y %H:%M:%S %#z").is_err());
-    // bad timezone data (partial minutes) with trailing space
-    assert!(parse("Aug 09 2013 23:54:35 -090 ", "%b %d %Y %H:%M:%S %#z ").is_err());
-    // bad timezone data (partial minutes) mid-string
-    assert!(parse("Aug 09 2013 -090 23:54:35", "%b %d %Y %#z %H:%M:%S").is_err());
-    // bad timezone data
-    assert!(parse("Aug 09 2013 -09:00:00 23:54:35", "%b %d %Y %#z %H:%M:%S").is_err());
-    // timezone data ambiguous with hours
-    assert!(parse("Aug 09 2013 -09:00:23:54:35", "%b %d %Y %#z%H:%M:%S").is_err());
 }
 
 #[test]

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -207,27 +207,27 @@ pub enum Fixed {
     ///
     /// It does not support parsing, its use in the parser is an immediate failure.
     TimezoneName,
-    /// Offset from the local time to UTC (`+09:00` or `-0400` or `+00:00`).
+    /// Offset from the local time to UTC (`+09:00` or `-04:00` or `+00:00`).
     ///
-    /// In the parser, the colon may be omitted,
+    /// In the parser, the colon can be omitted and/or surrounded with any amount of whitespace.
     /// The offset is limited from `-24:00` to `+24:00`,
     /// which is the same as [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.
     TimezoneOffsetColon,
     /// Offset from the local time to UTC with seconds (`+09:00:00` or `-04:00:00` or `+00:00:00`).
     ///
-    /// In the parser, the colon may be omitted,
+    /// In the parser, the colon can be omitted and/or surrounded with any amount of whitespace.
     /// The offset is limited from `-24:00:00` to `+24:00:00`,
     /// which is the same as [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.
     TimezoneOffsetDoubleColon,
     /// Offset from the local time to UTC without minutes (`+09` or `-04` or `+00`).
     ///
-    /// In the parser, the colon may be omitted,
+    /// In the parser, the colon can be omitted and/or surrounded with any amount of whitespace.
     /// The offset is limited from `-24` to `+24`,
     /// which is the same as [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.
     TimezoneOffsetTripleColon,
-    /// Offset from the local time to UTC (`+09:00` or `-0400` or `Z`).
+    /// Offset from the local time to UTC (`+09:00` or `-04:00` or `Z`).
     ///
-    /// In the parser, the colon may be omitted,
+    /// In the parser, the colon can be omitted and/or surrounded with any amount of whitespace,
     /// and `Z` can be either in upper case or in lower case.
     /// The offset is limited from `-24:00` to `+24:00`,
     /// which is the same as [`FixedOffset`](../offset/struct.FixedOffset.html)'s range.

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -504,9 +504,10 @@ where
 /// All of these examples are equivalent:
 /// ```
 /// # use chrono::{DateTime, offset::FixedOffset};
-/// "2012-12-12T12:12:12Z".parse::<DateTime<FixedOffset>>();
-/// "2012-12-12 12:12:12Z".parse::<DateTime<FixedOffset>>();
-/// "2012-  12-12T12:  12:12Z".parse::<DateTime<FixedOffset>>();
+/// "2012-12-12T12:12:12Z".parse::<DateTime<FixedOffset>>()?;
+/// "2012-12-12 12:12:12Z".parse::<DateTime<FixedOffset>>()?;
+/// "2012-  12-12T12:  12:12Z".parse::<DateTime<FixedOffset>>()?;
+/// # Ok::<(), chrono::ParseError>(())
 /// ```
 impl str::FromStr for DateTime<FixedOffset> {
     type Err = ParseError;

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -513,32 +513,12 @@ impl<'a> Iterator for StrftimeItems<'a> {
 fn test_strftime_items() {
     fn parse_and_collect(s: &str) -> Vec<Item<'_>> {
         // map any error into `[Item::Error]`. useful for easy testing.
-        eprintln!("test_strftime_items: parse_and_collect({:?})", s);
         let items = StrftimeItems::new(s);
         let items = items.map(|spec| if spec == Item::Error { None } else { Some(spec) });
         items.collect::<Option<Vec<_>>>().unwrap_or_else(|| vec![Item::Error])
     }
 
     assert_eq!(parse_and_collect(""), []);
-    assert_eq!(parse_and_collect(" "), [sp!(" ")]);
-    assert_eq!(parse_and_collect("  "), [sp!("  ")]);
-    // ne!
-    assert_ne!(parse_and_collect("  "), [sp!(" "), sp!(" ")]);
-    // eq!
-    assert_eq!(parse_and_collect("  "), [sp!("  ")]);
-    assert_eq!(parse_and_collect("a"), [lit!("a")]);
-    assert_eq!(parse_and_collect("ab"), [lit!("ab")]);
-    assert_eq!(parse_and_collect("😽"), [lit!("😽")]);
-    assert_eq!(parse_and_collect("a😽"), [lit!("a😽")]);
-    assert_eq!(parse_and_collect("😽a"), [lit!("😽a")]);
-    assert_eq!(parse_and_collect(" 😽"), [sp!(" "), lit!("😽")]);
-    assert_eq!(parse_and_collect("😽 "), [lit!("😽"), sp!(" ")]);
-    // ne!
-    assert_ne!(parse_and_collect("😽😽"), [lit!("😽")]);
-    assert_ne!(parse_and_collect("😽"), [lit!("😽😽")]);
-    assert_ne!(parse_and_collect("😽😽"), [lit!("😽😽"), lit!("😽")]);
-    // eq!
-    assert_eq!(parse_and_collect("😽😽"), [lit!("😽😽")]);
     assert_eq!(parse_and_collect(" \t\n\r "), [sp!(" \t\n\r ")]);
     assert_eq!(parse_and_collect("hello?"), [lit!("hello?")]);
     assert_eq!(
@@ -552,63 +532,12 @@ fn test_strftime_items() {
         parse_and_collect("%Y-%m-%d"),
         [num0!(Year), lit!("-"), num0!(Month), lit!("-"), num0!(Day)]
     );
-    assert_eq!(parse_and_collect("😽   "), [lit!("😽"), sp!("   ")]);
-    assert_eq!(parse_and_collect("😽😽"), [lit!("😽😽")]);
-    assert_eq!(parse_and_collect("😽😽😽"), [lit!("😽😽😽")]);
-    assert_eq!(parse_and_collect("😽😽 😽"), [lit!("😽😽"), sp!(" "), lit!("😽")]);
-    assert_eq!(parse_and_collect("😽😽a 😽"), [lit!("😽😽a"), sp!(" "), lit!("😽")]);
-    assert_eq!(parse_and_collect("😽😽a b😽"), [lit!("😽😽a"), sp!(" "), lit!("b😽")]);
-    assert_eq!(parse_and_collect("😽😽a b😽c"), [lit!("😽😽a"), sp!(" "), lit!("b😽c")]);
-    assert_eq!(parse_and_collect("😽😽   "), [lit!("😽😽"), sp!("   ")]);
-    assert_eq!(parse_and_collect("😽😽   😽"), [lit!("😽😽"), sp!("   "), lit!("😽")]);
-    assert_eq!(parse_and_collect("   😽"), [sp!("   "), lit!("😽")]);
-    assert_eq!(parse_and_collect("   😽 "), [sp!("   "), lit!("😽"), sp!(" ")]);
-    assert_eq!(parse_and_collect("   😽 😽"), [sp!("   "), lit!("😽"), sp!(" "), lit!("😽")]);
-    assert_eq!(
-        parse_and_collect("   😽 😽 "),
-        [sp!("   "), lit!("😽"), sp!(" "), lit!("😽"), sp!(" ")]
-    );
-    assert_eq!(
-        parse_and_collect("   😽  😽 "),
-        [sp!("   "), lit!("😽"), sp!("  "), lit!("😽"), sp!(" ")]
-    );
-    assert_eq!(
-        parse_and_collect("   😽  😽😽 "),
-        [sp!("   "), lit!("😽"), sp!("  "), lit!("😽😽"), sp!(" ")]
-    );
-    assert_eq!(parse_and_collect("   😽😽"), [sp!("   "), lit!("😽😽")]);
-    assert_eq!(parse_and_collect("   😽😽 "), [sp!("   "), lit!("😽😽"), sp!(" ")]);
-    assert_eq!(parse_and_collect("   😽😽    "), [sp!("   "), lit!("😽😽"), sp!("    ")]);
-    assert_eq!(parse_and_collect("   😽😽    "), [sp!("   "), lit!("😽😽"), sp!("    ")]);
-    assert_eq!(parse_and_collect(" 😽😽    "), [sp!(" "), lit!("😽😽"), sp!("    ")]);
-    assert_eq!(
-        parse_and_collect(" 😽 😽😽    "),
-        [sp!(" "), lit!("😽"), sp!(" "), lit!("😽😽"), sp!("    ")]
-    );
-    assert_eq!(
-        parse_and_collect(" 😽 😽はい😽    ハンバーガー"),
-        [sp!(" "), lit!("😽"), sp!(" "), lit!("😽はい😽"), sp!("    "), lit!("ハンバーガー")]
-    );
-    assert_eq!(parse_and_collect("%%😽%%😽"), [lit!("%"), lit!("😽"), lit!("%"), lit!("😽")]);
-    assert_eq!(parse_and_collect("%Y--%m"), [num0!(Year), lit!("--"), num0!(Month)]);
     assert_eq!(parse_and_collect("[%F]"), parse_and_collect("[%Y-%m-%d]"));
-    assert_eq!(parse_and_collect("100%%😽"), [lit!("100"), lit!("%"), lit!("😽")]);
-    assert_eq!(
-        parse_and_collect("100%%😽%%a"),
-        [lit!("100"), lit!("%"), lit!("😽"), lit!("%"), lit!("a")]
-    );
-    assert_eq!(parse_and_collect("😽100%%"), [lit!("😽100"), lit!("%")]);
     assert_eq!(parse_and_collect("%m %d"), [num0!(Month), sp!(" "), num0!(Day)]);
     assert_eq!(parse_and_collect("%"), [Item::Error]);
     assert_eq!(parse_and_collect("%%"), [lit!("%")]);
     assert_eq!(parse_and_collect("%%%"), [Item::Error]);
-    assert_eq!(parse_and_collect("%a"), [fix!(ShortWeekdayName)]);
-    assert_eq!(parse_and_collect("%aa"), [fix!(ShortWeekdayName), lit!("a")]);
-    assert_eq!(parse_and_collect("%%a%"), [Item::Error]);
-    assert_eq!(parse_and_collect("%😽"), [Item::Error]);
-    assert_eq!(parse_and_collect("%😽😽"), [Item::Error]);
     assert_eq!(parse_and_collect("%%%%"), [lit!("%"), lit!("%")]);
-    assert_eq!(parse_and_collect("%%%%ハンバーガー"), [lit!("%"), lit!("%"), lit!("ハンバーガー")]);
     assert_eq!(parse_and_collect("foo%?"), [Item::Error]);
     assert_eq!(parse_and_collect("bar%42"), [Item::Error]);
     assert_eq!(parse_and_collect("quux% +"), [Item::Error]);
@@ -628,10 +557,6 @@ fn test_strftime_items() {
     assert_eq!(parse_and_collect("%0e"), [num0!(Day)]);
     assert_eq!(parse_and_collect("%_e"), [nums!(Day)]);
     assert_eq!(parse_and_collect("%z"), [fix!(TimezoneOffset)]);
-    assert_eq!(parse_and_collect("%:z"), [fix!(TimezoneOffsetColon)]);
-    assert_eq!(parse_and_collect("%Z"), [fix!(TimezoneName)]);
-    assert_eq!(parse_and_collect("%ZZZZ"), [fix!(TimezoneName), lit!("ZZZ")]);
-    assert_eq!(parse_and_collect("%Z😽"), [fix!(TimezoneName), lit!("😽")]);
     assert_eq!(parse_and_collect("%#z"), [internal_fix!(TimezoneOffsetPermissive)]);
     assert_eq!(parse_and_collect("%#m"), [Item::Error]);
 }
@@ -741,13 +666,6 @@ fn test_strftime_docs() {
     assert_eq!(dt.format("%t").to_string(), "\t");
     assert_eq!(dt.format("%n").to_string(), "\n");
     assert_eq!(dt.format("%%").to_string(), "%");
-
-    // complex format specifiers
-    assert_eq!(dt.format("  %Y%d%m%%%%%t%H%M%S\t").to_string(), "  20010807%%\t003460\t");
-    assert_eq!(
-        dt.format("  %Y%d%m%%%%%t%H:%P:%M%S%:::z\t").to_string(),
-        "  20010807%%\t00:am:3460+09\t"
-    );
 }
 
 #[cfg(feature = "unstable-locales")]

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -2061,10 +2061,13 @@ impl str::FromStr for NaiveDate {
     fn from_str(s: &str) -> ParseResult<NaiveDate> {
         const ITEMS: &[Item<'static>] = &[
             Item::Numeric(Numeric::Year, Pad::Zero),
+            Item::Space(""),
             Item::Literal("-"),
             Item::Numeric(Numeric::Month, Pad::Zero),
+            Item::Space(""),
             Item::Literal("-"),
             Item::Numeric(Numeric::Day, Pad::Zero),
+            Item::Space(""),
         ];
 
         let mut parsed = Parsed::new();
@@ -2868,28 +2871,24 @@ mod tests {
         // valid cases
         let valid = [
             "-0000000123456-1-2",
-            "-123456-1-2",
+            "    -123456 - 1 - 2    ",
             "-12345-1-2",
             "-1234-12-31",
             "-7-6-5",
             "350-2-28",
             "360-02-29",
             "0360-02-29",
-            "2015-2-18",
-            "2015-02-18",
+            "2015-2 -18",
             "+70-2-18",
             "+70000-2-18",
             "+00007-2-18",
         ];
         for &s in &valid {
-            eprintln!("test_date_from_str valid {:?}", s);
             let d = match s.parse::<NaiveDate>() {
                 Ok(d) => d,
                 Err(e) => panic!("parsing `{}` has failed: {}", s, e),
             };
-            eprintln!("d {:?} (NaiveDate)", d);
             let s_ = format!("{:?}", d);
-            eprintln!("s_ {:?}", s_);
             // `s` and `s_` may differ, but `s.parse()` and `s_.parse()` must be same
             let d_ = match s_.parse::<NaiveDate>() {
                 Ok(d) => d,
@@ -2897,7 +2896,6 @@ mod tests {
                     panic!("`{}` is parsed into `{:?}`, but reparsing that has failed: {}", s, d, e)
                 }
             };
-            eprintln!("d_ {:?} (NaiveDate)", d_);
             assert!(
                 d == d_,
                 "`{}` is parsed into `{:?}`, but reparsed result \
@@ -2910,36 +2908,13 @@ mod tests {
 
         // some invalid cases
         // since `ParseErrorKind` is private, all we can do is to check if there was an error
-        let invalid = [
-            "",                        // empty
-            "x",                       // invalid
-            "Fri, 09 Aug 2013 GMT",    // valid date, wrong format
-            "Sat Jun 30 2012",         // valid date, wrong format
-            "1441497364.649",          // valid datetime, wrong format
-            "+1441497364.649",         // valid datetime, wrong format
-            "+1441497364",             // valid datetime, wrong format
-            "2014/02/03",              // valid date, wrong format
-            "2014",                    // datetime missing data
-            "2014-01",                 // datetime missing data
-            "2014-01-00",              // invalid day
-            "2014-11-32",              // invalid day
-            "2014-13-01",              // invalid month
-            "2014-13-57",              // invalid month, day
-            "2001 -02-03",             // space after year
-            "2001- 02-03",             // space before month
-            "2001 - 02-03",            // space around year-month divider
-            "2001-02 -03",             // space after month
-            "2001-02- 03",             // space before day
-            "2001-02 - 03",            // space around month-day divider
-            "2001-02-03 ",             // trailing space
-            " 2001-02-03",             // leading space
-            "    -123456 - 1 - 2    ", // many spaces
-            "9999999-9-9",             // invalid year (out of bounds)
-        ];
-        for &s in &invalid {
-            eprintln!("test_date_from_str invalid {:?}", s);
-            assert!(s.parse::<NaiveDate>().is_err());
-        }
+        assert!("".parse::<NaiveDate>().is_err());
+        assert!("x".parse::<NaiveDate>().is_err());
+        assert!("2014".parse::<NaiveDate>().is_err());
+        assert!("2014-01".parse::<NaiveDate>().is_err());
+        assert!("2014-01-00".parse::<NaiveDate>().is_err());
+        assert!("2014-13-57".parse::<NaiveDate>().is_err());
+        assert!("9999999-9-9".parse::<NaiveDate>().is_err()); // out-of-bounds
     }
 
     #[test]
@@ -2950,7 +2925,7 @@ mod tests {
             Ok(ymd(2014, 5, 7))
         ); // ignore time and offset
         assert_eq!(
-            NaiveDate::parse_from_str("2015-W06-1=2015-033", "%G-W%V-%u=%Y-%j"),
+            NaiveDate::parse_from_str("2015-W06-1=2015-033", "%G-W%V-%u = %Y-%j"),
             Ok(ymd(2015, 2, 2))
         );
         assert_eq!(

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -197,15 +197,11 @@ fn test_datetime_timestamp() {
 fn test_datetime_from_str() {
     // valid cases
     let valid = [
-        "2001-02-03T04:05:06",
-        "2012-12-12T12:12:12",
-        "2015-02-18T23:16:09.153",
-        "2015-2-18T23:16:09.153",
+        "2015-2-18T23:16:9.15",
         "-77-02-18T23:16:09",
-        "+82701-05-6T15:9:60.898989898989",
+        "  +82701  -  05  -  6  T  15  :  9  : 60.898989898989   ",
     ];
     for &s in &valid {
-        eprintln!("test_parse_naivedatetime valid {:?}", s);
         let d = match s.parse::<NaiveDateTime>() {
             Ok(d) => d,
             Err(e) => panic!("parsing `{}` has failed: {}", s, e),
@@ -230,48 +226,16 @@ fn test_datetime_from_str() {
 
     // some invalid cases
     // since `ParseErrorKind` is private, all we can do is to check if there was an error
-    let invalid = [
-        "",                                                         // empty
-        "x",                                                        // invalid / missing data
-        "15",                                                       // missing data
-        "15:8:9",                        // looks like a time (invalid date)
-        "15-8-9",                        // looks like a date (invalid)
-        "Fri, 09 Aug 2013 23:54:35 GMT", // valid date, wrong format
-        "Sat Jun 30 23:59:60 2012",      // valid date, wrong format
-        "1441497364.649",                // valid date, wrong format
-        "+1441497364.649",               // valid date, wrong format
-        "+1441497364",                   // valid date, wrong format
-        "2014/02/03 04:05:06",           // valid date, wrong format
-        "2015-15-15T15:15:15",           // invalid date
-        "2012-12-12T12:12:12x",          // bad timezone / trailing literal
-        "2012-12-12T12:12:12+00:00",     // unexpected timezone / trailing literal
-        "2012-12-12T12:12:12 +00:00",    // unexpected timezone / trailing literal
-        "2012-12-12T12:12:12 GMT",       // unexpected timezone / trailing literal
-        "2012-123-12T12:12:12",          // invalid month
-        "2012 -12-12T12:12:12",          // space after year
-        "2012  -12-12T12:12:12",         // multi space after year
-        "2012- 12-12T12:12:12",          // space before month
-        "2012-  12-12T12:12:12",         // multi space before month
-        "2012-12-12 T12:12:12",          // space after day
-        "2012-12-12T 12:12:12",          // space after date-time divider
-        "2012-12-12T12 :12:12",          // space after hour
-        "2012-12-12T12  :12:12",         // multi space after hour
-        "2012-12-12T12: 12:12",          // space before minute
-        "2012-12-12T12:  12:12",         // multi space before minute
-        "2012-12-12T12 : 12:12",         // space around hour-minute divider
-        "2012-12-12T12:12:12 ",          // trailing space
-        " 2012-12-12T12:12:12",          // leading space
-        "2012-12-12t12:12:12",           // bad divider 't'
-        "2012-12-12 12:12:12",           // missing divider 'T'
-        "2012-12-12T12:12:12Z",          // trailing char 'Z'
-        "+ 82701-123-12T12:12:12",       // strange year, invalid month
-        "+802701-123-12T12:12:12",       // out-of-bound year, invalid month
-        "  +82701  -  05  -  6  T  15  :  9  : 60.898989898989   ", // many spaces
-    ];
-    for &s in invalid.iter() {
-        eprintln!("test_datetime_from_str invalid {:?}", s);
-        assert!(s.parse::<NaiveDateTime>().is_err());
-    }
+    assert!("".parse::<NaiveDateTime>().is_err());
+    assert!("x".parse::<NaiveDateTime>().is_err());
+    assert!("15".parse::<NaiveDateTime>().is_err());
+    assert!("15:8:9".parse::<NaiveDateTime>().is_err());
+    assert!("15-8-9".parse::<NaiveDateTime>().is_err());
+    assert!("2015-15-15T15:15:15".parse::<NaiveDateTime>().is_err());
+    assert!("2012-12-12T12:12:12x".parse::<NaiveDateTime>().is_err());
+    assert!("2012-123-12T12:12:12".parse::<NaiveDateTime>().is_err());
+    assert!("+ 82701-123-12T12:12:12".parse::<NaiveDateTime>().is_err());
+    assert!("+802701-123-12T12:12:12".parse::<NaiveDateTime>().is_err()); // out-of-bound
 }
 
 #[test]
@@ -285,12 +249,8 @@ fn test_datetime_parse_from_str() {
         NaiveDateTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
         Ok(ymdhms(2014, 5, 7, 12, 34, 56))
     ); // ignore offset
-    assert!(
-        // intermixed whitespace
-        NaiveDateTime::parse_from_str("2015-W06-1 000000", "%G-W%V-%u%H%M%S").is_err()
-    );
     assert_eq!(
-        NaiveDateTime::parse_from_str("2015-W06-1 000000", "%G-W%V-%u %H%M%S"),
+        NaiveDateTime::parse_from_str("2015-W06-1 000000", "%G-W%V-%u%H%M%S"),
         Ok(ymdhms(2015, 2, 2, 0, 0, 0))
     );
     assert_eq!(

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -1305,11 +1305,14 @@ impl str::FromStr for NaiveTime {
     fn from_str(s: &str) -> ParseResult<NaiveTime> {
         const ITEMS: &[Item<'static>] = &[
             Item::Numeric(Numeric::Hour, Pad::Zero),
+            Item::Space(""),
             Item::Literal(":"),
             Item::Numeric(Numeric::Minute, Pad::Zero),
+            Item::Space(""),
             Item::Literal(":"),
             Item::Numeric(Numeric::Second, Pad::Zero),
             Item::Fixed(Fixed::Nanosecond),
+            Item::Space(""),
         ];
 
         let mut parsed = Parsed::new();

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -232,37 +232,12 @@ fn test_date_from_str() {
         "0:0:0",
         "0:0:0.0000000",
         "0:0:0.0000003",
-        "01:02:03",
-        "4:3:2.1",
-        "9:8:7",
-        "09:8:7",
-        "9:08:7",
-        "9:8:07",
-        "09:08:7",
-        "09:8:07",
-        "09:08:7",
-        "9:08:07",
-        "09:08:07",
-        "9:8:07.123",
-        "9:08:7.123",
-        "09:8:7.123",
-        "09:08:7.123",
-        "9:08:07.123",
-        "09:8:07.123",
-        "09:08:07.123",
-        "09:08:07.123",
-        "09:08:07.1234",
-        "09:08:07.12345",
-        "09:08:07.123456",
-        "09:08:07.1234567",
-        "09:08:07.12345678",
-        "09:08:07.123456789",
-        "09:08:07.1234567891",
-        "09:08:07.12345678912",
+        " 4 : 3 : 2.1 ",
+        " 09:08:07 ",
+        " 9:8:07 ",
         "23:59:60.373929310237",
     ];
     for &s in &valid {
-        eprintln!("test_time_parse_from_str valid {:?}", s);
         let d = match s.parse::<NaiveTime>() {
             Ok(d) => d,
             Err(e) => panic!("parsing `{}` has failed: {}", s, e),
@@ -287,42 +262,15 @@ fn test_date_from_str() {
 
     // some invalid cases
     // since `ParseErrorKind` is private, all we can do is to check if there was an error
-    let invalid = [
-        "",                  // empty
-        "x",                 // invalid
-        "15",                // missing data
-        "15:8",              // missing data
-        "15:8:x",            // missing data, invalid data
-        "15:8:9x",           // missing data, invalid data
-        "23:59:61",          // invalid second (out of bounds)
-        "23:54:35 GMT",      // invalid (timezone non-sensical for NaiveTime)
-        "23:54:35 +0000",    // invalid (timezone non-sensical for NaiveTime)
-        "1441497364.649",    // valid datetime, not a NaiveTime
-        "+1441497364.649",   // valid datetime, not a NaiveTime
-        "+1441497364",       // valid datetime, not a NaiveTime
-        "01 :02:03",         // space after hour
-        "01: 02:03",         // space before minute
-        "01 : 02:03",        // space around hour-minute divider
-        "01:02 :03",         // space after minute
-        "01:02: 03",         // space before second
-        "01:02 : 03",        // space around minute-second divider
-        "01:02:03 .456",     // space after second
-        "01:02:03. 456",     // space before fraction
-        "01:02:03 ",         // trailing space
-        "01:02:03.456 ",     // trailing space
-        " 01:02:03",         // leading space
-        " 4 : 3 : 2.1 ",     // spaces intermixed throughout
-        "001:02:03",         // invalid hour
-        "01:002:03",         // invalid minute
-        "01:02:003",         // invalid second
-        "12:34:56.x",        // invalid fraction
-        "12:34:56. 0",       // invalid fraction format
-        "09:08:00000000007", // invalid second / invalid fraction format
-    ];
-    for &s in &invalid {
-        eprintln!("test_time_parse_from_str invalid {:?}", s);
-        assert!(s.parse::<NaiveTime>().is_err());
-    }
+    assert!("".parse::<NaiveTime>().is_err());
+    assert!("x".parse::<NaiveTime>().is_err());
+    assert!("15".parse::<NaiveTime>().is_err());
+    assert!("15:8".parse::<NaiveTime>().is_err());
+    assert!("15:8:x".parse::<NaiveTime>().is_err());
+    assert!("15:8:9x".parse::<NaiveTime>().is_err());
+    assert!("23:59:61".parse::<NaiveTime>().is_err());
+    assert!("12:34:56.x".parse::<NaiveTime>().is_err());
+    assert!("12:34:56. 0".parse::<NaiveTime>().is_err());
 }
 
 #[test]
@@ -333,15 +281,6 @@ fn test_time_parse_from_str() {
         Ok(hms(12, 34, 56))
     ); // ignore date and offset
     assert_eq!(NaiveTime::parse_from_str("PM 12:59", "%P %H:%M"), Ok(hms(12, 59, 0)));
-    assert_eq!(NaiveTime::parse_from_str("12:59 \n\t PM", "%H:%M \n\t %P"), Ok(hms(12, 59, 0)));
-    assert_eq!(NaiveTime::parse_from_str("\t\t12:59\tPM\t", "\t\t%H:%M\t%P\t"), Ok(hms(12, 59, 0)));
-    assert_eq!(
-        NaiveTime::parse_from_str("\t\t1259\t\tPM\t", "\t\t%H%M\t\t%P\t"),
-        Ok(hms(12, 59, 0))
-    );
-    assert!(NaiveTime::parse_from_str("12:59 PM", "%H:%M\t%P").is_err());
-    assert!(NaiveTime::parse_from_str("\t\t12:59 PM\t", "\t\t%H:%M\t%P\t").is_err());
-    assert!(NaiveTime::parse_from_str("12:59  PM", "%H:%M %P").is_err());
     assert!(NaiveTime::parse_from_str("12:3456", "%H:%M:%S").is_err());
 }
 


### PR DESCRIPTION
See https://github.com/chronotope/chrono/issues/1112.

After 0.4.26, can we discuss what to do with bugs in the current parsing code? It would be unfortunate if it could only be improved with a major version.