### PR TITLE
Move all tests into modules, fix clippy warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,9 +17,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --check -- --color=always
       - run: cargo fmt --check --manifest-path fuzz/Cargo.toml
-      - run: cargo clippy --color=always -- -D warnings
       - run: |
-          cargo clippy --color=always --target x86_64-pc-windows-msvc \
+          cargo clippy --all-features --all-targets --color=always \
             -- -D warnings
       - run: |
           cargo clippy --manifest-path fuzz/Cargo.toml --color=always \

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1423,34 +1423,6 @@ where
     }
 }
 
-#[test]
-fn test_add_sub_months() {
-    let utc_dt = Utc.with_ymd_and_hms(2018, 9, 5, 23, 58, 0).unwrap();
-    assert_eq!(utc_dt + Months::new(15), Utc.with_ymd_and_hms(2019, 12, 5, 23, 58, 0).unwrap());
-
-    let utc_dt = Utc.with_ymd_and_hms(2020, 1, 31, 23, 58, 0).unwrap();
-    assert_eq!(utc_dt + Months::new(1), Utc.with_ymd_and_hms(2020, 2, 29, 23, 58, 0).unwrap());
-    assert_eq!(utc_dt + Months::new(2), Utc.with_ymd_and_hms(2020, 3, 31, 23, 58, 0).unwrap());
-
-    let utc_dt = Utc.with_ymd_and_hms(2018, 9, 5, 23, 58, 0).unwrap();
-    assert_eq!(utc_dt - Months::new(15), Utc.with_ymd_and_hms(2017, 6, 5, 23, 58, 0).unwrap());
-
-    let utc_dt = Utc.with_ymd_and_hms(2020, 3, 31, 23, 58, 0).unwrap();
-    assert_eq!(utc_dt - Months::new(1), Utc.with_ymd_and_hms(2020, 2, 29, 23, 58, 0).unwrap());
-    assert_eq!(utc_dt - Months::new(2), Utc.with_ymd_and_hms(2020, 1, 31, 23, 58, 0).unwrap());
-}
-
-#[test]
-fn test_auto_conversion() {
-    let utc_dt = Utc.with_ymd_and_hms(2018, 9, 5, 23, 58, 0).unwrap();
-    let cdt_dt = FixedOffset::west_opt(5 * 60 * 60)
-        .unwrap()
-        .with_ymd_and_hms(2018, 9, 5, 18, 58, 0)
-        .unwrap();
-    let utc_dt2: DateTime<Utc> = cdt_dt.into();
-    assert_eq!(utc_dt, utc_dt2);
-}
-
 #[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
 fn test_encodable_json<FUtc, FFixed, E>(to_string_utc: FUtc, to_string_fixed: FFixed)
 where

--- a/src/datetime/rustc_serialize.rs
+++ b/src/datetime/rustc_serialize.rs
@@ -103,21 +103,25 @@ impl Decodable for TsSeconds<Local> {
 }
 
 #[cfg(test)]
-use rustc_serialize::json;
+mod tests {
+    use crate::datetime::test_encodable_json;
+    use crate::datetime::{test_decodable_json, test_decodable_json_timestamps};
+    use rustc_serialize::json;
 
-#[test]
-fn test_encodable() {
-    super::test_encodable_json(json::encode, json::encode);
-}
+    #[test]
+    fn test_encodable() {
+        test_encodable_json(json::encode, json::encode);
+    }
 
-#[cfg(feature = "clock")]
-#[test]
-fn test_decodable() {
-    super::test_decodable_json(json::decode, json::decode, json::decode);
-}
+    #[cfg(feature = "clock")]
+    #[test]
+    fn test_decodable() {
+        test_decodable_json(json::decode, json::decode, json::decode);
+    }
 
-#[cfg(feature = "clock")]
-#[test]
-fn test_decodable_timestamps() {
-    super::test_decodable_json_timestamps(json::decode, json::decode, json::decode);
+    #[cfg(feature = "clock")]
+    #[test]
+    fn test_decodable_timestamps() {
+        test_decodable_json_timestamps(json::decode, json::decode, json::decode);
+    }
 }

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -1128,30 +1128,36 @@ pub mod ts_seconds_option {
     }
 }
 
