### PR TITLE
Format to string

### DIFF
--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1022,3 +1022,9 @@ fn test_datetime_fixed_offset() {
     let datetime_fixed = fixed_offset.from_local_datetime(&naivedatetime).unwrap();
     assert_eq!(datetime_fixed.fixed_offset(), datetime_fixed);
 }
+
+#[test]
+fn test_formatting_permissive_offset_no_panic() {
+    let dt = Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap();
+    assert!(dt.format_to_string("%#z").is_err());
+}

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -675,7 +675,7 @@ fn format_inner(
                         off.map(|&(_, off)| write_local_minus_utc(result, off, true, Colons::None))
                     }
                     Internal(InternalFixed { val: InternalInternal::TimezoneOffsetPermissive }) => {
-                        panic!("Do not try to write %#z it is undefined")
+                        None // Do not try to write %#z it is undefined
                     }
                     RFC2822 =>
                     // same as `%a, %d %b %Y %H:%M:%S %z`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,8 @@
 //!
 //! ### Formatting and Parsing
 //!
-//! Formatting is done via the [`format`](./struct.DateTime.html#method.format) method,
+//! Formatting is done via the [`format`](./struct.DateTime.html#method.format) and
+//! [`format_to_string`](./struct.DateTime.html#method.format_to_string) methods,
 //! which format is equivalent to the familiar `strftime` format.
 //!
 //! See [`format::strftime`](./format/strftime/index.html#specifiers)
@@ -233,8 +234,11 @@
 //! # fn test() {
 //! let dt = Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap();
 //! assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2014-11-28 12:00:09");
-//! assert_eq!(dt.format("%a %b %e %T %Y").to_string(), "Fri Nov 28 12:00:09 2014");
-//! assert_eq!(dt.format_localized("%A %e %B %Y, %T", Locale::fr_BE).to_string(), "vendredi 28 novembre 2014, 12:00:09");
+//! assert_eq!(dt.format_to_string("%a %b %e %T %Y"), Ok("Fri Nov 28 12:00:09 2014".to_owned()));
+//! assert_eq!(
+//!     dt.format_localized("%A %e %B %Y, %T", Locale::fr_BE).to_string(),
+//!     "vendredi 28 novembre 2014, 12:00:09"
+//! );
 //!
 //! assert_eq!(dt.format("%a %b %e %T %Y").to_string(), dt.format("%c").to_string());
 //! assert_eq!(dt.to_string(), "2014-11-28 12:00:09 UTC");

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -3,6 +3,11 @@
 
 //! ISO 8601 date and time without timezone.
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::string::String;
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::fmt::Write;
@@ -858,19 +863,36 @@ impl NaiveDateTime {
         DelayedFormat::new(Some(self.date), Some(self.time), items)
     }
 
-    /// Formats the combined date and time with the specified format string.
-    /// See the [`format::strftime` module](../format/strftime/index.html)
-    /// on the supported escape sequences.
+    /// Formats the date and time with the specified format string.
     ///
-    /// This returns a `DelayedFormat`,
-    /// which gets converted to a string only when actual formatting happens.
-    /// You may use the `to_string` method to get a `String`,
-    /// or just feed it into `print!` and other formatting macros.
-    /// (In this way it avoids the redundant memory allocation.)
+    /// See the [`format::strftime` module](crate::format::strftime) for the supported escape
+    /// sequences.
     ///
-    /// A wrong format string does *not* issue an error immediately.
-    /// Rather, converting or formatting the `DelayedFormat` fails.
-    /// You are recommended to immediately use `DelayedFormat` for this reason.
+    /// This returns a `DelayedFormat`, which gets converted to a string only when actual formatting
+    /// happens. You can feed this into [`print!`] and other formatting macros.
+    /// (This can avoid a memory allocation.)
+    ///
+    /// If you want to format to a `String`, consider using the more direct method
+    /// [`format_to_string`](#method.format_to_string).
+    /// This is an alternative to calling [`ToString::to_string`] on the `DelayedFormat` returned by
+    /// this method.
+    ///
+    /// # Errors/panics
+    ///
+    /// This function does not panic or return an error.
+    ///
+    /// However the `Display` implementation of `DelayedFormat` can return an error if the format
+    /// string is invalid, or if the format string contains offset fields (which a `NaiveDateTime`
+    /// can not provide). Returning an error goes against the [contract for `Display`][1]. This will
+    /// be fixed in the next major version of chrono.
+    ///
+    /// Consumers of the `Display` trait, such as [`format!`], [`println!`] and [`to_string`] will
+    /// generally panic on an invalid formatting string. Consider using this function in combination
+    /// with formatting macro's that can pass on an error instead such as [`write!`] and
+    /// [`writeln!`].
+    ///
+    /// [1]: https://doc.rust-lang.org/stable/std/fmt/index.html#formatting-traits
+    /// [`to_string`]: ToString::to_string
     ///
     /// # Example
     ///
