### PR TITLE
Make `StrftimeItems` with `unstable-locales` work without allocating

### DIFF
--- a/benches/chrono.rs
+++ b/benches/chrono.rs
@@ -3,7 +3,10 @@
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
+use chrono::format::StrftimeItems;
 use chrono::prelude::*;
+#[cfg(feature = "unstable-locales")]
+use chrono::Locale;
 use chrono::{DateTime, FixedOffset, Local, Utc, __BenchYearFlags};
 
 fn bench_datetime_parse_from_rfc2822(c: &mut Criterion) {
@@ -122,6 +125,27 @@ fn bench_num_days_from_ce(c: &mut Criterion) {
     }
 }
 
+fn bench_parse_strftime(c: &mut Criterion) {
+    c.bench_function("bench_parse_strftime", |b| {
+        b.iter(|| {
+            let str = black_box("%a, %d %b %Y %H:%M:%S GMT");
+            let items = StrftimeItems::new(str);
+            black_box(items.collect::<Vec<_>>());
+        })
+    });
+}
+
+#[cfg(feature = "unstable-locales")]
+fn bench_parse_strftime_localized(c: &mut Criterion) {
+    c.bench_function("bench_parse_strftime_localized", |b| {
+        b.iter(|| {
+            let str = black_box("%a, %d %b %Y %H:%M:%S GMT");
+            let items = StrftimeItems::new_with_locale(str, Locale::nl_NL);
+            black_box(items.collect::<Vec<_>>());
+        })
+    });
+}
+
 criterion_group!(
     benches,
     bench_datetime_parse_from_rfc2822,
@@ -132,6 +156,13 @@ criterion_group!(
     bench_year_flags_from_year,
     bench_num_days_from_ce,
     bench_get_local_time,
+    bench_parse_strftime,
 );
 
+#[cfg(feature = "unstable-locales")]
+criterion_group!(unstable_locales, bench_parse_strftime_localized,);
+
+#[cfg(not(feature = "unstable-locales"))]
 criterion_main!(benches);
+#[cfg(feature = "unstable-locales")]
+criterion_main!(benches, unstable_locales);

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -742,4 +742,21 @@ mod tests {
         let mut buf = String::new();
         let _ = write!(buf, "{}", dt.format("%#z")).expect_err("parse-only formatter should fail");
     }
+
+    #[test]
+    #[cfg(not(feature = "unstable-locales"))]
+    fn test_type_sizes() {
+        use core::mem::size_of;
+        assert_eq!(size_of::<Item>(), 24);
+        assert_eq!(size_of::<StrftimeItems>(), 80);
+    }
+
+    #[test]
+    #[cfg(feature = "unstable-locales")]
+    fn test_type_sizes() {
+        use core::mem::size_of;
+        assert_eq!(size_of::<Item>(), 24);
+        assert_eq!(size_of::<StrftimeItems>(), 112);
+        assert_eq!(size_of::<Locale>(), 2);
+    }
 }

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -220,7 +220,7 @@ pub struct StrftimeItems<'a> {
 impl<'a> StrftimeItems<'a> {
     /// Creates a new parsing iterator from the `strftime`-like format string.
     #[must_use]
-    pub fn new(s: &'a str) -> StrftimeItems<'a> {
+    pub const fn new(s: &'a str) -> StrftimeItems<'a> {
         #[cfg(not(feature = "unstable-locales"))]
         {
             StrftimeItems { remainder: s, queue: &[] }
@@ -235,7 +235,7 @@ impl<'a> StrftimeItems<'a> {
     #[cfg(feature = "unstable-locales")]
     #[cfg_attr(docsrs, doc(cfg(feature = "unstable-locales")))]
     #[must_use]
-    pub fn new_with_locale(s: &'a str, locale: Locale) -> StrftimeItems<'a> {
+    pub const fn new_with_locale(s: &'a str, locale: Locale) -> StrftimeItems<'a> {
         StrftimeItems { remainder: s, queue: &[], locale_str: "", locale: Some(locale) }
     }
 }


### PR DESCRIPTION
For https://github.com/chronotope/chrono/issues/1127 I am slowly exploring some options around `StrftimeItems`. Nothing I am happy with yet though :smile:.

This seems like a simple and useful change by itself. This makes `StrftimeItems` quite a bit faster with the `unstable-locales` feature, work without allocating, and shrinks the size of `StrftimeItems`.

Previously with the `unstable_locales` feature, on every `StrftimeItems::new_localized` we would lookup and parse three localized formatting strings and store them in `Vec`'s. Just in case they would be needed.

I changed it to delay the lookup until there is a specifier that uses one.
And instead of pre-parsing the localized format string into a `Vec` and returning the items one by one, we now store only a reference to the localized string and switch to parsing that, and when done continue with parsing the user-supplied format string.

The size of `StrftimeItems` goes from 80 bytes to 32 without the `unstable-locales` feature, and from 112 bytes to 56 with the feature.