### PR TITLE
Format toml with taplo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,14 @@ jobs:
         env:
           RUSTFLAGS: "-Dwarnings"
 
+  toml:
+    runs-on: ubuntu-latest
+    container:
+      image: tamasfe/taplo:0.8.0
+    steps:
+      - run: taplo lint
+      - run: taplo fmt --check --diff
+
   cargo-deny:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,12 @@ rustc-serialize = { version = "0.3.20", optional = true }
 serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.5.2", optional = true }
 criterion = { version = "0.4.0", optional = true }
-rkyv = {version = "0.7", optional = true}
+rkyv = { version = "0.7", optional = true }
 arbitrary = { version = "1.0.0", features = ["derive"], optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 wasm-bindgen = { version = "0.2", optional = true }
-js-sys = { version = "0.3", optional = true } # contains FFI bindings for the JS Date API
+js-sys = { version = "0.3", optional = true }       # contains FFI bindings for the JS Date API
 
 
 [target.'cfg(windows)'.dependencies]

--- a/ci/core-test/Cargo.toml
+++ b/ci/core-test/Cargo.toml
@@ -2,8 +2,8 @@
 name = "core-test"
 version = "0.1.0"
 authors = [
-    "Kang Seonghoon <public+rust@mearie.org>",
-    "Brandon W Maister <quodlibetor@gmail.com>",
+  "Kang Seonghoon <public+rust@mearie.org>",
+  "Brandon W Maister <quodlibetor@gmail.com>",
 ]
 edition = "2018"
 

--- a/deny.toml
+++ b/deny.toml
@@ -4,9 +4,9 @@ copyleft = "deny"
 
 [advisories]
 ignore = [
-    "RUSTSEC-2020-0071", # time 0.1, doesn't affect the API we use
-    "RUSTSEC-2021-0145", # atty (dev-deps only, dependency of criterion)
-    "RUSTSEC-2022-0004", # rustc_serialize, cannot remove due to compatibility
+  "RUSTSEC-2020-0071", # time 0.1, doesn't affect the API we use
+  "RUSTSEC-2021-0145", # atty (dev-deps only, dependency of criterion)
+  "RUSTSEC-2022-0004", # rustc_serialize, cannot remove due to compatibility
 ]
 unmaintained = "deny"
 unsound = "deny"

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,4 @@
+include = ["deny.toml", "**/Cargo.toml"]
+
+[formatting]
+inline_table_expand = false


### PR DESCRIPTION
This pull request proposes to format `toml` files with [`taplo`](https://github.com/tamasfe/taplo). I believe mechanical linting and formatting improve formatting consistency and reduces costs to maintain them by hand.

The followings will be introduced:
- Uses `taplo` [default settings](https://taplo.tamasfe.dev/configuration/formatter-options.html) except of not collapsing list automatically when the line length is longer than the max length (which is defaultly set to `80`).
- Uses two spaces indent, which is used in [rust repository](https://github.com/rust-lang/rust) and is the default by `taplo`.
- Leaves the comment indentations to `taplo`.
- Adds a ci to check the `toml` files with `taplo`.

When having more preferred settings for this project, please feel free to request them.