### PR TITLE
Use `NonZeroI32` inside `NaiveDate`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -639,15 +639,15 @@ mod tests {
     fn test_type_sizes() {
         use core::mem::size_of;
         assert_eq!(size_of::<NaiveDate>(), 4);
-        assert_eq!(size_of::<Option<NaiveDate>>(), 8);
+        assert_eq!(size_of::<Option<NaiveDate>>(), 4);
         assert_eq!(size_of::<NaiveTime>(), 8);
         assert_eq!(size_of::<Option<NaiveTime>>(), 12);
         assert_eq!(size_of::<NaiveDateTime>(), 12);
-        assert_eq!(size_of::<Option<NaiveDateTime>>(), 16);
+        assert_eq!(size_of::<Option<NaiveDateTime>>(), 12);
 
         assert_eq!(size_of::<DateTime<Utc>>(), 12);
         assert_eq!(size_of::<DateTime<FixedOffset>>(), 16);
         assert_eq!(size_of::<DateTime<Local>>(), 16);
-        assert_eq!(size_of::<Option<DateTime<FixedOffset>>>(), 20);
+        assert_eq!(size_of::<Option<DateTime<FixedOffset>>>(), 16);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -627,3 +627,27 @@ macro_rules! expect {
         }
     };
 }
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "clock")]
+    use crate::{DateTime, FixedOffset, Local, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+
+    #[test]
+    #[allow(deprecated)]
+    #[cfg(feature = "clock")]
+    fn test_type_sizes() {
+        use core::mem::size_of;
+        assert_eq!(size_of::<NaiveDate>(), 4);
+        assert_eq!(size_of::<Option<NaiveDate>>(), 8);
+        assert_eq!(size_of::<NaiveTime>(), 8);
+        assert_eq!(size_of::<Option<NaiveTime>>(), 12);
+        assert_eq!(size_of::<NaiveDateTime>(), 12);
+        assert_eq!(size_of::<Option<NaiveDateTime>>(), 16);
+
+        assert_eq!(size_of::<DateTime<Utc>>(), 12);
+        assert_eq!(size_of::<DateTime<FixedOffset>>(), 16);
+        assert_eq!(size_of::<DateTime<Local>>(), 16);
+        assert_eq!(size_of::<Option<DateTime<FixedOffset>>>(), 20);
+    }
+}


### PR DESCRIPTION
`NonZeroI32` is ugly to work with. But I really like what it brings: `NaiveDate`, `NaiveDateTime` and `DateTime` take up te same size when wrapped in `Option`.

We can easily make it a `NonZeroI32` because a `NaiveDate` consists of a year, ordinal and flags. The ordinal is always in the range `1..=366`, and the flags are also never `0`.

I considered if switching the `Of` type to `NonZero*32` would make things easier. But we do most calculations on that type, and it quickly gets unergonomic (I tried).