### PR TITLE
Don't test the same thing twice in `test_date_extreme_offset`

### DIFF
--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -262,45 +262,25 @@ mod tests {
     fn test_date_extreme_offset() {
         // starting from 0.3 we don't have an offset exceeding one day.
         // this makes everything easier!
+        let offset = FixedOffset::east_opt(86399).unwrap();
         assert_eq!(
-            format!(
-                "{:?}",
-                FixedOffset::east_opt(86399)
-                    .unwrap()
-                    .with_ymd_and_hms(2012, 2, 29, 5, 6, 7)
-                    .unwrap()
-            ),
-            "2012-02-29T05:06:07+23:59:59".to_string()
+            format!("{:?}", offset.with_ymd_and_hms(2012, 2, 29, 5, 6, 7).unwrap()),
+            "2012-02-29T05:06:07+23:59:59"
         );
+        let offset = FixedOffset::east_opt(-86399).unwrap();
         assert_eq!(
-            format!(
-                "{:?}",
-                FixedOffset::east_opt(86399)
-                    .unwrap()
-                    .with_ymd_and_hms(2012, 2, 29, 5, 6, 7)
-                    .unwrap()
-            ),
-            "2012-02-29T05:06:07+23:59:59".to_string()
+            format!("{:?}", offset.with_ymd_and_hms(2012, 2, 29, 5, 6, 7).unwrap()),
+            "2012-02-29T05:06:07-23:59:59"
         );
+        let offset = FixedOffset::west_opt(86399).unwrap();
         assert_eq!(
-            format!(
-                "{:?}",
-                FixedOffset::west_opt(86399)
-                    .unwrap()
-                    .with_ymd_and_hms(2012, 3, 4, 5, 6, 7)
-                    .unwrap()
-            ),
-            "2012-03-04T05:06:07-23:59:59".to_string()
+            format!("{:?}", offset.with_ymd_and_hms(2012, 3, 4, 5, 6, 7).unwrap()),
+            "2012-03-04T05:06:07-23:59:59"
         );
+        let offset = FixedOffset::west_opt(-86399).unwrap();
         assert_eq!(
-            format!(
-                "{:?}",
-                FixedOffset::west_opt(86399)
-                    .unwrap()
-                    .with_ymd_and_hms(2012, 3, 4, 5, 6, 7)
-                    .unwrap()
-            ),
-            "2012-03-04T05:06:07-23:59:59".to_string()
+            format!("{:?}", offset.with_ymd_and_hms(2012, 3, 4, 5, 6, 7).unwrap()),
+            "2012-03-04T05:06:07+23:59:59"
         );
     }
 


### PR DESCRIPTION
It was testing `FixedOffset::east_opt(86399)` twice instead of also testing `FixedOffset::east_opt(-86399)`. Same for `west_opt`.