### PR TITLE
Feature gate tests instead of methods

### DIFF
--- a/src/date.rs
+++ b/src/date.rs
@@ -4,7 +4,7 @@
 //! ISO 8601 calendar date with time zone.
 #![allow(deprecated)]
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 use core::borrow::Borrow;
 use core::cmp::Ordering;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
@@ -15,7 +15,7 @@ use rkyv::{Archive, Deserialize, Serialize};
 
 #[cfg(feature = "unstable-locales")]
 use crate::format::Locale;
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 use crate::format::{DelayedFormat, Item, StrftimeItems};
 use crate::naive::{IsoWeek, NaiveDate, NaiveTime};
 use crate::offset::{TimeZone, Utc};
@@ -333,7 +333,7 @@ where
     Tz::Offset: fmt::Display,
 {
     /// Formats the date with the specified formatting items.
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]
@@ -348,7 +348,7 @@ where
     /// Formats the date with the specified format string.
     /// See the [`crate::format::strftime`] module
     /// on the supported escape sequences.
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -15,7 +15,7 @@ use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::{fmt, hash, str};
 #[cfg(feature = "std")]
 use std::string::ToString;
-#[cfg(any(feature = "std", test))]
+#[cfg(feature = "std")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(any(feature = "alloc", feature = "std", test))]
@@ -1301,7 +1301,7 @@ impl str::FromStr for DateTime<Local> {
     }
 }
 
-#[cfg(any(feature = "std", test))]
+#[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl From<SystemTime> for DateTime<Utc> {
     fn from(t: SystemTime) -> DateTime<Utc> {
@@ -1330,7 +1330,7 @@ impl From<SystemTime> for DateTime<Local> {
     }
 }
 
