### PR TITLE
`DateTime::to_rfc_*` optimizations

### DIFF
--- a/benches/chrono.rs
+++ b/benches/chrono.rs
@@ -63,6 +63,21 @@ fn bench_datetime_to_rfc3339(c: &mut Criterion) {
     c.bench_function("bench_datetime_to_rfc3339", |b| b.iter(|| black_box(dt).to_rfc3339()));
 }
 
+fn bench_datetime_to_rfc3339_opts(c: &mut Criterion) {
+    let pst = FixedOffset::east_opt(8 * 60 * 60).unwrap();
+    let dt = pst
+        .from_local_datetime(
+            &NaiveDate::from_ymd_opt(2018, 1, 11)
+                .unwrap()
+                .and_hms_nano_opt(10, 5, 13, 84_660_000)
+                .unwrap(),
+        )
+        .unwrap();
+    c.bench_function("bench_datetime_to_rfc3339_opts", |b| {
+        b.iter(|| black_box(dt).to_rfc3339_opts(SecondsFormat::Nanos, true))
+    });
+}
+
 fn bench_year_flags_from_year(c: &mut Criterion) {
     c.bench_function("bench_year_flags_from_year", |b| {
         b.iter(|| {
@@ -188,6 +203,7 @@ criterion_group!(
     bench_datetime_from_str,
     bench_datetime_to_rfc2822,
     bench_datetime_to_rfc3339,
+    bench_datetime_to_rfc3339_opts,
     bench_year_flags_from_year,
     bench_num_days_from_ce,
     bench_get_local_time,

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -531,6 +531,7 @@ pub(crate) fn write_rfc3339(
     // reuse `Debug` impls which already print ISO 8601 format.
     // this is faster in this way.
     write!(w, "{:?}", dt)?;
+
     OffsetFormat {
         precision: OffsetPrecision::Minutes,
         colons: Colons::Colon,
@@ -574,11 +575,13 @@ fn write_rfc2822_inner(
     write_hundreds(w, (year / 100) as u8)?;
     write_hundreds(w, (year % 100) as u8)?;
     w.write_char(' ')?;
-    write_hundreds(w, t.hour() as u8)?;
+
+    let (hour, min, sec) = t.hms();
+    write_hundreds(w, hour as u8)?;
     w.write_char(':')?;
-    write_hundreds(w, t.minute() as u8)?;
+    write_hundreds(w, min as u8)?;
     w.write_char(':')?;
-    let sec = t.second() + t.nanosecond() / 1_000_000_000;
+    let sec = sec + t.nanosecond() / 1_000_000_000;
     write_hundreds(w, sec as u8)?;
     w.write_char(' ')?;
     OffsetFormat {

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -801,7 +801,7 @@ impl NaiveTime {
     }
 
     /// Returns a triple of the hour, minute and second numbers.
-    fn hms(&self) -> (u32, u32, u32) {
+    pub(crate) fn hms(&self) -> (u32, u32, u32) {
         let sec = self.secs % 60;
         let mins = self.secs / 60;
         let min = mins % 60;


### PR DESCRIPTION
Split out of https://github.com/chronotope/chrono/pull/1196.

Previously `to_rfc3339` reused the `Debug` implementation of `DateTime`, which in turn used those of `FixedOffset`, `NaiveDateTime`, `NaiveDate` and `NaiveTime`. Going through the formatting machinery of the standard library for each adds some overhead. Writing it out manually is only 35 lines.

Having everything in one function also makes it easy to merge the completely different implementation in `to_rfc3339_opt`.

Before:
```
bench_datetime_to_rfc2822
                        time:   [98.849 ns 99.212 ns 99.611 ns]
Found 9 outliers among 100 measurements (9.00%)
  8 (8.00%) high mild
  1 (1.00%) high severe

bench_datetime_to_rfc3339
                        time:   [198.38 ns 199.69 ns 201.17 ns]
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

bench_datetime_to_rfc3339_opts
                        time:   [702.91 ns 705.77 ns 708.85 ns]
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
```

After:
```
bench_datetime_to_rfc2822
                        time:   [100.66 ns 101.16 ns 101.73 ns]
                        change: [+0.5475% +1.2171% +1.8937%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

bench_datetime_to_rfc3339
                        time:   [128.61 ns 130.09 ns 131.72 ns]
                        change: [-35.653% -34.787% -33.971%] (p = 0.00 < 0.05)
                        Performance has improved.

bench_datetime_to_rfc3339_opts
                        time:   [125.60 ns 126.14 ns 126.79 ns]
                        change: [-82.265% -82.158% -82.037%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
```

`DateTime::to_rfc3339_opts` sees the best improvement from 700 ns down to 130 ns.