-#[test]
-fn test_serde_serialize() {
-    super::test_encodable_json(serde_json::to_string, serde_json::to_string);
-}
+#[cfg(test)]
+mod tests {
+    use crate::datetime::{test_decodable_json, test_encodable_json};
+    use crate::{DateTime, TimeZone, Utc};
 
-#[cfg(feature = "clock")]
-#[test]
-fn test_serde_deserialize() {
-    super::test_decodable_json(
-        |input| serde_json::from_str(input),
-        |input| serde_json::from_str(input),
-        |input| serde_json::from_str(input),
-    );
-}
+    #[test]
+    fn test_serde_serialize() {
+        test_encodable_json(serde_json::to_string, serde_json::to_string);
+    }
 
-#[test]
-fn test_serde_bincode() {
-    // Bincode is relevant to test separately from JSON because
-    // it is not self-describing.
-    use bincode::{deserialize, serialize};
+    #[cfg(feature = "clock")]
+    #[test]
+    fn test_serde_deserialize() {
+        test_decodable_json(
+            |input| serde_json::from_str(input),
+            |input| serde_json::from_str(input),
+            |input| serde_json::from_str(input),
+        );
+    }
 
-    let dt = Utc.with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap();
-    let encoded = serialize(&dt).unwrap();
-    let decoded: DateTime<Utc> = deserialize(&encoded).unwrap();
-    assert_eq!(dt, decoded);
-    assert_eq!(dt.offset(), decoded.offset());
+    #[test]
+    fn test_serde_bincode() {
+        // Bincode is relevant to test separately from JSON because
+        // it is not self-describing.
+        use bincode::{deserialize, serialize};
+
+        let dt = Utc.with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap();
+        let encoded = serialize(&dt).unwrap();
+        let decoded: DateTime<Utc> = deserialize(&encoded).unwrap();
+        assert_eq!(dt, decoded);
+        assert_eq!(dt.offset(), decoded.offset());
+    }
 }

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -174,7 +174,6 @@ pub mod ts_nanoseconds {
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -202,7 +201,6 @@ pub mod ts_nanoseconds {
     /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1526522699, 918355733).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -299,7 +297,6 @@ pub mod ts_nanoseconds_option {
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -330,7 +327,6 @@ pub mod ts_nanoseconds_option {
     /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1526522699, 918355733).single() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -431,7 +427,6 @@ pub mod ts_microseconds {
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -459,7 +454,6 @@ pub mod ts_microseconds {
     /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1526522699, 918355000).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -555,7 +549,6 @@ pub mod ts_microseconds_option {
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -586,7 +579,6 @@ pub mod ts_microseconds_option {
     /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1526522699, 918355000).single() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -687,7 +679,6 @@ pub mod ts_milliseconds {
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -715,7 +706,6 @@ pub mod ts_milliseconds {
     /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1526522699, 918000000).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -808,7 +798,6 @@ pub mod ts_milliseconds_option {
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -850,7 +839,6 @@ pub mod ts_milliseconds_option {
     /// assert_eq!(t, E::V(S { time: None }));
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -952,7 +940,6 @@ pub mod ts_seconds {
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(dt: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -980,7 +967,6 @@ pub mod ts_seconds {
     /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1431684000, 0).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -1070,7 +1056,6 @@ pub mod ts_seconds_option {
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(opt: &Option<DateTime<Utc>>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -1101,7 +1086,6 @@ pub mod ts_seconds_option {
     /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1431684000, 0).single() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
     where
         D: de::Deserializer<'de>,

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -314,6 +314,7 @@ fn test_datetime_offset() {
 }
 
 #[test]
+#[allow(clippy::needless_borrow, clippy::op_ref)]
 fn signed_duration_since_autoref() {
     let dt1 = Utc.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap();
     let dt2 = Utc.with_ymd_and_hms(2014, 3, 4, 5, 6, 7).unwrap();

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1027,3 +1027,31 @@ fn test_datetime_fixed_offset() {
     let datetime_fixed = fixed_offset.from_local_datetime(&naivedatetime).unwrap();
     assert_eq!(datetime_fixed.fixed_offset(), datetime_fixed);
 }
+
+#[test]
+fn test_add_sub_months() {
+    let utc_dt = Utc.with_ymd_and_hms(2018, 9, 5, 23, 58, 0).unwrap();
+    assert_eq!(utc_dt + Months::new(15), Utc.with_ymd_and_hms(2019, 12, 5, 23, 58, 0).unwrap());
+
+    let utc_dt = Utc.with_ymd_and_hms(2020, 1, 31, 23, 58, 0).unwrap();
+    assert_eq!(utc_dt + Months::new(1), Utc.with_ymd_and_hms(2020, 2, 29, 23, 58, 0).unwrap());
+    assert_eq!(utc_dt + Months::new(2), Utc.with_ymd_and_hms(2020, 3, 31, 23, 58, 0).unwrap());
+
+    let utc_dt = Utc.with_ymd_and_hms(2018, 9, 5, 23, 58, 0).unwrap();
+    assert_eq!(utc_dt - Months::new(15), Utc.with_ymd_and_hms(2017, 6, 5, 23, 58, 0).unwrap());
+
+    let utc_dt = Utc.with_ymd_and_hms(2020, 3, 31, 23, 58, 0).unwrap();
+    assert_eq!(utc_dt - Months::new(1), Utc.with_ymd_and_hms(2020, 2, 29, 23, 58, 0).unwrap());
+    assert_eq!(utc_dt - Months::new(2), Utc.with_ymd_and_hms(2020, 1, 31, 23, 58, 0).unwrap());
+}
+
+#[test]
+fn test_auto_conversion() {
+    let utc_dt = Utc.with_ymd_and_hms(2018, 9, 5, 23, 58, 0).unwrap();
+    let cdt_dt = FixedOffset::west_opt(5 * 60 * 60)
+        .unwrap()
+        .with_ymd_and_hms(2018, 9, 5, 18, 58, 0)
+        .unwrap();
+    let utc_dt2: DateTime<Utc> = cdt_dt.into();
+    assert_eq!(utc_dt, utc_dt2);
+}

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -994,12 +994,12 @@ impl FromStr for Weekday {
 /// Formats single formatting item
 #[cfg(feature = "unstable-locales")]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
-pub fn format_item_localized<'a>(
+pub fn format_item_localized(
     w: &mut fmt::Formatter,
     date: Option<&NaiveDate>,
     time: Option<&NaiveTime>,
     off: Option<&(String, FixedOffset)>,
-    item: &Item<'a>,
+    item: &Item<'_>,
     locale: Locale,
 ) -> fmt::Result {
     let mut result = String::new();

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -671,14 +671,14 @@ fn test_strftime_docs() {
 #[cfg(feature = "unstable-locales")]
 #[test]
 fn test_strftime_docs_localized() {
-    use crate::{FixedOffset, NaiveDate, TimeZone};
+    use crate::{FixedOffset, NaiveDate, TimeZone, Timelike};
 
-    let dt = FixedOffset::east_opt(34200).unwrap().ymd_opt(2001, 7, 8).unwrap().and_hms_nano(
-        0,
-        34,
-        59,
-        1_026_490_708,
-    );
+    let dt = FixedOffset::east_opt(34200)
+        .unwrap()
+        .with_ymd_and_hms(2001, 7, 8, 0, 34, 59)
+        .unwrap()
+        .with_nanosecond(1_026_490_708)
+        .unwrap();
 
     // date specifiers
     assert_eq!(dt.format_localized("%b", Locale::fr_BE).to_string(), "jui");

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -509,212 +509,213 @@ impl<'a> Iterator for StrftimeItems<'a> {
 }
 
 #[cfg(test)]
-#[test]
-fn test_strftime_items() {
-    fn parse_and_collect(s: &str) -> Vec<Item<'_>> {
-        // map any error into `[Item::Error]`. useful for easy testing.
-        let items = StrftimeItems::new(s);
-        let items = items.map(|spec| if spec == Item::Error { None } else { Some(spec) });
-        items.collect::<Option<Vec<_>>>().unwrap_or_else(|| vec![Item::Error])
+mod tests {
+    #[cfg(feature = "unstable-locales")]
+    use super::Locale;
+    use super::{Fixed, InternalFixed, InternalInternal, Item, Numeric, Pad, StrftimeItems};
+    use crate::{DateTime, FixedOffset, NaiveDate, TimeZone, Timelike, Utc};
+
+    #[test]
+    fn test_strftime_items() {
+        fn parse_and_collect(s: &str) -> Vec<Item<'_>> {
+            // map any error into `[Item::Error]`. useful for easy testing.
+            let items = StrftimeItems::new(s);
+            let items = items.map(|spec| if spec == Item::Error { None } else { Some(spec) });
+            items.collect::<Option<Vec<_>>>().unwrap_or_else(|| vec![Item::Error])
+        }
+
+        assert_eq!(parse_and_collect(""), []);
+        assert_eq!(parse_and_collect(" \t\n\r "), [sp!(" \t\n\r ")]);
+        assert_eq!(parse_and_collect("hello?"), [lit!("hello?")]);
+        assert_eq!(
+            parse_and_collect("a  b\t\nc"),
+            [lit!("a"), sp!("  "), lit!("b"), sp!("\t\n"), lit!("c")]
+        );
+        assert_eq!(parse_and_collect("100%%"), [lit!("100"), lit!("%")]);
+        assert_eq!(parse_and_collect("100%% ok"), [lit!("100"), lit!("%"), sp!(" "), lit!("ok")]);
+        assert_eq!(parse_and_collect("%%PDF-1.0"), [lit!("%"), lit!("PDF-1.0")]);
+        assert_eq!(
+            parse_and_collect("%Y-%m-%d"),
+            [num0!(Year), lit!("-"), num0!(Month), lit!("-"), num0!(Day)]
+        );
+        assert_eq!(parse_and_collect("[%F]"), parse_and_collect("[%Y-%m-%d]"));
+        assert_eq!(parse_and_collect("%m %d"), [num0!(Month), sp!(" "), num0!(Day)]);
+        assert_eq!(parse_and_collect("%"), [Item::Error]);
+        assert_eq!(parse_and_collect("%%"), [lit!("%")]);
+        assert_eq!(parse_and_collect("%%%"), [Item::Error]);
+        assert_eq!(parse_and_collect("%%%%"), [lit!("%"), lit!("%")]);
+        assert_eq!(parse_and_collect("foo%?"), [Item::Error]);
+        assert_eq!(parse_and_collect("bar%42"), [Item::Error]);
+        assert_eq!(parse_and_collect("quux% +"), [Item::Error]);
+        assert_eq!(parse_and_collect("%.Z"), [Item::Error]);
+        assert_eq!(parse_and_collect("%:Z"), [Item::Error]);
+        assert_eq!(parse_and_collect("%-Z"), [Item::Error]);
+        assert_eq!(parse_and_collect("%0Z"), [Item::Error]);
+        assert_eq!(parse_and_collect("%_Z"), [Item::Error]);
+        assert_eq!(parse_and_collect("%.j"), [Item::Error]);
+        assert_eq!(parse_and_collect("%:j"), [Item::Error]);
+        assert_eq!(parse_and_collect("%-j"), [num!(Ordinal)]);
+        assert_eq!(parse_and_collect("%0j"), [num0!(Ordinal)]);
+        assert_eq!(parse_and_collect("%_j"), [nums!(Ordinal)]);
+        assert_eq!(parse_and_collect("%.e"), [Item::Error]);
+        assert_eq!(parse_and_collect("%:e"), [Item::Error]);
+        assert_eq!(parse_and_collect("%-e"), [num!(Day)]);
+        assert_eq!(parse_and_collect("%0e"), [num0!(Day)]);
+        assert_eq!(parse_and_collect("%_e"), [nums!(Day)]);
+        assert_eq!(parse_and_collect("%z"), [fix!(TimezoneOffset)]);
+        assert_eq!(parse_and_collect("%#z"), [internal_fix!(TimezoneOffsetPermissive)]);
+        assert_eq!(parse_and_collect("%#m"), [Item::Error]);
     }
 
-    assert_eq!(parse_and_collect(""), []);
-    assert_eq!(parse_and_collect(" \t\n\r "), [sp!(" \t\n\r ")]);
-    assert_eq!(parse_and_collect("hello?"), [lit!("hello?")]);
-    assert_eq!(
-        parse_and_collect("a  b\t\nc"),
-        [lit!("a"), sp!("  "), lit!("b"), sp!("\t\n"), lit!("c")]
-    );
-    assert_eq!(parse_and_collect("100%%"), [lit!("100"), lit!("%")]);
-    assert_eq!(parse_and_collect("100%% ok"), [lit!("100"), lit!("%"), sp!(" "), lit!("ok")]);
-    assert_eq!(parse_and_collect("%%PDF-1.0"), [lit!("%"), lit!("PDF-1.0")]);
-    assert_eq!(
-        parse_and_collect("%Y-%m-%d"),
-        [num0!(Year), lit!("-"), num0!(Month), lit!("-"), num0!(Day)]
-    );
-    assert_eq!(parse_and_collect("[%F]"), parse_and_collect("[%Y-%m-%d]"));
-    assert_eq!(parse_and_collect("%m %d"), [num0!(Month), sp!(" "), num0!(Day)]);
-    assert_eq!(parse_and_collect("%"), [Item::Error]);
-    assert_eq!(parse_and_collect("%%"), [lit!("%")]);
-    assert_eq!(parse_and_collect("%%%"), [Item::Error]);
-    assert_eq!(parse_and_collect("%%%%"), [lit!("%"), lit!("%")]);
-    assert_eq!(parse_and_collect("foo%?"), [Item::Error]);
-    assert_eq!(parse_and_collect("bar%42"), [Item::Error]);
-    assert_eq!(parse_and_collect("quux% +"), [Item::Error]);
-    assert_eq!(parse_and_collect("%.Z"), [Item::Error]);
-    assert_eq!(parse_and_collect("%:Z"), [Item::Error]);
-    assert_eq!(parse_and_collect("%-Z"), [Item::Error]);
-    assert_eq!(parse_and_collect("%0Z"), [Item::Error]);
-    assert_eq!(parse_and_collect("%_Z"), [Item::Error]);
-    assert_eq!(parse_and_collect("%.j"), [Item::Error]);
-    assert_eq!(parse_and_collect("%:j"), [Item::Error]);
-    assert_eq!(parse_and_collect("%-j"), [num!(Ordinal)]);
-    assert_eq!(parse_and_collect("%0j"), [num0!(Ordinal)]);
-    assert_eq!(parse_and_collect("%_j"), [nums!(Ordinal)]);
-    assert_eq!(parse_and_collect("%.e"), [Item::Error]);
-    assert_eq!(parse_and_collect("%:e"), [Item::Error]);
-    assert_eq!(parse_and_collect("%-e"), [num!(Day)]);
-    assert_eq!(parse_and_collect("%0e"), [num0!(Day)]);
-    assert_eq!(parse_and_collect("%_e"), [nums!(Day)]);
-    assert_eq!(parse_and_collect("%z"), [fix!(TimezoneOffset)]);
-    assert_eq!(parse_and_collect("%#z"), [internal_fix!(TimezoneOffsetPermissive)]);
-    assert_eq!(parse_and_collect("%#m"), [Item::Error]);
-}
+    #[test]
+    fn test_strftime_docs() {
+        let dt = FixedOffset::east_opt(34200)
+            .unwrap()
+            .from_local_datetime(
+                &NaiveDate::from_ymd_opt(2001, 7, 8)
+                    .unwrap()
+                    .and_hms_nano_opt(0, 34, 59, 1_026_490_708)
+                    .unwrap(),
+            )
+            .unwrap();
 
-#[cfg(test)]
-#[test]
-fn test_strftime_docs() {
-    use crate::NaiveDate;
-    use crate::{DateTime, FixedOffset, TimeZone, Timelike, Utc};
+        // date specifiers
+        assert_eq!(dt.format("%Y").to_string(), "2001");
+        assert_eq!(dt.format("%C").to_string(), "20");
+        assert_eq!(dt.format("%y").to_string(), "01");
+        assert_eq!(dt.format("%m").to_string(), "07");
+        assert_eq!(dt.format("%b").to_string(), "Jul");
+        assert_eq!(dt.format("%B").to_string(), "July");
+        assert_eq!(dt.format("%h").to_string(), "Jul");
+        assert_eq!(dt.format("%d").to_string(), "08");
+        assert_eq!(dt.format("%e").to_string(), " 8");
+        assert_eq!(dt.format("%e").to_string(), dt.format("%_d").to_string());
+        assert_eq!(dt.format("%a").to_string(), "Sun");
+        assert_eq!(dt.format("%A").to_string(), "Sunday");
+        assert_eq!(dt.format("%w").to_string(), "0");
+        assert_eq!(dt.format("%u").to_string(), "7");
+        assert_eq!(dt.format("%U").to_string(), "27");
+        assert_eq!(dt.format("%W").to_string(), "27");
+        assert_eq!(dt.format("%G").to_string(), "2001");
+        assert_eq!(dt.format("%g").to_string(), "01");
+        assert_eq!(dt.format("%V").to_string(), "27");
+        assert_eq!(dt.format("%j").to_string(), "189");
+        assert_eq!(dt.format("%D").to_string(), "07/08/01");
+        assert_eq!(dt.format("%x").to_string(), "07/08/01");
+        assert_eq!(dt.format("%F").to_string(), "2001-07-08");
+        assert_eq!(dt.format("%v").to_string(), " 8-Jul-2001");
 
-    let dt = FixedOffset::east_opt(34200)
-        .unwrap()
-        .from_local_datetime(
-            &NaiveDate::from_ymd_opt(2001, 7, 8)
-                .unwrap()
-                .and_hms_nano_opt(0, 34, 59, 1_026_490_708)
-                .unwrap(),
-        )
-        .unwrap();
+        // time specifiers
+        assert_eq!(dt.format("%H").to_string(), "00");
+        assert_eq!(dt.format("%k").to_string(), " 0");
+        assert_eq!(dt.format("%k").to_string(), dt.format("%_H").to_string());
+        assert_eq!(dt.format("%I").to_string(), "12");
+        assert_eq!(dt.format("%l").to_string(), "12");
+        assert_eq!(dt.format("%l").to_string(), dt.format("%_I").to_string());
+        assert_eq!(dt.format("%P").to_string(), "am");
+        assert_eq!(dt.format("%p").to_string(), "AM");
+        assert_eq!(dt.format("%M").to_string(), "34");
+        assert_eq!(dt.format("%S").to_string(), "60");
+        assert_eq!(dt.format("%f").to_string(), "026490708");
+        assert_eq!(dt.format("%.f").to_string(), ".026490708");
+        assert_eq!(dt.with_nanosecond(1_026_490_000).unwrap().format("%.f").to_string(), ".026490");
+        assert_eq!(dt.format("%.3f").to_string(), ".026");
+        assert_eq!(dt.format("%.6f").to_string(), ".026490");
+        assert_eq!(dt.format("%.9f").to_string(), ".026490708");
+        assert_eq!(dt.format("%3f").to_string(), "026");
+        assert_eq!(dt.format("%6f").to_string(), "026490");
+        assert_eq!(dt.format("%9f").to_string(), "026490708");
+        assert_eq!(dt.format("%R").to_string(), "00:34");
+        assert_eq!(dt.format("%T").to_string(), "00:34:60");
+        assert_eq!(dt.format("%X").to_string(), "00:34:60");
+        assert_eq!(dt.format("%r").to_string(), "12:34:60 AM");
 
-    // date specifiers
-    assert_eq!(dt.format("%Y").to_string(), "2001");
-    assert_eq!(dt.format("%C").to_string(), "20");
-    assert_eq!(dt.format("%y").to_string(), "01");
-    assert_eq!(dt.format("%m").to_string(), "07");
-    assert_eq!(dt.format("%b").to_string(), "Jul");
-    assert_eq!(dt.format("%B").to_string(), "July");
-    assert_eq!(dt.format("%h").to_string(), "Jul");
-    assert_eq!(dt.format("%d").to_string(), "08");
-    assert_eq!(dt.format("%e").to_string(), " 8");
-    assert_eq!(dt.format("%e").to_string(), dt.format("%_d").to_string());
-    assert_eq!(dt.format("%a").to_string(), "Sun");
-    assert_eq!(dt.format("%A").to_string(), "Sunday");
-    assert_eq!(dt.format("%w").to_string(), "0");
-    assert_eq!(dt.format("%u").to_string(), "7");
-    assert_eq!(dt.format("%U").to_string(), "27");
-    assert_eq!(dt.format("%W").to_string(), "27");
-    assert_eq!(dt.format("%G").to_string(), "2001");
-    assert_eq!(dt.format("%g").to_string(), "01");
-    assert_eq!(dt.format("%V").to_string(), "27");
-    assert_eq!(dt.format("%j").to_string(), "189");
-    assert_eq!(dt.format("%D").to_string(), "07/08/01");
-    assert_eq!(dt.format("%x").to_string(), "07/08/01");
-    assert_eq!(dt.format("%F").to_string(), "2001-07-08");
-    assert_eq!(dt.format("%v").to_string(), " 8-Jul-2001");
+        // time zone specifiers
+        //assert_eq!(dt.format("%Z").to_string(), "ACST");
+        assert_eq!(dt.format("%z").to_string(), "+0930");
+        assert_eq!(dt.format("%:z").to_string(), "+09:30");
+        assert_eq!(dt.format("%::z").to_string(), "+09:30:00");
+        assert_eq!(dt.format("%:::z").to_string(), "+09");
 
-    // time specifiers
-    assert_eq!(dt.format("%H").to_string(), "00");
-    assert_eq!(dt.format("%k").to_string(), " 0");
-    assert_eq!(dt.format("%k").to_string(), dt.format("%_H").to_string());
-    assert_eq!(dt.format("%I").to_string(), "12");
-    assert_eq!(dt.format("%l").to_string(), "12");
-    assert_eq!(dt.format("%l").to_string(), dt.format("%_I").to_string());
-    assert_eq!(dt.format("%P").to_string(), "am");
-    assert_eq!(dt.format("%p").to_string(), "AM");
-    assert_eq!(dt.format("%M").to_string(), "34");
-    assert_eq!(dt.format("%S").to_string(), "60");
-    assert_eq!(dt.format("%f").to_string(), "026490708");
-    assert_eq!(dt.format("%.f").to_string(), ".026490708");
-    assert_eq!(dt.with_nanosecond(1_026_490_000).unwrap().format("%.f").to_string(), ".026490");
-    assert_eq!(dt.format("%.3f").to_string(), ".026");
-    assert_eq!(dt.format("%.6f").to_string(), ".026490");
-    assert_eq!(dt.format("%.9f").to_string(), ".026490708");
-    assert_eq!(dt.format("%3f").to_string(), "026");
-    assert_eq!(dt.format("%6f").to_string(), "026490");
-    assert_eq!(dt.format("%9f").to_string(), "026490708");
-    assert_eq!(dt.format("%R").to_string(), "00:34");
-    assert_eq!(dt.format("%T").to_string(), "00:34:60");
-    assert_eq!(dt.format("%X").to_string(), "00:34:60");
-    assert_eq!(dt.format("%r").to_string(), "12:34:60 AM");
+        // date & time specifiers
+        assert_eq!(dt.format("%c").to_string(), "Sun Jul  8 00:34:60 2001");
+        assert_eq!(dt.format("%+").to_string(), "2001-07-08T00:34:60.026490708+09:30");
 
-    // time zone specifiers
-    //assert_eq!(dt.format("%Z").to_string(), "ACST");
-    assert_eq!(dt.format("%z").to_string(), "+0930");
-    assert_eq!(dt.format("%:z").to_string(), "+09:30");
-    assert_eq!(dt.format("%::z").to_string(), "+09:30:00");
-    assert_eq!(dt.format("%:::z").to_string(), "+09");
+        assert_eq!(
+            dt.with_timezone(&Utc).format("%+").to_string(),
+            "2001-07-07T15:04:60.026490708+00:00"
+        );
+        assert_eq!(
+            dt.with_timezone(&Utc),
+            DateTime::parse_from_str("2001-07-07T15:04:60.026490708Z", "%+").unwrap()
+        );
+        assert_eq!(
+            dt.with_timezone(&Utc),
+            DateTime::parse_from_str("2001-07-07T15:04:60.026490708UTC", "%+").unwrap()
+        );
+        assert_eq!(
+            dt.with_timezone(&Utc),
+            DateTime::parse_from_str("2001-07-07t15:04:60.026490708utc", "%+").unwrap()
+        );
 
-    // date & time specifiers
-    assert_eq!(dt.format("%c").to_string(), "Sun Jul  8 00:34:60 2001");
-    assert_eq!(dt.format("%+").to_string(), "2001-07-08T00:34:60.026490708+09:30");
+        assert_eq!(
+            dt.with_nanosecond(1_026_490_000).unwrap().format("%+").to_string(),
+            "2001-07-08T00:34:60.026490+09:30"
+        );
+        assert_eq!(dt.format("%s").to_string(), "994518299");
 
-    assert_eq!(
-        dt.with_timezone(&Utc).format("%+").to_string(),
-        "2001-07-07T15:04:60.026490708+00:00"
-    );
-    assert_eq!(
-        dt.with_timezone(&Utc),
-        DateTime::parse_from_str("2001-07-07T15:04:60.026490708Z", "%+").unwrap()
-    );
-    assert_eq!(
-        dt.with_timezone(&Utc),
-        DateTime::parse_from_str("2001-07-07T15:04:60.026490708UTC", "%+").unwrap()
-    );
-    assert_eq!(
-        dt.with_timezone(&Utc),
-        DateTime::parse_from_str("2001-07-07t15:04:60.026490708utc", "%+").unwrap()
-    );
+        // special specifiers
+        assert_eq!(dt.format("%t").to_string(), "\t");
+        assert_eq!(dt.format("%n").to_string(), "\n");
+        assert_eq!(dt.format("%%").to_string(), "%");
+    }
 
-    assert_eq!(
-        dt.with_nanosecond(1_026_490_000).unwrap().format("%+").to_string(),
-        "2001-07-08T00:34:60.026490+09:30"
-    );
-    assert_eq!(dt.format("%s").to_string(), "994518299");
+    #[cfg(feature = "unstable-locales")]
+    #[test]
+    fn test_strftime_docs_localized() {
+        let dt = FixedOffset::east_opt(34200)
+            .unwrap()
+            .with_ymd_and_hms(2001, 7, 8, 0, 34, 59)
+            .unwrap()
+            .with_nanosecond(1_026_490_708)
+            .unwrap();
 
-    // special specifiers
-    assert_eq!(dt.format("%t").to_string(), "\t");
-    assert_eq!(dt.format("%n").to_string(), "\n");
-    assert_eq!(dt.format("%%").to_string(), "%");
-}
+        // date specifiers
+        assert_eq!(dt.format_localized("%b", Locale::fr_BE).to_string(), "jui");
+        assert_eq!(dt.format_localized("%B", Locale::fr_BE).to_string(), "juillet");
+        assert_eq!(dt.format_localized("%h", Locale::fr_BE).to_string(), "jui");
+        assert_eq!(dt.format_localized("%a", Locale::fr_BE).to_string(), "dim");
+        assert_eq!(dt.format_localized("%A", Locale::fr_BE).to_string(), "dimanche");
+        assert_eq!(dt.format_localized("%D", Locale::fr_BE).to_string(), "07/08/01");
+        assert_eq!(dt.format_localized("%x", Locale::fr_BE).to_string(), "08/07/01");
+        assert_eq!(dt.format_localized("%F", Locale::fr_BE).to_string(), "2001-07-08");
+        assert_eq!(dt.format_localized("%v", Locale::fr_BE).to_string(), " 8-jui-2001");
 
-#[cfg(feature = "unstable-locales")]
-#[test]
-fn test_strftime_docs_localized() {
-    use crate::{FixedOffset, NaiveDate, TimeZone, Timelike};
+        // time specifiers
+        assert_eq!(dt.format_localized("%P", Locale::fr_BE).to_string(), "");
+        assert_eq!(dt.format_localized("%p", Locale::fr_BE).to_string(), "");
+        assert_eq!(dt.format_localized("%R", Locale::fr_BE).to_string(), "00:34");
+        assert_eq!(dt.format_localized("%T", Locale::fr_BE).to_string(), "00:34:60");
+        assert_eq!(dt.format_localized("%X", Locale::fr_BE).to_string(), "00:34:60");
+        assert_eq!(dt.format_localized("%r", Locale::fr_BE).to_string(), "12:34:60 ");
 
-    let dt = FixedOffset::east_opt(34200)
-        .unwrap()
-        .with_ymd_and_hms(2001, 7, 8, 0, 34, 59)
-        .unwrap()
-        .with_nanosecond(1_026_490_708)
-        .unwrap();
+        // date & time specifiers
+        assert_eq!(
+            dt.format_localized("%c", Locale::fr_BE).to_string(),
+            "dim 08 jui 2001 00:34:60 +09:30"
+        );
 
-    // date specifiers
-    assert_eq!(dt.format_localized("%b", Locale::fr_BE).to_string(), "jui");
-    assert_eq!(dt.format_localized("%B", Locale::fr_BE).to_string(), "juillet");
-    assert_eq!(dt.format_localized("%h", Locale::fr_BE).to_string(), "jui");
-    assert_eq!(dt.format_localized("%a", Locale::fr_BE).to_string(), "dim");
-    assert_eq!(dt.format_localized("%A", Locale::fr_BE).to_string(), "dimanche");
-    assert_eq!(dt.format_localized("%D", Locale::fr_BE).to_string(), "07/08/01");
-    assert_eq!(dt.format_localized("%x", Locale::fr_BE).to_string(), "08/07/01");
-    assert_eq!(dt.format_localized("%F", Locale::fr_BE).to_string(), "2001-07-08");
-    assert_eq!(dt.format_localized("%v", Locale::fr_BE).to_string(), " 8-jui-2001");
+        let nd = NaiveDate::from_ymd_opt(2001, 7, 8).unwrap();
 
-    // time specifiers
-    assert_eq!(dt.format_localized("%P", Locale::fr_BE).to_string(), "");
-    assert_eq!(dt.format_localized("%p", Locale::fr_BE).to_string(), "");
-    assert_eq!(dt.format_localized("%R", Locale::fr_BE).to_string(), "00:34");
-    assert_eq!(dt.format_localized("%T", Locale::fr_BE).to_string(), "00:34:60");
-    assert_eq!(dt.format_localized("%X", Locale::fr_BE).to_string(), "00:34:60");
-    assert_eq!(dt.format_localized("%r", Locale::fr_BE).to_string(), "12:34:60 ");
-
-    // date & time specifiers
-    assert_eq!(
-        dt.format_localized("%c", Locale::fr_BE).to_string(),
-        "dim 08 jui 2001 00:34:60 +09:30"
-    );
-
-    let nd = NaiveDate::from_ymd_opt(2001, 7, 8).unwrap();
-
-    // date specifiers
-    assert_eq!(nd.format_localized("%b", Locale::de_DE).to_string(), "Jul");
-    assert_eq!(nd.format_localized("%B", Locale::de_DE).to_string(), "Juli");
-    assert_eq!(nd.format_localized("%h", Locale::de_DE).to_string(), "Jul");
-    assert_eq!(nd.format_localized("%a", Locale::de_DE).to_string(), "So");
-    assert_eq!(nd.format_localized("%A", Locale::de_DE).to_string(), "Sonntag");
-    assert_eq!(nd.format_localized("%D", Locale::de_DE).to_string(), "07/08/01");
-    assert_eq!(nd.format_localized("%x", Locale::de_DE).to_string(), "08.07.2001");
-    assert_eq!(nd.format_localized("%F", Locale::de_DE).to_string(), "2001-07-08");
-    assert_eq!(nd.format_localized("%v", Locale::de_DE).to_string(), " 8-Jul-2001");
+        // date specifiers
+        assert_eq!(nd.format_localized("%b", Locale::de_DE).to_string(), "Jul");
+        assert_eq!(nd.format_localized("%B", Locale::de_DE).to_string(), "Juli");
+        assert_eq!(nd.format_localized("%h", Locale::de_DE).to_string(), "Jul");
+        assert_eq!(nd.format_localized("%a", Locale::de_DE).to_string(), "So");
+        assert_eq!(nd.format_localized("%A", Locale::de_DE).to_string(), "Sonntag");
+        assert_eq!(nd.format_localized("%D", Locale::de_DE).to_string(), "07/08/01");
+        assert_eq!(nd.format_localized("%x", Locale::de_DE).to_string(), "08.07.2001");
+        assert_eq!(nd.format_localized("%F", Locale::de_DE).to_string(), "2001-07-08");
+        assert_eq!(nd.format_localized("%v", Locale::de_DE).to_string(), " 8-Jul-2001");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,6 +388,7 @@
 #![deny(missing_debug_implementations)]
 #![warn(unreachable_pub)]
 #![deny(dead_code)]
+#![deny(clippy::tests_outside_test_module)]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 // can remove this if/when rustc-serialize support is removed
 // keeps clippy happy in the meantime

--- a/src/month.rs
+++ b/src/month.rs
@@ -283,67 +283,6 @@ mod month_serde {
             deserializer.deserialize_str(MonthVisitor)
         }
     }
-
-    #[test]
-    fn test_serde_serialize() {
-        use serde_json::to_string;
-        use Month::*;
-
-        let cases: Vec<(Month, &str)> = vec![
-            (January, "\"January\""),
-            (February, "\"February\""),
-            (March, "\"March\""),
-            (April, "\"April\""),
-            (May, "\"May\""),
-            (June, "\"June\""),
-            (July, "\"July\""),
-            (August, "\"August\""),
-            (September, "\"September\""),
-            (October, "\"October\""),
-            (November, "\"November\""),
-            (December, "\"December\""),
-        ];
-
-        for (month, expected_str) in cases {
-            let string = to_string(&month).unwrap();
-            assert_eq!(string, expected_str);
-        }
-    }
-
-    #[test]
-    fn test_serde_deserialize() {
-        use serde_json::from_str;
-        use Month::*;
-
-        let cases: Vec<(&str, Month)> = vec![
-            ("\"january\"", January),
-            ("\"jan\"", January),
-            ("\"FeB\"", February),
-            ("\"MAR\"", March),
-            ("\"mar\"", March),
-            ("\"april\"", April),
-            ("\"may\"", May),
-            ("\"june\"", June),
-            ("\"JULY\"", July),
-            ("\"august\"", August),
-            ("\"september\"", September),
-            ("\"October\"", October),
-            ("\"November\"", November),
-            ("\"DECEmbEr\"", December),
-        ];
-
-        for (string, expected_month) in cases {
-            let month = from_str::<Month>(string).unwrap();
-            assert_eq!(month, expected_month);
-        }
-
-        let errors: Vec<&str> =
-            vec!["\"not a month\"", "\"ja\"", "\"Dece\"", "Dec", "\"Augustin\""];
-
-        for string in errors {
-            from_str::<Month>(string).unwrap_err();
-        }
-    }
 }
 
 #[cfg(test)]
@@ -402,5 +341,68 @@ mod tests {
         assert!(Month::January < Month::December);
         assert!(Month::July >= Month::May);
         assert!(Month::September > Month::March);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_serialize() {
+        use serde_json::to_string;
+        use Month::*;
+
+        let cases: Vec<(Month, &str)> = vec![
+            (January, "\"January\""),
+            (February, "\"February\""),
+            (March, "\"March\""),
+            (April, "\"April\""),
+            (May, "\"May\""),
+            (June, "\"June\""),
+            (July, "\"July\""),
+            (August, "\"August\""),
+            (September, "\"September\""),
+            (October, "\"October\""),
+            (November, "\"November\""),
+            (December, "\"December\""),
+        ];
+
+        for (month, expected_str) in cases {
+            let string = to_string(&month).unwrap();
+            assert_eq!(string, expected_str);
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_deserialize() {
+        use serde_json::from_str;
+        use Month::*;
+
+        let cases: Vec<(&str, Month)> = vec![
+            ("\"january\"", January),
+            ("\"jan\"", January),
+            ("\"FeB\"", February),
+            ("\"MAR\"", March),
+            ("\"mar\"", March),
+            ("\"april\"", April),
+            ("\"may\"", May),
+            ("\"june\"", June),
+            ("\"JULY\"", July),
+            ("\"august\"", August),
+            ("\"september\"", September),
+            ("\"October\"", October),
+            ("\"November\"", November),
+            ("\"DECEmbEr\"", December),
+        ];
+
+        for (string, expected_month) in cases {
+            let month = from_str::<Month>(string).unwrap();
+            assert_eq!(month, expected_month);
+        }
+
+        let errors: Vec<&str> =
+            vec!["\"not a month\"", "\"ja\"", "\"Dece\"", "Dec", "\"Augustin\""];
+
+        for string in errors {
+            from_str::<Month>(string).unwrap_err();
+        }
     }
 }

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -2237,16 +2237,19 @@ mod rustc_serialize {
     }
 
     #[cfg(test)]
-    use rustc_serialize::json;
+    mod tests {
+        use crate::naive::date::{test_decodable_json, test_encodable_json};
+        use rustc_serialize::json;
 
-    #[test]
-    fn test_encodable() {
-        super::test_encodable_json(json::encode);
-    }
+        #[test]
+        fn test_encodable() {
+            test_encodable_json(json::encode);
+        }
 
-    #[test]
-    fn test_decodable() {
-        super::test_decodable_json(json::decode);
+        #[test]
+        fn test_decodable() {
+            test_decodable_json(json::decode);
+        }
     }
 }
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -2313,26 +2313,32 @@ mod serde {
         }
     }
 
-    #[test]
-    fn test_serde_serialize() {
-        super::test_encodable_json(serde_json::to_string);
-    }
+    #[cfg(test)]
+    mod tests {
+        use crate::naive::date::{test_decodable_json, test_encodable_json};
+        use crate::NaiveDate;
 
-    #[test]
-    fn test_serde_deserialize() {
-        super::test_decodable_json(|input| serde_json::from_str(input));
-    }
+        #[test]
+        fn test_serde_serialize() {
+            test_encodable_json(serde_json::to_string);
+        }
 
-    #[test]
-    fn test_serde_bincode() {
-        // Bincode is relevant to test separately from JSON because
-        // it is not self-describing.
-        use bincode::{deserialize, serialize};
+        #[test]
+        fn test_serde_deserialize() {
+            test_decodable_json(|input| serde_json::from_str(input));
+        }
 
-        let d = NaiveDate::from_ymd_opt(2014, 7, 24).unwrap();
-        let encoded = serialize(&d).unwrap();
-        let decoded: NaiveDate = deserialize(&encoded).unwrap();
-        assert_eq!(d, decoded);
+        #[test]
+        fn test_serde_bincode() {
+            // Bincode is relevant to test separately from JSON because
+            // it is not self-describing.
+            use bincode::{deserialize, serialize};
+
+            let d = NaiveDate::from_ymd_opt(2014, 7, 24).unwrap();
+            let encoded = serialize(&d).unwrap();
+            let decoded: NaiveDate = deserialize(&encoded).unwrap();
+            assert_eq!(d, decoded);
+        }
     }
 }
 

--- a/src/naive/datetime/rustc_serialize.rs
+++ b/src/naive/datetime/rustc_serialize.rs
@@ -55,19 +55,23 @@ impl Decodable for TsSeconds {
 }
 
 #[cfg(test)]
-use rustc_serialize::json;
+mod tests {
+    use crate::naive::datetime::test_encodable_json;
+    use crate::naive::datetime::{test_decodable_json, test_decodable_json_timestamp};
+    use rustc_serialize::json;
 
-#[test]
-fn test_encodable() {
-    super::test_encodable_json(json::encode);
-}
+    #[test]
+    fn test_encodable() {
+        test_encodable_json(json::encode);
+    }
 
-#[test]
-fn test_decodable() {
-    super::test_decodable_json(json::decode);
-}
+    #[test]
+    fn test_decodable() {
+        test_decodable_json(json::decode);
+    }
 
-#[test]
-fn test_decodable_timestamps() {
-    super::test_decodable_json_timestamp(json::decode);
+    #[test]
+    fn test_decodable_timestamps() {
+        test_decodable_json_timestamp(json::decode);
+    }
 }

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -110,7 +110,6 @@ pub mod ts_nanoseconds {
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -138,7 +137,6 @@ pub mod ts_nanoseconds {
     /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918355733).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -233,7 +231,6 @@ pub mod ts_nanoseconds_option {
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(opt: &Option<NaiveDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -264,7 +261,6 @@ pub mod ts_nanoseconds_option {
     /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918355733) });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -362,7 +358,6 @@ pub mod ts_microseconds {
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -390,7 +385,6 @@ pub mod ts_microseconds {
     /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918355000).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -488,7 +482,6 @@ pub mod ts_microseconds_option {
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(opt: &Option<NaiveDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -519,7 +512,6 @@ pub mod ts_microseconds_option {
     /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918355000) });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -617,7 +609,6 @@ pub mod ts_milliseconds {
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -645,7 +636,6 @@ pub mod ts_milliseconds {
     /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918000000).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -740,7 +730,6 @@ pub mod ts_milliseconds_option {
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(opt: &Option<NaiveDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -771,7 +760,6 @@ pub mod ts_milliseconds_option {
     /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918000000) });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -869,7 +857,6 @@ pub mod ts_seconds {
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(dt: &NaiveDateTime, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -897,7 +884,6 @@ pub mod ts_seconds {
     /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1431684000, 0).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -989,7 +975,6 @@ pub mod ts_seconds_option {
     /// assert_eq!(as_string, r#"{"time":1526522699}"#);
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn serialize<S>(opt: &Option<NaiveDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,
@@ -1020,7 +1005,6 @@ pub mod ts_seconds_option {
     /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1431684000, 0) });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
-    #[must_use]
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
     where
         D: de::Deserializer<'de>,

--- a/src/naive/time/rustc_serialize.rs
+++ b/src/naive/time/rustc_serialize.rs
@@ -16,14 +16,17 @@ impl Decodable for NaiveTime {
 }
 
 #[cfg(test)]
-use rustc_serialize::json;
+mod tests {
+    use crate::naive::time::{test_decodable_json, test_encodable_json};
+    use rustc_serialize::json;
 
-#[test]
-fn test_encodable() {
-    super::test_encodable_json(json::encode);
-}
+    #[test]
+    fn test_encodable() {
+        test_encodable_json(json::encode);
+    }
 
-#[test]
-fn test_decodable() {
-    super::test_decodable_json(json::decode);
+    #[test]
+    fn test_decodable() {
+        test_decodable_json(json::decode);
+    }
 }

--- a/src/naive/time/serde.rs
+++ b/src/naive/time/serde.rs
@@ -42,24 +42,30 @@ impl<'de> de::Deserialize<'de> for NaiveTime {
     }
 }
 
-#[test]
-fn test_serde_serialize() {
-    super::test_encodable_json(serde_json::to_string);
-}
+#[cfg(test)]
+mod tests {
+    use crate::naive::time::{test_decodable_json, test_encodable_json};
+    use crate::NaiveTime;
 
-#[test]
-fn test_serde_deserialize() {
-    super::test_decodable_json(|input| serde_json::from_str(input));
-}
+    #[test]
+    fn test_serde_serialize() {
+        test_encodable_json(serde_json::to_string);
+    }
 
-#[test]
-fn test_serde_bincode() {
-    // Bincode is relevant to test separately from JSON because
-    // it is not self-describing.
-    use bincode::{deserialize, serialize};
+    #[test]
+    fn test_serde_deserialize() {
+        test_decodable_json(|input| serde_json::from_str(input));
+    }
 
-    let t = NaiveTime::from_hms_nano_opt(3, 5, 7, 98765432).unwrap();
-    let encoded = serialize(&t).unwrap();
-    let decoded: NaiveTime = deserialize(&encoded).unwrap();
-    assert_eq!(t, decoded);
+    #[test]
+    fn test_serde_bincode() {
+        // Bincode is relevant to test separately from JSON because
+        // it is not self-describing.
+        use bincode::{deserialize, serialize};
+
+        let t = NaiveTime::from_hms_nano_opt(3, 5, 7, 98765432).unwrap();
+        let encoded = serialize(&t).unwrap();
+        let decoded: NaiveTime = deserialize(&encoded).unwrap();
+        assert_eq!(t, decoded);
+    }
 }

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -229,43 +229,6 @@ impl fmt::Debug for ParseWeekdayError {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::Weekday;
-
-    #[test]
-    fn test_num_days_from() {
-        for i in 0..7 {
-            let base_day = Weekday::try_from(i).unwrap();
-
-            assert_eq!(base_day.num_days_from_monday(), base_day.num_days_from(Weekday::Mon));
-            assert_eq!(base_day.num_days_from_sunday(), base_day.num_days_from(Weekday::Sun));
-
-            assert_eq!(base_day.num_days_from(base_day), 0);
-
-            assert_eq!(base_day.num_days_from(base_day.pred()), 1);
-            assert_eq!(base_day.num_days_from(base_day.pred().pred()), 2);
-            assert_eq!(base_day.num_days_from(base_day.pred().pred().pred()), 3);
-            assert_eq!(base_day.num_days_from(base_day.pred().pred().pred().pred()), 4);
-            assert_eq!(base_day.num_days_from(base_day.pred().pred().pred().pred().pred()), 5);
-            assert_eq!(
-                base_day.num_days_from(base_day.pred().pred().pred().pred().pred().pred()),
-                6
-            );
-
-            assert_eq!(base_day.num_days_from(base_day.succ()), 6);
-            assert_eq!(base_day.num_days_from(base_day.succ().succ()), 5);
-            assert_eq!(base_day.num_days_from(base_day.succ().succ().succ()), 4);
-            assert_eq!(base_day.num_days_from(base_day.succ().succ().succ().succ()), 3);
-            assert_eq!(base_day.num_days_from(base_day.succ().succ().succ().succ().succ()), 2);
-            assert_eq!(
-                base_day.num_days_from(base_day.succ().succ().succ().succ().succ().succ()),
-                1
-            );
-        }
-    }
-}
-
 // the actual `FromStr` implementation is in the `format` module to leverage the existing code
 
 #[cfg(feature = "serde")]
@@ -365,6 +328,43 @@ mod weekday_serde {
 
         for str in errors {
             from_str::<Weekday>(str).unwrap_err();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Weekday;
+
+    #[test]
+    fn test_num_days_from() {
+        for i in 0..7 {
+            let base_day = Weekday::try_from(i).unwrap();
+
+            assert_eq!(base_day.num_days_from_monday(), base_day.num_days_from(Weekday::Mon));
+            assert_eq!(base_day.num_days_from_sunday(), base_day.num_days_from(Weekday::Sun));
+
+            assert_eq!(base_day.num_days_from(base_day), 0);
+
+            assert_eq!(base_day.num_days_from(base_day.pred()), 1);
+            assert_eq!(base_day.num_days_from(base_day.pred().pred()), 2);
+            assert_eq!(base_day.num_days_from(base_day.pred().pred().pred()), 3);
+            assert_eq!(base_day.num_days_from(base_day.pred().pred().pred().pred()), 4);
+            assert_eq!(base_day.num_days_from(base_day.pred().pred().pred().pred().pred()), 5);
+            assert_eq!(
+                base_day.num_days_from(base_day.pred().pred().pred().pred().pred().pred()),
+                6
+            );
+
+            assert_eq!(base_day.num_days_from(base_day.succ()), 6);
+            assert_eq!(base_day.num_days_from(base_day.succ().succ()), 5);
+            assert_eq!(base_day.num_days_from(base_day.succ().succ().succ()), 4);
+            assert_eq!(base_day.num_days_from(base_day.succ().succ().succ().succ()), 3);
+            assert_eq!(base_day.num_days_from(base_day.succ().succ().succ().succ().succ()), 2);
+            assert_eq!(
+                base_day.num_days_from(base_day.succ().succ().succ().succ().succ().succ()),
+                1
+            );
         }
     }
 }

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -272,64 +272,6 @@ mod weekday_serde {
             deserializer.deserialize_str(WeekdayVisitor)
         }
     }
-
-    #[test]
-    fn test_serde_serialize() {
-        use serde_json::to_string;
-        use Weekday::*;
-
-        let cases: Vec<(Weekday, &str)> = vec![
-            (Mon, "\"Mon\""),
-            (Tue, "\"Tue\""),
-            (Wed, "\"Wed\""),
-            (Thu, "\"Thu\""),
-            (Fri, "\"Fri\""),
-            (Sat, "\"Sat\""),
-            (Sun, "\"Sun\""),
-        ];
-
-        for (weekday, expected_str) in cases {
-            let string = to_string(&weekday).unwrap();
-            assert_eq!(string, expected_str);
-        }
-    }
-
-    #[test]
-    fn test_serde_deserialize() {
-        use serde_json::from_str;
-        use Weekday::*;
-
-        let cases: Vec<(&str, Weekday)> = vec![
-            ("\"mon\"", Mon),
-            ("\"MONDAY\"", Mon),
-            ("\"MonDay\"", Mon),
-            ("\"mOn\"", Mon),
-            ("\"tue\"", Tue),
-            ("\"tuesday\"", Tue),
-            ("\"wed\"", Wed),
-            ("\"wednesday\"", Wed),
-            ("\"thu\"", Thu),
-            ("\"thursday\"", Thu),
-            ("\"fri\"", Fri),
-            ("\"friday\"", Fri),
-            ("\"sat\"", Sat),
-            ("\"saturday\"", Sat),
-            ("\"sun\"", Sun),
-            ("\"sunday\"", Sun),
-        ];
-
-        for (str, expected_weekday) in cases {
-            let weekday = from_str::<Weekday>(str).unwrap();
-            assert_eq!(weekday, expected_weekday);
-        }
-
-        let errors: Vec<&str> =
-            vec!["\"not a weekday\"", "\"monDAYs\"", "\"mond\"", "mon", "\"thur\"", "\"thurs\""];
-
-        for str in errors {
-            from_str::<Weekday>(str).unwrap_err();
-        }
-    }
 }
 
 #[cfg(test)]
@@ -365,6 +307,66 @@ mod tests {
                 base_day.num_days_from(base_day.succ().succ().succ().succ().succ().succ()),
                 1
             );
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_serialize() {
+        use serde_json::to_string;
+        use Weekday::*;
+
+        let cases: Vec<(Weekday, &str)> = vec![
+            (Mon, "\"Mon\""),
+            (Tue, "\"Tue\""),
+            (Wed, "\"Wed\""),
+            (Thu, "\"Thu\""),
+            (Fri, "\"Fri\""),
+            (Sat, "\"Sat\""),
+            (Sun, "\"Sun\""),
+        ];
+
+        for (weekday, expected_str) in cases {
+            let string = to_string(&weekday).unwrap();
+            assert_eq!(string, expected_str);
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde_deserialize() {
+        use serde_json::from_str;
+        use Weekday::*;
+
+        let cases: Vec<(&str, Weekday)> = vec![
+            ("\"mon\"", Mon),
+            ("\"MONDAY\"", Mon),
+            ("\"MonDay\"", Mon),
+            ("\"mOn\"", Mon),
+            ("\"tue\"", Tue),
+            ("\"tuesday\"", Tue),
+            ("\"wed\"", Wed),
+            ("\"wednesday\"", Wed),
+            ("\"thu\"", Thu),
+            ("\"thursday\"", Thu),
+            ("\"fri\"", Fri),
+            ("\"friday\"", Fri),
+            ("\"sat\"", Sat),
+            ("\"saturday\"", Sat),
+            ("\"sun\"", Sun),
+            ("\"sunday\"", Sun),
+        ];
+
+        for (str, expected_weekday) in cases {
+            let weekday = from_str::<Weekday>(str).unwrap();
+            assert_eq!(weekday, expected_weekday);
+        }
+
+        let errors: Vec<&str> =
+            vec!["\"not a weekday\"", "\"monDAYs\"", "\"mond\"", "mon", "\"thur\"", "\"thurs\""];
+
+        for str in errors {
+            from_str::<Weekday>(str).unwrap_err();
         }
     }
 }

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -58,10 +58,10 @@ fn verify_against_date_command_local(path: &'static str, dt: NaiveDateTime) {
 /// for testing only
 #[allow(dead_code)]
 #[cfg(not(target_os = "aix"))]
-const DATE_PATH: &'static str = "/usr/bin/date";
+const DATE_PATH: &str = "/usr/bin/date";
 #[allow(dead_code)]
 #[cfg(target_os = "aix")]
-const DATE_PATH: &'static str = "/opt/freeware/bin/date";
+const DATE_PATH: &str = "/opt/freeware/bin/date";
 
 #[cfg(test)]
 #[cfg(unix)]


### PR DESCRIPTION
Most of this PR is just moving code around so that all tests are inside a `tests` module.
Then it adds `#![deny(clippy::tests_outside_test_module)]` to make sure it stays this way.

Clippy didn't check tests on CI, and also didn't check code behind feature flags.
I enabled them and had to fix a couple of warnings. They are in the first 4 commits.