### PR TITLE
const from_ymd_opt

### DIFF
--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -285,9 +285,14 @@ impl NaiveDate {
     /// assert!(from_ymd_opt(-400000, 1, 1).is_none());
     /// ```
     #[must_use]
-    pub fn from_ymd_opt(year: i32, month: u32, day: u32) -> Option<NaiveDate> {
+    pub const fn from_ymd_opt(year: i32, month: u32, day: u32) -> Option<NaiveDate> {
         let flags = YearFlags::from_year(year);
-        NaiveDate::from_mdf(year, Mdf::new(month, day, flags)?)
+
+        if let Some(mdf) = Mdf::new(month, day, flags) {
+            NaiveDate::from_mdf(year, mdf)
+        } else {
+            None
+        }
     }
 
     /// Makes a new `NaiveDate` from the [ordinal date](#ordinal-date)


### PR DESCRIPTION
There are some functions that could be const. My main use case is being able to create a compile-time array of some important dates for my application. By doing it at compile time I can be sure that it's a valid date at compile-time, and thus, won't fail at runtime