### PR TITLE
Small fixes to `NaiveDateDaysIterator` and `NaiveDateWeeksIterator`

### DIFF
--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -5,6 +5,7 @@
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
 use core::borrow::Borrow;
+use core::iter::FusedIterator;
 use core::ops::{Add, AddAssign, RangeInclusive, Sub, SubAssign};
 use core::{fmt, str};
 
@@ -2045,6 +2046,8 @@ impl DoubleEndedIterator for NaiveDateDaysIterator {
     }
 }
 
+impl FusedIterator for NaiveDateDaysIterator {}
+
 /// Iterator over `NaiveDate` with a step size of one week.
 #[derive(Debug, Copy, Clone, Hash, PartialEq, PartialOrd, Eq, Ord)]
 pub struct NaiveDateWeeksIterator {
@@ -2081,6 +2084,8 @@ impl DoubleEndedIterator for NaiveDateWeeksIterator {
         Some(current)
     }
 }
+
+impl FusedIterator for NaiveDateWeeksIterator {}
 
 // TODO: NaiveDateDaysIterator and NaiveDateWeeksIterator should implement FusedIterator,
 // TrustedLen, and Step once they becomes stable.

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -2076,10 +2076,6 @@ impl DoubleEndedIterator for NaiveDateWeeksIterator {
 
 impl FusedIterator for NaiveDateWeeksIterator {}
 
-// TODO: NaiveDateDaysIterator and NaiveDateWeeksIterator should implement FusedIterator,
-// TrustedLen, and Step once they becomes stable.
-// See: https://github.com/chronotope/chrono/issues/208
-
 /// The `Debug` output of the naive date `d` is the same as
 /// [`d.format("%Y-%m-%d")`](../format/strftime/index.html).
 ///

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -2045,6 +2045,7 @@ impl DoubleEndedIterator for NaiveDateDaysIterator {
     }
 }
 
+/// Iterator over `NaiveDate` with a step size of one week.
 #[derive(Debug, Copy, Clone, Hash, PartialEq, PartialOrd, Eq, Ord)]
 pub struct NaiveDateWeeksIterator {
     value: NaiveDate,

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -2017,13 +2017,10 @@ impl Iterator for NaiveDateDaysIterator {
     type Item = NaiveDate;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.value == NaiveDate::MAX {
-            return None;
-        }
-        // current < NaiveDate::MAX from here on:
+        // We return the current value, and have no way to return `NaiveDate::MAX`.
         let current = self.value;
         // This can't panic because current is < NaiveDate::MAX:
-        self.value = current.succ_opt().unwrap();
+        self.value = current.succ_opt()?;
         Some(current)
     }
 
@@ -2037,11 +2034,9 @@ impl ExactSizeIterator for NaiveDateDaysIterator {}
 
 impl DoubleEndedIterator for NaiveDateDaysIterator {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if self.value == NaiveDate::MIN {
-            return None;
-        }
+        // We return the current value, and have no way to return `NaiveDate::MIN`.
         let current = self.value;
-        self.value = current.pred_opt().unwrap();
+        self.value = current.pred_opt()?;
         Some(current)
     }
 }
@@ -2058,11 +2053,8 @@ impl Iterator for NaiveDateWeeksIterator {
     type Item = NaiveDate;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if NaiveDate::MAX - self.value < OldDuration::weeks(1) {
-            return None;
-        }
         let current = self.value;
-        self.value = current + OldDuration::weeks(1);
+        self.value = current.checked_add_signed(OldDuration::weeks(1))?;
         Some(current)
     }
 
@@ -2076,11 +2068,8 @@ impl ExactSizeIterator for NaiveDateWeeksIterator {}
 
 impl DoubleEndedIterator for NaiveDateWeeksIterator {
     fn next_back(&mut self) -> Option<Self::Item> {
-        if self.value - NaiveDate::MIN < OldDuration::weeks(1) {
-            return None;
-        }
         let current = self.value;
-        self.value = current - OldDuration::weeks(1);
+        self.value = current.checked_sub_signed(OldDuration::weeks(1))?;
         Some(current)
     }
 }

--- a/src/naive/mod.rs
+++ b/src/naive/mod.rs
@@ -10,8 +10,9 @@ mod internals;
 mod isoweek;
 mod time;
 
+pub use self::date::{Days, NaiveDate, NaiveDateDaysIterator, NaiveDateWeeksIterator, NaiveWeek};
 #[allow(deprecated)]
-pub use self::date::{Days, NaiveDate, NaiveWeek, MAX_DATE, MIN_DATE};
+pub use self::date::{MAX_DATE, MIN_DATE};
 #[cfg(feature = "rustc-serialize")]
 #[allow(deprecated)]
 pub use self::datetime::rustc_serialize::TsSeconds;


### PR DESCRIPTION
- These two iterators were not public enough (is that a thing?) to be named or to show up in the documentation. See https://github.com/chronotope/chrono/issues/597.
- They duplicated the logic in in `NaiveDate::succ_opt`, `NaiveDate::pred_opt`, and `NaiveDate::checked_(add|sub)_signed`, maybe they predated those methods?
- They can now implement `FusedIterator`, which has been stable since 1.26.
- I have removed the TODO about implementing `TrustedLen` and `Step`. It is also tracked in https://github.com/chronotope/chrono/issues/208. The `TrustedLen` trait ([tracking issue](https://github.com/rust-lang/rust/issues/37572)) and the `Step` trait ([tracking issue](https://github.com/rust-lang/rust/issues/42168)) haven't seen much progress towards stabilization in the past 6 years.

Fixes https://github.com/chronotope/chrono/issues/597.