### PR TITLE
Let `DateTime::signed_duration_since` take argument with `Borrow`

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1048,6 +1048,15 @@ impl<Tz: TimeZone> Sub<DateTime<Tz>> for DateTime<Tz> {
     }
 }
 
+impl<Tz: TimeZone> Sub<&DateTime<Tz>> for DateTime<Tz> {
+    type Output = OldDuration;
+
+    #[inline]
+    fn sub(self, rhs: &DateTime<Tz>) -> OldDuration {
+        self.signed_duration_since(rhs)
+    }
+}
+
 impl<Tz: TimeZone> Add<Days> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -8,7 +8,6 @@ extern crate alloc;
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::string::{String, ToString};
-#[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::fmt::Write;
@@ -409,8 +408,11 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// This does not overflow or underflow at all.
     #[inline]
     #[must_use]
-    pub fn signed_duration_since<Tz2: TimeZone>(self, rhs: DateTime<Tz2>) -> OldDuration {
-        self.datetime.signed_duration_since(rhs.datetime)
+    pub fn signed_duration_since<Tz2: TimeZone>(
+        self,
+        rhs: impl Borrow<DateTime<Tz2>>,
+    ) -> OldDuration {
+        self.datetime.signed_duration_since(rhs.borrow().datetime)
     }
 
     /// Returns a view to the naive UTC datetime.

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -314,6 +314,15 @@ fn test_datetime_offset() {
 }
 
 #[test]
+fn signed_duration_since_autoref() {
+    let dt1 = Utc.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap();
+    let dt2 = Utc.with_ymd_and_hms(2014, 3, 4, 5, 6, 7).unwrap();
+    let diff1 = dt1.signed_duration_since(dt2); // Copy/consume
+    let diff2 = dt2.signed_duration_since(&dt1); // Take by reference
+    assert_eq!(diff1, -diff2);
+}
+
+#[test]
 fn test_datetime_date_and_time() {
     let tz = FixedOffset::east_opt(5 * 60 * 60).unwrap();
     let d = tz.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap();

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -320,6 +320,10 @@ fn signed_duration_since_autoref() {
     let diff1 = dt1.signed_duration_since(dt2); // Copy/consume
     let diff2 = dt2.signed_duration_since(&dt1); // Take by reference
     assert_eq!(diff1, -diff2);
+
+    let diff1 = dt1 - &dt2; // We can choose to substract rhs by reference
+    let diff2 = dt2 - dt1; // Or consume rhs
+    assert_eq!(diff1, -diff2);
 }
 
 #[test]


### PR DESCRIPTION
Fixes https://github.com/chronotope/chrono/issues/573.

It is unfortunate that `DateTime::signed_duration_since` currently consumes its argument.

I am not sure if this would be a breaking change. Making an argument generic can change type inference. But I don't yet see how you could end up with a `DateTime` as argument to this function in a way where the type is not yet known.