### PR TITLE
Backports

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,12 @@ updates:
   - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+  - package-ecosystem: cargo
+    directory: "/fuzz/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,10 @@
 version: 2
 updates:
-  - package-ecosystem: cargo
+  - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: cargo
+  - package-ecosystem: "cargo"
     directory: "/fuzz/"
     schedule:
       interval: "weekly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,6 @@
 ### Thanks for contributing to chrono!
 
+If your feature is semver-compatible, please target the 0.4.x branch;
+the main branch will be used for 0.5.0 development going forward.
+
 Please consider adding a test to ensure your bug fix/feature will not break in the future.

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -700,6 +700,9 @@ impl DateTime<FixedOffset> {
     /// RFC 2822 is the internet message standard that specifies the representation of times in HTTP
     /// and email headers.
     ///
+    /// The RFC 2822 standard allows arbitrary intermixed whitespace.
+    /// See [RFC 2822 Appendix A.5]
+    ///
     /// ```
     /// # use chrono::{DateTime, FixedOffset, TimeZone};
     /// assert_eq!(
@@ -707,6 +710,8 @@ impl DateTime<FixedOffset> {
     ///     FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap()
     /// );
     /// ```
+    ///
+    /// [RFC 2822 Appendix A.5]: https://www.rfc-editor.org/rfc/rfc2822#appendix-A.5
     pub fn parse_from_rfc2822(s: &str) -> ParseResult<DateTime<FixedOffset>> {
         const ITEMS: &[Item<'static>] = &[Item::Fixed(Fixed::RFC2822)];
         let mut parsed = Parsed::new();

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -31,8 +31,7 @@ use crate::offset::{FixedOffset, Offset, TimeZone, Utc};
 use crate::oldtime::Duration as OldDuration;
 #[allow(deprecated)]
 use crate::Date;
-use crate::Months;
-use crate::{Datelike, Timelike, Weekday};
+use crate::{Datelike, Months, Timelike, Weekday};
 
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -238,6 +238,100 @@ fn test_datetime_sub_months() {
     );
 }
 
+// local helper function to easily create a DateTime<FixedOffset>
+#[allow(clippy::too_many_arguments)]
+fn ymdhms(
+    fixedoffset: &FixedOffset,
+    year: i32,
+    month: u32,
+    day: u32,
+    hour: u32,
+    min: u32,
+    sec: u32,
+) -> DateTime<FixedOffset> {
+    fixedoffset.with_ymd_and_hms(year, month, day, hour, min, sec).unwrap()
+}
+
+// local helper function to easily create a DateTime<FixedOffset>
+#[allow(clippy::too_many_arguments)]
+fn ymdhms_milli(
+    fixedoffset: &FixedOffset,
+    year: i32,
+    month: u32,
+    day: u32,
+    hour: u32,
+    min: u32,
+    sec: u32,
+    milli: i64,
+) -> DateTime<FixedOffset> {
+    fixedoffset
+        .with_ymd_and_hms(year, month, day, hour, min, sec)
+        .unwrap()
+        .checked_add_signed(Duration::milliseconds(milli))
+        .unwrap()
+}
+
+// local helper function to easily create a DateTime<FixedOffset>
+#[allow(clippy::too_many_arguments)]
+#[cfg(any(feature = "alloc", feature = "std"))]
+fn ymdhms_micro(
+    fixedoffset: &FixedOffset,
+    year: i32,
+    month: u32,
+    day: u32,
+    hour: u32,
+    min: u32,
+    sec: u32,
+    micro: i64,
+) -> DateTime<FixedOffset> {
+    fixedoffset
+        .with_ymd_and_hms(year, month, day, hour, min, sec)
+        .unwrap()
+        .checked_add_signed(Duration::microseconds(micro))
+        .unwrap()
+}
+
+// local helper function to easily create a DateTime<FixedOffset>
+#[allow(clippy::too_many_arguments)]
+#[cfg(any(feature = "alloc", feature = "std"))]
+fn ymdhms_nano(
+    fixedoffset: &FixedOffset,
+    year: i32,
+    month: u32,
+    day: u32,
+    hour: u32,
+    min: u32,
+    sec: u32,
+    nano: i64,
+) -> DateTime<FixedOffset> {
+    fixedoffset
+        .with_ymd_and_hms(year, month, day, hour, min, sec)
+        .unwrap()
+        .checked_add_signed(Duration::nanoseconds(nano))
+        .unwrap()
+}
+
+// local helper function to easily create a DateTime<Utc>
+fn ymdhms_utc(year: i32, month: u32, day: u32, hour: u32, min: u32, sec: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(year, month, day, hour, min, sec).unwrap()
+}
+
+// local helper function to easily create a DateTime<Utc>
+fn ymdhms_milli_utc(
+    year: i32,
+    month: u32,
+    day: u32,
+    hour: u32,
+    min: u32,
+    sec: u32,
+    milli: i64,
+) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(year, month, day, hour, min, sec)
+        .unwrap()
+        .checked_add_signed(Duration::milliseconds(milli))
+        .unwrap()
+}
+
 #[test]
 fn test_datetime_offset() {
     let est = FixedOffset::west_opt(5 * 60 * 60).unwrap();
@@ -365,10 +459,6 @@ fn test_datetime_rfc2822() {
         Utc.with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap().to_rfc2822(),
         "Wed, 18 Feb 2015 23:16:09 +0000"
     );
-    assert_eq!(
-        Utc.with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap().to_rfc3339(),
-        "2015-02-18T23:16:09+00:00"
-    );
     // timezone +05
     assert_eq!(
         edt.from_local_datetime(
@@ -380,17 +470,6 @@ fn test_datetime_rfc2822() {
         .unwrap()
         .to_rfc2822(),
         "Wed, 18 Feb 2015 23:16:09 +0500"
-    );
-    assert_eq!(
-        edt.from_local_datetime(
-            &NaiveDate::from_ymd_opt(2015, 2, 18)
-                .unwrap()
-                .and_hms_milli_opt(23, 16, 9, 150)
-                .unwrap()
-        )
-        .unwrap()
-        .to_rfc3339(),
-        "2015-02-18T23:16:09.150+05:00"
     );
     // seconds 60
     assert_eq!(
@@ -404,17 +483,6 @@ fn test_datetime_rfc2822() {
         .to_rfc2822(),
         "Wed, 18 Feb 2015 23:59:60 +0500"
     );
-    assert_eq!(
-        edt.from_local_datetime(
-            &NaiveDate::from_ymd_opt(2015, 2, 18)
-                .unwrap()
-                .and_hms_micro_opt(23, 59, 59, 1_234_567)
-                .unwrap()
-        )
-        .unwrap()
-        .to_rfc3339(),
-        "2015-02-18T23:59:60.234567+05:00"
-    );
 
     assert_eq!(
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +0000"),
@@ -425,136 +493,130 @@ fn test_datetime_rfc2822() {
         Ok(FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
     );
     assert_eq!(
-        edt.ymd_opt(2015, 2, 18)
-            .unwrap()
-            .and_hms_micro_opt(23, 59, 59, 1_234_567)
-            .unwrap()
-            .to_rfc2822(),
-        "Wed, 18 Feb 2015 23:59:60 +0500"
+        ymdhms_milli(&edt, 2015, 2, 18, 23, 59, 58, 1_234_567).to_rfc2822(),
+        "Thu, 19 Feb 2015 00:20:32 +0500"
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:60 +0500"),
-        Ok(edt.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 59, 59, 1_000).unwrap())
+        DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:58 +0500"),
+        Ok(ymdhms(&edt, 2015, 2, 18, 23, 59, 58))
+    );
+    assert_ne!(
+        DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:58 +0500"),
+        Ok(ymdhms_milli(&edt, 2015, 2, 18, 23, 59, 58, 500))
     );
 
     // many varying whitespace intermixed
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822(
-            "\t\t\tWed,\n\t\t18 \r\n\t\tFeb \u{3000} 2015\r\n\t\t\t23:59:60    \t+0500"
+        DateTime::parse_from_rfc2822(
+            "\t\t\tWed,\n\t\t18 \r\n\t\tFeb \u{3000} 2015\r\n\t\t\t23:59:58    \t+0500"
         ),
-        Ok(edt.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 59, 59, 1_000).unwrap())
+        Ok(ymdhms(&edt, 2015, 2, 18, 23, 59, 58))
     );
     // example from RFC 2822 Appendix A.5.
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822(
+        DateTime::parse_from_rfc2822(
             "Thu,\n\t13\n      Feb\n        1969\n    23:32\n             -0330 (Newfoundland Time)"
         ),
-        Ok(FixedOffset::east_opt(-3 * 60 * 60 - 30 * 60)
-            .unwrap()
-            .ymd_opt(1969, 2, 13)
-            .unwrap()
-            .and_hms_opt(23, 32, 0)
-            .unwrap()
+        Ok(
+            ymdhms(
+                &FixedOffset::east_opt(-3 * 60 * 60 - 30 * 60).unwrap(),
+                1969, 2, 13, 23, 32, 0,
+            )
         )
     );
     // example from RFC 2822 Appendix A.5. without trailing " (Newfoundland Time)"
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822(
+        DateTime::parse_from_rfc2822(
             "Thu,\n\t13\n      Feb\n        1969\n    23:32\n             -0330"
         ),
-        Ok(FixedOffset::east_opt(-3 * 60 * 60 - 30 * 60)
-            .unwrap()
-            .ymd_opt(1969, 2, 13)
-            .unwrap()
-            .and_hms_opt(23, 32, 0)
-            .unwrap())
+        Ok(
+            ymdhms(&FixedOffset::east_opt(-3 * 60 * 60 - 30 * 60).unwrap(), 1969, 2, 13, 23, 32, 0,)
+        )
     );
 
     // bad year
-    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("31 DEC 262143 23:59 -2359").is_err());
+    assert!(DateTime::parse_from_rfc2822("31 DEC 262143 23:59 -2359").is_err());
     // wrong format
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +00:00").is_err()
-    );
+    assert!(DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +00:00").is_err());
     // full name day of week
-    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("Wednesday, 18 Feb 2015 23:16:09 +0000")
-        .is_err());
+    assert!(DateTime::parse_from_rfc2822("Wednesday, 18 Feb 2015 23:16:09 +0000").is_err());
     // full name day of week
-    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("Wednesday 18 Feb 2015 23:16:09 +0000")
-        .is_err());
+    assert!(DateTime::parse_from_rfc2822("Wednesday 18 Feb 2015 23:16:09 +0000").is_err());
     // wrong day of week separator '.'
-    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("Wed. 18 Feb 2015 23:16:09 +0000").is_err());
+    assert!(DateTime::parse_from_rfc2822("Wed. 18 Feb 2015 23:16:09 +0000").is_err());
     // *trailing* space causes failure
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +0000   ").is_err()
-    );
+    assert!(DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +0000   ").is_err());
 }
 
 #[test]
 #[cfg(any(feature = "alloc", feature = "std"))]
 fn test_datetime_rfc3339() {
-    let edt = FixedOffset::east_opt(5 * 60 * 60).unwrap();
+    let edt5 = FixedOffset::east_opt(5 * 60 * 60).unwrap();
+    let edt0 = FixedOffset::east_opt(0).unwrap();
+
+    // timezone 0
     assert_eq!(
-        Utc.ymd_opt(2015, 2, 18).unwrap().and_hms_opt(23, 16, 9).unwrap().to_rfc3339(),
+        Utc.with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap().to_rfc3339(),
         "2015-02-18T23:16:09+00:00"
     );
+    // timezone +05
     assert_eq!(
-        edt.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap().to_rfc3339(),
+        edt5.from_local_datetime(
+            &NaiveDate::from_ymd_opt(2015, 2, 18)
+                .unwrap()
+                .and_hms_milli_opt(23, 16, 9, 150)
+                .unwrap()
+        )
+        .unwrap()
+        .to_rfc3339(),
+        "2015-02-18T23:16:09.150+05:00"
+    );
+
+    assert_eq!(ymdhms_utc(2015, 2, 18, 23, 16, 9).to_rfc3339(), "2015-02-18T23:16:09+00:00");
+    assert_eq!(
+        ymdhms_milli(&edt5, 2015, 2, 18, 23, 16, 9, 150).to_rfc3339(),
         "2015-02-18T23:16:09.150+05:00"
     );
     assert_eq!(
-        edt.ymd_opt(2015, 2, 18)
-            .unwrap()
-            .and_hms_micro_opt(23, 59, 59, 1_234_567)
-            .unwrap()
-            .to_rfc3339(),
-        "2015-02-18T23:59:60.234567+05:00"
+        ymdhms_micro(&edt5, 2015, 2, 18, 23, 59, 59, 1_234_567).to_rfc3339(),
+        "2015-02-19T00:00:00.234567+05:00"
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:59.123+05:00"),
-        Ok(edt.ymd_opt(2015, 2, 18).unwrap().and_hms_micro_opt(23, 59, 59, 123_000).unwrap())
+        DateTime::parse_from_rfc3339("2015-02-18T23:59:59.123+05:00"),
+        Ok(ymdhms_micro(&edt5, 2015, 2, 18, 23, 59, 59, 123_000))
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:59.123456+05:00"),
-        Ok(edt.ymd_opt(2015, 2, 18).unwrap().and_hms_micro_opt(23, 59, 59, 123_456).unwrap())
+        DateTime::parse_from_rfc3339("2015-02-18T23:59:59.123456+05:00"),
+        Ok(ymdhms_micro(&edt5, 2015, 2, 18, 23, 59, 59, 123_456))
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:59.123456789+05:00"),
-        Ok(edt.ymd_opt(2015, 2, 18).unwrap().and_hms_nano_opt(23, 59, 59, 123_456_789).unwrap())
+        DateTime::parse_from_rfc3339("2015-02-18T23:59:59.123456789+05:00"),
+        Ok(ymdhms_nano(&edt5, 2015, 2, 18, 23, 59, 59, 123_456_789))
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:16:09Z"),
-        Ok(FixedOffset::east_opt(0)
-            .unwrap()
-            .ymd_opt(2015, 2, 18)
-            .unwrap()
-            .and_hms_opt(23, 16, 9)
-            .unwrap())
+        DateTime::parse_from_rfc3339("2015-02-18T23:16:09Z"),
+        Ok(ymdhms(&edt0, 2015, 2, 18, 23, 16, 9))
     );
 
     assert_eq!(
-        edt.ymd_opt(2015, 2, 18)
-            .unwrap()
-            .and_hms_micro_opt(23, 59, 59, 1_234_567)
-            .unwrap()
-            .to_rfc3339(),
-        "2015-02-18T23:59:60.234567+05:00"
+        ymdhms_micro(&edt5, 2015, 2, 18, 23, 59, 59, 1_234_567).to_rfc3339(),
+        "2015-02-19T00:00:00.234567+05:00"
     );
     assert_eq!(
-        edt.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap().to_rfc3339(),
+        ymdhms_milli(&edt5, 2015, 2, 18, 23, 16, 9, 150).to_rfc3339(),
         "2015-02-18T23:16:09.150+05:00"
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00"),
-        Ok(edt.ymd_opt(2015, 2, 18).unwrap().and_hms_micro_opt(23, 59, 59, 1_234_567).unwrap())
+        DateTime::parse_from_rfc3339("2015-02-18T00:00:00.234567+05:00"),
+        Ok(ymdhms_micro(&edt5, 2015, 2, 18, 0, 0, 0, 234_567))
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:16:09Z"),
-        Ok(FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
+        DateTime::parse_from_rfc3339("2015-02-18T23:16:09Z"),
+        Ok(ymdhms(&edt0, 2015, 2, 18, 23, 16, 9))
     );
     assert_eq!(
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:60 +0500"),
-        Ok(edt
+        Ok(edt5
             .from_local_datetime(
                 &NaiveDate::from_ymd_opt(2015, 2, 18)
                     .unwrap()
@@ -566,7 +628,7 @@ fn test_datetime_rfc3339() {
     assert!(DateTime::parse_from_rfc2822("31 DEC 262143 23:59 -2359").is_err());
     assert_eq!(
         DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00"),
-        Ok(edt
+        Ok(edt5
             .from_local_datetime(
                 &NaiveDate::from_ymd_opt(2015, 2, 18)
                     .unwrap()
@@ -575,44 +637,21 @@ fn test_datetime_rfc3339() {
             )
             .unwrap())
     );
-    assert_eq!(
-        Utc.ymd_opt(2015, 2, 18).unwrap().and_hms_opt(23, 16, 9).unwrap().to_rfc3339(),
-        "2015-02-18T23:16:09+00:00"
-    );
+    assert_eq!(ymdhms_utc(2015, 2, 18, 23, 16, 9).to_rfc3339(), "2015-02-18T23:16:09+00:00");
 
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567 +05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:059:60.234567+05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00PST").is_err()
-    );
-    assert!(DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+PST").is_err());
-    assert!(DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567PST").is_err());
-    assert!(DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+0500").is_err());
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18 23:59:60.234567+05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567:+05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00 ").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339(" 2015-02-18T23:59:60.234567+05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015- 02-18T23:59:60.234567+05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567A+05:00").is_err()
-    );
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567 +05:00").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:059:60.234567+05:00").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00PST").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+PST").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567PST").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+0500").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00:00").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18 23:59:60.234567+05:00").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567:+05:00").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00 ").is_err());
+    assert!(DateTime::parse_from_rfc3339(" 2015-02-18T23:59:60.234567+05:00").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015- 02-18T23:59:60.234567+05:00").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567A+05:00").is_err());
 }
 
 #[test]
@@ -844,12 +883,12 @@ fn test_parse_datetime_utc() {
 
 #[test]
 fn test_utc_datetime_from_str() {
-    let ymdhms = |y, m, d, h, n, s, off| {
-        FixedOffset::east_opt(off).unwrap().with_ymd_and_hms(y, m, d, h, n, s).unwrap()
-    };
+    let edt = FixedOffset::east_opt(570 * 60).unwrap();
+    let edt0 = FixedOffset::east_opt(0).unwrap();
+    let wdt = FixedOffset::west_opt(10 * 3600).unwrap();
     assert_eq!(
         DateTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
-        Ok(ymdhms(2014, 5, 7, 12, 34, 56, 570 * 60))
+        Ok(ymdhms(&edt, 2014, 5, 7, 12, 34, 56))
     ); // ignore offset
     assert!(DateTime::parse_from_str("20140507000000", "%Y%m%d%H%M%S").is_err()); // no offset
     assert!(DateTime::parse_from_str("Fri, 09 Aug 2013 23:54:35 GMT", "%a, %d %b %Y %H:%M:%S GMT")
@@ -858,56 +897,45 @@ fn test_utc_datetime_from_str() {
         Utc.datetime_from_str("Fri, 09 Aug 2013 23:54:35 GMT", "%a, %d %b %Y %H:%M:%S GMT"),
         Ok(Utc.with_ymd_and_hms(2013, 8, 9, 23, 54, 35).unwrap())
     );
+    assert_eq!(
+        DateTime::parse_from_str("0", "%s").unwrap(),
+        NaiveDateTime::from_timestamp_opt(0, 0).unwrap().and_utc().fixed_offset()
+    );
 
     assert_eq!(
         "2015-02-18T23:16:9.15Z".parse::<DateTime<FixedOffset>>(),
-        Ok(FixedOffset::east_opt(0)
-            .unwrap()
-            .ymd_opt(2015, 2, 18)
-            .unwrap()
-            .and_hms_milli_opt(23, 16, 9, 150)
-            .unwrap())
+        Ok(ymdhms_milli(&edt0, 2015, 2, 18, 23, 16, 9, 150))
     );
     assert_eq!(
         "2015-02-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
-        Ok(Utc.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap())
+        Ok(ymdhms_milli_utc(2015, 2, 18, 23, 16, 9, 150)),
     );
     assert_eq!(
         "2015-02-18T23:16:9.15 UTC".parse::<DateTime<Utc>>(),
-        Ok(Utc.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap())
+        Ok(ymdhms_milli_utc(2015, 2, 18, 23, 16, 9, 150))
     );
     assert_eq!(
         "2015-02-18T23:16:9.15UTC".parse::<DateTime<Utc>>(),
-        Ok(Utc.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap())
+        Ok(ymdhms_milli_utc(2015, 2, 18, 23, 16, 9, 150))
     );
 
     assert_eq!(
         "2015-2-18T23:16:9.15Z".parse::<DateTime<FixedOffset>>(),
-        Ok(FixedOffset::east_opt(0)
-            .unwrap()
-            .ymd_opt(2015, 2, 18)
-            .unwrap()
-            .and_hms_milli_opt(23, 16, 9, 150)
-            .unwrap())
+        Ok(ymdhms_milli(&edt0, 2015, 2, 18, 23, 16, 9, 150))
     );
     assert_eq!(
         "2015-2-18T13:16:9.15-10:00".parse::<DateTime<FixedOffset>>(),
-        Ok(FixedOffset::west_opt(10 * 3600)
-            .unwrap()
-            .ymd_opt(2015, 2, 18)
-            .unwrap()
-            .and_hms_milli_opt(13, 16, 9, 150)
-            .unwrap())
+        Ok(ymdhms_milli(&wdt, 2015, 2, 18, 13, 16, 9, 150))
     );
     assert!("2015-2-18T23:16:9.15".parse::<DateTime<FixedOffset>>().is_err());
 
     assert_eq!(
         "2015-2-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
-        Ok(Utc.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap())
+        Ok(ymdhms_milli_utc(2015, 2, 18, 23, 16, 9, 150))
     );
     assert_eq!(
         "2015-2-18T13:16:9.15-10:00".parse::<DateTime<Utc>>(),
-        Ok(Utc.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap())
+        Ok(ymdhms_milli_utc(2015, 2, 18, 23, 16, 9, 150))
     );
     assert!("2015-2-18T23:16:9.15".parse::<DateTime<Utc>>().is_err());
 
@@ -916,7 +944,7 @@ fn test_utc_datetime_from_str() {
 
 #[test]
 fn test_utc_datetime_from_str_with_spaces() {
-    let dt = Utc.ymd_opt(2013, 8, 9).unwrap().and_hms_opt(23, 54, 35).unwrap();
+    let dt = ymdhms_utc(2013, 8, 9, 23, 54, 35);
     // with varying spaces - should succeed
     assert_eq!(Utc.datetime_from_str(" Aug 09 2013 23:54:35", " %b %d %Y %H:%M:%S"), Ok(dt),);
     assert_eq!(Utc.datetime_from_str("Aug 09 2013 23:54:35 ", "%b %d %Y %H:%M:%S "), Ok(dt),);
@@ -952,12 +980,8 @@ fn test_utc_datetime_from_str_with_spaces() {
 
 #[test]
 fn test_datetime_parse_from_str() {
-    let dt = FixedOffset::east_opt(-9 * 60 * 60)
-        .unwrap()
-        .ymd_opt(2013, 8, 9)
-        .unwrap()
-        .and_hms_opt(23, 54, 35)
-        .unwrap();
+    let dt = ymdhms(&FixedOffset::east_opt(-9 * 60 * 60).unwrap(), 2013, 8, 9, 23, 54, 35);
+    let parse = DateTime::parse_from_str;
 
     // timezone variations
 
@@ -965,542 +989,136 @@ fn test_datetime_parse_from_str() {
     // %Z
     //
     // wrong timezone format
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -0900",
-        "%b %d %Y %H:%M:%S %Z"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %Z").is_err());
     // bad timezone data?
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 PST",
-        "%b %d %Y %H:%M:%S %Z"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 PST", "%b %d %Y %H:%M:%S %Z").is_err());
     // bad timezone data
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 XXXXX",
-        "%b %d %Y %H:%M:%S %Z"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 XXXXX", "%b %d %Y %H:%M:%S %Z").is_err());
 
     //
     // %z
     //
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -0900",
-            "%b %d %Y %H:%M:%S %z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09 00",
-            "%b %d %Y %H:%M:%S %z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09:00",
-            "%b %d %Y %H:%M:%S %z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09 : 00",
-            "%b %d %Y %H:%M:%S %z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 --0900",
-            "%b %d %Y %H:%M:%S -%z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 +-0900",
-            "%b %d %Y %H:%M:%S +%z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09:00 ",
-            "%b %d %Y %H:%M:%S %z "
-        ),
-        Ok(dt),
-    );
+    assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09 00", "%b %d %Y %H:%M:%S %z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00", "%b %d %Y %H:%M:%S %z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09 : 00", "%b %d %Y %H:%M:%S %z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 --0900", "%b %d %Y %H:%M:%S -%z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 +-0900", "%b %d %Y %H:%M:%S +%z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00 ", "%b %d %Y %H:%M:%S %z "), Ok(dt));
     // trailing newline after timezone
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09:00\n",
-        "%b %d %Y %H:%M:%S %z"
-    )
-    .is_err());
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09:00\n",
-            "%b %d %Y %H:%M:%S %z "
-        ),
-        Ok(dt),
-    );
+    assert!(parse("Aug 09 2013 23:54:35 -09:00\n", "%b %d %Y %H:%M:%S %z").is_err());
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00\n", "%b %d %Y %H:%M:%S %z "), Ok(dt));
     // trailing colon
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09:00:",
-        "%b %d %Y %H:%M:%S %z"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09:00:", "%b %d %Y %H:%M:%S %z").is_err());
     // trailing colon with space
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09:00: ",
-        "%b %d %Y %H:%M:%S %z "
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09:00: ", "%b %d %Y %H:%M:%S %z ").is_err());
     // trailing colon, mismatch space
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09:00:",
-        "%b %d %Y %H:%M:%S %z "
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09:00:", "%b %d %Y %H:%M:%S %z ").is_err());
     // wrong timezone data
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09",
-        "%b %d %Y %H:%M:%S %z"
-    )
-    .is_err());
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09::00",
-            "%b %d %Y %H:%M:%S %z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -0900::",
-            "%b %d %Y %H:%M:%S %z::"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09:00:00",
-            "%b %d %Y %H:%M:%S %z:00"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09:00:00 ",
-            "%b %d %Y %H:%M:%S %z:00 "
-        ),
-        Ok(dt),
-    );
+    assert!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %z").is_err());
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -0900::", "%b %d %Y %H:%M:%S %z::"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00:00", "%b %d %Y %H:%M:%S %z:00"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00:00 ", "%b %d %Y %H:%M:%S %z:00 "), Ok(dt));
 
     //
     // %:z
     //
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35  -09:00",
-            "%b %d %Y %H:%M:%S  %:z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -0900",
-            "%b %d %Y %H:%M:%S %:z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09 00",
-            "%b %d %Y %H:%M:%S %:z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09 : 00",
-            "%b %d %Y %H:%M:%S %:z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09 : 00:",
-            "%b %d %Y %H:%M:%S %:z:"
-        ),
-        Ok(dt),
-    );
+    assert_eq!(parse("Aug 09 2013 23:54:35  -09:00", "%b %d %Y %H:%M:%S  %:z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %:z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09 00", "%b %d %Y %H:%M:%S %:z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09 : 00", "%b %d %Y %H:%M:%S %:z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09 : 00:", "%b %d %Y %H:%M:%S %:z:"), Ok(dt));
     // wrong timezone data
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09",
-        "%b %d %Y %H:%M:%S %:z"
-    )
-    .is_err());
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09::00",
-            "%b %d %Y %H:%M:%S %:z"
-        ),
-        Ok(dt),
-    );
+    assert!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %:z").is_err());
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %:z"), Ok(dt));
     // timezone data hs too many colons
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09:00:",
-        "%b %d %Y %H:%M:%S %:z"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09:00:", "%b %d %Y %H:%M:%S %:z").is_err());
     // timezone data hs too many colons
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09:00::",
-        "%b %d %Y %H:%M:%S %:z"
-    )
-    .is_err());
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09:00::",
-            "%b %d %Y %H:%M:%S %:z::"
-        ),
-        Ok(dt),
-    );
+    assert!(parse("Aug 09 2013 23:54:35 -09:00::", "%b %d %Y %H:%M:%S %:z").is_err());
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00::", "%b %d %Y %H:%M:%S %:z::"), Ok(dt));
 
     //
