### PR TITLE
Ensure `timestamp_nanos` panics on overflow in release builds

### DIFF
--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -480,8 +480,10 @@ impl NaiveDateTime {
     #[inline]
     #[must_use]
     pub fn timestamp_nanos(&self) -> i64 {
-        let as_ns = self.timestamp() * 1_000_000_000;
-        as_ns + i64::from(self.timestamp_subsec_nanos())
+        self.timestamp()
+            .checked_mul(1_000_000_000)
+            .and_then(|ns| ns.checked_add(i64::from(self.timestamp_subsec_nanos())))
+            .expect("value can not be represented in a timestamp with nanosecond precision.")
     }
 
     /// Returns the number of milliseconds since the last whole non-leap second.

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -330,6 +330,24 @@ fn test_nanosecond_range() {
 }
 
 #[test]
+#[should_panic]
+fn test_nanosecond_just_beyond_range() {
+    let maximum = "2262-04-11T23:47:16.854775804";
+    let parsed: NaiveDateTime = maximum.parse().unwrap();
+    let beyond_max = parsed + Duration::milliseconds(300);
+    let _ = beyond_max.timestamp_nanos();
+}
+
+#[test]
+#[should_panic]
+fn test_nanosecond_far_beyond_range() {
+    let maximum = "2262-04-11T23:47:16.854775804";
+    let parsed: NaiveDateTime = maximum.parse().unwrap();
+    let beyond_max = parsed + Duration::days(365);
+    let _ = beyond_max.timestamp_nanos();
+}
+
+#[test]
 fn test_and_local_timezone() {
     let ndt = NaiveDate::from_ymd_opt(2022, 6, 15).unwrap().and_hms_opt(18, 59, 36).unwrap();
     let dt_utc = ndt.and_local_timezone(Utc).unwrap();


### PR DESCRIPTION
`NaiveDateTime::timestamp_nanos` already panics on overflow in debug builds, but it should also panic on release builds instead of returning invalid values.