### PR TITLE
Make formatting available without `alloc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See [docs.rs](https://docs.rs/chrono/latest/chrono/) for the API reference.
 
 Default features:
 
-* `alloc`: Enable features that depend on allocation (primarily string formatting)
+* `alloc`: Enable features that depend on allocation (some formatting methods)
 * `std`: Enables functionality that depends on the standard library. This is a superset of `alloc`
   and adds interoperation with standard library types and traits.
 * `clock`: Enables reading the system time (`now`) and local timezone (`Local`).

--- a/src/date.rs
+++ b/src/date.rs
@@ -4,7 +4,6 @@
 //! ISO 8601 calendar date with time zone.
 #![allow(deprecated)]
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
@@ -15,7 +14,6 @@ use rkyv::{Archive, Deserialize, Serialize};
 
 #[cfg(feature = "unstable-locales")]
 use crate::format::Locale;
-#[cfg(any(feature = "alloc", feature = "std", test))]
 use crate::format::{DelayedFormat, Item, StrftimeItems};
 use crate::naive::{IsoWeek, NaiveDate, NaiveTime};
 use crate::offset::{TimeZone, Utc};
@@ -333,8 +331,6 @@ where
     Tz::Offset: fmt::Display,
 {
     /// Formats the date with the specified formatting items.
-    #[cfg(any(feature = "alloc", feature = "std", test))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
@@ -348,8 +344,6 @@ where
     /// Formats the date with the specified format string.
     /// See the [`crate::format::strftime`] module
     /// on the supported escape sequences.
-    #[cfg(any(feature = "alloc", feature = "std", test))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -18,7 +18,6 @@ use std::string::ToString;
 #[cfg(any(feature = "std", test))]
 use std::time::{SystemTime, UNIX_EPOCH};
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 use crate::format::DelayedFormat;
 #[cfg(feature = "unstable-locales")]
 use crate::format::Locale;
@@ -798,8 +797,6 @@ where
     }
 
     /// Formats the combined date and time with the specified formatting items.
-    #[cfg(any(feature = "alloc", feature = "std", test))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
@@ -823,8 +820,6 @@ where
     /// let formatted = format!("{}", date_time.format("%d/%m/%Y %H:%M"));
     /// assert_eq!(formatted, "02/04/2017 12:50");
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -572,116 +572,116 @@ fn format_inner(
         Item::Fixed(ref spec) => {
             use self::Fixed::*;
 
-            let ret =
-                match *spec {
-                    ShortMonthName => date.map(|d| {
-                        result.write_str(locale.short_months[d.month0() as usize])
-                    }),
-                    LongMonthName => date.map(|d| {
-                        result.write_str(locale.long_months[d.month0() as usize])
-                    }),
-                    ShortWeekdayName => date.map(|d| {
-                        result.write_str(
-                            locale.short_weekdays[d.weekday().num_days_from_sunday() as usize],
-                        )
-                    }),
-                    LongWeekdayName => date.map(|d| {
-                        result.write_str(
-                            locale.long_weekdays[d.weekday().num_days_from_sunday() as usize],
-                        )
-                    }),
-                    LowerAmPm => time.map(|t| {
-                        let ampm = if t.hour12().0 { locale.am_pm[1] } else { locale.am_pm[0] };
-                        for c in ampm.chars().flat_map(|c| c.to_lowercase()) {
-                            result.write_char(c)?
-                        }
+            let ret = match *spec {
+                ShortMonthName => {
+                    date.map(|d| result.write_str(locale.short_months[d.month0() as usize]))
+                }
+                LongMonthName => {
+                    date.map(|d| result.write_str(locale.long_months[d.month0() as usize]))
+                }
+                ShortWeekdayName => date.map(|d| {
+                    result.write_str(
+                        locale.short_weekdays[d.weekday().num_days_from_sunday() as usize],
+                    )
+                }),
+                LongWeekdayName => date.map(|d| {
+                    result.write_str(
+                        locale.long_weekdays[d.weekday().num_days_from_sunday() as usize],
+                    )
+                }),
+                LowerAmPm => time.map(|t| {
+                    let ampm = if t.hour12().0 { locale.am_pm[1] } else { locale.am_pm[0] };
+                    for c in ampm.chars().flat_map(|c| c.to_lowercase()) {
+                        result.write_char(c)?
+                    }
+                    Ok(())
+                }),
+                UpperAmPm => time.map(|t| {
+                    result.write_str(if t.hour12().0 { locale.am_pm[1] } else { locale.am_pm[0] })
+                }),
+                Nanosecond => time.map(|t| {
+                    let nano = t.nanosecond() % 1_000_000_000;
+                    if nano == 0 {
                         Ok(())
-                    }),
-                    UpperAmPm => time.map(|t| {
-                        result.write_str(if t.hour12().0 {
-                            locale.am_pm[1]
-                        } else {
-                            locale.am_pm[0]
-                        })
-                    }),
-                    Nanosecond => time.map(|t| {
-                        let nano = t.nanosecond() % 1_000_000_000;
-                        if nano == 0 {
-                            Ok(())
-                        } else if nano % 1_000_000 == 0 {
-                            write!(result, ".{:03}", nano / 1_000_000)
-                        } else if nano % 1_000 == 0 {
-                            write!(result, ".{:06}", nano / 1_000)
-                        } else {
-                            write!(result, ".{:09}", nano)
-                        }
-                    }),
-                    Nanosecond3 => time.map(|t| {
-                        let nano = t.nanosecond() % 1_000_000_000;
+                    } else if nano % 1_000_000 == 0 {
                         write!(result, ".{:03}", nano / 1_000_000)
-                    }),
-                    Nanosecond6 => time.map(|t| {
-                        let nano = t.nanosecond() % 1_000_000_000;
+                    } else if nano % 1_000 == 0 {
                         write!(result, ".{:06}", nano / 1_000)
-                    }),
-                    Nanosecond9 => time.map(|t| {
-                        let nano = t.nanosecond() % 1_000_000_000;
+                    } else {
                         write!(result, ".{:09}", nano)
-                    }),
-                    Internal(InternalFixed { val: InternalInternal::Nanosecond3NoDot }) => time
-                        .map(|t| {
-                            let nano = t.nanosecond() % 1_000_000_000;
-                            write!(result, "{:03}", nano / 1_000_000)
-                        }),
-                    Internal(InternalFixed { val: InternalInternal::Nanosecond6NoDot }) => time
-                        .map(|t| {
-                            let nano = t.nanosecond() % 1_000_000_000;
-                            write!(result, "{:06}", nano / 1_000)
-                        }),
-                    Internal(InternalFixed { val: InternalInternal::Nanosecond9NoDot }) => time
-                        .map(|t| {
-                            let nano = t.nanosecond() % 1_000_000_000;
-                            write!(result, "{:09}", nano)
-                        }),
-                    TimezoneName => off.map(|(name, _)| {
-                        result.write_str(name)
-                    }),
-                    TimezoneOffsetColon => off
-                        .map(|(_, off)| write_local_minus_utc(result, off, false, Colons::Single)),
-                    TimezoneOffsetDoubleColon => off
-                        .map(|(_, off)| write_local_minus_utc(result, off, false, Colons::Double)),
-                    TimezoneOffsetTripleColon => off
-                        .map(|(_, off)| write_local_minus_utc(result, off, false, Colons::Triple)),
-                    TimezoneOffsetColonZ => off
-                        .map(|(_, off)| write_local_minus_utc(result, off, true, Colons::Single)),
-                    TimezoneOffset => {
-                        off.map(|(_, off)| write_local_minus_utc(result, off, false, Colons::None))
                     }
-                    TimezoneOffsetZ => {
-                        off.map(|(_, off)| write_local_minus_utc(result, off, true, Colons::None))
+                }),
+                Nanosecond3 => time.map(|t| {
+                    let nano = t.nanosecond() % 1_000_000_000;
+                    write!(result, ".{:03}", nano / 1_000_000)
+                }),
+                Nanosecond6 => time.map(|t| {
+                    let nano = t.nanosecond() % 1_000_000_000;
+                    write!(result, ".{:06}", nano / 1_000)
+                }),
+                Nanosecond9 => time.map(|t| {
+                    let nano = t.nanosecond() % 1_000_000_000;
+                    write!(result, ".{:09}", nano)
+                }),
+                Internal(InternalFixed { val: InternalInternal::Nanosecond3NoDot }) => {
+                    time.map(|t| {
+                        let nano = t.nanosecond() % 1_000_000_000;
+                        write!(result, "{:03}", nano / 1_000_000)
+                    })
+                }
+                Internal(InternalFixed { val: InternalInternal::Nanosecond6NoDot }) => {
+                    time.map(|t| {
+                        let nano = t.nanosecond() % 1_000_000_000;
+                        write!(result, "{:06}", nano / 1_000)
+                    })
+                }
+                Internal(InternalFixed { val: InternalInternal::Nanosecond9NoDot }) => {
+                    time.map(|t| {
+                        let nano = t.nanosecond() % 1_000_000_000;
+                        write!(result, "{:09}", nano)
+                    })
+                }
+                TimezoneName => off.map(|(name, _)| result.write_str(name)),
+                TimezoneOffsetColon => {
+                    off.map(|(_, off)| write_local_minus_utc(result, off, false, Colons::Single))
+                }
+                TimezoneOffsetDoubleColon => {
+                    off.map(|(_, off)| write_local_minus_utc(result, off, false, Colons::Double))
+                }
+                TimezoneOffsetTripleColon => {
+                    off.map(|(_, off)| write_local_minus_utc(result, off, false, Colons::Triple))
+                }
+                TimezoneOffsetColonZ => {
+                    off.map(|(_, off)| write_local_minus_utc(result, off, true, Colons::Single))
+                }
+                TimezoneOffset => {
+                    off.map(|(_, off)| write_local_minus_utc(result, off, false, Colons::None))
+                }
+                TimezoneOffsetZ => {
+                    off.map(|(_, off)| write_local_minus_utc(result, off, true, Colons::None))
+                }
+                Internal(InternalFixed { val: InternalInternal::TimezoneOffsetPermissive }) => {
+                    return Err(fmt::Error);
+                }
+                RFC2822 =>
+                // same as `%a, %d %b %Y %H:%M:%S %z`
+                {
+                    if let (Some(d), Some(t), Some((_, off))) = (date, time, off) {
+                        Some(write_rfc2822_inner(result, d, t, off, locale))
+                    } else {
+                        None
                     }
-                    Internal(InternalFixed { val: InternalInternal::TimezoneOffsetPermissive }) => {
-                        return Err(fmt::Error);
+                }
+                RFC3339 =>
+                // same as `%Y-%m-%dT%H:%M:%S%.f%:z`
+                {
+                    if let (Some(d), Some(t), Some((_, off))) = (date, time, off) {
+                        Some(write_rfc3339_inner(result, crate::NaiveDateTime::new(*d, *t), off))
+                    } else {
+                        None
                     }
-                    RFC2822 =>
-                    // same as `%a, %d %b %Y %H:%M:%S %z`
-                    {
-                        if let (Some(d), Some(t), Some((_, off))) = (date, time, off) {
-                            Some(write_rfc2822_inner(result, d, t, off, locale))
-                        } else {
-                            None
-                        }
-                    }
-                    RFC3339 =>
-                    // same as `%Y-%m-%dT%H:%M:%S%.f%:z`
-                    {
-                        if let (Some(d), Some(t), Some((_, off))) = (date, time, off) {
-                            Some(write_rfc3339_inner(result, crate::NaiveDateTime::new(*d, *t), off))
-                        } else {
-                            None
-                        }
-                    }
-                };
+                }
+            };
 
             ret.unwrap_or(Err(fmt::Error)) // insufficient arguments for given format
         }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -37,7 +37,6 @@ extern crate alloc;
 use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
 use alloc::string::String;
-#[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::fmt;
 use core::fmt::Write;
@@ -46,11 +45,8 @@ use core::str::FromStr;
 #[cfg(any(feature = "std", test))]
 use std::error::Error;
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 use crate::naive::{NaiveDate, NaiveTime};
-#[cfg(any(feature = "alloc", feature = "std", test))]
 use crate::offset::{FixedOffset, Offset};
-#[cfg(any(feature = "alloc", feature = "std", test))]
 use crate::{Datelike, Timelike};
 use crate::{Month, ParseMonthError, ParseWeekdayError, Weekday};
 
@@ -276,7 +272,6 @@ enum InternalInternal {
     Nanosecond9NoDot,
 }
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum Colons {
     None,
@@ -429,7 +424,6 @@ const TOO_SHORT: ParseError = ParseError(ParseErrorKind::TooShort);
 const TOO_LONG: ParseError = ParseError(ParseErrorKind::TooLong);
 const BAD_FORMAT: ParseError = ParseError(ParseErrorKind::BadFormat);
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 struct Locales {
     short_months: &'static [&'static str],
     long_months: &'static [&'static str],
@@ -438,7 +432,6 @@ struct Locales {
     am_pm: &'static [&'static str],
 }
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 impl Locales {
     fn new(_locale: Option<Locale>) -> Self {
         #[cfg(feature = "unstable-locales")]
@@ -500,7 +493,6 @@ pub fn format_item(
     format_inner(w, date, time, off, item, None)
 }
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 fn format_inner(
     result: &mut fmt::Formatter,
     date: Option<&NaiveDate>,
@@ -700,7 +692,6 @@ fn format_inner(
 
 /// Prints an offset from UTC in the format of `+HHMM` or `+HH:MM`.
 /// `Z` instead of `+00[:]00` is allowed when `allow_zulu` is true.
-#[cfg(any(feature = "alloc", feature = "std", test))]
 fn write_local_minus_utc(
     result: &mut fmt::Formatter,
     off: FixedOffset,
@@ -748,7 +739,6 @@ pub(crate) fn write_rfc3339(
 }
 
 /// Writes the date, time and offset to the string. same as `%Y-%m-%dT%H:%M:%S%.f%:z`
-#[cfg(any(feature = "alloc", feature = "std", test))]
 pub(crate) fn write_rfc3339_inner(
     result: &mut fmt::Formatter,
     dt: crate::NaiveDateTime,
@@ -773,7 +763,6 @@ pub(crate) fn write_rfc2822(
     write!(result, "{}", formatter)
 }
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 /// write datetimes like `Tue, 1 Jul 2003 10:52:37 +0200`, same as `%a, %d %b %Y %H:%M:%S %z`
 fn write_rfc2822_inner(
     result: &mut fmt::Formatter,
@@ -822,7 +811,6 @@ pub(crate) fn write_hundreds(w: &mut impl Write, n: u8) -> fmt::Result {
 /// Tries to format given arguments with given formatting items.
 /// Internally used by `DelayedFormat`.
 #[cfg(any(feature = "alloc", feature = "std", test))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
 pub fn format<'a, I, B>(
     w: &mut fmt::Formatter,
     date: Option<&NaiveDate>,
@@ -851,8 +839,6 @@ pub mod strftime;
 
 /// A *temporary* object which can be used as an argument to `format!` or others.
 /// This is normally constructed via `format` methods of each date and time type.
-#[cfg(any(feature = "alloc", feature = "std", test))]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
 #[derive(Debug)]
 pub struct DelayedFormat<I> {
     /// The date view, if any.
@@ -870,7 +856,6 @@ pub struct DelayedFormat<I> {
     locale: Option<Locale>,
 }
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
     /// Makes a new `DelayedFormat` value out of local date and time.
     #[must_use]
@@ -939,7 +924,6 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
     }
 }
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> fmt::Display for DelayedFormat<I> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         #[cfg(not(feature = "unstable-locales"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! Default features:
 //!
-//! - `alloc`: Enable features that depend on allocation (primarily string formatting)
+//! - `alloc`: Enable features that depend on allocation (some formatting methods)
 //! - `std`: Enables functionality that depends on the standard library. This
 //!   is a superset of `alloc` and adds interoperation with standard library types
 //!   and traits.

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -3,7 +3,6 @@
 
 //! ISO 8601 calendar date without timezone.
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::iter::FusedIterator;
 use core::ops::{Add, AddAssign, RangeInclusive, Sub, SubAssign};
@@ -16,7 +15,6 @@ use rkyv::{Archive, Deserialize, Serialize};
 #[cfg(feature = "unstable-locales")]
 use pure_rust_locales::Locale;
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 use crate::format::DelayedFormat;
 use crate::format::{
     parse, parse_and_remainder, write_hundreds, Item, Numeric, Pad, ParseError, ParseResult,
@@ -1246,8 +1244,6 @@ impl NaiveDate {
     /// # let d = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap();
     /// assert_eq!(format!("{}", d.format_with_items(fmt)), "2015-09-05");
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
@@ -1290,8 +1286,6 @@ impl NaiveDate {
     /// assert_eq!(format!("{}", d.format("%Y-%m-%d")), "2015-09-05");
     /// assert_eq!(format!("{}", d.format("%A, %-d %B, %C%y")), "Saturday, 5 September, 2015");
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -3,7 +3,6 @@
 
 //! ISO 8601 date and time without timezone.
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::fmt::Write;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
@@ -12,7 +11,6 @@ use core::{fmt, str};
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 use crate::format::DelayedFormat;
 use crate::format::{parse, parse_and_remainder, ParseError, ParseResult, Parsed, StrftimeItems};
 use crate::format::{Fixed, Item, Numeric, Pad};
@@ -855,8 +853,6 @@ impl NaiveDateTime {
     /// # let dt = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
     /// assert_eq!(format!("{}", dt.format_with_items(fmt)), "2015-09-05 23:56:04");
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
@@ -899,8 +895,6 @@ impl NaiveDateTime {
     /// assert_eq!(format!("{}", dt.format("%Y-%m-%d %H:%M:%S")), "2015-09-05 23:56:04");
     /// assert_eq!(format!("{}", dt.format("around %l %p on %b %-d")), "around 11 PM on Sep 5");
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -3,7 +3,6 @@
 
 //! ISO 8601 time without timezone.
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::{fmt, str};
@@ -11,7 +10,6 @@ use core::{fmt, str};
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
 use crate::format::DelayedFormat;
 use crate::format::{
     parse, parse_and_remainder, write_hundreds, Fixed, Item, Numeric, Pad, ParseError, ParseResult,
@@ -746,8 +744,6 @@ impl NaiveTime {
     /// # let t = NaiveTime::from_hms_opt(23, 56, 4).unwrap();
     /// assert_eq!(format!("{}", t.format_with_items(fmt)), "23:56:04");
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]
     pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
@@ -792,8 +788,6 @@ impl NaiveTime {
     /// assert_eq!(format!("{}", t.format("%H:%M:%S%.6f")), "23:56:04.012345");
     /// assert_eq!(format!("{}", t.format("%-I:%M %p")), "11:56 PM");
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]
     pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {


### PR DESCRIPTION
It is possible to make the formatting methods available without the `alloc` feature with relatively little changes.

1. Format to `fmt::Formatter` instead of `String`. This means replacing `push_str()` with `write_str()?`, and replacing `push()` with `write_chr()?`.
2. When creating a `DelayedFormat` the timezone name is rendered to a `String`. I have replaced this with a fixed-size buffer of 63 bytes. It was slightly tricky to get the `Display` method of `Offset` to format into a byte buffer, that is what `TzName` is for.
3. `Display` can take some tricky formatting specifiers to justify/pad/truncate our formatting result. This is very difficult to do without rendering the intermediate result to a `String`. As solution I choose to render to an intermediate string in such a case in `Display::fmt`, and to ignore the specifiers in `no_std`.

Part 2 and 3 seem like a small price to pay for making all these methods available to `no_std` targets.

Previously `DelayedFormat` gave the impression it would work without allocations (also in the documentation), because 'why else would we have this type'? But the first thing it did was create a temporary string to write into :laughing:.