### PR TITLE
Add "Errors" and "Panics" sections to API docs

### DIFF
--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -66,6 +66,11 @@ pub struct NaiveWeek {
 impl NaiveWeek {
     /// Returns a date representing the first day of the week.
     ///
+    /// # Panics
+    ///
+    /// Panics if the first day of the week happens to fall just out of range of `NaiveDate`
+    /// (more than ca. 262,000 years away from common era).
+    ///
     /// # Examples
     ///
     /// ```
@@ -88,6 +93,11 @@ impl NaiveWeek {
     }
 
     /// Returns a date representing the last day of the week.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the last day of the week happens to fall just out of range of `NaiveDate`
+    /// (more than ca. 262,000 years away from common era).
     ///
     /// # Examples
     ///
@@ -113,6 +123,11 @@ impl NaiveWeek {
     /// Returns a [`RangeInclusive<T>`] representing the whole week bounded by
     /// [first_day](./struct.NaiveWeek.html#method.first_day) and
     /// [last_day](./struct.NaiveWeek.html#method.last_day) functions.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the either the first or last day of the week happens to fall just out of range of
+    /// `NaiveDate` (more than ca. 262,000 years away from common era).
     ///
     /// # Examples
     ///

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -300,7 +300,10 @@ impl NaiveDate {
     /// Makes a new `NaiveDate` from the [calendar date](#calendar-date)
     /// (year, month and day).
     ///
-    /// Panics on the out-of-range date, invalid month and/or day.
+    /// # Panics
+    ///
+    /// Panics if the specified calendar day does not exist, on invalid values for `month` or `day`,
+    /// or if `year` is out of range for `NaiveDate`.
     #[deprecated(since = "0.4.23", note = "use `from_ymd_opt()` instead")]
     #[must_use]
     pub fn from_ymd(year: i32, month: u32, day: u32) -> NaiveDate {
@@ -310,7 +313,12 @@ impl NaiveDate {
     /// Makes a new `NaiveDate` from the [calendar date](#calendar-date)
     /// (year, month and day).
     ///
-    /// Returns `None` on the out-of-range date, invalid month and/or day.
+    /// # Errors
+    ///
+    /// Returns `None` if:
+    /// - The specified calendar day does not exist (for example 2023-04-31).
+    /// - The value for `month` or `day` is invalid.
+    /// - `year` is out of range for `NaiveDate`.
     ///
     /// # Example
     ///
@@ -335,7 +343,10 @@ impl NaiveDate {
     /// Makes a new `NaiveDate` from the [ordinal date](#ordinal-date)
     /// (year and day of the year).
     ///
-    /// Panics on the out-of-range date and/or invalid day of year.
+    /// # Panics
+    ///
+    /// Panics if the specified ordinal day does not exist, on invalid values for `ordinal`, or if
+    /// `year` is out of range for `NaiveDate`.
     #[deprecated(since = "0.4.23", note = "use `from_yo_opt()` instead")]
     #[must_use]
     pub fn from_yo(year: i32, ordinal: u32) -> NaiveDate {
@@ -345,7 +356,12 @@ impl NaiveDate {
     /// Makes a new `NaiveDate` from the [ordinal date](#ordinal-date)
     /// (year and day of the year).
     ///
-    /// Returns `None` on the out-of-range date and/or invalid day of year.
+    /// # Errors
+    ///
+    /// Returns `None` if:
+    /// - The specified ordinal day does not exist (for example 2023-366).
+    /// - The value for `ordinal` is invalid (for example: `0`, `400`).
+    /// - `year` is out of range for `NaiveDate`.
     ///
     /// # Example
     ///
@@ -372,7 +388,10 @@ impl NaiveDate {
     /// (year, week number and day of the week).
     /// The resulting `NaiveDate` may have a different year from the input year.
     ///
-    /// Panics on the out-of-range date and/or invalid week number.
+    /// # Panics
+    ///
+    /// Panics if the specified week does not exist in that year, on invalid values for `week`, or
+    /// if the resulting date is out of range for `NaiveDate`.
     #[deprecated(since = "0.4.23", note = "use `from_isoywd_opt()` instead")]
     #[must_use]
     pub fn from_isoywd(year: i32, week: u32, weekday: Weekday) -> NaiveDate {
@@ -383,7 +402,12 @@ impl NaiveDate {
     /// (year, week number and day of the week).
     /// The resulting `NaiveDate` may have a different year from the input year.
     ///
-    /// Returns `None` on the out-of-range date and/or invalid week number.
+    /// # Errors
+    ///
+    /// Returns `None` if:
+    /// - The specified week does not exist in that year (for example 2023 week 53).
+    /// - The value for `week` is invalid (for example: `0`, `60`).
+    /// - If the resulting date is out of range for `NaiveDate`.
     ///
     /// # Example
     ///
@@ -459,6 +483,8 @@ impl NaiveDate {
     /// Makes a new `NaiveDate` from a day's number in the proleptic Gregorian calendar, with
     /// January 1, 1 being day 1.
     ///
+    /// # Panics
+    ///
     /// Panics if the date is out of range.
     #[deprecated(since = "0.4.23", note = "use `from_num_days_from_ce_opt()` instead")]
     #[inline]
@@ -469,6 +495,8 @@ impl NaiveDate {
 
     /// Makes a new `NaiveDate` from a day's number in the proleptic Gregorian calendar, with
     /// January 1, 1 being day 1.
+    ///
+    /// # Errors
     ///
     /// Returns `None` if the date is out of range.
     ///
@@ -497,15 +525,15 @@ impl NaiveDate {
     }
 
     /// Makes a new `NaiveDate` by counting the number of occurrences of a particular day-of-week
-    /// since the beginning of the given month.  For instance, if you want the 2nd Friday of March
+    /// since the beginning of the given month. For instance, if you want the 2nd Friday of March
     /// 2017, you would use `NaiveDate::from_weekday_of_month(2017, 3, Weekday::Fri, 2)`.
+    ///
+    /// `n` is 1-indexed.
     ///
     /// # Panics
     ///
-    /// The resulting `NaiveDate` is guaranteed to be in `month`.  If `n` is larger than the number
-    /// of `weekday` in `month` (eg. the 6th Friday of March 2017) then this function will panic.
-    ///
-    /// `n` is 1-indexed.  Passing `n=0` will cause a panic.
+    /// Panics if the specified day does not exist in that month, on invalid values for `month` or
+    /// `n`, or if `year` is out of range for `NaiveDate`.
     #[deprecated(since = "0.4.23", note = "use `from_weekday_of_month_opt()` instead")]
     #[must_use]
     pub fn from_weekday_of_month(year: i32, month: u32, weekday: Weekday, n: u8) -> NaiveDate {
@@ -513,17 +541,25 @@ impl NaiveDate {
     }
 
     /// Makes a new `NaiveDate` by counting the number of occurrences of a particular day-of-week
-    /// since the beginning of the given month.  For instance, if you want the 2nd Friday of March
-    /// 2017, you would use `NaiveDate::from_weekday_of_month(2017, 3, Weekday::Fri, 2)`.  `n` is 1-indexed.
+    /// since the beginning of the given month. For instance, if you want the 2nd Friday of March
+    /// 2017, you would use `NaiveDate::from_weekday_of_month(2017, 3, Weekday::Fri, 2)`.
+    ///
+    /// `n` is 1-indexed.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if:
+    /// - The specified day does not exist in that month (for example the 5th Monday of Apr. 2023).
+    /// - The value for `month` or `n` is invalid.
+    /// - `year` is out of range for `NaiveDate`.
+    ///
+    /// # Example
     ///
     /// ```
     /// use chrono::{NaiveDate, Weekday};
     /// assert_eq!(NaiveDate::from_weekday_of_month_opt(2017, 3, Weekday::Fri, 2),
     ///            NaiveDate::from_ymd_opt(2017, 3, 10))
     /// ```
-    ///
-    /// Returns `None` if `n` out-of-range; ie. if `n` is larger than the number of `weekday` in
-    /// `month` (eg. the 6th Friday of March 2017), or if `n == 0`.
     #[must_use]
     pub fn from_weekday_of_month_opt(
         year: i32,
@@ -612,9 +648,13 @@ impl NaiveDate {
 
     /// Add a duration in [`Months`] to the date
     ///
-    /// If the day would be out of range for the resulting month, use the last day for that month.
+    /// Uses the last day of the month if the day does not exist in the resulting month.
+    ///
+    /// # Errors
     ///
     /// Returns `None` if the resulting date would be out of range.
+    ///
+    /// # Example
     ///
     /// ```
     /// # use chrono::{NaiveDate, Months};
@@ -641,9 +681,13 @@ impl NaiveDate {
 
     /// Subtract a duration in [`Months`] from the date
     ///
-    /// If the day would be out of range for the resulting month, use the last day for that month.
+    /// Uses the last day of the month if the day does not exist in the resulting month.
+    ///
+    /// # Errors
     ///
     /// Returns `None` if the resulting date would be out of range.
+    ///
+    /// # Example
     ///
     /// ```
     /// # use chrono::{NaiveDate, Months};
@@ -715,7 +759,11 @@ impl NaiveDate {
 
     /// Add a duration in [`Days`] to the date
     ///
+    /// # Errors
+    ///
     /// Returns `None` if the resulting date would be out of range.
+    ///
+    /// # Example
     ///
     /// ```
     /// # use chrono::{NaiveDate, Days};
@@ -743,7 +791,11 @@ impl NaiveDate {
 
     /// Subtract a duration in [`Days`] from the date
     ///
+    /// # Errors
+    ///
     /// Returns `None` if the resulting date would be out of range.
+    ///
+    /// # Example
     ///
     /// ```
     /// # use chrono::{NaiveDate, Days};
@@ -798,6 +850,8 @@ impl NaiveDate {
     /// No [leap second](./struct.NaiveTime.html#leap-second-handling) is allowed here;
     /// use `NaiveDate::and_hms_*` methods with a subsecond parameter instead.
     ///
+    /// # Panics
+    ///
     /// Panics on invalid hour, minute and/or second.
     #[deprecated(since = "0.4.23", note = "use `and_hms_opt()` instead")]
     #[inline]
@@ -810,6 +864,8 @@ impl NaiveDate {
     ///
     /// No [leap second](./struct.NaiveTime.html#leap-second-handling) is allowed here;
     /// use `NaiveDate::and_hms_*_opt` methods with a subsecond parameter instead.
+    ///
+    /// # Errors
     ///
     /// Returns `None` on invalid hour, minute and/or second.
     ///
@@ -835,6 +891,8 @@ impl NaiveDate {
     /// The millisecond part can exceed 1,000
     /// in order to represent the [leap second](./struct.NaiveTime.html#leap-second-handling).
     ///
+    /// # Panics
+    ///
     /// Panics on invalid hour, minute, second and/or millisecond.
     #[deprecated(since = "0.4.23", note = "use `and_hms_milli_opt()` instead")]
     #[inline]
@@ -847,6 +905,8 @@ impl NaiveDate {
     ///
     /// The millisecond part can exceed 1,000
     /// in order to represent the [leap second](./struct.NaiveTime.html#leap-second-handling).
+    ///
+    /// # Errors
     ///
     /// Returns `None` on invalid hour, minute, second and/or millisecond.
     ///
@@ -880,6 +940,8 @@ impl NaiveDate {
     /// The microsecond part can exceed 1,000,000
     /// in order to represent the [leap second](./struct.NaiveTime.html#leap-second-handling).
     ///
+    /// # Panics
+    ///
     /// Panics on invalid hour, minute, second and/or microsecond.
     ///
     /// # Example
@@ -906,6 +968,8 @@ impl NaiveDate {
     ///
     /// The microsecond part can exceed 1,000,000
     /// in order to represent the [leap second](./struct.NaiveTime.html#leap-second-handling).
+    ///
+    /// # Errors
     ///
     /// Returns `None` on invalid hour, minute, second and/or microsecond.
     ///
@@ -939,6 +1003,8 @@ impl NaiveDate {
     /// The nanosecond part can exceed 1,000,000,000
     /// in order to represent the [leap second](./struct.NaiveTime.html#leap-second-handling).
     ///
+    /// # Panics
+    ///
     /// Panics on invalid hour, minute, second and/or nanosecond.
     #[deprecated(since = "0.4.23", note = "use `and_hms_nano_opt()` instead")]
     #[inline]
@@ -951,6 +1017,8 @@ impl NaiveDate {
     ///
     /// The nanosecond part can exceed 1,000,000,000
     /// in order to represent the [leap second](./struct.NaiveTime.html#leap-second-handling).
+    ///
+    /// # Errors
     ///
     /// Returns `None` on invalid hour, minute, second and/or nanosecond.
     ///
@@ -1010,6 +1078,8 @@ impl NaiveDate {
 
     /// Makes a new `NaiveDate` for the next calendar date.
     ///
+    /// # Panics
+    ///
     /// Panics when `self` is the last representable date.
     #[deprecated(since = "0.4.23", note = "use `succ_opt()` instead")]
     #[inline]
@@ -1019,6 +1089,8 @@ impl NaiveDate {
     }
 
     /// Makes a new `NaiveDate` for the next calendar date.
+    ///
+    /// # Errors
     ///
     /// Returns `None` when `self` is the last representable date.
     ///
@@ -1042,6 +1114,8 @@ impl NaiveDate {
 
     /// Makes a new `NaiveDate` for the previous calendar date.
     ///
+    /// # Panics
+    ///
     /// Panics when `self` is the first representable date.
     #[deprecated(since = "0.4.23", note = "use `pred_opt()` instead")]
     #[inline]
@@ -1051,6 +1125,8 @@ impl NaiveDate {
     }
 
     /// Makes a new `NaiveDate` for the previous calendar date.
+    ///
+    /// # Errors
     ///
     /// Returns `None` when `self` is the first representable date.
     ///
@@ -1072,9 +1148,11 @@ impl NaiveDate {
         }
     }
 
-    /// Adds the `days` part of given `Duration` to the current date.
+    /// Adds the number of whole days in the given `Duration` to the current date.
     ///
-    /// Returns `None` when it will result in overflow.
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date would be out of range.
     ///
     /// # Example
     ///
@@ -1104,9 +1182,11 @@ impl NaiveDate {
         NaiveDate::from_ordinal_and_flags(year_div_400 * 400 + year_mod_400 as i32, ordinal, flags)
     }
 
-    /// Subtracts the `days` part of given `Duration` from the current date.
+    /// Subtracts the number of whole days in the given `Duration` from the current date.
     ///
-    /// Returns `None` when it will result in overflow.
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date would be out of range.
     ///
     /// # Example
     ///
@@ -1172,6 +1252,10 @@ impl NaiveDate {
     }
 
     /// Returns the number of whole years from the given `base` until `self`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if `base < self`.
     #[must_use]
     pub fn years_since(&self, base: Self) -> Option<u32> {
         let mut years = self.year() - base.year();
@@ -1555,9 +1639,12 @@ impl Datelike for NaiveDate {
         isoweek::iso_week_from_yof(self.year(), self.of())
     }
 
-    /// Makes a new `NaiveDate` with the year number changed.
+    /// Makes a new `NaiveDate` with the year number changed, while keeping the same month and day.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date does not exist, or when the `NaiveDate` would be
+    /// out of range.
     ///
     /// # Example
     ///
@@ -1591,7 +1678,9 @@ impl Datelike for NaiveDate {
 
     /// Makes a new `NaiveDate` with the month number (starting from 1) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date does not exist, or if the value for `month` is invalid.
     ///
     /// # Example
     ///
@@ -1610,7 +1699,10 @@ impl Datelike for NaiveDate {
 
     /// Makes a new `NaiveDate` with the month number (starting from 0) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date does not exist, or if the value for `month0` is
+    /// invalid.
     ///
     /// # Example
     ///
@@ -1630,7 +1722,9 @@ impl Datelike for NaiveDate {
 
     /// Makes a new `NaiveDate` with the day of month (starting from 1) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date does not exist, or if the value for `day` is invalid.
     ///
     /// # Example
     ///
@@ -1649,7 +1743,9 @@ impl Datelike for NaiveDate {
 
     /// Makes a new `NaiveDate` with the day of month (starting from 0) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date does not exist, or if the value for `day0` is invalid.
     ///
     /// # Example
     ///
@@ -1669,7 +1765,10 @@ impl Datelike for NaiveDate {
 
     /// Makes a new `NaiveDate` with the day of year (starting from 1) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date does not exist, or if the value for `ordinal` is
+    /// invalid.
     ///
     /// # Example
     ///
@@ -1693,7 +1792,10 @@ impl Datelike for NaiveDate {
 
     /// Makes a new `NaiveDate` with the day of year (starting from 0) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date does not exist, or if the value for `ordinal0` is
+    /// invalid.
     ///
     /// # Example
     ///

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -113,7 +113,11 @@ impl NaiveDateTime {
     /// [leap second](./struct.NaiveTime.html#leap-second-handling). (The true "UNIX
     /// timestamp" cannot represent a leap second unambiguously.)
     ///
-    /// Panics on the out-of-range number of seconds and/or invalid nanosecond.
+    /// # Panics
+    ///
+    /// Panics if the number of seconds would be out of range for a `NaiveDateTime` (more than
+    /// ca. 262,000 years away from common era), and panics on an invalid nanosecond (2 seconds or
+    /// more).
     #[deprecated(since = "0.4.23", note = "use `from_timestamp_opt()` instead")]
     #[inline]
     #[must_use]
@@ -126,7 +130,10 @@ impl NaiveDateTime {
     ///
     /// The UNIX epoch starts on midnight, January 1, 1970, UTC.
     ///
-    /// Returns `None` on an out-of-range number of milliseconds.
+    /// # Errors
+    ///
+    /// Returns `None` if the number of milliseconds would be out of range for a `NaiveDateTime`
+    /// (more than ca. 262,000 years away from common era)
     ///
     /// # Example
     ///
@@ -155,7 +162,10 @@ impl NaiveDateTime {
     ///
     /// The UNIX epoch starts on midnight, January 1, 1970, UTC.
     ///
-    /// Returns `None` on an out-of-range number of microseconds.
+    /// # Errors
+    ///
+    /// Returns `None` if the number of microseconds would be out of range for a `NaiveDateTime`
+    /// (more than ca. 262,000 years away from common era)
     ///
     /// # Example
     ///
@@ -189,8 +199,11 @@ impl NaiveDateTime {
     /// in order to represent the [leap second](./struct.NaiveTime.html#leap-second-handling).
     /// (The true "UNIX timestamp" cannot represent a leap second unambiguously.)
     ///
-    /// Returns `None` on the out-of-range number of seconds (more than 262 000 years away
-    /// from common era) and/or invalid nanosecond (2 seconds or more).
+    /// # Errors
+    ///
+    /// Returns `None` if the number of seconds would be out of range for a `NaiveDateTime` (more
+    /// than ca. 262,000 years away from common era), and panics on an invalid nanosecond
+    /// (2 seconds or more).
     ///
     /// # Example
     ///
@@ -390,11 +403,6 @@ impl NaiveDateTime {
     /// Note that this does *not* account for the timezone!
     /// The true "UNIX timestamp" would count seconds since the midnight *UTC* on the epoch.
     ///
-    /// Note also that this does reduce the number of years that can be
-    /// represented from ~584 Billion to ~584 Million. (If this is a problem,
-    /// please file an issue to let me know what domain needs millisecond
-    /// precision over billions of years, I'm curious.)
-    ///
     /// # Example
     ///
     /// ```
@@ -421,11 +429,6 @@ impl NaiveDateTime {
     /// Note that this does *not* account for the timezone!
     /// The true "UNIX timestamp" would count seconds since the midnight *UTC* on the epoch.
     ///
-    /// Note also that this does reduce the number of years that can be
-    /// represented from ~584 Billion to ~584 Thousand. (If this is a problem,
-    /// please file an issue to let me know what domain needs microsecond
-    /// precision over millennia, I'm curious.)
-    ///
     /// # Example
     ///
     /// ```
@@ -451,13 +454,11 @@ impl NaiveDateTime {
     ///
     /// # Panics
     ///
-    /// Note also that this does reduce the number of years that can be
-    /// represented from ~584 Billion to ~584 years. The dates that can be
-    /// represented as nanoseconds are between 1677-09-21T00:12:44.0 and
-    /// 2262-04-11T23:47:16.854775804.
+    /// An `i64` with nanosecond precision can span a range of ~584 years. This function panics on
+    /// an out of range `NaiveDateTime`.
     ///
-    /// (If this is a problem, please file an issue to let me know what domain
-    /// needs nanosecond precision over millennia, I'm curious.)
+    /// The dates that can be represented as nanoseconds are between 1677-09-21T00:12:44.0 and
+    /// 2262-04-11T23:47:16.854775804.
     ///
     /// # Example
     ///
@@ -557,7 +558,9 @@ impl NaiveDateTime {
     /// except when the `NaiveDateTime` itself represents a leap second
     /// in which case the assumption becomes that **there is exactly a single leap second ever**.
     ///
-    /// Returns `None` when it will result in overflow.
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date would be out of range.
     ///
     /// # Example
     ///
@@ -630,9 +633,11 @@ impl NaiveDateTime {
 
     /// Adds given `Months` to the current date and time.
     ///
-    /// Returns `None` when it will result in overflow.
+    /// Uses the last day of the month if the day does not exist in the resulting month.
     ///
-    /// Overflow returns `None`.
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date would be out of range.
     ///
     /// # Example
     ///
@@ -663,7 +668,9 @@ impl NaiveDateTime {
     /// except when the `NaiveDateTime` itself represents a leap second
     /// in which case the assumption becomes that **there is exactly a single leap second ever**.
     ///
-    /// Returns `None` when it will result in overflow.
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date would be out of range.
     ///
     /// # Example
     ///
@@ -732,9 +739,11 @@ impl NaiveDateTime {
 
     /// Subtracts given `Months` from the current date and time.
     ///
-    /// Returns `None` when it will result in overflow.
+    /// Uses the last day of the month if the day does not exist in the resulting month.
     ///
-    /// Overflow returns `None`.
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date would be out of range.
     ///
     /// # Example
     ///
@@ -1095,11 +1104,15 @@ impl Datelike for NaiveDateTime {
         self.date.iso_week()
     }
 
-    /// Makes a new `NaiveDateTime` with the year number changed.
-    ///
-    /// Returns `None` when the resulting `NaiveDateTime` would be invalid.
+    /// Makes a new `NaiveDateTime` with the year number changed, while keeping the same month and
+    /// day.
     ///
     /// See also the [`NaiveDate::with_year`] method.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date does not exist, or when the `NaiveDateTime` would be
+    /// out of range.
     ///
     /// # Example
     ///
@@ -1117,9 +1130,11 @@ impl Datelike for NaiveDateTime {
 
     /// Makes a new `NaiveDateTime` with the month number (starting from 1) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDateTime` would be invalid.
-    ///
     /// See also the [`NaiveDate::with_month`] method.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date does not exist, or if the value for `month` is invalid.
     ///
     /// # Example
     ///
@@ -1138,9 +1153,12 @@ impl Datelike for NaiveDateTime {
 
     /// Makes a new `NaiveDateTime` with the month number (starting from 0) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDateTime` would be invalid.
-    ///
     /// See also the [`NaiveDate::with_month0`] method.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date does not exist, or if the value for `month0` is
+    /// invalid.
     ///
     /// # Example
     ///
@@ -1159,9 +1177,11 @@ impl Datelike for NaiveDateTime {
 
     /// Makes a new `NaiveDateTime` with the day of month (starting from 1) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDateTime` would be invalid.
-    ///
     /// See also the [`NaiveDate::with_day`] method.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date does not exist, or if the value for `day` is invalid.
     ///
     /// # Example
     ///
@@ -1179,9 +1199,11 @@ impl Datelike for NaiveDateTime {
 
     /// Makes a new `NaiveDateTime` with the day of month (starting from 0) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDateTime` would be invalid.
-    ///
     /// See also the [`NaiveDate::with_day0`] method.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date does not exist, or if the value for `day0` is invalid.
     ///
     /// # Example
     ///
@@ -1199,9 +1221,12 @@ impl Datelike for NaiveDateTime {
 
     /// Makes a new `NaiveDateTime` with the day of year (starting from 1) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDateTime` would be invalid.
-    ///
     /// See also the [`NaiveDate::with_ordinal`] method.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date does not exist, or if the value for `ordinal` is
+    /// invalid.
     ///
     /// # Example
     ///
@@ -1226,9 +1251,12 @@ impl Datelike for NaiveDateTime {
 
     /// Makes a new `NaiveDateTime` with the day of year (starting from 0) changed.
     ///
-    /// Returns `None` when the resulting `NaiveDateTime` would be invalid.
-    ///
     /// See also the [`NaiveDate::with_ordinal0`] method.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if the resulting date does not exist, or if the value for `ordinal0` is
+    /// invalid.
     ///
     /// # Example
     ///
@@ -1325,9 +1353,11 @@ impl Timelike for NaiveDateTime {
 
     /// Makes a new `NaiveDateTime` with the hour number changed.
     ///
-    /// Returns `None` when the resulting `NaiveDateTime` would be invalid.
-    ///
     /// See also the [`NaiveTime::with_hour`] method.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if the value for `hour` is invalid.
     ///
     /// # Example
     ///
@@ -1346,10 +1376,11 @@ impl Timelike for NaiveDateTime {
 
     /// Makes a new `NaiveDateTime` with the minute number changed.
     ///
-    /// Returns `None` when the resulting `NaiveDateTime` would be invalid.
+    /// See also the [`NaiveTime::with_minute`] method.
     ///
-    /// See also the
-    /// [`NaiveTime::with_minute`] method.
+    /// # Errors
+    ///
+    /// Returns `None` if the value for `minute` is invalid.
     ///
     /// # Example
     ///
@@ -1368,11 +1399,14 @@ impl Timelike for NaiveDateTime {
 
     /// Makes a new `NaiveDateTime` with the second number changed.
     ///
-    /// Returns `None` when the resulting `NaiveDateTime` would be invalid. As
-    /// with the [`NaiveDateTime::second`] method, the input range is
-    /// restricted to 0 through 59.
+    /// As with the [`second`](#method.second) method,
+    /// the input range is restricted to 0 through 59.
     ///
     /// See also the [`NaiveTime::with_second`] method.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if the value for `second` is invalid.
     ///
     /// # Example
     ///
@@ -1396,6 +1430,10 @@ impl Timelike for NaiveDateTime {
     /// the input range can exceed 1,000,000,000 for leap seconds.
     ///
     /// See also the [`NaiveTime::with_nanosecond`] method.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if `nanosecond >= 2,000,000,000`.
     ///
     /// # Example
     ///
@@ -1421,7 +1459,9 @@ impl Timelike for NaiveDateTime {
 /// second ever**, except when the `NaiveDateTime` itself represents a leap  second in which case
 /// the assumption becomes that **there is exactly a single leap second ever**.
 ///
-/// Panics on underflow or overflow. Use [`NaiveDateTime::checked_add_signed`]
+/// # Panics
+///
+/// Panics if the resulting date would be out of range. Use [`NaiveDateTime::checked_add_signed`]
 /// to detect that.
 ///
 /// # Example

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -212,6 +212,8 @@ impl NaiveTime {
     /// No [leap second](#leap-second-handling) is allowed here;
     /// use `NaiveTime::from_hms_*` methods with a subsecond parameter instead.
     ///
+    /// # Panics
+    ///
     /// Panics on invalid hour, minute and/or second.
     #[deprecated(since = "0.4.23", note = "use `from_hms_opt()` instead")]
     #[inline]
@@ -224,6 +226,8 @@ impl NaiveTime {
     ///
     /// No [leap second](#leap-second-handling) is allowed here;
     /// use `NaiveTime::from_hms_*_opt` methods with a subsecond parameter instead.
+    ///
+    /// # Errors
     ///
     /// Returns `None` on invalid hour, minute and/or second.
     ///
@@ -251,6 +255,8 @@ impl NaiveTime {
     /// The millisecond part can exceed 1,000
     /// in order to represent the [leap second](#leap-second-handling).
     ///
+    /// # Panics
+    ///
     /// Panics on invalid hour, minute, second and/or millisecond.
     #[deprecated(since = "0.4.23", note = "use `from_hms_milli_opt()` instead")]
     #[inline]
@@ -263,6 +269,8 @@ impl NaiveTime {
     ///
     /// The millisecond part can exceed 1,000
     /// in order to represent the [leap second](#leap-second-handling).
+    ///
+    /// # Errors
     ///
     /// Returns `None` on invalid hour, minute, second and/or millisecond.
     ///
@@ -294,6 +302,8 @@ impl NaiveTime {
     /// The microsecond part can exceed 1,000,000
     /// in order to represent the [leap second](#leap-second-handling).
     ///
+    /// # Panics
+    ///
     /// Panics on invalid hour, minute, second and/or microsecond.
     #[deprecated(since = "0.4.23", note = "use `from_hms_micro_opt()` instead")]
     #[inline]
@@ -306,6 +316,8 @@ impl NaiveTime {
     ///
     /// The microsecond part can exceed 1,000,000
     /// in order to represent the [leap second](#leap-second-handling).
+    ///
+    /// # Errors
     ///
     /// Returns `None` on invalid hour, minute, second and/or microsecond.
     ///
@@ -335,6 +347,8 @@ impl NaiveTime {
     /// The nanosecond part can exceed 1,000,000,000
     /// in order to represent the [leap second](#leap-second-handling).
     ///
+    /// # Panics
+    ///
     /// Panics on invalid hour, minute, second and/or nanosecond.
     #[deprecated(since = "0.4.23", note = "use `from_hms_nano_opt()` instead")]
     #[inline]
@@ -347,6 +361,8 @@ impl NaiveTime {
     ///
     /// The nanosecond part can exceed 1,000,000,000
     /// in order to represent the [leap second](#leap-second-handling).
+    ///
+    /// # Errors
     ///
     /// Returns `None` on invalid hour, minute, second and/or nanosecond.
     ///
@@ -380,6 +396,8 @@ impl NaiveTime {
     /// The nanosecond part can exceed 1,000,000,000
     /// in order to represent the [leap second](#leap-second-handling).
     ///
+    /// # Panics
+    ///
     /// Panics on invalid number of seconds and/or nanosecond.
     #[deprecated(since = "0.4.23", note = "use `from_num_seconds_from_midnight_opt()` instead")]
     #[inline]
@@ -392,6 +410,8 @@ impl NaiveTime {
     ///
     /// The nanosecond part can exceed 1,000,000,000
     /// in order to represent the [leap second](#leap-second-handling).
+    ///
+    /// # Errors
     ///
     /// Returns `None` on invalid number of seconds and/or nanosecond.
     ///
@@ -506,10 +526,8 @@ impl NaiveTime {
         parsed.to_naive_time().map(|t| (t, remainder))
     }
 
-    /// Adds given `Duration` to the current time,
-    /// and also returns the number of *seconds*
+    /// Adds given `Duration` to the current time, and also returns the number of *seconds*
     /// in the integral number of days ignored from the addition.
-    /// (We cannot return `Duration` because it is subject to overflow or underflow.)
     ///
     /// # Example
     ///
@@ -589,10 +607,8 @@ impl NaiveTime {
         (NaiveTime { secs: secs as u32, frac: frac as u32 }, morerhssecs)
     }
 
-    /// Subtracts given `Duration` from the current time,
-    /// and also returns the number of *seconds*
+    /// Subtracts given `Duration` from the current time, and also returns the number of *seconds*
     /// in the integral number of days ignored from the subtraction.
-    /// (We cannot return `Duration` because it is subject to overflow or underflow.)
     ///
     /// # Example
     ///
@@ -886,7 +902,9 @@ impl Timelike for NaiveTime {
 
     /// Makes a new `NaiveTime` with the hour number changed.
     ///
-    /// Returns `None` when the resulting `NaiveTime` would be invalid.
+    /// # Errors
+    ///
+    /// Returns `None` if the value for `hour` is invalid.
     ///
     /// # Example
     ///
@@ -908,7 +926,9 @@ impl Timelike for NaiveTime {
 
     /// Makes a new `NaiveTime` with the minute number changed.
     ///
-    /// Returns `None` when the resulting `NaiveTime` would be invalid.
+    /// # Errors
+    ///
+    /// Returns `None` if the value for `minute` is invalid.
     ///
     /// # Example
     ///
@@ -930,9 +950,12 @@ impl Timelike for NaiveTime {
 
     /// Makes a new `NaiveTime` with the second number changed.
     ///
-    /// Returns `None` when the resulting `NaiveTime` would be invalid.
     /// As with the [`second`](#method.second) method,
     /// the input range is restricted to 0 through 59.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if the value for `second` is invalid.
     ///
     /// # Example
     ///
@@ -954,9 +977,12 @@ impl Timelike for NaiveTime {
 
     /// Makes a new `NaiveTime` with nanoseconds since the whole non-leap second changed.
     ///
-    /// Returns `None` when the resulting `NaiveTime` would be invalid.
     /// As with the [`nanosecond`](#method.nanosecond) method,
     /// the input range can exceed 1,000,000,000 for leap seconds.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if `nanosecond >= 2,000,000,000`.
     ///
     /// # Example
     ///

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -53,7 +53,7 @@ pub trait Datelike: Sized {
     /// Returns the ISO week.
     fn iso_week(&self) -> IsoWeek;
 
-    /// Makes a new value with the year number changed.
+    /// Makes a new value with the year number changed, while keeping the same month and day.
     ///
     /// Returns `None` when the resulting value would be invalid.
     fn with_year(&self, year: i32) -> Option<Self>;


### PR DESCRIPTION
It is [recommended by the API guidelines](https://rust-lang.github.io/api-guidelines/documentation.html#function-docs-include-error-panic-and-safety-considerations-c-failure) to have "Errors" and/or "Panics" sections in the API documentation.

Many methods already documented under what circumstances they would panic or return `None`. In that case I only added a header.

I made sure the list of failure causes for each method are complete. Only the panics in https://github.com/chronotope/chrono/pull/1048 have been left out because I consider them bugs that are going to be fixed soonish.

In a couple of cases I made a drive-by fix to the surrounding documentation.