-    // %:::z
+    // %::z
     //
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -0900",
-            "%b %d %Y %H:%M:%S %::z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09:00",
-            "%b %d %Y %H:%M:%S %::z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09 : 00",
-            "%b %d %Y %H:%M:%S %::z"
-        ),
-        Ok(dt),
-    );
+    assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %::z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00", "%b %d %Y %H:%M:%S %::z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09 : 00", "%b %d %Y %H:%M:%S %::z"), Ok(dt));
     // mismatching colon expectations
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09:00:00",
-        "%b %d %Y %H:%M:%S %::z"
-    )
-    .is_err());
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09::00",
-            "%b %d %Y %H:%M:%S %::z"
-        ),
-        Ok(dt),
-    );
+    assert!(parse("Aug 09 2013 23:54:35 -09:00:00", "%b %d %Y %H:%M:%S %::z").is_err());
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %::z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09::00", "%b %d %Y %H:%M:%S %:z"), Ok(dt));
     // wrong timezone data
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09",
-        "%b %d %Y %H:%M:%S %::z"
-    )
-    .is_err());
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09001234",
-            "%b %d %Y %H:%M:%S %::z1234"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09:001234",
-            "%b %d %Y %H:%M:%S %::z1234"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -0900 ",
-            "%b %d %Y %H:%M:%S %::z "
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -0900\t\n",
-            "%b %d %Y %H:%M:%S %::z\t\n"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -0900:",
-            "%b %d %Y %H:%M:%S %::z:"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 :-0900:0",
-            "%b %d %Y %H:%M:%S :%::z:0"
-        ),
-        Ok(dt),
-    );
+    assert!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %::z").is_err());
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09001234", "%b %d %Y %H:%M:%S %::z1234"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09:001234", "%b %d %Y %H:%M:%S %::z1234"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -0900 ", "%b %d %Y %H:%M:%S %::z "), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -0900\t\n", "%b %d %Y %H:%M:%S %::z\t\n"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -0900:", "%b %d %Y %H:%M:%S %::z:"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 :-0900:0", "%b %d %Y %H:%M:%S :%::z:0"), Ok(dt));
     // mismatching colons and spaces
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 :-0900: ",
-        "%b %d %Y %H:%M:%S :%::z::"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 :-0900: ", "%b %d %Y %H:%M:%S :%::z::").is_err());
     // mismatching colons expectations
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09:00:00",
-        "%b %d %Y %H:%M:%S %::z"
-    )
-    .is_err());
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 -0900: 23:54:35",
-            "%b %d %Y %::z: %H:%M:%S"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 :-0900:0 23:54:35",
-            "%b %d %Y :%::z:0 %H:%M:%S"
-        ),
-        Ok(dt),
-    );
+    assert!(parse("Aug 09 2013 23:54:35 -09:00:00", "%b %d %Y %H:%M:%S %::z").is_err());
+    assert_eq!(parse("Aug 09 2013 -0900: 23:54:35", "%b %d %Y %::z: %H:%M:%S"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 :-0900:0 23:54:35", "%b %d %Y :%::z:0 %H:%M:%S"), Ok(dt));
     // mismatching colons expectations mid-string
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 :-0900: 23:54:35",
-        "%b %d %Y :%::z  %H:%M:%S"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 :-0900: 23:54:35", "%b %d %Y :%::z  %H:%M:%S").is_err());
     // mismatching colons expectations, before end
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09:00:00 ",
-        "%b %d %Y %H:%M:%S %::z "
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09:00:00 ", "%b %d %Y %H:%M:%S %::z ").is_err());
 
     //
     // %:::z
     //
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09:00",
-            "%b %d %Y %H:%M:%S %:::z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -0900",
-            "%b %d %Y %H:%M:%S %:::z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -0900  ",
-            "%b %d %Y %H:%M:%S %:::z  "
-        ),
-        Ok(dt),
-    );
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00", "%b %d %Y %H:%M:%S %:::z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %:::z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -0900  ", "%b %d %Y %H:%M:%S %:::z  "), Ok(dt));
     // wrong timezone data
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09",
-        "%b %d %Y %H:%M:%S %:::z"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %:::z").is_err());
 
     //
     // %::::z
     //
     // too many colons
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -0900",
-        "%b %d %Y %H:%M:%S %::::z"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %::::z").is_err());
     // too many colons
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09:00",
-        "%b %d %Y %H:%M:%S %::::z"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09:00", "%b %d %Y %H:%M:%S %::::z").is_err());
     // too many colons
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09:00:",
-        "%b %d %Y %H:%M:%S %::::z"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09:00:", "%b %d %Y %H:%M:%S %::::z").is_err());
     // too many colons
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09:00:00",
-        "%b %d %Y %H:%M:%S %::::z"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09:00:00", "%b %d %Y %H:%M:%S %::::z").is_err());
 
     //
     // %#z
     //
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09:00",
-            "%b %d %Y %H:%M:%S %#z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -0900",
-            "%b %d %Y %H:%M:%S %#z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35  -09:00  ",
-            "%b %d %Y %H:%M:%S  %#z  "
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35  -0900  ",
-            "%b %d %Y %H:%M:%S  %#z  "
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09",
-            "%b %d %Y %H:%M:%S %#z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -0900",
-            "%b %d %Y %H:%M:%S %#z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09:",
-            "%b %d %Y %H:%M:%S %#z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35 -09: ",
-            "%b %d %Y %H:%M:%S %#z "
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35+-09",
-            "%b %d %Y %H:%M:%S+%#z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 23:54:35--09",
-            "%b %d %Y %H:%M:%S-%#z"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 -09:00 23:54:35",
-            "%b %d %Y %#z%H:%M:%S"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 -0900 23:54:35",
-            "%b %d %Y %#z%H:%M:%S"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 -090023:54:35",
-            "%b %d %Y %#z%H:%M:%S"
-        ),
-        Ok(dt),
-    );
-    assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str(
-            "Aug 09 2013 -09:0023:54:35",
-            "%b %d %Y %#z%H:%M:%S"
-        ),
-        Ok(dt),
-    );
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09:00", "%b %d %Y %H:%M:%S %#z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %#z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35  -09:00  ", "%b %d %Y %H:%M:%S  %#z  "), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35  -0900  ", "%b %d %Y %H:%M:%S  %#z  "), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09", "%b %d %Y %H:%M:%S %#z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -0900", "%b %d %Y %H:%M:%S %#z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09:", "%b %d %Y %H:%M:%S %#z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35 -09: ", "%b %d %Y %H:%M:%S %#z "), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35+-09", "%b %d %Y %H:%M:%S+%#z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 23:54:35--09", "%b %d %Y %H:%M:%S-%#z"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 -09:00 23:54:35", "%b %d %Y %#z%H:%M:%S"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 -0900 23:54:35", "%b %d %Y %#z%H:%M:%S"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 -090023:54:35", "%b %d %Y %#z%H:%M:%S"), Ok(dt));
+    assert_eq!(parse("Aug 09 2013 -09:0023:54:35", "%b %d %Y %#z%H:%M:%S"), Ok(dt));
     // timezone with partial minutes adjacent hours
