### PR TITLE
Added Ord and Eq traits for types, which already derives PartialOrd and PartialEq

### DIFF
--- a/src/month.rs
+++ b/src/month.rs
@@ -28,7 +28,7 @@ use crate::OutOfRange;
 /// Allows mapping from and to month, from 1-January to 12-December.
 /// Can be Serialized/Deserialized with serde
 // Actual implementation is zero-indexed, API intended as 1-indexed for more intuitive behavior.
-#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash, PartialOrd)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "rustc-serialize", derive(RustcEncodable, RustcDecodable))]
 #[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -218,7 +218,7 @@ impl num_traits::FromPrimitive for Month {
 }
 
 /// A duration in calendar months
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Months(pub(crate) u32);
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -137,7 +137,7 @@ impl NaiveWeek {
 /// that adding `Duration::days(1)` doesn't increment the day value as expected due to it being a
 /// fixed number of seconds. This difference applies only when dealing with `DateTime<TimeZone>` data types
 /// and in other cases `Duration::days(n)` and `Days::new(n)` are equivalent.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct Days(pub(crate) u64);
 
 impl Days {

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -268,7 +268,7 @@ const OL_TO_MDL: &[u8; MAX_OL as usize + 1] = &[
 /// which is an index to the `OL_TO_MDL` lookup table.
 ///
 /// The methods implemented on `Of` always return a valid value.
-#[derive(PartialEq, PartialOrd, Copy, Clone)]
+#[derive(PartialEq, PartialOrd, Copy, Clone, Ord, Eq)]
 pub(super) struct Of(u32);
 
 impl Of {
@@ -391,7 +391,7 @@ impl fmt::Debug for Of {
 /// The methods implemented on `Mdf` do not always return a valid value.
 /// Dates that can't exist, like February 30, can still be represented.
 /// Use `Mdl::valid` to check whether the date is valid.
-#[derive(PartialEq, PartialOrd, Copy, Clone)]
+#[derive(PartialEq, PartialOrd, Copy, Clone, Ord, Eq)]
 pub(super) struct Mdf(u32);
 
 impl Mdf {

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -268,7 +268,7 @@ const OL_TO_MDL: &[u8; MAX_OL as usize + 1] = &[
 /// which is an index to the `OL_TO_MDL` lookup table.
 ///
 /// The methods implemented on `Of` always return a valid value.
-#[derive(PartialEq, PartialOrd, Copy, Clone, Ord, Eq)]
+#[derive(PartialEq, PartialOrd, Copy, Clone)]
 pub(super) struct Of(u32);
 
 impl Of {
@@ -391,7 +391,7 @@ impl fmt::Debug for Of {
 /// The methods implemented on `Mdf` do not always return a valid value.
 /// Dates that can't exist, like February 30, can still be represented.
 /// Use `Mdl::valid` to check whether the date is valid.
-#[derive(PartialEq, PartialOrd, Copy, Clone, Ord, Eq)]
+#[derive(PartialEq, PartialOrd, Copy, Clone)]
 pub(super) struct Mdf(u32);
 
 impl Mdf {


### PR DESCRIPTION
It is generally a good idea to derive this traits in pairs (`PartialX` + `X`), unless explicitly inapplicable to the type under consideration.