-#[cfg(any(feature = "std", test))]
+#[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl<Tz: TimeZone> From<DateTime<Tz>> for SystemTime {
     fn from(dt: DateTime<Tz>) -> SystemTime {

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -18,7 +18,7 @@ use std::string::ToString;
 #[cfg(feature = "std")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 use crate::format::DelayedFormat;
 #[cfg(feature = "unstable-locales")]
 use crate::format::Locale;
@@ -707,7 +707,7 @@ where
     ///
     /// Panics if the date can not be represented in this format: the year may not be negative and
     /// can not have more than 4 digits.
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[must_use]
     pub fn to_rfc2822(&self) -> String {
@@ -718,7 +718,7 @@ where
     }
 
     /// Returns an RFC 3339 and ISO 8601 date and time string such as `1996-12-19T16:39:57-08:00`.
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[must_use]
     pub fn to_rfc3339(&self) -> String {
@@ -752,7 +752,7 @@ where
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Secs, true),
     ///            "2018-01-26T10:30:09+08:00");
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[must_use]
     pub fn to_rfc3339_opts(&self, secform: SecondsFormat, use_z: bool) -> String {
@@ -798,7 +798,7 @@ where
     }
 
     /// Formats the combined date and time with the specified formatting items.
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]
@@ -823,7 +823,7 @@ where
     /// let formatted = format!("{}", date_time.format("%d/%m/%Y %H:%M"));
     /// assert_eq!(formatted, "02/04/2017 12:50");
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1495,7 +1495,7 @@ fn test_decodable_json<FUtc, FFixed, FLocal, E>(
     // we don't know the exact local offset but we can check that
     // the conversion didn't change the instant itself
     assert_eq!(
-        local_from_str(r#""2014-07-24T12:34:06Z""#).expect("local shouuld parse"),
+        local_from_str(r#""2014-07-24T12:34:06Z""#).expect("local should parse"),
         Utc.with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
     );
     assert_eq!(

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -1130,7 +1130,9 @@ pub mod ts_seconds_option {
 
 #[cfg(test)]
 mod tests {
-    use crate::datetime::{test_decodable_json, test_encodable_json};
+    #[cfg(feature = "clock")]
+    use crate::datetime::test_decodable_json;
+    use crate::datetime::test_encodable_json;
     use crate::{DateTime, TimeZone, Utc};
 
     #[test]

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -356,6 +356,7 @@ fn test_datetime_with_timezone() {
 }
 
 #[test]
+#[cfg(any(feature = "alloc", feature = "std"))]
 fn test_datetime_rfc2822_and_rfc3339() {
     let edt = FixedOffset::east_opt(5 * 60 * 60).unwrap();
     assert_eq!(
@@ -449,6 +450,7 @@ fn test_datetime_rfc2822_and_rfc3339() {
 }
 
 #[test]
+#[cfg(any(feature = "alloc", feature = "std"))]
 fn test_rfc3339_opts() {
     use crate::SecondsFormat::*;
     let pst = FixedOffset::east_opt(8 * 60 * 60).unwrap();
@@ -479,6 +481,7 @@ fn test_rfc3339_opts() {
 
 #[test]
 #[should_panic]
+#[cfg(any(feature = "alloc", feature = "std"))]
 fn test_rfc3339_opts_nonexhaustive() {
     use crate::SecondsFormat;
     let dt = Utc.with_ymd_and_hms(1999, 10, 9, 1, 2, 3).unwrap();
@@ -749,6 +752,7 @@ fn test_from_system_time() {
 }
 
 #[test]
+#[cfg(any(feature = "alloc", feature = "std"))]
 fn test_datetime_format_alignment() {
     let datetime = Utc.with_ymd_and_hms(2007, 1, 2, 0, 0, 0).unwrap();
 

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1,5 +1,3 @@
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use super::DateTime;
 use crate::naive::{NaiveDate, NaiveTime};
 use crate::offset::{FixedOffset, TimeZone, Utc};
@@ -679,7 +677,7 @@ fn test_subsecond_part() {
 #[test]
 #[cfg(feature = "std")]
 fn test_from_system_time() {
-    use std::time::Duration;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     let nanos = 999_999_000;
 

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -677,77 +677,7 @@ fn test_subsecond_part() {
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
-fn test_from_system_time() {
-    use std::time::Duration;
-
-    let epoch = Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap();
-    let nanos = 999_999_999;
-
-    // SystemTime -> DateTime<Utc>
-    assert_eq!(DateTime::<Utc>::from(UNIX_EPOCH), epoch);
-    assert_eq!(
-        DateTime::<Utc>::from(UNIX_EPOCH + Duration::new(999_999_999, nanos)),
-        Utc.from_local_datetime(
-            &NaiveDate::from_ymd_opt(2001, 9, 9)
-                .unwrap()
-                .and_hms_nano_opt(1, 46, 39, nanos)
-                .unwrap()
-        )
-        .unwrap()
-    );
-    assert_eq!(
-        DateTime::<Utc>::from(UNIX_EPOCH - Duration::new(999_999_999, nanos)),
-        Utc.from_local_datetime(
-            &NaiveDate::from_ymd_opt(1938, 4, 24).unwrap().and_hms_nano_opt(22, 13, 20, 1).unwrap()
-        )
-        .unwrap()
-    );
-
-    // DateTime<Utc> -> SystemTime
-    assert_eq!(SystemTime::from(epoch), UNIX_EPOCH);
-    assert_eq!(
-        SystemTime::from(
-            Utc.from_local_datetime(
-                &NaiveDate::from_ymd_opt(2001, 9, 9)
-                    .unwrap()
-                    .and_hms_nano_opt(1, 46, 39, nanos)
-                    .unwrap()
-            )
-            .unwrap()
-        ),
-        UNIX_EPOCH + Duration::new(999_999_999, nanos)
-    );
-    assert_eq!(
-        SystemTime::from(
-            Utc.from_local_datetime(
-                &NaiveDate::from_ymd_opt(1938, 4, 24)
-                    .unwrap()
-                    .and_hms_nano_opt(22, 13, 20, 1)
-                    .unwrap()
-            )
-            .unwrap()
-        ),
-        UNIX_EPOCH - Duration::new(999_999_999, 999_999_999)
-    );
-
-    // DateTime<any tz> -> SystemTime (via `with_timezone`)
-    #[cfg(feature = "clock")]
-    {
-        assert_eq!(SystemTime::from(epoch.with_timezone(&Local)), UNIX_EPOCH);
-    }
-    assert_eq!(
-        SystemTime::from(epoch.with_timezone(&FixedOffset::east_opt(32400).unwrap())),
-        UNIX_EPOCH
-    );
-    assert_eq!(
-        SystemTime::from(epoch.with_timezone(&FixedOffset::west_opt(28800).unwrap())),
-        UNIX_EPOCH
-    );
-}
-
-#[test]
-#[cfg(target_os = "windows")]
+#[cfg(feature = "std")]
 fn test_from_system_time() {
     use std::time::Duration;
 

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -8,24 +8,24 @@ extern crate alloc;
 
 #[cfg(feature = "alloc")]
 use alloc::string::{String, ToString};
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 use core::borrow::Borrow;
 use core::fmt;
 use core::fmt::Write;
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 use crate::naive::{NaiveDate, NaiveTime};
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 use crate::offset::{FixedOffset, Offset};
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 use crate::{Datelike, Timelike, Weekday};
 
 #[cfg(feature = "unstable-locales")]
 use super::locales;
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 use super::{Fixed, InternalFixed, InternalInternal, Item, Locale, Numeric, Pad};
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 struct Locales {
     short_months: &'static [&'static str],
     long_months: &'static [&'static str],
@@ -34,7 +34,7 @@ struct Locales {
     am_pm: &'static [&'static str],
 }
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl Locales {
     fn new(_locale: Option<Locale>) -> Self {
         #[cfg(feature = "unstable-locales")]
@@ -84,7 +84,7 @@ impl Locales {
 
 /// A *temporary* object which can be used as an argument to `format!` or others.
 /// This is normally constructed via `format` methods of each date and time type.
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
 #[derive(Debug)]
 pub struct DelayedFormat<I> {
@@ -103,7 +103,7 @@ pub struct DelayedFormat<I> {
     locale: Option<Locale>,
 }
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
     /// Makes a new `DelayedFormat` value out of local date and time.
     #[must_use]
@@ -172,7 +172,7 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
     }
 }
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> fmt::Display for DelayedFormat<I> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         #[cfg(feature = "unstable-locales")]
@@ -195,7 +195,7 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> fmt::Display for De
 
 /// Tries to format given arguments with given formatting items.
 /// Internally used by `DelayedFormat`.
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
 pub fn format<'a, I, B>(
     w: &mut fmt::Formatter,
@@ -215,7 +215,7 @@ where
     w.pad(&result)
 }
 /// Formats single formatting item
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
 pub fn format_item(
     w: &mut fmt::Formatter,
@@ -268,7 +268,7 @@ pub fn format_item_localized(
     w.pad(&result)
 }
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 fn format_inner(
     result: &mut String,
     date: Option<&NaiveDate>,
@@ -281,7 +281,7 @@ fn format_inner(
 
     match *item {
         Item::Literal(s) | Item::Space(s) => result.push_str(s),
-        #[cfg(any(feature = "alloc", feature = "std", test))]
+        #[cfg(any(feature = "alloc", feature = "std"))]
         Item::OwnedLiteral(ref s) | Item::OwnedSpace(ref s) => result.push_str(s),
 
         Item::Numeric(ref spec, ref pad) => {
@@ -476,7 +476,7 @@ fn format_inner(
     Ok(())
 }
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum Colons {
     None,
@@ -487,7 +487,7 @@ enum Colons {
 
 /// Prints an offset from UTC in the format of `+HHMM` or `+HH:MM`.
 /// `Z` instead of `+00[:]00` is allowed when `allow_zulu` is true.
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 fn write_local_minus_utc(
     result: &mut String,
     off: FixedOffset,
@@ -521,7 +521,7 @@ fn write_local_minus_utc(
 }
 
 /// Writes the date, time and offset to the string. same as `%Y-%m-%dT%H:%M:%S%.f%:z`
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub(crate) fn write_rfc3339(
     result: &mut String,
     dt: crate::NaiveDateTime,
@@ -533,7 +533,7 @@ pub(crate) fn write_rfc3339(
     write_local_minus_utc(result, off, false, Colons::Single)
 }
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 /// write datetimes like `Tue, 1 Jul 2003 10:52:37 +0200`, same as `%a, %d %b %Y %H:%M:%S %z`
 pub(crate) fn write_rfc2822(
     result: &mut String,
@@ -543,7 +543,7 @@ pub(crate) fn write_rfc2822(
     write_rfc2822_inner(result, &dt.date(), &dt.time(), off, Locales::new(None))
 }
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 /// write datetimes like `Tue, 1 Jul 2003 10:52:37 +0200`, same as `%a, %d %b %Y %H:%M:%S %z`
 fn write_rfc2822_inner(
     result: &mut String,

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -37,7 +37,7 @@ extern crate alloc;
 use alloc::boxed::Box;
 use core::fmt;
 use core::str::FromStr;
-#[cfg(any(feature = "std", test))]
+#[cfg(feature = "std")]
 use std::error::Error;
 
 use crate::{Month, ParseMonthError, ParseWeekdayError, Weekday};
@@ -390,7 +390,7 @@ impl fmt::Display for ParseError {
     }
 }
 
-#[cfg(any(feature = "std", test))]
+#[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl Error for ParseError {
     #[allow(deprecated)]

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -55,11 +55,11 @@ pub mod strftime;
 pub(crate) mod locales;
 
 pub(crate) use formatting::write_hundreds;
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub use formatting::{format, format_item, DelayedFormat};
 #[cfg(feature = "unstable-locales")]
 pub use formatting::{format_item_localized, format_localized};
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub(crate) use formatting::{write_rfc2822, write_rfc3339};
 pub use parse::{parse, parse_and_remainder};
 pub use parsed::Parsed;
@@ -286,13 +286,13 @@ pub enum Item<'a> {
     /// A literally printed and parsed text.
     Literal(&'a str),
     /// Same as `Literal` but with the string owned by the item.
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     OwnedLiteral(Box<str>),
     /// Whitespace. Prints literally but reads zero or more whitespace.
     Space(&'a str),
     /// Same as `Space` but with the string owned by the item.
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     OwnedSpace(Box<str>),
     /// Numeric item. Can be optionally padded to the maximal length (if any) when formatting;

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -562,7 +562,7 @@ impl str::FromStr for DateTime<FixedOffset> {
 #[cfg(test)]
 mod tests {
     use crate::format::*;
-    use crate::{DateTime, FixedOffset, TimeZone, Utc};
+    use crate::{DateTime, FixedOffset, TimeZone, Timelike, Utc};
 
     #[test]
     fn test_parse() {
@@ -1353,6 +1353,7 @@ mod tests {
         let dt = Utc.with_ymd_and_hms(1994, 11, 6, 8, 49, 37).unwrap();
 
         // Check that the format is what we expect
+        #[cfg(any(feature = "alloc", feature = "std"))]
         assert_eq!(dt.format(RFC850_FMT).to_string(), dt_str);
 
         // Check that it parses correctly

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -309,7 +309,7 @@ where
                 s = &s[prefix.len()..];
             }
 
-            #[cfg(any(feature = "alloc", feature = "std", test))]
+            #[cfg(any(feature = "alloc", feature = "std"))]
             Item::OwnedLiteral(ref prefix) => {
                 if s.len() < prefix.len() {
                     return Err((s, TOO_SHORT));
@@ -324,7 +324,7 @@ where
                 s = s.trim_start();
             }
 
-            #[cfg(any(feature = "alloc", feature = "std", test))]
+            #[cfg(any(feature = "alloc", feature = "std"))]
             Item::OwnedSpace(_) => {
                 s = s.trim_start();
             }
@@ -1349,12 +1349,11 @@ mod tests {
     fn parse_rfc850() {
         static RFC850_FMT: &str = "%A, %d-%b-%y %T GMT";
 
-        let dt_str = "Sunday, 06-Nov-94 08:49:37 GMT";
         let dt = Utc.with_ymd_and_hms(1994, 11, 6, 8, 49, 37).unwrap();
 
         // Check that the format is what we expect
         #[cfg(any(feature = "alloc", feature = "std"))]
-        assert_eq!(dt.format(RFC850_FMT).to_string(), dt_str);
+        assert_eq!(dt.format(RFC850_FMT).to_string(), "Sunday, 06-Nov-94 08:49:37 GMT");
 
         // Check that it parses correctly
         assert_eq!(Ok(dt), Utc.datetime_from_str("Sunday, 06-Nov-94 08:49:37 GMT", RFC850_FMT));

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -1251,28 +1251,37 @@ mod tests {
 
     #[test]
     fn test_rfc2822() {
-        // Test data - (input, Ok(expected result after parse and format) or Err(error code))
+        let ymd_hmsn = |y, m, d, h, n, s, nano, off| {
+            FixedOffset::east_opt(off * 60 * 60)
+                .unwrap()
+                .with_ymd_and_hms(y, m, d, h, n, s)
+                .unwrap()
+                .with_nanosecond(nano)
+                .unwrap()
+        };
+
+        // Test data - (input, Ok(expected result) or Err(error code))
         let testdates = [
-            ("Tue, 20 Jan 2015 17:35:20 -0800", Ok("Tue, 20 Jan 2015 17:35:20 -0800")), // normal case
-            ("Fri,  2 Jan 2015 17:35:20 -0800", Ok("Fri, 02 Jan 2015 17:35:20 -0800")), // folding whitespace
-            ("Fri, 02 Jan 2015 17:35:20 -0800", Ok("Fri, 02 Jan 2015 17:35:20 -0800")), // leading zero
-            ("Tue, 20 Jan 2015 17:35:20 -0800 (UTC)", Ok("Tue, 20 Jan 2015 17:35:20 -0800")), // trailing comment
+            ("Tue, 20 Jan 2015 17:35:20 -0800", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -8))), // normal case
+            ("Fri,  2 Jan 2015 17:35:20 -0800", Ok(ymd_hmsn(2015, 1, 2, 17, 35, 20, 0, -8))), // folding whitespace
+            ("Fri, 02 Jan 2015 17:35:20 -0800", Ok(ymd_hmsn(2015, 1, 2, 17, 35, 20, 0, -8))), // leading zero
+            ("Tue, 20 Jan 2015 17:35:20 -0800 (UTC)", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -8))), // trailing comment
             (
                 r"Tue, 20 Jan 2015 17:35:20 -0800 ( (UTC ) (\( (a)\(( \t ) ) \\( \) ))",
-                Ok("Tue, 20 Jan 2015 17:35:20 -0800"),
+                Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -8)),
             ), // complex trailing comment
             (r"Tue, 20 Jan 2015 17:35:20 -0800 (UTC\)", Err(TOO_LONG)), // incorrect comment, not enough closing parentheses
             (
                 "Tue, 20 Jan 2015 17:35:20 -0800 (UTC)\t \r\n(Anothercomment)",
-                Ok("Tue, 20 Jan 2015 17:35:20 -0800"),
+                Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -8)),
             ), // multiple comments
             ("Tue, 20 Jan 2015 17:35:20 -0800 (UTC) ", Err(TOO_LONG)), // trailing whitespace after comment
-            ("20 Jan 2015 17:35:20 -0800", Ok("Tue, 20 Jan 2015 17:35:20 -0800")), // no day of week
-            ("20 JAN 2015 17:35:20 -0800", Ok("Tue, 20 Jan 2015 17:35:20 -0800")), // upper case month
-            ("Tue, 20 Jan 2015 17:35 -0800", Ok("Tue, 20 Jan 2015 17:35:00 -0800")), // no second
-            ("11 Sep 2001 09:45:00 +0000", Ok("Tue, 11 Sep 2001 09:45:00 +0000")),
-            ("11 Sep 2001 09:45:00 EST", Ok("Tue, 11 Sep 2001 09:45:00 -0500")),
-            ("11 Sep 2001 09:45:00 GMT", Ok("Tue, 11 Sep 2001 09:45:00 +0000")),
+            ("20 Jan 2015 17:35:20 -0800", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -8))), // no day of week
+            ("20 JAN 2015 17:35:20 -0800", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -8))), // upper case month
+            ("Tue, 20 Jan 2015 17:35 -0800", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 0, 0, -8))), // no second
+            ("11 Sep 2001 09:45:00 +0000", Ok(ymd_hmsn(2001, 9, 11, 9, 45, 0, 0, 0))),
+            ("11 Sep 2001 09:45:00 EST", Ok(ymd_hmsn(2001, 9, 11, 9, 45, 0, 0, -5))),
+            ("11 Sep 2001 09:45:00 GMT", Ok(ymd_hmsn(2001, 9, 11, 9, 45, 0, 0, 0))),
             ("30 Feb 2015 17:35:20 -0800", Err(OUT_OF_RANGE)), // bad day of month
             ("Tue, 20 Jan 2015", Err(TOO_SHORT)),              // omitted fields
             ("Tue, 20 Avr 2015 17:35:20 -0800", Err(INVALID)), // bad month name
@@ -1285,24 +1294,24 @@ mod tests {
             ("Tue, 20 Jan 2015 17:35:20 HAS", Err(NOT_ENOUGH)), // bad named time zone
             // named timezones that have specific timezone offsets
             // see https://www.rfc-editor.org/rfc/rfc2822#section-4.3
-            ("Tue, 20 Jan 2015 17:35:20 GMT", Ok("Tue, 20 Jan 2015 17:35:20 +0000")),
-            ("Tue, 20 Jan 2015 17:35:20 UT", Ok("Tue, 20 Jan 2015 17:35:20 +0000")),
-            ("Tue, 20 Jan 2015 17:35:20 ut", Ok("Tue, 20 Jan 2015 17:35:20 +0000")),
-            ("Tue, 20 Jan 2015 17:35:20 EDT", Ok("Tue, 20 Jan 2015 17:35:20 -0400")),
-            ("Tue, 20 Jan 2015 17:35:20 EST", Ok("Tue, 20 Jan 2015 17:35:20 -0500")),
-            ("Tue, 20 Jan 2015 17:35:20 CDT", Ok("Tue, 20 Jan 2015 17:35:20 -0500")),
-            ("Tue, 20 Jan 2015 17:35:20 CST", Ok("Tue, 20 Jan 2015 17:35:20 -0600")),
-            ("Tue, 20 Jan 2015 17:35:20 MDT", Ok("Tue, 20 Jan 2015 17:35:20 -0600")),
-            ("Tue, 20 Jan 2015 17:35:20 MST", Ok("Tue, 20 Jan 2015 17:35:20 -0700")),
-            ("Tue, 20 Jan 2015 17:35:20 PDT", Ok("Tue, 20 Jan 2015 17:35:20 -0700")),
-            ("Tue, 20 Jan 2015 17:35:20 PST", Ok("Tue, 20 Jan 2015 17:35:20 -0800")),
-            ("Tue, 20 Jan 2015 17:35:20 pst", Ok("Tue, 20 Jan 2015 17:35:20 -0800")),
+            ("Tue, 20 Jan 2015 17:35:20 GMT", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, 0))),
+            ("Tue, 20 Jan 2015 17:35:20 UT", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, 0))),
+            ("Tue, 20 Jan 2015 17:35:20 ut", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, 0))),
+            ("Tue, 20 Jan 2015 17:35:20 EDT", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -4))),
+            ("Tue, 20 Jan 2015 17:35:20 EST", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -5))),
+            ("Tue, 20 Jan 2015 17:35:20 CDT", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -5))),
+            ("Tue, 20 Jan 2015 17:35:20 CST", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -6))),
+            ("Tue, 20 Jan 2015 17:35:20 MDT", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -6))),
+            ("Tue, 20 Jan 2015 17:35:20 MST", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -7))),
+            ("Tue, 20 Jan 2015 17:35:20 PDT", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -7))),
+            ("Tue, 20 Jan 2015 17:35:20 PST", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -8))),
+            ("Tue, 20 Jan 2015 17:35:20 pst", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -8))),
             // named single-letter military timezones must fallback to +0000
