### PR TITLE
Small fixes to the RFC 3339 parsers

### DIFF
--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -637,6 +637,10 @@ fn test_datetime_rfc3339() {
         DateTime::parse_from_rfc3339("2015-02-18T23:16:09Z"),
         Ok(ymdhms(&edt0, 2015, 2, 18, 23, 16, 9))
     );
+    assert_eq!(
+        DateTime::parse_from_rfc3339("2015-02-18 23:59:60.234567+05:00"),
+        Ok(ymdhms_micro(&edt5, 2015, 2, 18, 23, 59, 59, 1_234_567))
+    );
     assert_eq!(ymdhms_utc(2015, 2, 18, 23, 16, 9).to_rfc3339(), "2015-02-18T23:16:09+00:00");
 
     assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567 +05:00").is_err());
@@ -646,7 +650,6 @@ fn test_datetime_rfc3339() {
     assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567PST").is_err());
     assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+0500").is_err());
     assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00:00").is_err());
-    assert!(DateTime::parse_from_rfc3339("2015-02-18 23:59:60.234567+05:00").is_err());
     assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567:+05:00").is_err());
     assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00 ").is_err());
     assert!(DateTime::parse_from_rfc3339(" 2015-02-18T23:59:60.234567+05:00").is_err());

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -805,6 +805,8 @@ fn test_parse_datetime_utc() {
         "2001-02-03T04:05:06+0000",
         "2001-02-03T04:05:06-00:00",
         "2001-02-03T04:05:06-01:00",
+        "2012-12-12 12:12:12Z",
+        "2012-12-12t12:12:12Z",
         "2012-12-12T12:12:12Z",
         "2012 -12-12T12:12:12Z",
         "2012  -12-12T12:12:12Z",
@@ -871,7 +873,6 @@ fn test_parse_datetime_utc() {
         "2012-12-12T12:61:12Z",     // invalid minute
         "2012-12-12T12:12:62Z",     // invalid second
         "2012-12-12 T12:12:12Z",    // space after date
-        "2012-12-12t12:12:12Z",     // wrong divider 't'
         "2012-12-12T12:12:12ZZ",    // trailing literal 'Z'
         "+802701-12-12T12:12:12Z",  // invalid year (out of bounds)
         "+ 2012-12-12T12:12:12Z",   // invalid space before year

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -471,6 +471,29 @@ fn test_datetime_rfc2822() {
         .to_rfc2822(),
         "Wed, 18 Feb 2015 23:16:09 +0500"
     );
+    assert_eq!(
+        DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:60 +0500"),
+        Ok(edt
+            .from_local_datetime(
+                &NaiveDate::from_ymd_opt(2015, 2, 18)
+                    .unwrap()
+                    .and_hms_milli_opt(23, 59, 59, 1_000)
+                    .unwrap()
+            )
+            .unwrap())
+    );
+    assert!(DateTime::parse_from_rfc2822("31 DEC 262143 23:59 -2359").is_err());
+    assert_eq!(
+        DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00"),
+        Ok(edt
+            .from_local_datetime(
+                &NaiveDate::from_ymd_opt(2015, 2, 18)
+                    .unwrap()
+                    .and_hms_micro_opt(23, 59, 59, 1_234_567)
+                    .unwrap()
+            )
+            .unwrap())
+    );
     // seconds 60
     assert_eq!(
         edt.from_local_datetime(
@@ -613,29 +636,6 @@ fn test_datetime_rfc3339() {
     assert_eq!(
         DateTime::parse_from_rfc3339("2015-02-18T23:16:09Z"),
         Ok(ymdhms(&edt0, 2015, 2, 18, 23, 16, 9))
-    );
-    assert_eq!(
-        DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:60 +0500"),
-        Ok(edt5
-            .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2015, 2, 18)
-                    .unwrap()
-                    .and_hms_milli_opt(23, 59, 59, 1_000)
-                    .unwrap()
-            )
-            .unwrap())
-    );
-    assert!(DateTime::parse_from_rfc2822("31 DEC 262143 23:59 -2359").is_err());
-    assert_eq!(
-        DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00"),
-        Ok(edt5
-            .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2015, 2, 18)
-                    .unwrap()
-                    .and_hms_micro_opt(23, 59, 59, 1_234_567)
-                    .unwrap()
-            )
-            .unwrap())
     );
     assert_eq!(ymdhms_utc(2015, 2, 18, 23, 16, 9).to_rfc3339(), "2015-02-18T23:16:09+00:00");
 

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -743,6 +743,17 @@ fn test_datetime_from_str() {
             )
             .unwrap())
     );
