### PR TITLE
ISO 8601 parsers

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -770,17 +770,24 @@ impl DateTime<FixedOffset> {
 
     /// Parses an RFC 3339 date-and-time string into a `DateTime<FixedOffset>` value.
     ///
-    /// Parses all valid RFC 3339 values (as well as the subset of valid ISO 8601 values that are
-    /// also valid RFC 3339 date-and-time values) and returns a new [`DateTime`] with a
-    /// [`FixedOffset`] corresponding to the parsed timezone. While RFC 3339 values come in a wide
-    /// variety of shapes and sizes, `1996-12-19T16:39:57-08:00` is an example of the most commonly
-    /// encountered variety of RFC 3339 formats.
+    /// This parses valid RFC 3339 datetime strings (such as `1996-12-19T16:39:57-08:00`)
+    /// and returns a new [`DateTime`] instance with the parsed timezone as the [`FixedOffset`].
     ///
-    /// Why isn't this named `parse_from_iso8601`? That's because ISO 8601 allows representing
-    /// values in a wide range of formats, only some of which represent actual date-and-time
-    /// instances (rather than periods, ranges, dates, or times). Some valid ISO 8601 values are
-    /// also simultaneously valid RFC 3339 values, but not all RFC 3339 values are valid ISO 8601
-    /// values (or the other way around).
+    /// RFC 3339 is a clearly defined subset or profile of ISO 8601.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use chrono::{DateTime, FixedOffset, TimeZone};
+    /// assert_eq!(
+    ///     DateTime::parse_from_rfc3339("1996-12-19T16:39:57-08:00").unwrap(),
+    ///     FixedOffset::east_opt(-8 * 3600).unwrap().with_ymd_and_hms(1996, 12, 19, 16, 39, 57).unwrap()
+    /// );
+    /// assert_eq!(
+    ///     DateTime::parse_from_rfc3339("2023-06-10T07:15:00Z").unwrap(),
+    ///     FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2023, 6, 10, 7, 15, 0).unwrap()
+    /// );
+    /// ```
     pub fn parse_from_rfc3339(s: &str) -> ParseResult<DateTime<FixedOffset>> {
         let mut parsed = Parsed::new();
         let (s, _) = parse_rfc3339(&mut parsed, s)?;

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1549,3 +1549,12 @@ fn test_parse_from_iso8601() {
     );
     assert_eq!(parse("1985102T2350,5+01"), Ok(datetime(1985, 4, 12, 23, 50, 30, 0, 3600)));
 }
+
+#[test]
+fn test_iso8601_parses_debug() {
+    let parse = |s| DateTime::<FixedOffset>::parse_from_iso8601(s).map(|(dt, _)| dt);
+
+    let dt = FixedOffset::east_opt(3600).unwrap().with_ymd_and_hms(12345, 6, 7, 8, 9, 10).unwrap();
+    let debug = format!("{:?}", dt);
+    assert_eq!(parse(&debug), Ok(dt));
+}

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1519,3 +1519,33 @@ fn nano_roundrip() {
         assert_eq!(nanos, nanos2);
     }
 }
+
+#[test]
+fn test_parse_from_iso8601() {
+    let parse = |s| DateTime::<FixedOffset>::parse_from_iso8601(s).map(|(dt, _)| dt);
+    let datetime = |y, m, d, h, n, s, nano, o| {
+        FixedOffset::east_opt(o)
+            .unwrap()
+            .with_ymd_and_hms(y, m, d, h, n, s)
+            .unwrap()
+            .with_nanosecond(nano)
+            .unwrap()
+    };
+
+    // Taken from ISO 8601
+    assert_eq!(parse("19850412T101530Z"), Ok(datetime(1985, 4, 12, 10, 15, 30, 0, 0)));
+    assert_eq!(parse("19850412T101530+0400"), Ok(datetime(1985, 4, 12, 10, 15, 30, 0, 14400)));
+    assert_eq!(parse("19850412T101530-04"), Ok(datetime(1985, 4, 12, 10, 15, 30, 0, -14400)));
+    assert_eq!(parse("1985-04-12T10:15:30Z"), Ok(datetime(1985, 4, 12, 10, 15, 30, 0, 0)));
+    assert_eq!(parse("1985-04-12T10:15:30+04:00"), Ok(datetime(1985, 4, 12, 10, 15, 30, 0, 14400)));
+    assert_eq!(parse("1985-04-12T10:15:30-04"), Ok(datetime(1985, 4, 12, 10, 15, 30, 0, -14400)));
+    assert_eq!(parse("1985W155T1015+0400"), Ok(datetime(1985, 4, 12, 10, 15, 0, 0, 14400)));
+    assert_eq!(parse("1985-W15-5T10:15+04"), Ok(datetime(1985, 4, 12, 10, 15, 0, 0, 14400)));
+    assert_eq!(parse("1985102T235030Z"), Ok(datetime(1985, 4, 12, 23, 50, 30, 0, 0)));
+    // With fractions
+    assert_eq!(
+        parse("1985102T235030,5+01"),
+        Ok(datetime(1985, 4, 12, 23, 50, 30, 500_000_000, 3600))
+    );
+    assert_eq!(parse("1985102T2350,5+01"), Ok(datetime(1985, 4, 12, 23, 50, 30, 0, 3600)));
+}

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -44,6 +44,7 @@ mod parsed;
 
 // due to the size of parsing routines, they are in separate modules.
 mod parse;