-            ("Tue, 20 Jan 2015 17:35:20 Z", Ok("Tue, 20 Jan 2015 17:35:20 +0000")),
-            ("Tue, 20 Jan 2015 17:35:20 A", Ok("Tue, 20 Jan 2015 17:35:20 +0000")),
-            ("Tue, 20 Jan 2015 17:35:20 a", Ok("Tue, 20 Jan 2015 17:35:20 +0000")),
-            ("Tue, 20 Jan 2015 17:35:20 K", Ok("Tue, 20 Jan 2015 17:35:20 +0000")),
-            ("Tue, 20 Jan 2015 17:35:20 k", Ok("Tue, 20 Jan 2015 17:35:20 +0000")),
+            ("Tue, 20 Jan 2015 17:35:20 Z", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, 0))),
+            ("Tue, 20 Jan 2015 17:35:20 A", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, 0))),
+            ("Tue, 20 Jan 2015 17:35:20 a", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, 0))),
+            ("Tue, 20 Jan 2015 17:35:20 K", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, 0))),
+            ("Tue, 20 Jan 2015 17:35:20 k", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, 0))),
             // named single-letter timezone "J" is specifically not valid
             ("Tue, 20 Jan 2015 17:35:20 J", Err(NOT_ENOUGH)),
             ("Tue, 20 Jan 2015 17:35:20 -0890", Err(OUT_OF_RANGE)), // bad offset minutes