+    assert_eq!(
+        "2015-02-18T23:16:9.15Utc".parse::<DateTime<Utc>>(),
+        Ok(Utc
+            .from_local_datetime(
+                &NaiveDate::from_ymd_opt(2015, 2, 18)
+                    .unwrap()
+                    .and_hms_milli_opt(23, 16, 9, 150)
+                    .unwrap()
+            )
+            .unwrap())
+    );
 
     assert_eq!(
         "2015-2-18T23:16:9.15Z".parse::<DateTime<FixedOffset>>(),

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -69,6 +69,7 @@ pub use formatting::{format_item_localized, format_localized};
 pub use locales::Locale;
 #[cfg(all(not(feature = "unstable-locales"), any(feature = "alloc", feature = "std")))]
 pub(crate) use locales::Locale;
+pub(crate) use parse::parse_rfc3339;
 pub use parse::{parse, parse_and_remainder};
 pub use parsed::Parsed;
 pub use strftime::StrftimeItems;
@@ -450,7 +451,7 @@ const IMPOSSIBLE: ParseError = ParseError(ParseErrorKind::Impossible);
 const NOT_ENOUGH: ParseError = ParseError(ParseErrorKind::NotEnough);
 const INVALID: ParseError = ParseError(ParseErrorKind::Invalid);
 const TOO_SHORT: ParseError = ParseError(ParseErrorKind::TooShort);
-const TOO_LONG: ParseError = ParseError(ParseErrorKind::TooLong);
+pub(crate) const TOO_LONG: ParseError = ParseError(ParseErrorKind::TooLong);
 const BAD_FORMAT: ParseError = ParseError(ParseErrorKind::BadFormat);
 
 // this implementation is here only because we need some private code from `scan`

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -488,7 +488,13 @@ where
                     }
 
                     &RFC2822 => try_consume!(parse_rfc2822(parsed, s)),
-                    &RFC3339 => try_consume!(parse_rfc3339(parsed, s)),
+                    &RFC3339 => {
+                        // Used for the `%+` specifier, which has the description:
+                        // "Same as `%Y-%m-%dT%H:%M:%S%.f%:z` (...)
+                        // This format also supports having a `Z` or `UTC` in place of `%:z`."
+                        // Use the relaxed parser to match this description.
+                        try_consume!(parse_rfc3339_relaxed(parsed, s))
+                    }
                 }
             }
 

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -567,10 +567,14 @@ fn parse_rfc3339_relaxed<'a>(parsed: &mut Parsed, mut s: &'a str) -> ParseResult
         Err((_s, e)) => return Err(e),
         Ok(_) => return Err(NOT_ENOUGH),
     };
