### PR TITLE
Fix dead code error when running dateutils test on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --lib --all-features --color=always -- --color=always
-      - run: cargo test --doc --all-features --color=always -- --color=always
+      - run: cargo test --all-features --color=always -- --color=always
 
   # later this may be able to be included with the below
   # kept separate for now as the following don't compile on 1.56.1

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -64,6 +64,7 @@ const DATE_PATH: &'static str = "/usr/bin/date";
 const DATE_PATH: &'static str = "/opt/freeware/bin/date";
 
 #[cfg(test)]
+#[cfg(unix)]
 /// test helper to sanity check the date command behaves as expected
 /// asserts the command succeeded
 fn assert_run_date_version() {


### PR DESCRIPTION
The tests fail to run on Windows since https://github.com/chronotope/chrono/pull/1090.
The CI didn't catch it because it runs `cargo test --lib` and `cargo test --doc`, not plain `cargo test`.