+pub(crate) mod parse_iso8601;
 pub(crate) mod scan;
 
 pub mod strftime;
@@ -71,6 +72,7 @@ pub use locales::Locale;
 pub(crate) use locales::Locale;
 pub(crate) use parse::parse_rfc3339;
 pub use parse::{parse, parse_and_remainder};
+pub(crate) use parse_iso8601::parse_iso8601_date;
 pub use parsed::Parsed;
 pub use strftime::StrftimeItems;
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -72,7 +72,9 @@ pub use locales::Locale;
 pub(crate) use locales::Locale;
 pub(crate) use parse::parse_rfc3339;
 pub use parse::{parse, parse_and_remainder};
-pub(crate) use parse_iso8601::{parse_iso8601_date, parse_iso8601_datetime, parse_iso8601_time};
+pub(crate) use parse_iso8601::{
+    parse_iso8601, parse_iso8601_date, parse_iso8601_datetime, parse_iso8601_time,
+};
 pub use parsed::Parsed;
 pub use strftime::StrftimeItems;
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -72,7 +72,7 @@ pub use locales::Locale;
 pub(crate) use locales::Locale;
 pub(crate) use parse::parse_rfc3339;
 pub use parse::{parse, parse_and_remainder};
-pub(crate) use parse_iso8601::{parse_iso8601_date, parse_iso8601_time};
+pub(crate) use parse_iso8601::{parse_iso8601_date, parse_iso8601_datetime, parse_iso8601_time};
 pub use parsed::Parsed;
 pub use strftime::StrftimeItems;
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -72,7 +72,7 @@ pub use locales::Locale;
 pub(crate) use locales::Locale;
 pub(crate) use parse::parse_rfc3339;
 pub use parse::{parse, parse_and_remainder};
-pub(crate) use parse_iso8601::parse_iso8601_date;
+pub(crate) use parse_iso8601::{parse_iso8601_date, parse_iso8601_time};
 pub use parsed::Parsed;
 pub use strftime::StrftimeItems;
 

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -27,7 +27,7 @@ fn set_weekday_with_num_days_from_sunday(p: &mut Parsed, v: i64) -> ParseResult<
     })
 }
 
