### PR TITLE
New `Formatter` to replace `DelayedFormat`

### DIFF
--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -108,48 +108,88 @@ where
     fn format_numeric(&self, w: &mut impl Write, spec: &Numeric, pad: Pad) -> fmt::Result {
         use self::Numeric::*;
 
-        let (width, v) = match (spec, self.date, self.time) {
-            (Year, Some(d), _) => (4, i64::from(d.year())),
-            (YearDiv100, Some(d), _) => (2, i64::from(d.year()).div_euclid(100)),
-            (YearMod100, Some(d), _) => (2, i64::from(d.year()).rem_euclid(100)),
-            (IsoYear, Some(d), _) => (4, i64::from(d.iso_week().year())),
-            (IsoYearDiv100, Some(d), _) => (2, i64::from(d.iso_week().year()).div_euclid(100)),
-            (IsoYearMod100, Some(d), _) => (2, i64::from(d.iso_week().year()).rem_euclid(100)),
-            (Month, Some(d), _) => (2, i64::from(d.month())),
-            (Day, Some(d), _) => (2, i64::from(d.day())),
-            (WeekFromSun, Some(d), _) => (2, i64::from(d.weeks_from(Weekday::Sun))),
-            (WeekFromMon, Some(d), _) => (2, i64::from(d.weeks_from(Weekday::Mon))),
-            (IsoWeek, Some(d), _) => (2, i64::from(d.iso_week().week())),
-            (NumDaysFromSun, Some(d), _) => (1, i64::from(d.weekday().num_days_from_sunday())),
-            (WeekdayFromMon, Some(d), _) => (1, i64::from(d.weekday().number_from_monday())),
-            (Ordinal, Some(d), _) => (3, i64::from(d.ordinal())),
-            (Hour, _, Some(t)) => (2, i64::from(t.hour())),
-            (Hour12, _, Some(t)) => (2, i64::from(t.hour12().1)),
-            (Minute, _, Some(t)) => (2, i64::from(t.minute())),
-            (Second, _, Some(t)) => (2, i64::from(t.second() + t.nanosecond() / 1_000_000_000)),
-            (Nanosecond, _, Some(t)) => (9, i64::from(t.nanosecond() % 1_000_000_000)),
+        fn write_one(w: &mut impl Write, v: u8) -> fmt::Result {
+            w.write_char((b'0' + v) as char)
+        }
+
+        fn write_two(w: &mut impl Write, v: u8, pad: Pad) -> fmt::Result {
+            let ones = b'0' + v % 10;
+            match (v / 10, pad) {
+                (0, Pad::None) => {}
+                (0, Pad::Space) => w.write_char(' ')?,
+                (tens, _) => w.write_char((b'0' + tens) as char)?,
+            }
+            w.write_char(ones as char)
+        }
+
+        #[inline]
+        fn write_year(w: &mut impl Write, year: i32, pad: Pad) -> fmt::Result {
+            if (1000..=9999).contains(&year) {
+                // fast path
+                write_hundreds(w, (year / 100) as u8)?;
+                write_hundreds(w, (year % 100) as u8)
+            } else {
+                write_n(w, 4, year as i64, pad, !(0..10_000).contains(&year))
+            }
+        }
+
+        fn write_n(
+            w: &mut impl Write,
+            n: usize,
+            v: i64,
+            pad: Pad,
+            always_sign: bool,
+        ) -> fmt::Result {
+            if always_sign {
+                match pad {
+                    Pad::None => write!(w, "{:+}", v),
+                    Pad::Zero => write!(w, "{:+01$}", v, n + 1),
+                    Pad::Space => write!(w, "{:+1$}", v, n + 1),
+                }
+            } else {
+                match pad {
+                    Pad::None => write!(w, "{}", v),
+                    Pad::Zero => write!(w, "{:01$}", v, n),
+                    Pad::Space => write!(w, "{:1$}", v, n),
+                }
+            }
+        }
+
+        match (spec, self.date, self.time) {
+            (Year, Some(d), _) => write_year(w, d.year(), pad),
+            (YearDiv100, Some(d), _) => write_two(w, d.year().div_euclid(100) as u8, pad),
+            (YearMod100, Some(d), _) => write_two(w, d.year().rem_euclid(100) as u8, pad),
+            (IsoYear, Some(d), _) => write_year(w, d.iso_week().year(), pad),
+            (IsoYearDiv100, Some(d), _) => {
+                write_two(w, d.iso_week().year().div_euclid(100) as u8, pad)
+            }
+            (IsoYearMod100, Some(d), _) => {
+                write_two(w, d.iso_week().year().rem_euclid(100) as u8, pad)
+            }
+            (Month, Some(d), _) => write_two(w, d.month() as u8, pad),
+            (Day, Some(d), _) => write_two(w, d.day() as u8, pad),
+            (WeekFromSun, Some(d), _) => write_two(w, d.weeks_from(Weekday::Sun) as u8, pad),
+            (WeekFromMon, Some(d), _) => write_two(w, d.weeks_from(Weekday::Mon) as u8, pad),
+            (IsoWeek, Some(d), _) => write_two(w, d.iso_week().week() as u8, pad),
+            (NumDaysFromSun, Some(d), _) => write_one(w, d.weekday().num_days_from_sunday() as u8),
+            (WeekdayFromMon, Some(d), _) => write_one(w, d.weekday().number_from_monday() as u8),
+            (Ordinal, Some(d), _) => write_n(w, 3, d.ordinal() as i64, pad, false),
+            (Hour, _, Some(t)) => write_two(w, t.hour() as u8, pad),
+            (Hour12, _, Some(t)) => write_two(w, t.hour12().1 as u8, pad),
+            (Minute, _, Some(t)) => write_two(w, t.minute() as u8, pad),
+            (Second, _, Some(t)) => {
+                write_two(w, (t.second() + t.nanosecond() / 1_000_000_000) as u8, pad)
+            }
+            (Nanosecond, _, Some(t)) => {
+                write_n(w, 9, (t.nanosecond() % 1_000_000_000) as i64, pad, false)
+            }
             (Timestamp, Some(d), Some(t)) => {
                 let offset = self.offset.as_ref().map(|o| i64::from(o.fix().local_minus_utc()));
                 let timestamp = d.and_time(t).timestamp() - offset.unwrap_or(0);
-                (1, timestamp)
+                write_n(w, 9, timestamp, pad, false)
             }
-            (Internal(_), _, _) => return Ok(()), // for future expansion
-            _ => return Err(fmt::Error),          // insufficient arguments for given format
-        };
-
-        if (spec == &Year || spec == &IsoYear) && !(0..10_000).contains(&v) {
-            // non-four-digit years require an explicit sign as per ISO 8601
-            match pad {
-                Pad::None => write!(w, "{:+}", v),
-                Pad::Zero => write!(w, "{:+01$}", v, width + 1),
-                Pad::Space => write!(w, "{:+1$}", v, width + 1),
-            }
-        } else {
-            match pad {
-                Pad::None => write!(w, "{}", v),
-                Pad::Zero => write!(w, "{:01$}", v, width),
-                Pad::Space => write!(w, "{:1$}", v, width),
-            }
+            (Internal(_), _, _) => Ok(()), // for future expansion
+            _ => Err(fmt::Error),          // insufficient arguments for given format
         }
     }
 
@@ -198,21 +238,21 @@ where
             }
             (Nanosecond3, _, Some(t), _) => {
                 w.write_str(decimal_point(self.locale))?;
-                write!(w, "{:03}", t.nanosecond() % 1_000_000_000 / 1_000_000)
+                write!(w, "{:03}", t.nanosecond() / 1_000_000 % 1000)
             }
             (Nanosecond6, _, Some(t), _) => {
                 w.write_str(decimal_point(self.locale))?;
-                write!(w, "{:06}", t.nanosecond() % 1_000_000_000 / 1_000)
+                write!(w, "{:06}", t.nanosecond() / 1_000 % 1_000_000)
             }
             (Nanosecond9, _, Some(t), _) => {
                 w.write_str(decimal_point(self.locale))?;
                 write!(w, "{:09}", t.nanosecond() % 1_000_000_000)
             }
             (Internal(InternalFixed { val: Nanosecond3NoDot }), _, Some(t), _) => {
-                write!(w, "{:03}", t.nanosecond() % 1_000_000_000 / 1_000_000)
+                write!(w, "{:03}", t.nanosecond() / 1_000_000 % 1_000)
             }
             (Internal(InternalFixed { val: Nanosecond6NoDot }), _, Some(t), _) => {
-                write!(w, "{:06}", t.nanosecond() % 1_000_000_000 / 1_000)
+                write!(w, "{:06}", t.nanosecond() / 1_000 % 1_000_000)
             }
             (Internal(InternalFixed { val: Nanosecond9NoDot }), _, Some(t), _) => {
                 write!(w, "{:09}", t.nanosecond() % 1_000_000_000)

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -83,7 +83,7 @@ where
         for item in self.items.clone() {
             match *item.borrow() {
                 Item::Literal(s) | Item::Space(s) => w.write_str(s),
-                #[cfg(any(feature = "alloc", feature = "std"))]
+                #[cfg(feature = "alloc")]
                 Item::OwnedLiteral(ref s) | Item::OwnedSpace(ref s) => w.write_str(s),
                 Item::Numeric(ref spec, pad) => self.format_numeric(w, spec, pad),
                 Item::Fixed(ref spec) => self.format_fixed(w, spec),
@@ -93,7 +93,7 @@ where
         Ok(())
     }
 
-    #[cfg(any(feature = "alloc", feature = "std"))]
+    #[cfg(feature = "alloc")]
     fn format_with_parameters(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // Justify/pad/truncate the formatted result by rendering it to a temporary `String`
         // first.
@@ -102,7 +102,7 @@ where
         f.pad(&result)
     }
 
-    #[cfg(not(any(feature = "alloc", feature = "std")))]
+    #[cfg(not(feature = "alloc"))]
     fn format_with_parameters(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // We have to replicate the `fmt::Formatter:pad` method without allocating.
         let mut counter = CountingSink::new();
@@ -691,12 +691,12 @@ pub(crate) fn write_hundreds(w: &mut impl Write, n: u8) -> fmt::Result {
 }
 
 /// Sink that counts the number of bytes written to it.
-#[cfg(not(any(feature = "alloc", feature = "std")))]
+#[cfg(not(feature = "alloc"))]
 struct CountingSink {
     written: usize,
 }
 
-#[cfg(not(any(feature = "alloc", feature = "std")))]
+#[cfg(not(feature = "alloc"))]
 impl CountingSink {
     fn new() -> Self {
         Self { written: 0 }
@@ -707,7 +707,7 @@ impl CountingSink {
     }
 }
 
-#[cfg(not(any(feature = "alloc", feature = "std")))]
+#[cfg(not(feature = "alloc"))]
 impl Write for CountingSink {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         self.written = self.written.checked_add(s.chars().count()).ok_or(fmt::Error)?;
@@ -716,20 +716,20 @@ impl Write for CountingSink {
 }
 
 // `Write` adaptor that only emits up to `max` characters.
-#[cfg(not(any(feature = "alloc", feature = "std")))]
+#[cfg(not(feature = "alloc"))]
 struct TruncatingWriter<'a, 'b> {
     formatter: &'a mut fmt::Formatter<'b>,
     chars_remaining: usize,
 }
 
-#[cfg(not(any(feature = "alloc", feature = "std")))]
+#[cfg(not(feature = "alloc"))]
 impl<'a, 'b> TruncatingWriter<'a, 'b> {
     fn new(formatter: &'a mut fmt::Formatter<'b>, max: usize) -> Self {
         Self { formatter, chars_remaining: max }
     }
 }
 
-#[cfg(not(any(feature = "alloc", feature = "std")))]
+#[cfg(not(feature = "alloc"))]
 impl<'a, 'b> Write for TruncatingWriter<'a, 'b> {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         let max = self.chars_remaining;

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -48,9 +48,6 @@ pub(crate) mod scan;
 
 pub mod strftime;
 
-#[allow(unused)]
-// TODO: remove '#[allow(unused)]' once we use this module for parsing or something else that does
-// not require `alloc`.
 pub(crate) mod locales;
 
 pub(crate) use formatting::write_hundreds;
@@ -58,11 +55,15 @@ pub(crate) use formatting::write_hundreds;
 pub(crate) use formatting::write_rfc2822;
 #[cfg(any(feature = "alloc", feature = "serde", feature = "rustc-serialize"))]
 pub(crate) use formatting::write_rfc3339;
+pub use formatting::Formatter;
+#[allow(deprecated)]
 #[cfg(feature = "alloc")]
 #[allow(deprecated)]
-pub use formatting::{format, format_item, DelayedFormat, Formatter};
+pub use formatting::{format, format_item, DelayedFormat};
 #[cfg(feature = "unstable-locales")]
 pub use locales::Locale;
+#[cfg(not(feature = "unstable-locales"))]
+pub(crate) use locales::Locale;
 pub(crate) use parse::parse_rfc3339;
 pub use parse::{parse, parse_and_remainder};
 pub use parsed::Parsed;

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -60,7 +60,7 @@ pub(crate) use formatting::write_rfc2822;
 pub(crate) use formatting::write_rfc3339;
 #[cfg(feature = "alloc")]
 #[allow(deprecated)]
-pub use formatting::{format, format_item, DelayedFormat};
+pub use formatting::{format, format_item, DelayedFormat, Formatter};
 #[cfg(feature = "unstable-locales")]
 pub use locales::Locale;
 pub(crate) use parse::parse_rfc3339;


### PR DESCRIPTION
Add a new formatter that can work without allocating and has less performance overhead, as mentioned in https://github.com/chronotope/chrono/issues/1127#issuecomment-1612471735.

I have made an effort to make the formatting code more readable, and split it up into reasonable commits. ~My first PR to chrono that adds functionality but ends up with less lines :smile:.~

~I would like to depend on this PR to get https://github.com/chronotope/chrono/pull/1035 over the finish line. Serialization worked without allocating before, and the new offset formatter should work without allocating in order to use it there.~

This doesn't yet include extra benchmarks or the rest of my proposal for the new formatting API. But I have enough in another branch to test it all works.

Four standalone `format*` functions [`chrono::format`](https://docs.rs/chrono/latest/chrono/format/index.html#functions) are deprecated: they were near unusable, taking `&mut Formatter<'_>` as an argument, which can't be constructed outside of a `Display` implementation.

----

#### Why a new formatter?

This adds a new type `Formatter<I, O>`, that can replace `DelayedFormat<I>` in a new formatting API.

Our current formatting code has noticeable overhead (see https://github.com/chronotope/chrono/issues/94). This is mostly caused by one design choice: if `DelayedFormat::new` is given an offset, it first formats a timezone name into a `String`. In case of `DateTime<FixedOffset>` and `DateTime<Local>` this involves formatting the offset, as there is no name available. This is responsible for 20~25% of the ca. 40% overhead in the `format_with_items` benchmark.

`Formatter<I, O>` takes the offset as a generic, so it can delay formatting the timezone name until it is needed, which often is never.

I made a couple of other changes that all reduce the overhead a tiny bit or help readablility: split the formatting function into smaller methods on `Formatter`, make better use of `match`, format using a smaller integer type `i32`, and delay getting locale strings until use.

We also format to `impl Write` instead of `String` like in https://github.com/chronotope/chrono/pull/1126 to work without `alloc`.

All combined we have only about ~10% overhead left compared to the `format_manual` benchmark, which seems good enough to me.
