### PR TITLE
Fix deserialization of negative timestamps

### DIFF
--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -199,6 +199,9 @@ pub mod ts_nanoseconds {
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
     /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1526522699, 918355733).unwrap() });
+    ///
+    /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
+    /// assert_eq!(my_s, S { time: Utc.timestamp_opt(-1, 999_999_999).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
@@ -455,6 +458,9 @@ pub mod ts_microseconds {
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
     /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1526522699, 918355000).unwrap() });
+    ///
+    /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
+    /// assert_eq!(my_s, S { time: Utc.timestamp_opt(-1, 999_999_000).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
@@ -710,6 +716,9 @@ pub mod ts_milliseconds {
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
     /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1526522699, 918000000).unwrap() });
+    ///
+    /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
+    /// assert_eq!(my_s, S { time: Utc.timestamp_opt(-1, 999_000_000).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -157,8 +157,11 @@ pub mod ts_nanoseconds {
         where
             E: de::Error,
         {
-            NaiveDateTime::from_timestamp_opt(value / 1_000_000_000, (value % 1_000_000_000) as u32)
-                .ok_or_else(|| E::custom(ne_timestamp(value)))
+            NaiveDateTime::from_timestamp_opt(
+                value.div_euclid(1_000_000_000),
+                (value.rem_euclid(1_000_000_000)) as u32,
+            )
+            .ok_or_else(|| E::custom(ne_timestamp(value)))
         }
 
         fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
@@ -166,8 +169,8 @@ pub mod ts_nanoseconds {
             E: de::Error,
         {
             NaiveDateTime::from_timestamp_opt(
-                value as i64 / 1_000_000_000,
-                (value as i64 % 1_000_000_000) as u32,
+                (value / 1_000_000_000) as i64,
+                (value % 1_000_000_000) as u32,
             )
             .ok_or_else(|| E::custom(ne_timestamp(value)))
         }
@@ -405,11 +408,8 @@ pub mod ts_microseconds {
         where
             E: de::Error,
         {
-            NaiveDateTime::from_timestamp_opt(
-                value / 1_000_000,
-                ((value % 1_000_000) * 1000) as u32,
-            )
-            .ok_or_else(|| E::custom(ne_timestamp(value)))
+            NaiveDateTime::from_timestamp_micros(value)
+                .ok_or_else(|| E::custom(ne_timestamp(value)))
         }
 
         fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
@@ -656,7 +656,7 @@ pub mod ts_milliseconds {
         where
             E: de::Error,
         {
-            NaiveDateTime::from_timestamp_opt(value / 1000, ((value % 1000) * 1_000_000) as u32)
+            NaiveDateTime::from_timestamp_millis(value)
                 .ok_or_else(|| E::custom(ne_timestamp(value)))
         }
 

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -135,6 +135,9 @@ pub mod ts_nanoseconds {
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
     /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918355733).unwrap() });
+    ///
+    /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(-1, 999_999_999).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
@@ -262,6 +265,9 @@ pub mod ts_nanoseconds_option {
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
     /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918355733) });
+    ///
+    /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(-1, 999_999_999) });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
@@ -386,6 +392,9 @@ pub mod ts_microseconds {
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
     /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918355000).unwrap() });
+    ///
+    /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(-1, 999_999_000).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
@@ -510,6 +519,9 @@ pub mod ts_microseconds_option {
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
     /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918355000) });
+    ///
+    /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(-1, 999_999_000) });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
@@ -634,6 +646,9 @@ pub mod ts_milliseconds {
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
     /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918000000).unwrap() });
+    ///
+    /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(-1, 999_000_000).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
@@ -758,6 +773,9 @@ pub mod ts_milliseconds_option {
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
     /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918000000) });
+    ///
+    /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(-1, 999_000_000) });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>


### PR DESCRIPTION
Fixes https://github.com/chronotope/chrono/issues/577.

Deserialization should use `div_euclid` en `rem_euclid` like in the `DateTime::from_timestamp_millis`.
Where available I used the existing methods `timestamp_millis_opt`, `NaiveDateTime::from_timestamp_micros` and `NaiveDateTime::from_timestamp_millis`.

For deserializing `u64` values it doesn't matter, we can just use regular div and mod.

I also fixed two cases where the `u64` input was cast to an `i64` without checking the range.