-fn set_weekday_with_number_from_monday(p: &mut Parsed, v: i64) -> ParseResult<()> {
+pub(super) fn set_weekday_with_number_from_monday(p: &mut Parsed, v: i64) -> ParseResult<()> {
     p.set_weekday(match v {
         1 => Weekday::Mon,
         2 => Weekday::Tue,

--- a/src/format/parse_iso8601.rs
+++ b/src/format/parse_iso8601.rs
@@ -1,0 +1,185 @@
+use super::parse::set_weekday_with_number_from_monday;
+use super::scan;
+use super::{ParseResult, Parsed, TOO_SHORT};
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub(crate) enum Iso8601Format {
+    Basic,
+    Extended,
+    Unknown,
+}
+
+/// The ISO 8601 date format is a combination of 12 different date formats:
+///
+/// |                                           | calendar date | ordinal date |  week date   |
+/// |-------------------------------------------|---------------|--------------|--------------|
+/// | basic format                              | YYYYMMDD      | YYYYDDD      | YYYYWwwD     |
+/// | extended format                           | YYYY-MM-DD    | YYYY-DDD     | YYYY-Www-D   |
+/// | basic format, expanded representations    | ±Y̲YYYYMMDD    | ±Y̲YYYYDDD    | ±Y̲YYYYWwwD   |
+/// | extended format, expanded representations | ±Y̲YYYY-MM-DD  | ±Y̲YYYY-DDD   | ±Y̲YYYY-Www-D |
+///
+/// Returns `(remainder, Iso8601Format)`.
+//// - The ISO 8601 format of the date is returned so the calling function can check it matches the
+///   format of a time component (basic or extended format).
+pub(crate) fn parse_iso8601_date<'a>(
+    parsed: &mut Parsed,
+    mut s: &'a str,
+) -> ParseResult<(&'a str, Iso8601Format)> {
+    macro_rules! try_consume {
+        ($e:expr) => {{
+            let (s_, v) = $e?;
+            s = s_;
+            v
+        }};
+    }
+
+    let year = try_consume!(parse_iso8601_year(s));
+
+    let extended_format = s.as_bytes().first() == Some(&b'-');
+    if extended_format {
+        s = &s[1..];
+    }
+
+    if s.as_bytes().first() == Some(&b'W') {
+        // Week date. Basic format: `WwwD`. Extended format: `Www-D`.
+        parsed.set_isoyear(year)?;
+        parsed.set_isoweek(try_consume!(scan::number(&s[1..], 2, 2)))?;
+        if extended_format {
+            s = scan::char(s, b'-')?;
+        }
+        set_weekday_with_number_from_monday(parsed, try_consume!(scan::number(s, 1, 1)))?;
+    } else {
+        parsed.set_year(year)?;
+        let digits = s.as_bytes().iter().take_while(|c| c.is_ascii_digit()).count();
+        if digits == 3 {
+            // Week date. Format: `DDD`
+            parsed.set_ordinal(try_consume!(scan::number(s, 3, 3)))?;
+        } else {
+            // Calendar date. Basic format: `MMDD`. Extended format: `MM-DD`.
+            parsed.set_month(try_consume!(scan::number(s, 2, 2)))?;
+            if extended_format {
+                s = scan::char(s, b'-')?;
+            }
+            parsed.set_day(try_consume!(scan::number(s, 2, 2)))?;
+        }
+    }
+    let format = if extended_format { Iso8601Format::Extended } else { Iso8601Format::Basic };
+    Ok((s, format))
+}
+
+fn parse_iso8601_year(mut s: &str) -> ParseResult<(&str, i64)> {
+    match s.as_bytes().first() {
+        Some(sign) if sign == &b'-' || sign == &b'+' => {
+            // expanded representation
+            let negative = sign == &b'-';
+            s = &s[1..];
+            let mut digits = s.as_bytes().iter().take_while(|c| c.is_ascii_digit()).count();
+            if let Some(&b'-' | &b'W') = s.as_bytes().get(digits) {
+                // The date format is either an extended format with `-` as seperator between date
+                // fields, or it is a week date in basic format. In both cases all counted digits
+                // belong to the year.
+                if digits < 4 {
+                    return Err(TOO_SHORT);
+                }
+            } else if digits == 7 {
+                digits -= 3; // must be the format ±YYYYDDD
+            } else if digits > 7 {
+                // The basic format with expanded representation of a calendar date (±Y̲YYYYMMDD)
+                // and ordinal date (±Y̲YYYYDDD) are ambiguous. In this case we assume a calendar
+                // date, where the last 4 digits are for the month and day.
+                digits -= 4;
+            } else {
+                return Err(TOO_SHORT);
+            }
+            let (s, year) = scan::number(s, 4, digits)?;
+            Ok((s, if negative { -year } else { year }))
+        }
+        Some(_) => scan::number(s, 4, 4),
+        None => Err(TOO_SHORT),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::format::INVALID;
+    use crate::NaiveDate;
+
+    #[test]
+    fn test_parse_iso8601_date() {
+        use crate::Weekday::Fri;
+        fn parse(s: &str) -> ParseResult<(NaiveDate, &str)> {
+            let mut parsed = Parsed::new();
+            let (s, _) = parse_iso8601_date(&mut parsed, s)?;
+            parsed.to_naive_date().map(|d| (d, s))
+        }
+
+        // calendar date, basic format
+        assert_eq!(parse("20230609 "), Ok((NaiveDate::from_ymd_opt(2023, 6, 9).unwrap(), " ")));
+        // calendar date, extended format
+        assert_eq!(parse("2023-06-09 "), Ok((NaiveDate::from_ymd_opt(2023, 6, 9).unwrap(), " ")));
+        // calendar date, basic format, expanded representation
+        assert_eq!(parse("-20230609 "), Ok((NaiveDate::from_ymd_opt(-2023, 6, 9).unwrap(), " ")));
+        assert_eq!(parse("+20230609 "), Ok((NaiveDate::from_ymd_opt(2023, 6, 9).unwrap(), " ")));
+        assert_eq!(parse("+020230609 "), Ok((NaiveDate::from_ymd_opt(2023, 6, 9).unwrap(), " ")));
+        assert_eq!(parse("+120230609 "), Ok((NaiveDate::from_ymd_opt(12023, 6, 9).unwrap(), " ")));
+        // calendar date, extended format, expanded representation
+        assert_eq!(parse("-2023-06-09 "), Ok((NaiveDate::from_ymd_opt(-2023, 6, 9).unwrap(), " ")));
+        assert_eq!(parse("+2023-06-09 "), Ok((NaiveDate::from_ymd_opt(2023, 6, 9).unwrap(), " ")));
+        assert_eq!(parse("+02023-06-09 "), Ok((NaiveDate::from_ymd_opt(2023, 6, 9).unwrap(), " ")));
+        assert_eq!(parse("+12023-06-09"), Ok((NaiveDate::from_ymd_opt(12023, 6, 9).unwrap(), "")));
+        // mixed basic and extended format
+        assert_eq!(parse("2023-0609 "), Err(INVALID));
+        assert_eq!(parse("202306-09 "), Err(INVALID));
+        assert_eq!(parse("-2023-0609 "), Err(INVALID));
+        // No padding
+        assert_eq!(parse("2023-6-09 "), Err(INVALID));
+        assert_eq!(parse("2023-06-9 "), Err(INVALID));
+        assert_eq!(parse("23-06-09 "), Err(INVALID));
+
+        // ordinal date, basic format
+        assert_eq!(parse("2023160 "), Ok((NaiveDate::from_yo_opt(2023, 160).unwrap(), " ")));
+        // ordinal date, extended format
+        assert_eq!(parse("2023-160 "), Ok((NaiveDate::from_yo_opt(2023, 160).unwrap(), " ")));
+        // ordinal date, basic format, expanded representation
+        assert_eq!(parse("-2023160 "), Ok((NaiveDate::from_yo_opt(-2023, 160).unwrap(), " ")));
+        assert_eq!(parse("+2023160 "), Ok((NaiveDate::from_yo_opt(2023, 160).unwrap(), " ")));
+        // ordinal date, extended format, expanded representation
+        assert_eq!(parse("-2023-160 "), Ok((NaiveDate::from_yo_opt(-2023, 160).unwrap(), " ")));
+        assert_eq!(parse("+2023-160 "), Ok((NaiveDate::from_yo_opt(2023, 160).unwrap(), " ")));
+        assert_eq!(parse("+02023-160 "), Ok((NaiveDate::from_yo_opt(2023, 160).unwrap(), " ")));
+        assert_eq!(parse("+12023-160 "), Ok((NaiveDate::from_yo_opt(12023, 160).unwrap(), " ")));
+        // ambiguous, interpreted as calendar date
+        assert!(parse("+02023160 ").is_err());
+        assert!(parse("+12023160 ").is_err());
+        // No padding
+        assert_eq!(parse("2023-16 "), Err(INVALID));
+        assert_eq!(parse("2023-1 "), Err(INVALID));
+        assert_eq!(parse("23-160 "), Err(INVALID));
+
+        let from_isoywd_opt = NaiveDate::from_isoywd_opt;
+        // week date, basic format
+        assert_eq!(parse("2023W235 "), Ok((from_isoywd_opt(2023, 23, Fri).unwrap(), " ")));
+        // week date, extended format
+        assert_eq!(parse("2023-W23-5 "), Ok((from_isoywd_opt(2023, 23, Fri).unwrap(), " ")));
+        // week date, basic format, expanded representation
+        assert_eq!(parse("-2023W235 "), Ok((from_isoywd_opt(-2023, 23, Fri).unwrap(), " ")));
+        assert_eq!(parse("+2023W235 "), Ok((from_isoywd_opt(2023, 23, Fri).unwrap(), " ")));
+        assert_eq!(parse("+02023W235 "), Ok((from_isoywd_opt(2023, 23, Fri).unwrap(), " ")));
+        assert_eq!(parse("+12023W235 "), Ok((from_isoywd_opt(12023, 23, Fri).unwrap(), " ")));
+        // calendar date, extended format, expanded representation
+        assert_eq!(parse("-2023-W23-5 "), Ok((from_isoywd_opt(-2023, 23, Fri).unwrap(), " ")));
+        assert_eq!(parse("+2023-W23-5 "), Ok((from_isoywd_opt(2023, 23, Fri).unwrap(), " ")));
+        assert_eq!(parse("+02023-W23-5 "), Ok((from_isoywd_opt(2023, 23, Fri).unwrap(), " ")));
+        assert_eq!(parse("+12023-W23-5 "), Ok((from_isoywd_opt(12023, 23, Fri).unwrap(), " ")));
+        // mixed basic and extended format
+        assert_eq!(parse("2023-W235 "), Err(INVALID));
+        assert_eq!(parse("202306-W235 "), Err(INVALID));
+        assert_eq!(parse("-2023-W235 "), Err(INVALID));
+        // No padding
+        assert_eq!(parse("2023-W25 "), Err(INVALID));
+        assert_eq!(parse("23-W23-5 "), Err(INVALID));
+        // Year is interpreted as `iso_year`
+        assert_eq!(parse("2022-W52-7 "), Ok((NaiveDate::from_ymd_opt(2023, 1, 1).unwrap(), " ")));
+    }
+}

--- a/src/format/parse_iso8601.rs
+++ b/src/format/parse_iso8601.rs
@@ -99,6 +99,74 @@ fn parse_iso8601_year(mut s: &str) -> ParseResult<(&str, i64)> {
     }
 }
 
+/// Helper type for parsing fractional numbers.
+///
+/// The fractions is stored as an integer in the range 0..=10^15.
+/// With this limit `10^15 * 3600` fits in an `u64` without overflow.
+///
+// We don't use `f64` to support targets that may not have floating point support.
+struct Fraction(u64);
+
+impl Fraction {
+    /// Supported formats are `,fraction` and `.fraction`.
+    /// `fraction` can have an unlimited length. We only keep the first 15 digits, and look at the
+    /// 16th digit for correct rounding.
+    fn parse(mut s: &str) -> Option<(&str, Self)> {
+        s = match s.as_bytes().first() {
+            Some(&b',' | &b'.') => &s[1..],
+            _ => return None,
+        };
+        let digits_in_fraction = s.as_bytes().iter().take_while(|c| c.is_ascii_digit()).count();
+        let mut fraction = scan::number(s, 1, 15).map(|(_, f)| f).ok()? as u64;
+        if digits_in_fraction <= 15 {
+            fraction *= POW10[15 - digits_in_fraction];
+        } else if s.as_bytes()[15] >= b'5' {
+            fraction += 1;
+        }
+        s = &s[digits_in_fraction..];
+        Some((s, Fraction(fraction)))
+    }
+
+    /// Returns the result of multiplying this `Fraction` with `unit`.
+    ///
+    /// Rounds to the nearest integer.
+    fn mul(&self, unit: u64) -> i64 {
+        assert!(unit <= 3600); // assumption to prevent overflow later.
+        ((self.0 * unit + (POW10[15] / 2 - 1)) / POW10[15]) as i64
+    }
+
+    /// Returns the result of multiplying this `Fraction` with `unit`.
+    ///
+    /// Returns two integers to represent the whole number and the fraction as nanos.
+    fn mul_with_nanos(&self, unit: u64) -> (i64, i64) {
+        assert!(unit <= 3600); // assumption to prevent overflow later.
+        let div = POW10[15 - 9];
+        let huge = self.0 * unit + (div / 2 - 1);
+        let whole = huge / POW10[15];
+        let fraction_as_nanos = (huge % POW10[15]) / div;
+        (whole as i64, fraction_as_nanos as i64)
+    }
+}
+
+const POW10: [u64; 16] = [
+    1, // unused, for easy indexing
+    10,
+    100,
+    1_000,
+    10_000,
+    100_000,
+    1_000_000,
+    10_000_000,
+    100_000_000,
+    1_000_000_000,
+    10_000_000_000,
+    100_000_000_000,
+    1_000_000_000_000,
+    10_000_000_000_000,
+    100_000_000_000_000,
+    1_000_000_000_000_000,
+];
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,5 +249,20 @@ mod tests {
         assert_eq!(parse("23-W23-5 "), Err(INVALID));
         // Year is interpreted as `iso_year`
         assert_eq!(parse("2022-W52-7 "), Ok((NaiveDate::from_ymd_opt(2023, 1, 1).unwrap(), " ")));
+    }
+
+    #[test]
+    fn test_parse_fraction() {
+        let (_, fraction) = Fraction::parse(",123").unwrap();
+        assert_eq!(fraction.0, 123_000_000_000_000);
+        let (_, fraction) = Fraction::parse(",123456789012345").unwrap();
+        assert_eq!(fraction.0, 123_456_789_012_345);
+        let (_, fraction) = Fraction::parse(",1234567890123454").unwrap();
+        assert_eq!(fraction.0, 123_456_789_012_345);
+        let (_, fraction) = Fraction::parse(",1234567890123455").unwrap();
+        assert_eq!(fraction.0, 123_456_789_012_346);
+
+        let (_, fraction) = Fraction::parse(",5").unwrap();
+        assert_eq!(fraction.mul_with_nanos(1), (0, 500_000_000));
     }
 }

--- a/src/format/scan.rs
+++ b/src/format/scan.rs
@@ -257,7 +257,14 @@ where
     s = &s[2..];
 
     // colons (and possibly other separators)
-    s = consume_colon(s)?;
+    match (allow_missing_minutes, consume_colon(s)) {
+        (false, Err(e)) => return Err(e),
+        (true, Err(_)) => {
+            let seconds = hours * 3600;
+            return Ok((s, if negative { -seconds } else { seconds }));
+        }
+        (_, Ok(s_new)) => s = s_new,
+    }
 
     // minutes (00--59)
     // if the next two items are digits then we have to add minutes

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -16,8 +16,10 @@ use rkyv::{Archive, Deserialize, Serialize};
 use crate::duration::Duration as OldDuration;
 #[cfg(any(feature = "alloc", feature = "std"))]
 use crate::format::DelayedFormat;
-use crate::format::{parse, parse_and_remainder, ParseError, ParseResult, Parsed, StrftimeItems};
-use crate::format::{Fixed, Item, Numeric, Pad};
+use crate::format::{
+    parse, parse_and_remainder, parse_iso8601_datetime, Fixed, Item, Numeric, Pad, ParseError,
+    ParseResult, Parsed, StrftimeItems,
+};
 use crate::naive::{Days, IsoWeek, NaiveDate, NaiveTime};
 use crate::offset::Utc;
 use crate::{expect, DateTime, Datelike, LocalResult, Months, TimeZone, Timelike, Weekday};
@@ -337,6 +339,50 @@ impl NaiveDateTime {
         let mut parsed = Parsed::new();
         let remainder = parse_and_remainder(&mut parsed, s, StrftimeItems::new(fmt))?;
         parsed.to_naive_datetime_with_offset(0).map(|d| (d, remainder)) // no offset adjustment
+    }
+
+    /// Parses an ISO 8601 date and time string into a `NaiveDateTime` value.
+    ///
+    /// ISO 8601 allows representing values in a wide range of formats. See below for some examples.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use chrono::{NaiveDate, NaiveDateTime, Weekday};
+    /// // calendar date, regular time, basic format
+    /// assert_eq!(
+    ///     NaiveDateTime::parse_from_iso8601("20230609T101530").unwrap(),
+    ///     (NaiveDate::from_ymd_opt(2023, 6, 9).unwrap().and_hms_opt(10, 15, 30).unwrap(), "")
+    /// );
+    /// // calendar date, regular time, extended format
+    /// assert_eq!(
+    ///     NaiveDateTime::parse_from_iso8601("2023-06-09T10:15:30").unwrap(),
+    ///     (NaiveDate::from_ymd_opt(2023, 6, 9).unwrap().and_hms_opt(10, 15, 30).unwrap(), "")
+    /// );
+    /// // ordinal date, time with fraction of a second, extended format, `,` as decimal sign
+    /// assert_eq!(
+    ///     NaiveDateTime::parse_from_iso8601("2023-160T10:15:30,25").unwrap(),
+    ///     (NaiveDate::from_yo_opt(2023, 160)
+    ///         .unwrap()
+    ///         .and_hms_milli_opt(10, 15, 30, 250)
+    ///         .unwrap(), "")
+    /// );
+    /// // week date, time with fraction of an hour, basic format, `.` as decimal sign
+    /// assert_eq!(
+    ///     NaiveDateTime::parse_from_iso8601("2023W235T10.25").unwrap(),
+    ///     (NaiveDate::from_isoywd_opt(2023, 23, Weekday::Fri)
+    ///         .unwrap()
+    ///         .and_hms_opt(10, 15, 0)
+    ///         .unwrap(), "")
+    /// );
+    /// // calendar date, regular time, extended format, expanded representation
+    /// assert_eq!(
+    ///     NaiveDateTime::parse_from_iso8601("+12023-06-09T10:15:30").unwrap(),
+    ///     (NaiveDate::from_ymd_opt(12023, 6, 9).unwrap().and_hms_opt(10, 15, 30).unwrap(), "")
+    /// );
+    /// ```
+    pub fn parse_from_iso8601(s: &str) -> ParseResult<(NaiveDateTime, &str)> {
+        parse_iso8601_datetime(s).map(|(dt, remainder, _)| (dt, remainder))
     }
 
     /// Retrieves a date component.

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -433,3 +433,23 @@ fn test_and_utc() {
     assert_eq!(dt_utc.naive_local(), ndt);
     assert_eq!(dt_utc.timezone(), Utc);
 }
+
+#[test]
+fn test_parse_from_iso8601() {
+    let parse = |s| NaiveDateTime::parse_from_iso8601(s).map(|(dt, _)| dt);
+    let datetime = |y, m, d, h, n, s, nano| {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_nano_opt(h, n, s, nano).unwrap()
+    };
+
+    // Taken from ISO 8601
+    assert_eq!(parse("19850412T101530"), Ok(datetime(1985, 4, 12, 10, 15, 30, 0)));
+    assert_eq!(parse("1985-04-12T10:15:30"), Ok(datetime(1985, 4, 12, 10, 15, 30, 0)));
+    assert_eq!(parse("19850412T1015"), Ok(datetime(1985, 4, 12, 10, 15, 0, 0)));
+    assert_eq!(parse("1985-04-12T10:15"), Ok(datetime(1985, 4, 12, 10, 15, 0, 0)));
+    assert_eq!(parse("1985102T1015"), Ok(datetime(1985, 4, 12, 10, 15, 0, 0)));
+    assert_eq!(parse("1985-102T10:15"), Ok(datetime(1985, 4, 12, 10, 15, 0, 0)));
+    assert_eq!(parse("1985W155T1015"), Ok(datetime(1985, 4, 12, 10, 15, 0, 0)));
+    assert_eq!(parse("1985-W15-5T10:15"), Ok(datetime(1985, 4, 12, 10, 15, 0, 0)));
+    // Test 24:00:00 wraps to the next day
+    assert_eq!(parse("2023-06-09T24:00:00"), Ok(datetime(2023, 6, 10, 0, 0, 0, 0)));
+}

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -453,3 +453,12 @@ fn test_parse_from_iso8601() {
     // Test 24:00:00 wraps to the next day
     assert_eq!(parse("2023-06-09T24:00:00"), Ok(datetime(2023, 6, 10, 0, 0, 0, 0)));
 }
+
+#[test]
+fn test_iso8601_parses_debug() {
+    let parse = |s| NaiveDateTime::parse_from_iso8601(s).map(|(dt, _)| dt);
+
+    let dt = NaiveDate::from_ymd_opt(12345, 6, 7).unwrap().and_hms_nano_opt(8, 9, 10, 11).unwrap();
+    let debug = format!("{:?}", dt);
+    assert_eq!(parse(&debug), Ok(dt));
+}


### PR DESCRIPTION
My main motivation for adding an ISO 8601 parser is that chrono is currently unable to parse is own `Debug` output if the year is outside the `0..=9999` range supported by RFC 3339. Edit: I forgot the `FromString` implementation of `DateTime` is very forgiving and accepts this.

A second motivation is that this crate frequently mentions ISO 8601. Then it is strange it does not even have a parser for that format :laughing:.

ISO 8601 date/time strings have a pretty complex format. I see it as a combination of 12 different formats for the date, 12 formats for the time, and 4 for the offset.

I have made the parser public as a `parse_from_iso8601` method on `NaiveDate`, `NaiveTime`, `NaiveDateTime` and `DateTime::<FixedOffset>`.

Sorry that this is such a large PR.
The only thing I can say is that about half of it are tests and documentation.

Fixes https://github.com/chronotope/chrono/issues/587.