### PR TITLE
Localize decimal point

### DIFF
--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1463,3 +1463,22 @@ fn test_test_deprecated_from_offset() {
     assert_eq!(DateTime::<Local>::from_local(naive, offset), now);
     assert_eq!(DateTime::<Local>::from_utc(utc, offset), now);
 }
+
+#[test]
+#[cfg(all(feature = "unstable-locales", any(feature = "alloc", feature = "std")))]
+fn locale_decimal_point() {
+    use crate::Locale::{ar_SY, nl_NL};
+    use crate::Timelike;
+    let dt =
+        Utc.with_ymd_and_hms(2018, 9, 5, 18, 58, 0).unwrap().with_nanosecond(123456780).unwrap();
+
+    assert_eq!(dt.format_localized("%T%.f", nl_NL).to_string(), "18:58:00,123456780");
+    assert_eq!(dt.format_localized("%T%.3f", nl_NL).to_string(), "18:58:00,123");
+    assert_eq!(dt.format_localized("%T%.6f", nl_NL).to_string(), "18:58:00,123456");
+    assert_eq!(dt.format_localized("%T%.9f", nl_NL).to_string(), "18:58:00,123456780");
+
+    assert_eq!(dt.format_localized("%T%.f", ar_SY).to_string(), "18:58:00.123456780");
+    assert_eq!(dt.format_localized("%T%.3f", ar_SY).to_string(), "18:58:00.123");
+    assert_eq!(dt.format_localized("%T%.6f", ar_SY).to_string(), "18:58:00.123456");
+    assert_eq!(dt.format_localized("%T%.9f", ar_SY).to_string(), "18:58:00.123456780");
+}

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -327,25 +327,31 @@ fn format_inner(
                     let nano = t.nanosecond() % 1_000_000_000;
                     if nano == 0 {
                         Ok(())
-                    } else if nano % 1_000_000 == 0 {
-                        write!(w, ".{:03}", nano / 1_000_000)
-                    } else if nano % 1_000 == 0 {
-                        write!(w, ".{:06}", nano / 1_000)
                     } else {
-                        write!(w, ".{:09}", nano)
+                        w.write_str(decimal_point(locale))?;
+                        if nano % 1_000_000 == 0 {
+                            write!(w, "{:03}", nano / 1_000_000)
+                        } else if nano % 1_000 == 0 {
+                            write!(w, "{:06}", nano / 1_000)
+                        } else {
+                            write!(w, "{:09}", nano)
+                        }
                     }
                 }),
                 Nanosecond3 => time.map(|t| {
                     let nano = t.nanosecond() % 1_000_000_000;
-                    write!(w, ".{:03}", nano / 1_000_000)
+                    w.write_str(decimal_point(locale))?;
+                    write!(w, "{:03}", nano / 1_000_000)
                 }),
                 Nanosecond6 => time.map(|t| {
                     let nano = t.nanosecond() % 1_000_000_000;
-                    write!(w, ".{:06}", nano / 1_000)
+                    w.write_str(decimal_point(locale))?;
+                    write!(w, "{:06}", nano / 1_000)
                 }),
                 Nanosecond9 => time.map(|t| {
                     let nano = t.nanosecond() % 1_000_000_000;
-                    write!(w, ".{:09}", nano)
+                    w.write_str(decimal_point(locale))?;
+                    write!(w, "{:09}", nano)
                 }),
                 Internal(InternalFixed { val: InternalInternal::Nanosecond3NoDot }) => {
                     time.map(|t| {

--- a/src/format/locales.rs
+++ b/src/format/locales.rs
@@ -26,6 +26,10 @@ mod localized {
         locale_match!(locale => LC_TIME::AM_PM)
     }
 
+    pub(crate) const fn decimal_point(locale: Locale) -> &'static str {
+        locale_match!(locale => LC_NUMERIC::DECIMAL_POINT)
+    }
+
     pub(crate) const fn d_fmt(locale: Locale) -> &'static str {
         locale_match!(locale => LC_TIME::D_FMT)
     }
@@ -88,6 +92,10 @@ mod unlocalized {
 
     pub(crate) const fn am_pm(_locale: Locale) -> &'static [&'static str] {
         &["AM", "PM"]
+    }
+
+    pub(crate) const fn decimal_point(_locale: Locale) -> &'static str {
+        "."
     }
 }
 


### PR DESCRIPTION
Under the `unstable-locales` feature we did not yet localize the decimal point for fractional seconds.