### PR TITLE
fix #332: stricter %Y

### DIFF
--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -2186,7 +2186,9 @@ where
     assert_eq!(from_str(r#""2016-7-8""#).ok(), Some(NaiveDate::from_ymd_opt(2016, 7, 8).unwrap()));
     assert_eq!(from_str(r#""+002016-07-08""#).ok(), NaiveDate::from_ymd_opt(2016, 7, 8));
     assert_eq!(from_str(r#""0000-01-01""#).ok(), Some(NaiveDate::from_ymd_opt(0, 1, 1).unwrap()));
-    assert_eq!(from_str(r#""0-1-1""#).ok(), Some(NaiveDate::from_ymd_opt(0, 1, 1).unwrap()));
+    assert_eq!(from_str(r#""+0-1-1""#).ok(), Some(NaiveDate::from_ymd_opt(0, 1, 1).unwrap()));
+    assert_eq!(from_str(r#""-0-1-1""#).ok(), Some(NaiveDate::from_ymd_opt(0, 1, 1).unwrap()));
+    assert_eq!(from_str(r#""0000-1-1""#).ok(), Some(NaiveDate::from_ymd_opt(0, 1, 1).unwrap()));
     assert_eq!(
         from_str(r#""-0001-12-31""#).ok(),
         Some(NaiveDate::from_ymd_opt(-1, 12, 31).unwrap())
@@ -2927,8 +2929,11 @@ mod tests {
             "-12345-1-2",
             "-1234-12-31",
             "-7-6-5",
-            "350-2-28",
-            "360-02-29",
+            "+350-2-28",
+            "-350-2-28",
+            "0350-2-28",
+            "+360-02-29",
+            "-360-02-29",
             "0360-02-29",
             "2015-2-18",
             "2015-02-18",

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -1925,7 +1925,15 @@ where
         Some(NaiveDate::from_ymd_opt(0, 1, 1).unwrap().and_hms_milli_opt(0, 0, 59, 1_000).unwrap())
     );
     assert_eq!(
-        from_str(r#""0-1-1T0:0:60""#).ok(),
+        from_str(r#""+0-1-1T0:0:60""#).ok(),
+        Some(NaiveDate::from_ymd_opt(0, 1, 1).unwrap().and_hms_milli_opt(0, 0, 59, 1_000).unwrap())
+    );
+    assert_eq!(
+        from_str(r#""-0-1-1T0:0:60""#).ok(),
+        Some(NaiveDate::from_ymd_opt(0, 1, 1).unwrap().and_hms_milli_opt(0, 0, 59, 1_000).unwrap())
+    );
+    assert_eq!(
+        from_str(r#""0000-1-1T0:0:60""#).ok(),
         Some(NaiveDate::from_ymd_opt(0, 1, 1).unwrap().and_hms_milli_opt(0, 0, 59, 1_000).unwrap())
     );
     assert_eq!(


### PR DESCRIPTION
The main idea behind the fix is refactoring a little bit the parser so that:
- (same as before) When %Y or %G is used (which allows for a sign), and there is a `+` or `-` preceding the number, it parses from 1 to _infinity_ digits
- (changed) When %Y is used, the min_width was increased from 1 to 4
- (same as before) When %G is used, the min_width was kept at 1 (but happy to change it to 4 as well for consistency if the maintainers agree)
- (same as before) The remaining numeric directives parse as before

Closes #332
