### PR TITLE
Consider `%s` to be a timestamp in UTC

### DIFF
--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -603,6 +603,10 @@ fn test_datetime_parse_from_str() {
         Utc.datetime_from_str("Fri, 09 Aug 2013 23:54:35 GMT", "%a, %d %b %Y %H:%M:%S GMT"),
         Ok(Utc.with_ymd_and_hms(2013, 8, 9, 23, 54, 35).unwrap())
     );
+    assert_eq!(
+        DateTime::parse_from_str("0", "%s").unwrap(),
+        NaiveDateTime::from_timestamp_opt(0, 0).unwrap().and_utc().fixed_offset()
+    );
 }
 
 #[test]

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -627,7 +627,12 @@ impl Parsed {
     /// plus a time zone offset.
     /// Either way those fields have to be consistent to each other.
     pub fn to_datetime(&self) -> ParseResult<DateTime<FixedOffset>> {
-        let offset = self.offset.ok_or(NOT_ENOUGH)?;
+        // If there is no explicit offset, consider a timestamp value as indication of a UTC value.
+        let offset = match (self.offset, self.timestamp) {
+            (Some(off), _) => off,
+            (None, Some(_)) => 0, // UNIX timestamp may assume 0 offset
+            (None, None) => return Err(NOT_ENOUGH),
+        };
         let datetime = self.to_naive_datetime_with_offset(offset)?;
         let offset = FixedOffset::east_opt(offset).ok_or(OUT_OF_RANGE)?;
 


### PR DESCRIPTION
Everywhere in chrono we treat a Unix timestamp to be in UTC.
But when trying to parse a timestamp with `%s` to a `DateTime` it used to fail because there was no offset supplied.

We now fall back to an offset of `0` if there is a timestamp and no other offset.

Fixes https://github.com/chronotope/chrono/issues/214.