### PR TITLE
Be slightly more strict around whitespace parsing

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -513,9 +513,24 @@ fn format_inner(
     let locale = Locales::new(locale);
 
     match *item {
-        Item::Literal(s) | Item::Space(s) => result.push_str(s),
+        Item::Literal(s) => result.push_str(s),
         #[cfg(any(feature = "alloc", feature = "std", test))]
-        Item::OwnedLiteral(ref s) | Item::OwnedSpace(ref s) => result.push_str(s),
+        Item::OwnedLiteral(ref s) => result.push_str(s),
+        Item::Space(s) => {
+            if s.is_empty() {
+                result.push(' ') // print an optional space
+            } else {
+                result.push_str(s)
+            }
+        }
+        #[cfg(any(feature = "alloc", feature = "std", test))]
+        Item::OwnedSpace(ref s) => {
+            if s.is_empty() {
+                result.push(' ') // print an optional space
+            } else {
+                result.push_str(s)
+            }
+        }
 
         Item::Numeric(ref spec, ref pad) => {
             use self::Numeric::*;

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -293,7 +293,8 @@ pub enum Item<'a> {
     #[cfg(any(feature = "alloc", feature = "std", test))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     OwnedLiteral(Box<str>),
-    /// Whitespace. Prints literally but reads zero or more whitespace.
+    /// Whitespace. Prints as a literal but reads one or more Unicode whitespaces.
+    /// If the string literal is "" this acts as an optional whitespace.
     Space(&'a str),
     /// Same as `Space` but with the string owned by the item.
     #[cfg(any(feature = "alloc", feature = "std", test))]

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -320,7 +320,15 @@ where
                 s = &s[prefix.len()..];
             }
 
-            Item::Space(_) => {
+            Item::Space(chars) => {
+                if !chars.is_empty() {
+                    // match at least one character
+                    match s.chars().next() {
+                        None => return Err((s, TOO_SHORT)),
+                        Some(c) if !c.is_whitespace() => return Err((s, INVALID)),
+                        Some(c) => s = &s[c.len_utf8()..],
+                    }
+                }
                 s = s.trim_start();
             }
 

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -379,28 +379,28 @@ where
             Item::Fixed(ref spec) => {
                 use super::Fixed::*;
 
-                match spec {
-                    &ShortMonthName => {
+                match *spec {
+                    ShortMonthName => {
                         let month0 = try_consume!(scan::short_month0(s));
                         parsed.set_month(i64::from(month0) + 1).map_err(|e| (s, e))?;
                     }
 
-                    &LongMonthName => {
+                    LongMonthName => {
                         let month0 = try_consume!(scan::short_or_long_month0(s));
                         parsed.set_month(i64::from(month0) + 1).map_err(|e| (s, e))?;
                     }
 
-                    &ShortWeekdayName => {
+                    ShortWeekdayName => {
                         let weekday = try_consume!(scan::short_weekday(s));
                         parsed.set_weekday(weekday).map_err(|e| (s, e))?;
                     }
 
-                    &LongWeekdayName => {
+                    LongWeekdayName => {
                         let weekday = try_consume!(scan::short_or_long_weekday(s));
                         parsed.set_weekday(weekday).map_err(|e| (s, e))?;
                     }
 
-                    &LowerAmPm | &UpperAmPm => {
+                    LowerAmPm | UpperAmPm => {
                         if s.len() < 2 {
                             return Err((s, TOO_SHORT));
                         }
@@ -413,14 +413,14 @@ where
                         s = &s[2..];
                     }
 
-                    &Nanosecond | &Nanosecond3 | &Nanosecond6 | &Nanosecond9 => {
+                    Nanosecond | Nanosecond3 | Nanosecond6 | Nanosecond9 => {
                         if s.starts_with('.') {
                             let nano = try_consume!(scan::nanosecond(&s[1..]));
                             parsed.set_nanosecond(nano).map_err(|e| (s, e))?;
                         }
                     }
 
-                    &Internal(InternalFixed { val: InternalInternal::Nanosecond3NoDot }) => {
+                    Internal(InternalFixed { val: InternalInternal::Nanosecond3NoDot }) => {
                         if s.len() < 3 {
                             return Err((s, TOO_SHORT));
                         }
@@ -428,7 +428,7 @@ where
                         parsed.set_nanosecond(nano).map_err(|e| (s, e))?;
                     }
 
-                    &Internal(InternalFixed { val: InternalInternal::Nanosecond6NoDot }) => {
+                    Internal(InternalFixed { val: InternalInternal::Nanosecond6NoDot }) => {
                         if s.len() < 6 {
                             return Err((s, TOO_SHORT));
                         }
@@ -436,7 +436,7 @@ where
                         parsed.set_nanosecond(nano).map_err(|e| (s, e))?;
                     }
 
-                    &Internal(InternalFixed { val: InternalInternal::Nanosecond9NoDot }) => {
+                    Internal(InternalFixed { val: InternalInternal::Nanosecond9NoDot }) => {
                         if s.len() < 9 {
                             return Err((s, TOO_SHORT));
                         }
@@ -444,14 +444,14 @@ where
                         parsed.set_nanosecond(nano).map_err(|e| (s, e))?;
                     }
 
-                    &TimezoneName => {
+                    TimezoneName => {
                         try_consume!(scan::timezone_name_skip(s));
                     }
 
-                    &TimezoneOffsetColon
-                    | &TimezoneOffsetDoubleColon
-                    | &TimezoneOffsetTripleColon
-                    | &TimezoneOffset => {
+                    TimezoneOffsetColon
+                    | TimezoneOffsetDoubleColon
+                    | TimezoneOffsetTripleColon
+                    | TimezoneOffset => {
                         let offset = try_consume!(scan::timezone_offset(
                             s.trim_start(),
                             scan::colon_or_space
@@ -459,16 +459,14 @@ where
                         parsed.set_offset(i64::from(offset)).map_err(|e| (s, e))?;
                     }
 
-                    &TimezoneOffsetColonZ | &TimezoneOffsetZ => {
+                    TimezoneOffsetColonZ | TimezoneOffsetZ => {
                         let offset = try_consume!(scan::timezone_offset_zulu(
                             s.trim_start(),
                             scan::colon_or_space
                         ));
                         parsed.set_offset(i64::from(offset)).map_err(|e| (s, e))?;
                     }
-                    &Internal(InternalFixed {
-                        val: InternalInternal::TimezoneOffsetPermissive,
-                    }) => {
+                    Internal(InternalFixed { val: InternalInternal::TimezoneOffsetPermissive }) => {
                         let offset = try_consume!(scan::timezone_offset_permissive(
                             s.trim_start(),
                             scan::colon_or_space
@@ -476,8 +474,8 @@ where
                         parsed.set_offset(i64::from(offset)).map_err(|e| (s, e))?;
                     }
 
-                    &RFC2822 => try_consume!(parse_rfc2822(parsed, s)),
-                    &RFC3339 => try_consume!(parse_rfc3339(parsed, s)),
+                    RFC2822 => try_consume!(parse_rfc2822(parsed, s)),
+                    RFC3339 => try_consume!(parse_rfc3339(parsed, s)),
                 }
             }
 

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -423,6 +423,7 @@ impl<'a> Iterator for StrftimeItems<'a> {
                             fix!(TimezoneOffset)
                         }
                     }
+                    ' ' => sp!(""),
                     '+' => fix!(RFC3339),
                     ':' => {
                         if self.remainder.starts_with("::z") {
@@ -549,7 +550,7 @@ mod tests {
         assert_eq!(parse_and_collect("%%%%"), [lit!("%"), lit!("%")]);
         assert_eq!(parse_and_collect("foo%?"), [Item::Error]);
         assert_eq!(parse_and_collect("bar%42"), [Item::Error]);
-        assert_eq!(parse_and_collect("quux% +"), [Item::Error]);
+        assert_eq!(parse_and_collect("quux%"), [Item::Error]);
         assert_eq!(parse_and_collect("%.Z"), [Item::Error]);
         assert_eq!(parse_and_collect("%:Z"), [Item::Error]);
         assert_eq!(parse_and_collect("%-Z"), [Item::Error]);
@@ -568,6 +569,9 @@ mod tests {
         assert_eq!(parse_and_collect("%z"), [fix!(TimezoneOffset)]);
         assert_eq!(parse_and_collect("%#z"), [internal_fix!(TimezoneOffsetPermissive)]);
         assert_eq!(parse_and_collect("%#m"), [Item::Error]);
+        assert_eq!(parse_and_collect("%t"), [sp!("\t")]);
+        assert_eq!(parse_and_collect("%n"), [sp!("\n")]);
+        assert_eq!(parse_and_collect("% "), [sp!("")]);
     }
 
     #[test]

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -82,8 +82,8 @@ The following specifiers are available both to formatting and parsing.
 | `%s`  | `994518299`   | UNIX timestamp, the number of seconds since 1970-01-01 00:00 UTC. [^6]|
 |       |          |                                                                            |
 |       |          | **SPECIAL SPECIFIERS:**                                                    |
-| `%t`  |          | Literal tab (`\t`).                                                        |
-| `%n`  |          | Literal newline (`\n`).                                                    |
+| `%t`  |          | Literal tab (`\t`), accepts any Unicode whitespace when parsing.           |
+| `%n`  |          | Literal newline (`\n`), accepts any Unicode whitespace when parsing.       |
 | `%%`  |          | Literal percent sign.                                                      |
 
 It is possible to override the default padding behavior of numeric specifiers `%?`.
@@ -96,6 +96,9 @@ Modifier | Description
 `%0?`    | Uses zeroes as a padding. (e.g. `%e` = ` 9`, `%0e` = `09`)
 
 Notes:
+
+One or more Unicode whitespace characters are considered one 'space'-item. When formatting it will
+be inserted as a string literal. When parsing it wil match one or more whitespaces.
 
 [^1]: `%C`, `%y`:
    This is floor division, so 100 BCE (year number -99) will print `-1` and `99` respectively.

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -404,7 +404,7 @@ impl<'a> Iterator for StrftimeItems<'a> {
                         num0!(Minute),
                         lit!(":"),
                         num0!(Second),
-                        sp!(" "),
+                        sp!(""),
                         fix!(UpperAmPm)
                     ],
                     's' => num!(Timestamp),

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -3017,7 +3017,7 @@ mod tests {
             Ok(ymd(2014, 5, 7))
         ); // ignore time and offset
         assert_eq!(
-            NaiveDate::parse_from_str("2015-W06-1=2015-033", "%G-W%V-%u = %Y-%j"),
+            NaiveDate::parse_from_str("2015-W06-1 = 2015-033", "%G-W%V-%u = %Y-%j"),
             Ok(ymd(2015, 2, 2))
         );
         assert_eq!(


### PR DESCRIPTION
https://github.com/chronotope/chrono/pull/807 made a couple of changes that weren't obvious to me on first glance.

I would like to introduce the changes one by one (but in my own way to be honest...)

When parsing, `Item::Space`…
- Previously accepted an unlimited number of Unicode whitespaces. It accepted zero number of whitespace characters. And the whitespace characters did not have to match that of the formatting string.
- After https://github.com/chronotope/chrono/pull/807 it only accepted the same literal as in the formatting string.
- With this PR will accept an unlimited number of Unicode whitespaces which do not have to match that of the formatting string. With the change that now there has to be at least *one* character.

That any whitespace in the formatting string would correspond to *optional* whitespace when parsing was een undocumented feature.

Some examples that were previously accepted:
- `"%a, %d %b %Y"` accepts `"Sat, 09 Aug 2013"` and `"Sat,09Aug2013"`
- `"%P %H:%M"` accepts `"PM 12:59"` and `"PM12:59"`
- `"%H:%M %P"` accepts `"12:59 AM"` and `"12:59AM"`
- `"%r"` accepts `"12:34:60 AM"`, `"12:34:60AM"`
- any spaces inside `%c`, the local date and time format, were optional.
- `"%F %T %Z"` accepts `"2001-07-08 00:34:60 UTC"` and `"2001-07-0800:34:60UTC"`

I would say that at least in some of these cases a user would not expect the string to parse.

The two cases where I would expect breakage are a space before the AM/PM suffix behind a time (`"%H:%M %P"`), and a space before the timezone abbreviation. To allow creating a formatting string that can parse such cases I made three more changes:

- A formatting specifier that can parse optional spaces: `% `. It will be encoded as `Item::Space("")`.
- Formatting will write a space for `Item::Space("")`, where it would write nothing before. This item could only be created manually before, not parsed from a formatting string. And I don't see a reason someone would write, as it did nothing when formatting.
- `%r` is changed to make the space between the time and AM/PM optional.