### PR TITLE
Formatting benchmarks

### DIFF
--- a/benches/chrono.rs
+++ b/benches/chrono.rs
@@ -146,6 +146,36 @@ fn bench_parse_strftime_localized(c: &mut Criterion) {
     });
 }
 
+fn bench_format(c: &mut Criterion) {
+    let dt = Local::now();
+    c.bench_function("bench_format", |b| b.iter(|| format!("{}", dt.format("%Y-%m-%d %H-%M-%S"))));
+}
+
+fn bench_format_with_items(c: &mut Criterion) {
+    let dt = Local::now();
+    let items: Vec<_> = StrftimeItems::new("%Y-%m-%d %H-%M-%S").collect();
+    c.bench_function("bench_format_with_items", |b| {
+        b.iter(|| format!("{}", dt.format_with_items(items.iter())))
+    });
+}
+
+fn bench_format_manual(c: &mut Criterion) {
+    let dt = Local::now();
+    c.bench_function("bench_format_manual", |b| {
+        b.iter(|| {
+            format!(
+                "{}-{:02}-{:02} {:02}:{:02}:{:02}",
+                dt.year(),
+                dt.month(),
+                dt.day(),
+                dt.hour(),
+                dt.minute(),
+                dt.second()
+            )
+        })
+    });
+}
+
 criterion_group!(
     benches,
     bench_datetime_parse_from_rfc2822,
@@ -157,6 +187,9 @@ criterion_group!(
     bench_num_days_from_ce,
     bench_get_local_time,
     bench_parse_strftime,
+    bench_format,
+    bench_format_with_items,
+    bench_format_manual,
 );
 
 #[cfg(feature = "unstable-locales")]


### PR DESCRIPTION
https://github.com/chronotope/chrono/issues/94#issuecomment-394762058 has a nice idea for formatting benchmarks.

Results on my system:
```
     Running benches/chrono.rs (target/release/deps/chrono-eb588f69f700f098)
bench_format            time:   [740.11 ns 745.91 ns 752.24 ns]
Found 14 outliers among 100 measurements (14.00%)
  11 (11.00%) high mild
  3 (3.00%) high severe

bench_format_with_items time:   [600.06 ns 607.71 ns 616.05 ns]
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe

bench_format_manual     time:   [436.17 ns 438.23 ns 440.08 ns]
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
```

Reparsing the format string on every iteration (`bench_format`) takes about 1,2x as long as using a vector of formatting items (`bench_format_with_items`). But our formatting implementation has about 40% overhead compared to manual formatting.