-    if !(s.starts_with('T') || s.starts_with(' ')) {
-        return Err(INVALID);
-    }
-    match parse_internal(parsed, &s[1..], TIME_ITEMS.iter()) {
+
+    s = match s.as_bytes().first() {
+        Some(&b't' | &b'T' | &b' ') => &s[1..],
+        Some(_) => return Err(INVALID),
+        None => return Err(TOO_SHORT),
+    };
+
+    match parse_internal(parsed, s, TIME_ITEMS.iter()) {
         Err((s, e)) if e.0 == ParseErrorKind::TooLong => Ok((s, ())),
         Err((_s, e)) => Err(e),
         Ok(s) => Ok((s, ())),

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -155,7 +155,7 @@ fn parse_rfc2822<'a>(parsed: &mut Parsed, mut s: &'a str) -> ParseResult<(&'a st
     Ok((s, ()))
 }
 
-fn parse_rfc3339<'a>(parsed: &mut Parsed, mut s: &'a str) -> ParseResult<(&'a str, ())> {
+pub(crate) fn parse_rfc3339<'a>(parsed: &mut Parsed, mut s: &'a str) -> ParseResult<(&'a str, ())> {
     macro_rules! try_consume {
         ($e:expr) => {{
             let (s_, v) = $e?;
@@ -1817,15 +1817,9 @@ mod tests {
             ("2015-01-20T00:00:1-08:00", Err(INVALID)),  // missing complete S
         ];
 
-        fn rfc3339_to_datetime(date: &str) -> ParseResult<DateTime<FixedOffset>> {
-            let mut parsed = Parsed::new();
-            parse(&mut parsed, date, [Item::Fixed(Fixed::RFC3339)].iter())?;
-            parsed.to_datetime()
-        }
-
         // Test against test data above
         for &(date, checkdate) in testdates.iter() {
-            let dt = rfc3339_to_datetime(date); // parse a date
+            let dt = DateTime::<FixedOffset>::parse_from_rfc3339(date);
             if dt != checkdate {
                 // check for expected result
                 panic!(

--- a/src/format/scan.rs
+++ b/src/format/scan.rs
@@ -210,21 +210,8 @@ where
     F: FnMut(&str) -> ParseResult<&str>,
 {
     if allow_zulu {
-        let bytes = s.as_bytes();
-        match bytes.first() {
-            Some(&b'z') | Some(&b'Z') => return Ok((&s[1..], 0)),
-            Some(&b'u') | Some(&b'U') => {
-                if bytes.len() >= 3 {
-                    let (b, c) = (bytes[1], bytes[2]);
-                    match (b | 32, c | 32) {
-                        (b't', b'c') => return Ok((&s[3..], 0)),
-                        _ => return Err(INVALID),
-                    }
-                } else {
-                    return Err(INVALID);
-                }
-            }
-            _ => {}
+        if let Some(&b'Z' | &b'z') = s.as_bytes().first() {
+            return Ok((&s[1..], 0));
         }
     }
 


### PR DESCRIPTION
We have two RFC 3339 parsers in chrono:
- a strict parser in `format::parse::parse_rfc3339`, used by `DateTime<FixedOffset>::parse_from_rfc_3339` and `%+`.
- a permissive parser in `impl str::FromStr for DateTime<FixedOffset>`

This branch fixed a couple of issues with both parsers:

- The separator between a date and time can be a space.
  From the standard:
  > NOTE: ISO 8601 defines date and time separated by "T". Applications using this syntax may choose, for the sake of readability, to specify a full-date and full-time separated by (say) a space character.

  The permissive parser already accepted a space, now the strict parser also does.
  The vague wording suggest more characters than `'T'` and `' '` might be allowed, but I have stopped at adding just a space.

- Allow `'t'` as a seperator between date and time.
  From the standard:
  > NOTE: Per [ABNF] and ISO8601, the "T" and "Z" characters in this syntax may alternatively be lower case "t" or "z" respectively.

  The strict parser accepted `'t'`, now the relaxed parser also does.

- Don't support `UTC` as a timezone name in the strict parser.
  RFC 3339 only allows `'Z'` or an offset, not `UTC`.
  It seems https://github.com/chronotope/chrono/pull/378 accidentally made the strict parser accept this.
  For the relaxed parser it makes sense to accept `UTC`, as it allows roundtripping with the `Debug` format of `DateTime<Utc>`.

- The `%+` formatting specifier, which uses the `RFC3339` formatting item, has as documentation:
  > Same as `%Y-%m-%dT%H:%M:%S%.f%:z`, i.e. 0, 3, 6 or 9 fractional digits for seconds and colons in the time zone offset.
  >
  > This format also supports having a `Z` or `UTC` in place of `%:z`. They are equivalent to `+00:00`.
  >
  > Note that all `T`, `Z`, and `UTC` are parsed case-insensitively.
  >
  > The typical `strftime` implementations have different (and locale-dependent) formats for this specifier. While Chrono's format for `%+` is far more stable, it is best to avoid this specifier if you want to control the exact output.

  Al the formatting specifiers noted in this documentation are forgiving with padding. The permissive parser uses the exact formatting items listed here. So I factored out the permissive parser from the `FromString` implementation, and switched the `RFC3339` item to use that parser instead of the strict one.

The remaining differences of the permissive parser with the strict one are:
> - Values don't require padding to two digits.
> - Years outside the range 0...=9999 are accepted, but they must include a sign.
> - `UTC` is accepted as a valid timezone name/offset.
> - There can be spaces between any of the components.
> - The colon in the offset may be missing.