@@ -1321,21 +1330,12 @@ mod tests {
             parsed.to_datetime()
         }
 
-        fn fmt_rfc2822_datetime(dt: DateTime<FixedOffset>) -> String {
-            dt.format_with_items([Item::Fixed(Fixed::RFC2822)].iter()).to_string()
-        }
-
         // Test against test data above
         for &(date, checkdate) in testdates.iter() {
             eprintln!("Test input: {:?}", date);
             eprintln!("    Expect: {:?}", checkdate);
-            let d = rfc2822_to_datetime(date); // parse a date
-            let dt = match d {
-                // did we get a value?
-                Ok(dt) => Ok(fmt_rfc2822_datetime(dt)), // yes, go on
-                Err(e) => Err(e), // otherwise keep an error for the comparison
-            };
-            if dt != checkdate.map(|s| s.to_string()) {
+            let dt = rfc2822_to_datetime(date); // parse a date
+            if dt != checkdate {
                 // check for expected result
                 panic!(
                     "Date conversion failed for {}\nReceived: {:?}\nExpected: {:?}",

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -512,6 +512,7 @@ mod tests {
     use crate::format::Locale;
     use crate::format::{fixed, internal_fixed, num, num0, nums};
     use crate::format::{Fixed, InternalInternal, Numeric::*};
+    #[cfg(any(feature = "alloc", feature = "std"))]
     use crate::{DateTime, FixedOffset, NaiveDate, TimeZone, Timelike, Utc};
 
     #[test]
@@ -573,6 +574,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     fn test_strftime_docs() {
         let dt = FixedOffset::east_opt(34200)
             .unwrap()
@@ -675,8 +677,8 @@ mod tests {
         assert_eq!(dt.format("%%").to_string(), "%");
     }
 
-    #[cfg(feature = "unstable-locales")]
     #[test]
+    #[cfg(all(feature = "unstable-locales", any(feature = "alloc", feature = "std")))]
     fn test_strftime_docs_localized() {
         let dt = FixedOffset::east_opt(34200)
             .unwrap()
@@ -729,6 +731,7 @@ mod tests {
     ///
     /// See <https://github.com/chronotope/chrono/issues/1139>.
     #[test]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     fn test_parse_only_timezone_offset_permissive_no_panic() {
         use crate::NaiveDate;
         use crate::{FixedOffset, TimeZone};

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -3,7 +3,7 @@
 
 //! ISO 8601 calendar date without timezone.
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 use core::borrow::Borrow;
 use core::iter::FusedIterator;
 use core::ops::{Add, AddAssign, RangeInclusive, Sub, SubAssign};
@@ -16,7 +16,7 @@ use rkyv::{Archive, Deserialize, Serialize};
 #[cfg(feature = "unstable-locales")]
 use pure_rust_locales::Locale;
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 use crate::format::DelayedFormat;
 use crate::format::{
     parse, parse_and_remainder, write_hundreds, Item, Numeric, Pad, ParseError, ParseResult,
@@ -1246,7 +1246,7 @@ impl NaiveDate {
     /// # let d = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap();
     /// assert_eq!(format!("{}", d.format_with_items(fmt)), "2015-09-05");
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]
@@ -1290,7 +1290,7 @@ impl NaiveDate {
     /// assert_eq!(format!("{}", d.format("%Y-%m-%d")), "2015-09-05");
     /// assert_eq!(format!("{}", d.format("%A, %-d %B, %C%y")), "Saturday, 5 September, 2015");
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -3040,6 +3040,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     fn test_date_format() {
         let d = NaiveDate::from_ymd_opt(2012, 3, 4).unwrap();
         assert_eq!(d.format("%Y,%C,%y,%G,%g").to_string(), "2012,20,12,2012,12");

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -2290,15 +2290,6 @@ mod serde {
             formatter.write_str("a formatted date string")
         }
 
-        #[cfg(any(feature = "std", test))]
-        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-        where
-            E: de::Error,
-        {
-            value.parse().map_err(E::custom)
-        }
-
-        #[cfg(not(any(feature = "std", test)))]
         fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
         where
             E: de::Error,

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -3,7 +3,7 @@
 
 //! ISO 8601 date and time without timezone.
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 use core::borrow::Borrow;
 use core::fmt::Write;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
@@ -12,7 +12,7 @@ use core::{fmt, str};
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 use crate::format::DelayedFormat;
 use crate::format::{parse, parse_and_remainder, ParseError, ParseResult, Parsed, StrftimeItems};
 use crate::format::{Fixed, Item, Numeric, Pad};
@@ -855,7 +855,7 @@ impl NaiveDateTime {
     /// # let dt = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
     /// assert_eq!(format!("{}", dt.format_with_items(fmt)), "2015-09-05 23:56:04");
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]
@@ -899,7 +899,7 @@ impl NaiveDateTime {
     /// assert_eq!(format!("{}", dt.format("%Y-%m-%d %H:%M:%S")), "2015-09-05 23:56:04");
     /// assert_eq!(format!("{}", dt.format("around %l %p on %b %-d")), "around 11 PM on Sep 5");
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -17,10 +17,11 @@ fn test_datetime_from_timestamp_millis() {
         (2034061609000, "2034-06-16 09:06:49.000000000"),
     ];
 
-    for (timestamp_millis, formatted) in valid_map.iter().copied() {
+    for (timestamp_millis, _formatted) in valid_map.iter().copied() {
         let naive_datetime = NaiveDateTime::from_timestamp_millis(timestamp_millis);
         assert_eq!(timestamp_millis, naive_datetime.unwrap().timestamp_millis());
-        assert_eq!(naive_datetime.unwrap().format("%F %T%.9f").to_string(), formatted);
+        #[cfg(any(feature = "alloc", feature = "std"))]
+        assert_eq!(naive_datetime.unwrap().format("%F %T%.9f").to_string(), _formatted);
     }
 
     let invalid = [i64::MAX, i64::MIN];
@@ -54,10 +55,11 @@ fn test_datetime_from_timestamp_micros() {
         (2034061609000000, "2034-06-16 09:06:49.000000000"),
     ];
 
-    for (timestamp_micros, formatted) in valid_map.iter().copied() {
+    for (timestamp_micros, _formatted) in valid_map.iter().copied() {
         let naive_datetime = NaiveDateTime::from_timestamp_micros(timestamp_micros);
         assert_eq!(timestamp_micros, naive_datetime.unwrap().timestamp_micros());
-        assert_eq!(naive_datetime.unwrap().format("%F %T%.9f").to_string(), formatted);
+        #[cfg(any(feature = "alloc", feature = "std"))]
+        assert_eq!(naive_datetime.unwrap().format("%F %T%.9f").to_string(), _formatted);
     }
 
     let invalid = [i64::MAX, i64::MIN];
@@ -287,6 +289,7 @@ fn test_datetime_parse_from_str() {
 }
 
 #[test]
+#[cfg(any(feature = "alloc", feature = "std"))]
 fn test_datetime_format() {
     let dt = NaiveDate::from_ymd_opt(2010, 9, 8).unwrap().and_hms_milli_opt(7, 6, 54, 321).unwrap();
     assert_eq!(dt.format("%c").to_string(), "Wed Sep  8 07:06:54 2010");

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -158,11 +158,13 @@ mod tests {
         assert_eq!(minweek.year(), internals::MIN_YEAR);
         assert_eq!(minweek.week(), 1);
         assert_eq!(minweek.week0(), 0);
+        #[cfg(any(feature = "alloc", feature = "std"))]
         assert_eq!(format!("{:?}", minweek), NaiveDate::MIN.format("%G-W%V").to_string());
 
         assert_eq!(maxweek.year(), internals::MAX_YEAR + 1);
         assert_eq!(maxweek.week(), 1);
         assert_eq!(maxweek.week0(), 0);
+        #[cfg(any(feature = "alloc", feature = "std"))]
         assert_eq!(format!("{:?}", maxweek), NaiveDate::MAX.format("%G-W%V").to_string());
     }
 

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -3,7 +3,7 @@
 
 //! ISO 8601 time without timezone.
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 use core::borrow::Borrow;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::{fmt, str};
@@ -11,7 +11,7 @@ use core::{fmt, str};
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(any(feature = "alloc", feature = "std", test))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 use crate::format::DelayedFormat;
 use crate::format::{
     parse, parse_and_remainder, write_hundreds, Fixed, Item, Numeric, Pad, ParseError, ParseResult,
@@ -746,7 +746,7 @@ impl NaiveTime {
     /// # let t = NaiveTime::from_hms_opt(23, 56, 4).unwrap();
     /// assert_eq!(format!("{}", t.format_with_items(fmt)), "23:56:04");
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]
@@ -792,7 +792,7 @@ impl NaiveTime {
     /// assert_eq!(format!("{}", t.format("%H:%M:%S%.6f")), "23:56:04.012345");
     /// assert_eq!(format!("{}", t.format("%-I:%M %p")), "11:56 PM");
     /// ```
-    #[cfg(any(feature = "alloc", feature = "std", test))]
+    #[cfg(any(feature = "alloc", feature = "std"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "alloc", feature = "std"))))]
     #[inline]
     #[must_use]

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -285,6 +285,7 @@ fn test_time_parse_from_str() {
 }
 
 #[test]
+#[cfg(any(feature = "alloc", feature = "std"))]
 fn test_time_format() {
     let t = NaiveTime::from_hms_nano_opt(3, 5, 7, 98765432).unwrap();
     assert_eq!(t.format("%H,%k,%I,%l,%P,%p").to_string(), "03, 3,03, 3,am,AM");

--- a/src/round.rs
+++ b/src/round.rs
@@ -100,11 +100,11 @@ const fn span_for_digits(digits: u16) -> u32 {
 /// will also fail if the `Duration` is bigger than the timestamp.
 pub trait DurationRound: Sized {
     /// Error that can occur in rounding or truncating
-    #[cfg(any(feature = "std", test))]
+    #[cfg(any(feature = "std"))]
     type Err: std::error::Error;
 
     /// Error that can occur in rounding or truncating
-    #[cfg(not(any(feature = "std", test)))]
+    #[cfg(not(any(feature = "std")))]
     type Err: fmt::Debug + fmt::Display;
 
     /// Return a copy rounded by Duration.
@@ -299,7 +299,7 @@ impl fmt::Display for RoundingError {
     }
 }
 
-#[cfg(any(feature = "std", test))]
+#[cfg(any(feature = "std"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 impl std::error::Error for RoundingError {
     #[allow(deprecated)]


### PR DESCRIPTION
This gets rid of the `#[cfg(any(feature = "alloc", feature = "std", test))]` pattern on methods.

I adjusted parsing tests `test_rfc3339` and `test_rfc3339` to work without formatting. That seemed better to me than to make them conditional.