### PR TITLE
Remove `#![deny(dead_code)]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,7 +387,6 @@
 #![deny(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![warn(unreachable_pub)]
-#![deny(dead_code)]
 #![deny(clippy::tests_outside_test_module)]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 // can remove this if/when rustc-serialize support is removed


### PR DESCRIPTION
This would make development for more a bit easier.
And the CI fails on warnings anyway.