### PR TITLE
Add `StrftimeItems::{parse, parse_to_owned}` and more documentation

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -363,6 +363,22 @@ const fn internal_fixed(val: InternalInternal) -> Item<'static> {
     Item::Fixed(Fixed::Internal(InternalFixed { val }))
 }
 
+impl<'a> Item<'a> {
+    /// Convert items that contain a reference to the format string into an owned variant.
+    #[cfg(any(feature = "alloc", feature = "std"))]
+    pub fn to_owned(self) -> Item<'static> {
+        match self {
+            Item::Literal(s) => Item::OwnedLiteral(Box::from(s)),
+            Item::Space(s) => Item::OwnedSpace(Box::from(s)),
+            Item::Numeric(n, p) => Item::Numeric(n, p),
+            Item::Fixed(f) => Item::Fixed(f),
+            Item::OwnedLiteral(l) => Item::OwnedLiteral(l),
+            Item::OwnedSpace(s) => Item::OwnedSpace(s),
+            Item::Error => Item::Error,
+        }
+    }
+}
+
 /// An error from the `parse` function.
 #[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
 pub struct ParseError(ParseErrorKind);

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -162,6 +162,22 @@ use super::{locales, Locale};
 use super::{Fixed, InternalInternal, Item, Numeric, Pad};
 
 /// Parsing iterator for `strftime`-like format strings.
+///
+/// See the [`format::strftime` module](crate::format::strftime) for supported formatting
+/// specifiers.
+///
+/// `StrftimeItems` is used in combination with more low-level methods such as [`format::parse()`]
+/// or [`format_with_items`].
+///
+/// If formatting or parsing date and time values is not performance-critical, the methods
+/// [`parse_from_str`] and [`format`] on types such as [`DateTime`](crate::DateTime) are easier to
+/// use.
+///
+/// [`format`]: crate::DateTime::format
+/// [`format_with_items`]: crate::DateTime::format
+/// [`parse_from_str`]: crate::DateTime::parse_from_str
+/// [`DateTime`]: crate::DateTime
+/// [`format::parse()`]: crate::format::parse()
 #[derive(Clone, Debug)]
 pub struct StrftimeItems<'a> {
     /// Remaining portion of the string.
@@ -176,7 +192,30 @@ pub struct StrftimeItems<'a> {
 }
 
 impl<'a> StrftimeItems<'a> {
-    /// Creates a new parsing iterator from the `strftime`-like format string.
+    /// Creates a new parsing iterator from a `strftime`-like format string.
+    ///
+    /// # Errors
+    ///
+    /// While iterating [`Item::Error`] will be returned if the format string contains an invalid
+    /// or unrecognized formatting specifier.
+    ///
+    /// # Example
+    ///
+    #[cfg_attr(not(any(feature = "alloc", feature = "std")), doc = "```ignore")]
+    #[cfg_attr(any(feature = "alloc", feature = "std"), doc = "```rust")]
+    /// use chrono::format::*;
+    ///
+    /// let strftime_parser = StrftimeItems::new("%F"); // %F: year-month-day (ISO 8601)
+    ///
+    /// const ISO8601_YMD_ITEMS: &[Item<'static>] = &[
+    ///     Item::Numeric(Numeric::Year, Pad::Zero),
+    ///     Item::Literal("-"),
+    ///     Item::Numeric(Numeric::Month, Pad::Zero),
+    ///     Item::Literal("-"),
+    ///     Item::Numeric(Numeric::Day, Pad::Zero),
+    /// ];
+    /// assert!(strftime_parser.eq(ISO8601_YMD_ITEMS.iter().cloned()));
+    /// ```
     #[must_use]
     pub const fn new(s: &'a str) -> StrftimeItems<'a> {
         #[cfg(not(feature = "unstable-locales"))]

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -228,7 +228,51 @@ impl<'a> StrftimeItems<'a> {
         }
     }
 
-    /// Creates a new parsing iterator from the `strftime`-like format string.
+    /// Creates a new parsing iterator from a `strftime`-like format string, with some formatting
+    /// specifiers adjusted to match [`Locale`].
+    ///
+    /// Note: `StrftimeItems::new_with_locale` only localizes the *format*. You usually want to
+    /// combine it with other locale-aware methods such as
+    /// [`DateTime::format_localized_with_items`] to get things like localized month or day names.
+    ///
+    /// The `%x` formatting specifier will use the local date format, `%X` the local time format,
+    ///  and `%c` the local format for date and time.
+    /// `%r` will use the local 12-hour clock format (e.g., 11:11:04 PM). Not all locales have such
+    /// a format, in which case we fall back to a 24-hour clock (`%X`).
+    ///
+    /// See the [`format::strftime` module](crate::format::strftime) for all supported formatting
+    /// specifiers.
+    ///
+    ///  [`DateTime::format_localized_with_items`]: crate::DateTime::format_localized_with_items
+    ///
+    /// # Errors
+    ///
+    /// While iterating [`Item::Error`] will be returned if the format string contains an invalid
+    /// or unrecognized formatting specifier.
+    ///
+    /// # Example
+    ///
+    #[cfg_attr(not(any(feature = "alloc", feature = "std")), doc = "```ignore")]
+    #[cfg_attr(any(feature = "alloc", feature = "std"), doc = "```rust")]
+    /// use chrono::format::{Locale, StrftimeItems};
+    /// use chrono::{FixedOffset, TimeZone};
+    ///
+    /// let dt = FixedOffset::east_opt(9 * 60 * 60)
+    ///     .unwrap()
+    ///     .with_ymd_and_hms(2023, 7, 11, 0, 34, 59)
+    ///     .unwrap();
+    ///
+    /// // Note: you usually want to combine `StrftimeItems::new_with_locale` with other
+    /// // locale-aware methods such as `DateTime::format_localized_with_items`.
+    /// // We use the regular `format_with_items` to show only how the formatting changes.
+    ///
+    /// let fmtr = dt.format_with_items(StrftimeItems::new_with_locale("%x", Locale::en_US));
+    /// assert_eq!(fmtr.to_string(), "07/11/2023");
+    /// let fmtr = dt.format_with_items(StrftimeItems::new_with_locale("%x", Locale::ko_KR));
+    /// assert_eq!(fmtr.to_string(), "2023년 07월 11일");
+    /// let fmtr = dt.format_with_items(StrftimeItems::new_with_locale("%x", Locale::ja_JP));
+    /// assert_eq!(fmtr.to_string(), "2023年07月11日");
+    /// ```
     #[cfg(feature = "unstable-locales")]
     #[must_use]
     pub const fn new_with_locale(s: &'a str, locale: Locale) -> StrftimeItems<'a> {


### PR DESCRIPTION
Adds `StrftimeItems::parse` and `StrftimeItems::parse_to_owned`.

`parse` returns `Vec<Item<'_>>` and can return an error if the format string is invalid.

With the new formatting API the `Vec` hopefully gets more use, and then it may become difficult that is contains references to the format string. That is what the `OwnedLiteral` and `OwnedSpace` variants of `Item` are for, but we had no easy way to make those.
`parse_to_owned` returns `Vec<Item<'static>>`.

And I added some documentation and doctests.