@@ -882,13 +904,21 @@ impl NaiveDateTime {
     /// assert_eq!(dt.format("around %l %p on %b %-d").to_string(), "around 11 PM on Sep 5");
     /// ```
     ///
-    /// The resulting `DelayedFormat` can be formatted directly via the `Display` trait.
+    /// The resulting `DelayedFormat` can be used directly with formatting macro's via the `Display`
+    /// trait.
     ///
     /// ```
+    /// # use core::fmt::{Error, Write};
     /// # use chrono::NaiveDate;
     /// # let dt = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
     /// assert_eq!(format!("{}", dt.format("%Y-%m-%d %H:%M:%S")), "2015-09-05 23:56:04");
-    /// assert_eq!(format!("{}", dt.format("around %l %p on %b %-d")), "around 11 PM on Sep 5");
+    ///
+    /// let mut formatted = String::new();
+    /// write!(formatted, "{}", dt.format("around %l %p on %b %-d"))?;
+    /// assert_eq!(formatted, "around 11 PM on Sep 5");
+    ///
+    /// println!("{}", dt.format("%Y-%m-%d %H:%M:%S")); // prints "2015-09-05 23:56:04"
+    /// # Ok::<(), Error>(())
     /// ```
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
@@ -896,6 +926,36 @@ impl NaiveDateTime {
     #[must_use]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
         self.format_with_items(StrftimeItems::new(fmt))
+    }
+
+    /// Format the date and time with the specified format string directly to a `String`.
+    ///
+    /// See the [`format::strftime` module](crate::format::strftime) for the supported escape
+    /// sequences.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the format string is invalid, or if the format string contains offset
+    /// fields (which a `NaiveDateTime` can not provide).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use chrono::NaiveDate;
+    ///
+    /// let dt = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
+    /// assert_eq!(dt.format_to_string("%Y-%m-%d %H:%M:%S"), Ok("2015-09-05 23:56:04".to_owned()));
+    /// assert_eq!(
+    ///     dt.format_to_string("around %l %p on %b %-d"),
+    ///     Ok("around 11 PM on Sep 5".to_owned())
+    /// );
+    /// ```
+    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
+    pub fn format_to_string(&self, fmt: &str) -> Result<String, fmt::Error> {
+        let mut s = String::new();
+        write!(s, "{}", self.format_with_items(StrftimeItems::new(fmt)))?;
+        Ok(s)
     }
 
     /// Converts the `NaiveDateTime` into the timezone-aware `DateTime<Tz>`


### PR DESCRIPTION
This PR is meant as an alternative to https://github.com/chronotope/chrono/pull/902 and https://github.com/chronotope/chrono/pull/614, for the problem in described in https://github.com/chronotope/chrono/issues/575.

The problem is that if the format string is invalid, or contains a field that the type can not provide (such as time fields on a `NaiveDate`), the display implementation returns an error.

Some formattings macro's can correctly forward this error, such as `write!` and `writeln!`. Others, such as `println!`, `format!` and `to_string` panic instead.

- https://github.com/chronotope/chrono/pull/614 proposed to ignore any fields that return an error when formatting
- https://github.com/chronotope/chrono/pull/902 proposed to make `StrftimeItems::new` return a `Result`. It will need some more work to detect a string with fields the type can not provide.
- This PR proposes to add methods that return `fmt::Result<String>`.

Compared to https://github.com/chronotope/chrono/pull/902 I believe this solution is better because:
- It works on 0.4.x, no breaking changes
- It makes it _easier_ to get a `String`, instead of making it slightly _harder_ to get a `DelayedFormat`.
- There is no need to parse the formatting string twice.

---

There are 5 new methods, all just a couple of lines of code:

- `DelayedFormat::try_to_string`
- `NaiveDate::format_to_string`
- `NaiveTime::format_to_string`
- `NaiveDateTime::format_to_string`
- `DateTime::format_to_string`

Most of the effort in this PR is updating the surrounding documentation and examples, to make users more aware of the potential panic and the solutions.