### PR TITLE
Also run integration tests with `no_std` on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,8 +93,7 @@ jobs:
         # run using `bash` on all platforms for consistent
         # line-continuation marks
         shell: bash
-      - run: cargo test --lib --no-default-features
-      - run: cargo test --doc --no-default-features
+      - run: cargo test --no-default-features
 
   no_std:
     strategy:


### PR DESCRIPTION
See https://github.com/chronotope/chrono/pull/1162#issuecomment-1617653089.