### PR TITLE
Duration features

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -16,6 +16,8 @@ use core::{fmt, i64};
 #[cfg(feature = "std")]
 use std::error::Error;
 
+use crate::try_opt;
+
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -37,15 +39,6 @@ const SECS_PER_HOUR: i64 = 3600;
 const SECS_PER_DAY: i64 = 86_400;
 /// The number of (non-leap) seconds in a week.
 const SECS_PER_WEEK: i64 = 604_800;
-
-macro_rules! try_opt {
-    ($e:expr) => {
-        match $e {
-            Some(v) => v,
-            None => return None,
-        }
-    };
-}
 
 /// ISO 8601 time duration with nanosecond precision.
 ///

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -791,4 +791,38 @@ mod tests {
             Err(OutOfRangeError(()))
         );
     }
+
+    #[test]
+    fn test_duration_const() {
+        const ONE_WEEK: Duration = Duration::weeks(1);
+        const ONE_DAY: Duration = Duration::days(1);
+        const ONE_HOUR: Duration = Duration::hours(1);
+        const ONE_MINUTE: Duration = Duration::minutes(1);
+        const ONE_SECOND: Duration = Duration::seconds(1);
+        const ONE_MILLI: Duration = Duration::milliseconds(1);
+        const ONE_MICRO: Duration = Duration::microseconds(1);
+        const ONE_NANO: Duration = Duration::nanoseconds(1);
+        let combo: Duration = ONE_WEEK
+            + ONE_DAY
+            + ONE_HOUR
+            + ONE_MINUTE
+            + ONE_SECOND
+            + ONE_MILLI
+            + ONE_MICRO
+            + ONE_NANO;
+
+        assert!(ONE_WEEK != Duration::zero());
+        assert!(ONE_DAY != Duration::zero());
+        assert!(ONE_HOUR != Duration::zero());
+        assert!(ONE_MINUTE != Duration::zero());
+        assert!(ONE_SECOND != Duration::zero());
+        assert!(ONE_MILLI != Duration::zero());
+        assert!(ONE_MICRO != Duration::zero());
+        assert!(ONE_NANO != Duration::zero());
+        assert_eq!(
+            combo,
+            Duration::seconds(86400 * 7 + 86400 + 3600 + 60 + 1)
+                + Duration::nanoseconds(1 + 1_000 + 1_000_000)
+        );
+    }
 }

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -67,6 +67,23 @@ pub(crate) const MAX: Duration = Duration {
 };
 
 impl Duration {
+    /// Makes a new `Duration` with given number of seconds and nanoseconds.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` when the duration is out of bounds, or if `nanos` ≥ 1,000,000,000.
+    pub(crate) const fn new(secs: i64, nanos: u32) -> Option<Duration> {
+        if secs < MIN.secs
+            || secs > MAX.secs
+            || nanos > 1_000_000_000
+            || (secs == MAX.secs && nanos > MAX.nanos as u32)
+            || (secs == MIN.secs && nanos < MIN.nanos as u32)
+        {
+            return None;
+        }
+        Some(Duration { secs, nanos: nanos as i32 })
+    }
+
     /// Makes a new `Duration` with given number of weeks.
     /// Equivalent to `Duration::seconds(weeks * 7 * 24 * 60 * 60)` with overflow checks.
     /// Panics when the duration is out of bounds.

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -1194,7 +1194,7 @@ impl Add<Duration> for NaiveTime {
         // overflow during the conversion to `chrono::Duration`.
         // But we limit to double that just in case `self` is a leap-second.
         let secs = rhs.as_secs() % (2 * 24 * 60 * 60);
-        let d = OldDuration::from_std(Duration::new(secs, rhs.subsec_nanos())).unwrap();
+        let d = OldDuration::new(secs as i64, rhs.subsec_nanos()).unwrap();
         self.overflowing_add_signed(d).0
     }
 }
@@ -1304,7 +1304,7 @@ impl Sub<Duration> for NaiveTime {
         // overflow during the conversion to `chrono::Duration`.
         // But we limit to double that just in case `self` is a leap-second.
         let secs = rhs.as_secs() % (2 * 24 * 60 * 60);
-        let d = OldDuration::from_std(Duration::new(secs, rhs.subsec_nanos())).unwrap();
+        let d = OldDuration::new(secs as i64, rhs.subsec_nanos()).unwrap();
         self.overflowing_sub_signed(d).0
     }
 }


### PR DESCRIPTION
If we drop time 0.1 compatibility in https://github.com/chronotope/chrono/pull/1095 it would be nice if we could also take care of some of the wishlist items for `Duration`.

- Derive `Default`: https://github.com/chronotope/chrono/issues/717
- Add a `subsec_nanos` method: https://github.com/chronotope/chrono/issues/154
- Add `try_*` builders: https://github.com/chronotope/chrono/pull/941
- Implement `AddAssign` and `SubAssign`: https://github.com/chronotope/chrono/issues/1054

Three features that would be more involved and not part of this PR are:
- Parsing: https://github.com/chronotope/chrono/issues/579
- Format `Duration`: https://github.com/chronotope/chrono/issues/197
- Serde: https://github.com/chronotope/chrono/issues/117

Making the remaining methods const (https://github.com/chronotope/chrono/issues/309, https://github.com/chronotope/chrono/pull/638) would depend on raising the MSRV as in https://github.com/chronotope/chrono/pull/1080.

Based on https://github.com/chronotope/chrono/pull/1095.