-    assert_ne!(
-        DateTime::<FixedOffset>::parse_from_str("Aug 09 2013 -09023:54:35", "%b %d %Y %#z%H:%M:%S"),
-        Ok(dt),
-    );
+    assert_ne!(parse("Aug 09 2013 -09023:54:35", "%b %d %Y %#z%H:%M:%S"), Ok(dt));
     // bad timezone data
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -09:00:00",
-        "%b %d %Y %H:%M:%S %#z"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -09:00:00", "%b %d %Y %H:%M:%S %#z").is_err());
     // bad timezone data (partial minutes)
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -090",
-        "%b %d %Y %H:%M:%S %#z"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -090", "%b %d %Y %H:%M:%S %#z").is_err());
     // bad timezone data (partial minutes) with trailing space
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 23:54:35 -090 ",
-        "%b %d %Y %H:%M:%S %#z "
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 23:54:35 -090 ", "%b %d %Y %H:%M:%S %#z ").is_err());
     // bad timezone data (partial minutes) mid-string
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 -090 23:54:35",
-        "%b %d %Y %#z %H:%M:%S"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 -090 23:54:35", "%b %d %Y %#z %H:%M:%S").is_err());
     // bad timezone data
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 -09:00:00 23:54:35",
-        "%b %d %Y %#z %H:%M:%S"
-    )
-    .is_err());
+    assert!(parse("Aug 09 2013 -09:00:00 23:54:35", "%b %d %Y %#z %H:%M:%S").is_err());
     // timezone data ambiguous with hours
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Aug 09 2013 -09:00:23:54:35",
-        "%b %d %Y %#z%H:%M:%S"
-    )
-    .is_err());
-    assert_eq!(
-        DateTime::parse_from_str("0", "%s").unwrap(),
-        NaiveDateTime::from_timestamp_opt(0, 0).unwrap().and_utc().fixed_offset()
-    );
+    assert!(parse("Aug 09 2013 -09:00:23:54:35", "%b %d %Y %#z%H:%M:%S").is_err());
 }
 
 #[test]

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -357,8 +357,10 @@ fn test_datetime_with_timezone() {
 
 #[test]
 #[cfg(any(feature = "alloc", feature = "std"))]
-fn test_datetime_rfc2822_and_rfc3339() {
+fn test_datetime_rfc2822() {
     let edt = FixedOffset::east_opt(5 * 60 * 60).unwrap();
+
+    // timezone 0
     assert_eq!(
         Utc.with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap().to_rfc2822(),
         "Wed, 18 Feb 2015 23:16:09 +0000"
@@ -367,6 +369,7 @@ fn test_datetime_rfc2822_and_rfc3339() {
         Utc.with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap().to_rfc3339(),
         "2015-02-18T23:16:09+00:00"
     );
+    // timezone +05
     assert_eq!(
         edt.from_local_datetime(
             &NaiveDate::from_ymd_opt(2015, 2, 18)
@@ -389,6 +392,7 @@ fn test_datetime_rfc2822_and_rfc3339() {
         .to_rfc3339(),
         "2015-02-18T23:16:09.150+05:00"
     );
+    // seconds 60
     assert_eq!(
         edt.from_local_datetime(
             &NaiveDate::from_ymd_opt(2015, 2, 18)
@@ -421,7 +425,131 @@ fn test_datetime_rfc2822_and_rfc3339() {
         Ok(FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
     );
     assert_eq!(
-        DateTime::parse_from_rfc3339("2015-02-18T23:16:09Z"),
+        edt.ymd_opt(2015, 2, 18)
+            .unwrap()
+            .and_hms_micro_opt(23, 59, 59, 1_234_567)
+            .unwrap()
+            .to_rfc2822(),
+        "Wed, 18 Feb 2015 23:59:60 +0500"
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:60 +0500"),
+        Ok(edt.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 59, 59, 1_000).unwrap())
+    );
+
+    // many varying whitespace intermixed
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_rfc2822(
+            "\t\t\tWed,\n\t\t18 \r\n\t\tFeb \u{3000} 2015\r\n\t\t\t23:59:60    \t+0500"
+        ),
+        Ok(edt.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 59, 59, 1_000).unwrap())
+    );
+    // example from RFC 2822 Appendix A.5.
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_rfc2822(
+            "Thu,\n\t13\n      Feb\n        1969\n    23:32\n             -0330 (Newfoundland Time)"
+        ),
+        Ok(FixedOffset::east_opt(-3 * 60 * 60 - 30 * 60)
+            .unwrap()
+            .ymd_opt(1969, 2, 13)
+            .unwrap()
+            .and_hms_opt(23, 32, 0)
+            .unwrap()
+        )
+    );
+    // example from RFC 2822 Appendix A.5. without trailing " (Newfoundland Time)"
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_rfc2822(
+            "Thu,\n\t13\n      Feb\n        1969\n    23:32\n             -0330"
+        ),
+        Ok(FixedOffset::east_opt(-3 * 60 * 60 - 30 * 60)
+            .unwrap()
+            .ymd_opt(1969, 2, 13)
+            .unwrap()
+            .and_hms_opt(23, 32, 0)
+            .unwrap())
+    );
+
+    // bad year
+    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("31 DEC 262143 23:59 -2359").is_err());
+    // wrong format
+    assert!(
+        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +00:00").is_err()
+    );
+    // full name day of week
+    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("Wednesday, 18 Feb 2015 23:16:09 +0000")
+        .is_err());
+    // full name day of week
+    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("Wednesday 18 Feb 2015 23:16:09 +0000")
+        .is_err());
+    // wrong day of week separator '.'
+    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("Wed. 18 Feb 2015 23:16:09 +0000").is_err());
+    // *trailing* space causes failure
+    assert!(
+        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +0000   ").is_err()
+    );
+}
+
+#[test]
+#[cfg(any(feature = "alloc", feature = "std"))]
+fn test_datetime_rfc3339() {
+    let edt = FixedOffset::east_opt(5 * 60 * 60).unwrap();
+    assert_eq!(
+        Utc.ymd_opt(2015, 2, 18).unwrap().and_hms_opt(23, 16, 9).unwrap().to_rfc3339(),
+        "2015-02-18T23:16:09+00:00"
+    );
+    assert_eq!(
+        edt.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap().to_rfc3339(),
+        "2015-02-18T23:16:09.150+05:00"
+    );
+    assert_eq!(
+        edt.ymd_opt(2015, 2, 18)
+            .unwrap()
+            .and_hms_micro_opt(23, 59, 59, 1_234_567)
+            .unwrap()
+            .to_rfc3339(),
+        "2015-02-18T23:59:60.234567+05:00"
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:59.123+05:00"),
+        Ok(edt.ymd_opt(2015, 2, 18).unwrap().and_hms_micro_opt(23, 59, 59, 123_000).unwrap())
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:59.123456+05:00"),
+        Ok(edt.ymd_opt(2015, 2, 18).unwrap().and_hms_micro_opt(23, 59, 59, 123_456).unwrap())
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:59.123456789+05:00"),
+        Ok(edt.ymd_opt(2015, 2, 18).unwrap().and_hms_nano_opt(23, 59, 59, 123_456_789).unwrap())
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:16:09Z"),
+        Ok(FixedOffset::east_opt(0)
+            .unwrap()
+            .ymd_opt(2015, 2, 18)
+            .unwrap()
+            .and_hms_opt(23, 16, 9)
+            .unwrap())
+    );
+
+    assert_eq!(
+        edt.ymd_opt(2015, 2, 18)
+            .unwrap()
+            .and_hms_micro_opt(23, 59, 59, 1_234_567)
+            .unwrap()
+            .to_rfc3339(),
+        "2015-02-18T23:59:60.234567+05:00"
+    );
+    assert_eq!(
+        edt.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap().to_rfc3339(),
+        "2015-02-18T23:16:09.150+05:00"
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00"),
+        Ok(edt.ymd_opt(2015, 2, 18).unwrap().and_hms_micro_opt(23, 59, 59, 1_234_567).unwrap())
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:16:09Z"),
         Ok(FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
     );
     assert_eq!(
@@ -446,6 +574,44 @@ fn test_datetime_rfc2822_and_rfc3339() {
                     .unwrap()
             )
             .unwrap())
+    );
+    assert_eq!(
+        Utc.ymd_opt(2015, 2, 18).unwrap().and_hms_opt(23, 16, 9).unwrap().to_rfc3339(),
+        "2015-02-18T23:16:09+00:00"
+    );
+
+    assert!(
+        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567 +05:00").is_err()
+    );
+    assert!(
+        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:059:60.234567+05:00").is_err()
+    );
+    assert!(
+        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00PST").is_err()
+    );
+    assert!(DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+PST").is_err());
+    assert!(DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567PST").is_err());
+    assert!(DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+0500").is_err());
+    assert!(
+        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00:00").is_err()
+    );
+    assert!(
+        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18 23:59:60.234567+05:00").is_err()
+    );
+    assert!(
+        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567:+05:00").is_err()
+    );
+    assert!(
+        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00 ").is_err()
+    );
+    assert!(
+        DateTime::<FixedOffset>::parse_from_rfc3339(" 2015-02-18T23:59:60.234567+05:00").is_err()
+    );
+    assert!(
+        DateTime::<FixedOffset>::parse_from_rfc3339("2015- 02-18T23:59:60.234567+05:00").is_err()
+    );
+    assert!(
+        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567A+05:00").is_err()
     );
 }
 
@@ -590,7 +756,94 @@ fn test_datetime_from_str() {
 }
 
 #[test]
-fn test_datetime_parse_from_str() {
+fn test_parse_datetime_utc() {
+    // valid cases
+    let valid = [
+        "2001-02-03T04:05:06Z",
+        "2001-02-03T04:05:06+0000",
+        "2001-02-03T04:05:06-00:00",
+        "2001-02-03T04:05:06-01:00",
+        "2012-12-12T12:12:12Z",
+        "2012 -12-12T12:12:12Z",
+        "2012  -12-12T12:12:12Z",
+        "2012- 12-12T12:12:12Z",
+        "2012-  12-12T12:12:12Z",
+        "2012-12-12T 12:12:12Z",
+        "2012-12-12T12 :12:12Z",
+        "2012-12-12T12  :12:12Z",
+        "2012-12-12T12: 12:12Z",
+        "2012-12-12T12:  12:12Z",
+        "2012-12-12T12 : 12:12Z",
+        "2012-12-12T12:12:12Z ",
+        " 2012-12-12T12:12:12Z",
+        "2015-02-18T23:16:09.153Z",
+        "2015-2-18T23:16:09.153Z",
+        "+2015-2-18T23:16:09.153Z",
+        "-77-02-18T23:16:09Z",
+        "+82701-05-6T15:9:60.898989898989Z",
+    ];
+    for &s in &valid {
+        eprintln!("test_parse_datetime_utc valid {:?}", s);
+        let d = match s.parse::<DateTime<Utc>>() {
+            Ok(d) => d,
+            Err(e) => panic!("parsing `{}` has failed: {}", s, e),
+        };
+        let s_ = format!("{:?}", d);
+        // `s` and `s_` may differ, but `s.parse()` and `s_.parse()` must be same
+        let d_ = match s_.parse::<DateTime<Utc>>() {
+            Ok(d) => d,
+            Err(e) => {
+                panic!("`{}` is parsed into `{:?}`, but reparsing that has failed: {}", s, d, e)
+            }
+        };
+        assert!(
+            d == d_,
+            "`{}` is parsed into `{:?}`, but reparsed result \
+                              `{:?}` does not match",
+            s,
+            d,
+            d_
+        );
+    }
+
+    // some invalid cases
+    // since `ParseErrorKind` is private, all we can do is to check if there was an error
+    let invalid = [
+        "",                                                          // empty
+        "Z",                                                         // missing data
+        "15Z",                                                       // missing data
+        "15:8:9Z",                                                   // missing date
+        "15-8-9Z",                                                   // missing time or date
+        "Fri, 09 Aug 2013 23:54:35 GMT",                             // valid datetime, wrong format
+        "Sat Jun 30 23:59:60 2012",                                  // valid datetime, wrong format
+        "1441497364.649",                                            // valid datetime, wrong format
+        "+1441497364.649",                                           // valid datetime, wrong format
+        "+1441497364",                                               // valid datetime, wrong format
+        "+1441497364Z",                                              // valid datetime, wrong format
+        "2014/02/03 04:05:06Z",                                      // valid datetime, wrong format
+        "2001-02-03T04:05:0600:00", // valid datetime, timezone too close
+        "2015-15-15T15:15:15Z",     // invalid datetime
+        "2012-12-12T12:12:12x",     // invalid timezone
+        "2012-123-12T12:12:12Z",    // invalid month
+        "2012-12-77T12:12:12Z",     // invalid day
+        "2012-12-12T26:12:12Z",     // invalid hour
+        "2012-12-12T12:61:12Z",     // invalid minute
+        "2012-12-12T12:12:62Z",     // invalid second
+        "2012-12-12 T12:12:12Z",    // space after date
+        "2012-12-12t12:12:12Z",     // wrong divider 't'
+        "2012-12-12T12:12:12ZZ",    // trailing literal 'Z'
+        "+802701-12-12T12:12:12Z",  // invalid year (out of bounds)
+        "+ 2012-12-12T12:12:12Z",   // invalid space before year
+        "  +82701  -  05  -  6  T  15  :  9  : 60.898989898989   Z", // valid datetime, wrong format
+    ];
+    for &s in &invalid {
+        eprintln!("test_parse_datetime_utc invalid {:?}", s);
+        assert!(s.parse::<DateTime<Utc>>().is_err());
+    }
+}
+
+#[test]
+fn test_utc_datetime_from_str() {
     let ymdhms = |y, m, d, h, n, s, off| {
         FixedOffset::east_opt(off).unwrap().with_ymd_and_hms(y, m, d, h, n, s).unwrap()
     };
@@ -605,6 +858,645 @@ fn test_datetime_parse_from_str() {
         Utc.datetime_from_str("Fri, 09 Aug 2013 23:54:35 GMT", "%a, %d %b %Y %H:%M:%S GMT"),
         Ok(Utc.with_ymd_and_hms(2013, 8, 9, 23, 54, 35).unwrap())
     );
+
+    assert_eq!(
+        "2015-02-18T23:16:9.15Z".parse::<DateTime<FixedOffset>>(),
+        Ok(FixedOffset::east_opt(0)
+            .unwrap()
+            .ymd_opt(2015, 2, 18)
+            .unwrap()
+            .and_hms_milli_opt(23, 16, 9, 150)
+            .unwrap())
+    );
+    assert_eq!(
+        "2015-02-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
+        Ok(Utc.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap())
+    );
+    assert_eq!(
+        "2015-02-18T23:16:9.15 UTC".parse::<DateTime<Utc>>(),
+        Ok(Utc.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap())
+    );
+    assert_eq!(
+        "2015-02-18T23:16:9.15UTC".parse::<DateTime<Utc>>(),
+        Ok(Utc.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap())
+    );
+
+    assert_eq!(
+        "2015-2-18T23:16:9.15Z".parse::<DateTime<FixedOffset>>(),
+        Ok(FixedOffset::east_opt(0)
+            .unwrap()
+            .ymd_opt(2015, 2, 18)
+            .unwrap()
+            .and_hms_milli_opt(23, 16, 9, 150)
+            .unwrap())
+    );
+    assert_eq!(
+        "2015-2-18T13:16:9.15-10:00".parse::<DateTime<FixedOffset>>(),
+        Ok(FixedOffset::west_opt(10 * 3600)
+            .unwrap()
+            .ymd_opt(2015, 2, 18)
+            .unwrap()
+            .and_hms_milli_opt(13, 16, 9, 150)
+            .unwrap())
+    );
+    assert!("2015-2-18T23:16:9.15".parse::<DateTime<FixedOffset>>().is_err());
+
+    assert_eq!(
+        "2015-2-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
+        Ok(Utc.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap())
+    );
+    assert_eq!(
+        "2015-2-18T13:16:9.15-10:00".parse::<DateTime<Utc>>(),
+        Ok(Utc.ymd_opt(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap())
+    );
+    assert!("2015-2-18T23:16:9.15".parse::<DateTime<Utc>>().is_err());
+
+    // no test for `DateTime<Local>`, we cannot verify that much.
+}
+
+#[test]
+fn test_utc_datetime_from_str_with_spaces() {
+    let dt = Utc.ymd_opt(2013, 8, 9).unwrap().and_hms_opt(23, 54, 35).unwrap();
+    // with varying spaces - should succeed
+    assert_eq!(Utc.datetime_from_str(" Aug 09 2013 23:54:35", " %b %d %Y %H:%M:%S"), Ok(dt),);
+    assert_eq!(Utc.datetime_from_str("Aug 09 2013 23:54:35 ", "%b %d %Y %H:%M:%S "), Ok(dt),);
+    assert_eq!(Utc.datetime_from_str(" Aug 09 2013  23:54:35 ", " %b %d %Y  %H:%M:%S "), Ok(dt),);
+    assert_eq!(Utc.datetime_from_str("  Aug 09 2013 23:54:35", "  %b %d %Y %H:%M:%S"), Ok(dt),);
+    assert_eq!(Utc.datetime_from_str("   Aug 09 2013 23:54:35", "   %b %d %Y %H:%M:%S"), Ok(dt),);
+    assert_eq!(
+        Utc.datetime_from_str("\n\tAug 09 2013 23:54:35  ", "\n\t%b %d %Y %H:%M:%S  "),
+        Ok(dt),
+    );
+    assert_eq!(Utc.datetime_from_str("\tAug 09 2013 23:54:35\t", "\t%b %d %Y %H:%M:%S\t"), Ok(dt),);
+    assert_eq!(Utc.datetime_from_str("Aug  09 2013 23:54:35", "%b  %d %Y %H:%M:%S"), Ok(dt),);
+    assert_eq!(Utc.datetime_from_str("Aug    09 2013 23:54:35", "%b    %d %Y %H:%M:%S"), Ok(dt),);
+    assert_eq!(Utc.datetime_from_str("Aug  09 2013\t23:54:35", "%b  %d %Y\t%H:%M:%S"), Ok(dt),);
+    assert_eq!(Utc.datetime_from_str("Aug  09 2013\t\t23:54:35", "%b  %d %Y\t\t%H:%M:%S"), Ok(dt),);
+    assert_eq!(Utc.datetime_from_str("Aug 09 2013 23:54:35 ", "%b %d %Y %H:%M:%S\n"), Ok(dt),);
+    assert_eq!(Utc.datetime_from_str("Aug 09 2013 23:54:35", "%b %d %Y\t%H:%M:%S"), Ok(dt),);
+    assert_eq!(Utc.datetime_from_str("Aug 09 2013 23:54:35", "%b %d %Y %H:%M:%S "), Ok(dt),);
+    assert_eq!(Utc.datetime_from_str("Aug 09 2013 23:54:35", " %b %d %Y %H:%M:%S"), Ok(dt),);
+    assert_eq!(Utc.datetime_from_str("Aug 09 2013 23:54:35", "%b %d %Y %H:%M:%S\n"), Ok(dt),);
+    // with varying spaces - should fail
+    // leading space in data
+    assert!(Utc.datetime_from_str(" Aug 09 2013 23:54:35", "%b %d %Y %H:%M:%S").is_err());
+    // trailing space in data
+    assert!(Utc.datetime_from_str("Aug 09 2013 23:54:35 ", "%b %d %Y %H:%M:%S").is_err());
+    // trailing tab in data
+    assert!(Utc.datetime_from_str("Aug 09 2013 23:54:35\t", "%b %d %Y %H:%M:%S").is_err());
+    // mismatched newlines
+    assert!(Utc.datetime_from_str("\nAug 09 2013 23:54:35", "%b %d %Y %H:%M:%S\n").is_err());
+    // trailing literal in data
+    assert!(Utc.datetime_from_str("Aug 09 2013 23:54:35 !!!", "%b %d %Y %H:%M:%S ").is_err());
+}
+
+#[test]
+fn test_datetime_parse_from_str() {
+    let dt = FixedOffset::east_opt(-9 * 60 * 60)
+        .unwrap()
+        .ymd_opt(2013, 8, 9)
+        .unwrap()
+        .and_hms_opt(23, 54, 35)
+        .unwrap();
+
+    // timezone variations
+
+    //
+    // %Z
+    //
+    // wrong timezone format
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -0900",
+        "%b %d %Y %H:%M:%S %Z"
+    )
+    .is_err());
+    // bad timezone data?
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 PST",
+        "%b %d %Y %H:%M:%S %Z"
+    )
+    .is_err());
+    // bad timezone data
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 XXXXX",
+        "%b %d %Y %H:%M:%S %Z"
+    )
+    .is_err());
+
+    //
+    // %z
+    //
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -0900",
+            "%b %d %Y %H:%M:%S %z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09 00",
+            "%b %d %Y %H:%M:%S %z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09:00",
+            "%b %d %Y %H:%M:%S %z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09 : 00",
+            "%b %d %Y %H:%M:%S %z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 --0900",
+            "%b %d %Y %H:%M:%S -%z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 +-0900",
+            "%b %d %Y %H:%M:%S +%z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09:00 ",
+            "%b %d %Y %H:%M:%S %z "
+        ),
+        Ok(dt),
+    );
+    // trailing newline after timezone
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09:00\n",
+        "%b %d %Y %H:%M:%S %z"
+    )
+    .is_err());
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09:00\n",
+            "%b %d %Y %H:%M:%S %z "
+        ),
+        Ok(dt),
+    );
+    // trailing colon
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09:00:",
+        "%b %d %Y %H:%M:%S %z"
+    )
+    .is_err());
+    // trailing colon with space
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09:00: ",
+        "%b %d %Y %H:%M:%S %z "
+    )
+    .is_err());
+    // trailing colon, mismatch space
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09:00:",
+        "%b %d %Y %H:%M:%S %z "
+    )
+    .is_err());
+    // wrong timezone data
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09",
+        "%b %d %Y %H:%M:%S %z"
+    )
+    .is_err());
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09::00",
+            "%b %d %Y %H:%M:%S %z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -0900::",
+            "%b %d %Y %H:%M:%S %z::"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09:00:00",
+            "%b %d %Y %H:%M:%S %z:00"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09:00:00 ",
+            "%b %d %Y %H:%M:%S %z:00 "
+        ),
+        Ok(dt),
+    );
+
+    //
+    // %:z
+    //
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35  -09:00",
+            "%b %d %Y %H:%M:%S  %:z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -0900",
+            "%b %d %Y %H:%M:%S %:z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09 00",
+            "%b %d %Y %H:%M:%S %:z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09 : 00",
+            "%b %d %Y %H:%M:%S %:z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09 : 00:",
+            "%b %d %Y %H:%M:%S %:z:"
+        ),
+        Ok(dt),
+    );
+    // wrong timezone data
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09",
+        "%b %d %Y %H:%M:%S %:z"
+    )
+    .is_err());
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09::00",
+            "%b %d %Y %H:%M:%S %:z"
+        ),
+        Ok(dt),
+    );
+    // timezone data hs too many colons
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09:00:",
+        "%b %d %Y %H:%M:%S %:z"
+    )
+    .is_err());
+    // timezone data hs too many colons
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09:00::",
+        "%b %d %Y %H:%M:%S %:z"
+    )
+    .is_err());
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09:00::",
+            "%b %d %Y %H:%M:%S %:z::"
+        ),
+        Ok(dt),
+    );
+
+    //
+    // %:::z
+    //
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -0900",
+            "%b %d %Y %H:%M:%S %::z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09:00",
+            "%b %d %Y %H:%M:%S %::z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09 : 00",
+            "%b %d %Y %H:%M:%S %::z"
+        ),
+        Ok(dt),
+    );
+    // mismatching colon expectations
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09:00:00",
+        "%b %d %Y %H:%M:%S %::z"
+    )
+    .is_err());
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09::00",
+            "%b %d %Y %H:%M:%S %::z"
+        ),
+        Ok(dt),
+    );
+    // wrong timezone data
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09",
+        "%b %d %Y %H:%M:%S %::z"
+    )
+    .is_err());
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09001234",
+            "%b %d %Y %H:%M:%S %::z1234"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09:001234",
+            "%b %d %Y %H:%M:%S %::z1234"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -0900 ",
+            "%b %d %Y %H:%M:%S %::z "
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -0900\t\n",
+            "%b %d %Y %H:%M:%S %::z\t\n"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -0900:",
+            "%b %d %Y %H:%M:%S %::z:"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 :-0900:0",
+            "%b %d %Y %H:%M:%S :%::z:0"
+        ),
+        Ok(dt),
+    );
+    // mismatching colons and spaces
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 :-0900: ",
+        "%b %d %Y %H:%M:%S :%::z::"
+    )
+    .is_err());
+    // mismatching colons expectations
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09:00:00",
+        "%b %d %Y %H:%M:%S %::z"
+    )
+    .is_err());
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 -0900: 23:54:35",
+            "%b %d %Y %::z: %H:%M:%S"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 :-0900:0 23:54:35",
+            "%b %d %Y :%::z:0 %H:%M:%S"
+        ),
+        Ok(dt),
+    );
+    // mismatching colons expectations mid-string
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 :-0900: 23:54:35",
+        "%b %d %Y :%::z  %H:%M:%S"
+    )
+    .is_err());
+    // mismatching colons expectations, before end
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09:00:00 ",
+        "%b %d %Y %H:%M:%S %::z "
+    )
+    .is_err());
+
+    //
+    // %:::z
+    //
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09:00",
+            "%b %d %Y %H:%M:%S %:::z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -0900",
+            "%b %d %Y %H:%M:%S %:::z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -0900  ",
+            "%b %d %Y %H:%M:%S %:::z  "
+        ),
+        Ok(dt),
+    );
+    // wrong timezone data
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09",
+        "%b %d %Y %H:%M:%S %:::z"
+    )
+    .is_err());
+
+    //
+    // %::::z
+    //
+    // too many colons
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -0900",
+        "%b %d %Y %H:%M:%S %::::z"
+    )
+    .is_err());
+    // too many colons
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09:00",
+        "%b %d %Y %H:%M:%S %::::z"
+    )
+    .is_err());
+    // too many colons
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09:00:",
+        "%b %d %Y %H:%M:%S %::::z"
+    )
+    .is_err());
+    // too many colons
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09:00:00",
+        "%b %d %Y %H:%M:%S %::::z"
+    )
+    .is_err());
+
+    //
+    // %#z
+    //
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09:00",
+            "%b %d %Y %H:%M:%S %#z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -0900",
+            "%b %d %Y %H:%M:%S %#z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35  -09:00  ",
+            "%b %d %Y %H:%M:%S  %#z  "
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35  -0900  ",
+            "%b %d %Y %H:%M:%S  %#z  "
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09",
+            "%b %d %Y %H:%M:%S %#z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -0900",
+            "%b %d %Y %H:%M:%S %#z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09:",
+            "%b %d %Y %H:%M:%S %#z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35 -09: ",
+            "%b %d %Y %H:%M:%S %#z "
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35+-09",
+            "%b %d %Y %H:%M:%S+%#z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 23:54:35--09",
+            "%b %d %Y %H:%M:%S-%#z"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 -09:00 23:54:35",
+            "%b %d %Y %#z%H:%M:%S"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 -0900 23:54:35",
+            "%b %d %Y %#z%H:%M:%S"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 -090023:54:35",
+            "%b %d %Y %#z%H:%M:%S"
+        ),
+        Ok(dt),
+    );
+    assert_eq!(
+        DateTime::<FixedOffset>::parse_from_str(
+            "Aug 09 2013 -09:0023:54:35",
+            "%b %d %Y %#z%H:%M:%S"
+        ),
+        Ok(dt),
+    );
+    // timezone with partial minutes adjacent hours
+    assert_ne!(
+        DateTime::<FixedOffset>::parse_from_str("Aug 09 2013 -09023:54:35", "%b %d %Y %#z%H:%M:%S"),
+        Ok(dt),
+    );
+    // bad timezone data
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -09:00:00",
+        "%b %d %Y %H:%M:%S %#z"
+    )
+    .is_err());
+    // bad timezone data (partial minutes)
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -090",
+        "%b %d %Y %H:%M:%S %#z"
+    )
+    .is_err());
+    // bad timezone data (partial minutes) with trailing space
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 23:54:35 -090 ",
+        "%b %d %Y %H:%M:%S %#z "
+    )
+    .is_err());
+    // bad timezone data (partial minutes) mid-string
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 -090 23:54:35",
+        "%b %d %Y %#z %H:%M:%S"
+    )
+    .is_err());
+    // bad timezone data
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 -09:00:00 23:54:35",
+        "%b %d %Y %#z %H:%M:%S"
+    )
+    .is_err());
+    // timezone data ambiguous with hours
+    assert!(DateTime::<FixedOffset>::parse_from_str(
+        "Aug 09 2013 -09:00:23:54:35",
+        "%b %d %Y %#z%H:%M:%S"
+    )
+    .is_err());
     assert_eq!(
         DateTime::parse_from_str("0", "%s").unwrap(),
         NaiveDateTime::from_timestamp_opt(0, 0).unwrap().and_utc().fixed_offset()

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -8,9 +8,7 @@ use super::{ParseResult, IMPOSSIBLE, NOT_ENOUGH, OUT_OF_RANGE};
 use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
 use crate::offset::{FixedOffset, LocalResult, Offset, TimeZone};
 use crate::oldtime::Duration as OldDuration;
-use crate::DateTime;
-use crate::Weekday;
-use crate::{Datelike, Timelike};
+use crate::{DateTime, Datelike, Timelike, Weekday};
 
 /// Parsed parts of date and time. There are two classes of methods:
 ///

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -2967,16 +2967,20 @@ mod tests {
             "360-02-29",
             "0360-02-29",
             "2015-2 -18",
+            "2015-02-18",
             "+70-2-18",
             "+70000-2-18",
             "+00007-2-18",
         ];
         for &s in &valid {
+            eprintln!("test_date_from_str valid {:?}", s);
             let d = match s.parse::<NaiveDate>() {
                 Ok(d) => d,
                 Err(e) => panic!("parsing `{}` has failed: {}", s, e),
             };
+            eprintln!("d {:?} (NaiveDate)", d);
             let s_ = format!("{:?}", d);
+            eprintln!("s_ {:?}", s_);
             // `s` and `s_` may differ, but `s.parse()` and `s_.parse()` must be same
             let d_ = match s_.parse::<NaiveDate>() {
                 Ok(d) => d,
@@ -2984,6 +2988,7 @@ mod tests {
                     panic!("`{}` is parsed into `{:?}`, but reparsing that has failed: {}", s, d, e)
                 }
             };
+            eprintln!("d_ {:?} (NaiveDate)", d_);
             assert!(
                 d == d_,
                 "`{}` is parsed into `{:?}`, but reparsed result \
@@ -2996,13 +3001,27 @@ mod tests {
 
         // some invalid cases
         // since `ParseErrorKind` is private, all we can do is to check if there was an error
-        assert!("".parse::<NaiveDate>().is_err());
-        assert!("x".parse::<NaiveDate>().is_err());
-        assert!("2014".parse::<NaiveDate>().is_err());
-        assert!("2014-01".parse::<NaiveDate>().is_err());
-        assert!("2014-01-00".parse::<NaiveDate>().is_err());
-        assert!("2014-13-57".parse::<NaiveDate>().is_err());
-        assert!("9999999-9-9".parse::<NaiveDate>().is_err()); // out-of-bounds
+        let invalid = [
+            "",                     // empty
+            "x",                    // invalid
+            "Fri, 09 Aug 2013 GMT", // valid date, wrong format
+            "Sat Jun 30 2012",      // valid date, wrong format
+            "1441497364.649",       // valid datetime, wrong format
+            "+1441497364.649",      // valid datetime, wrong format
+            "+1441497364",          // valid datetime, wrong format
+            "2014/02/03",           // valid date, wrong format
+            "2014",                 // datetime missing data
+            "2014-01",              // datetime missing data
+            "2014-01-00",           // invalid day
+            "2014-11-32",           // invalid day
+            "2014-13-01",           // invalid month
+            "2014-13-57",           // invalid month, day
+            "9999999-9-9",          // invalid year (out of bounds)
+        ];
+        for &s in &invalid {
+            eprintln!("test_date_from_str invalid {:?}", s);
+            assert!(s.parse::<NaiveDate>().is_err());
+        }
     }
 
     #[test]

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -199,11 +199,16 @@ fn test_datetime_timestamp() {
 fn test_datetime_from_str() {
     // valid cases
     let valid = [
-        "2015-2-18T23:16:9.15",
+        "2001-02-03T04:05:06",
+        "2012-12-12T12:12:12",
+        "2015-02-18T23:16:09.153",
+        "2015-2-18T23:16:09.153",
         "-77-02-18T23:16:09",
+        "+82701-05-6T15:9:60.898989898989",
         "  +82701  -  05  -  6  T  15  :  9  : 60.898989898989   ",
     ];
     for &s in &valid {
+        eprintln!("test_parse_naivedatetime valid {:?}", s);
         let d = match s.parse::<NaiveDateTime>() {
             Ok(d) => d,
             Err(e) => panic!("parsing `{}` has failed: {}", s, e),
@@ -228,16 +233,34 @@ fn test_datetime_from_str() {
 
     // some invalid cases
     // since `ParseErrorKind` is private, all we can do is to check if there was an error
-    assert!("".parse::<NaiveDateTime>().is_err());
-    assert!("x".parse::<NaiveDateTime>().is_err());
-    assert!("15".parse::<NaiveDateTime>().is_err());
-    assert!("15:8:9".parse::<NaiveDateTime>().is_err());
-    assert!("15-8-9".parse::<NaiveDateTime>().is_err());
-    assert!("2015-15-15T15:15:15".parse::<NaiveDateTime>().is_err());
-    assert!("2012-12-12T12:12:12x".parse::<NaiveDateTime>().is_err());
-    assert!("2012-123-12T12:12:12".parse::<NaiveDateTime>().is_err());
-    assert!("+ 82701-123-12T12:12:12".parse::<NaiveDateTime>().is_err());
-    assert!("+802701-123-12T12:12:12".parse::<NaiveDateTime>().is_err()); // out-of-bound
+    let invalid = [
+        "",                              // empty
+        "x",                             // invalid / missing data
+        "15",                            // missing data
+        "15:8:9",                        // looks like a time (invalid date)
+        "15-8-9",                        // looks like a date (invalid)
+        "Fri, 09 Aug 2013 23:54:35 GMT", // valid date, wrong format
+        "Sat Jun 30 23:59:60 2012",      // valid date, wrong format
+        "1441497364.649",                // valid date, wrong format
+        "+1441497364.649",               // valid date, wrong format
+        "+1441497364",                   // valid date, wrong format
+        "2014/02/03 04:05:06",           // valid date, wrong format
+        "2015-15-15T15:15:15",           // invalid date
+        "2012-12-12T12:12:12x",          // bad timezone / trailing literal
+        "2012-12-12T12:12:12+00:00",     // unexpected timezone / trailing literal
+        "2012-12-12T12:12:12 +00:00",    // unexpected timezone / trailing literal
+        "2012-12-12T12:12:12 GMT",       // unexpected timezone / trailing literal
+        "2012-123-12T12:12:12",          // invalid month
+        "2012-12-12t12:12:12",           // bad divider 't'
+        "2012-12-12 12:12:12",           // missing divider 'T'
+        "2012-12-12T12:12:12Z",          // trailing char 'Z'
+        "+ 82701-123-12T12:12:12",       // strange year, invalid month
+        "+802701-123-12T12:12:12",       // out-of-bound year, invalid month
+    ];
+    for &s in &invalid {
+        eprintln!("test_datetime_from_str invalid {:?}", s);
+        assert!(s.parse::<NaiveDateTime>().is_err());
+    }
 }
 
 #[test]


### PR DESCRIPTION
I missed the following PR to main in earlier backports, because I mostly looked at changes to `src/`:
- https://github.com/chronotope/chrono/pull/907
- the second commit from https://github.com/chronotope/chrono/pull/967
- https://github.com/chronotope/chrono/pull/797

I also backported the first commit from https://github.com/chronotope/chrono/pull/807 that adds more parsing tests, and parts from the second commit that added more tests.

This will help reduce merge conflicts with main in the future.