### PR TITLE
Refactor `internals` module

### DIFF
--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1045,13 +1045,7 @@ impl NaiveDate {
     /// Returns the packed month-day-flags.
     #[inline]
     const fn mdf(&self) -> Mdf {
-        self.of().to_mdf()
-    }
-
-    /// Returns the packed ordinal-flags.
-    #[inline]
-    const fn of(&self) -> Of {
-        Of::from_date_impl(self.yof)
+        Mdf::from_ol((self.yof & OL_MASK) >> 3, self.year_flags())
     }
 
     /// Makes a new `NaiveDate` with the packed month-day-flags changed.

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1135,9 +1135,10 @@ impl NaiveDate {
     #[inline]
     #[must_use]
     pub const fn pred_opt(&self) -> Option<NaiveDate> {
-        match self.of().pred() {
-            Some(of) => Some(self.with_of(of)),
-            None => NaiveDate::from_ymd_opt(self.year() - 1, 12, 31),
+        let new_shifted_ordinal = (self.yof & ORDINAL_MASK) - (1 << 4);
+        match new_shifted_ordinal > 0 {
+            true => Some(NaiveDate { yof: self.yof & !ORDINAL_MASK | new_shifted_ordinal }),
+            false => NaiveDate::from_ymd_opt(self.year() - 1, 12, 31),
         }
     }
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -40,9 +40,6 @@ use crate::{Datelike, TimeDelta, Weekday};
 use super::internals::{self, Mdf, Of, YearFlags};
 use super::isoweek;
 
-const MAX_YEAR: i32 = internals::MAX_YEAR;
-const MIN_YEAR: i32 = internals::MIN_YEAR;
-
 /// A week represented by a [`NaiveDate`] and a [`Weekday`] which is the first
 /// day of the week.
 #[derive(Debug)]
@@ -2301,6 +2298,16 @@ impl Default for NaiveDate {
 const fn div_mod_floor(val: i32, div: i32) -> (i32, i32) {
     (val.div_euclid(div), val.rem_euclid(div))
 }
+
+/// MAX_YEAR is one year less than the type is capable of representing. Internally we may sometimes
+/// use the headroom, notably to handle cases where the offset of a `DateTime` constructed with
+/// `NaiveDate::MAX` pushes it beyond the valid, representable range.
+pub(super) const MAX_YEAR: i32 = (i32::MAX >> 13) - 1;
+
+/// MIN_YEAR is one year more than the type is capable of representing. Internally we may sometimes
+/// use the headroom, notably to handle cases where the offset of a `DateTime` constructed with
+/// `NaiveDate::MIN` pushes it beyond the valid, representable range.
+pub(super) const MIN_YEAR: i32 = (i32::MIN >> 13) + 1;
 
 #[cfg(all(test, any(feature = "rustc-serialize", feature = "serde")))]
 fn test_encodable_json<F, E>(to_string: F)

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -251,11 +251,8 @@ impl NaiveDate {
     /// Makes a new `NaiveDate` from year and packed month-day-flags.
     /// Does not check whether the flags are correct for the provided year.
     const fn from_mdf(year: i32, mdf: Mdf) -> Option<NaiveDate> {
-        if year < MIN_YEAR || year > MAX_YEAR {
-            return None; // Out-of-range
-        }
-        match mdf.to_of() {
-            Some(of) => Some(NaiveDate { yof: (year << 13) | (of.inner() as i32) }),
+        match mdf.ordinal() {
+            Some(ordinal) => NaiveDate::from_ordinal_and_flags(year, ordinal, mdf.year_flags()),
             None => None, // Non-existing date
         }
     }
@@ -3419,6 +3416,16 @@ mod tests {
             let iso_week = jan4.iso_week();
             assert_eq!(jan4.year_flags(), year_flags);
             assert_eq!(iso_week.week(), 1);
+        }
+    }
+
+    #[test]
+    fn test_date_to_mdf_to_date() {
+        for (year, year_flags, _) in YEAR_FLAGS {
+            for ordinal in 1..=year_flags.ndays() {
+                let date = NaiveDate::from_yo_opt(year, ordinal).unwrap();
+                assert_eq!(date, NaiveDate::from_mdf(date.year(), date.mdf()).unwrap());
+            }
         }
     }
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1688,7 +1688,7 @@ impl Datelike for NaiveDate {
 
     #[inline]
     fn iso_week(&self) -> IsoWeek {
-        IsoWeek::from_yof(self.year(), self.of())
+        IsoWeek::from_yof(self.year(), self.ordinal(), self.of().flags())
     }
 
     /// Makes a new `NaiveDate` with the year number changed, while keeping the same month and day.
@@ -2516,7 +2516,7 @@ mod serde {
 #[cfg(test)]
 mod tests {
     use super::{Days, Months, NaiveDate, MAX_YEAR, MIN_YEAR};
-    use crate::naive::internals::YearFlags;
+    use crate::naive::internals::{YearFlags, A, AG, B, BA, C, CB, D, DC, E, ED, F, FE, G, GF};
     use crate::{Datelike, TimeDelta, Weekday};
 
     // as it is hard to verify year flags in `NaiveDate::MIN` and `NaiveDate::MAX`,
@@ -3374,6 +3374,36 @@ mod tests {
             assert_eq!(date.leap_year(), date.with_ordinal(366).is_some());
         }
     }
+
+    #[test]
+    fn test_isoweekdate_with_yearflags() {
+        for (year, year_flags, _) in YEAR_FLAGS {
+            // January 4 should be in the first week
+            let jan4 = NaiveDate::from_ymd_opt(year, 1, 4).unwrap();
+            let iso_week = jan4.iso_week();
+            assert_eq!(jan4.of().flags(), year_flags);
+            assert_eq!(iso_week.week(), 1);
+        }
+    }
+
+    // Used for testing some methods with all combinations of `YearFlags`.
+    // (year, flags, first weekday of year)
+    const YEAR_FLAGS: [(i32, YearFlags, Weekday); 14] = [
+        (2006, A, Weekday::Sun),
+        (2005, B, Weekday::Sat),
+        (2010, C, Weekday::Fri),
+        (2009, D, Weekday::Thu),
+        (2003, E, Weekday::Wed),
+        (2002, F, Weekday::Tue),
+        (2001, G, Weekday::Mon),
+        (2012, AG, Weekday::Sun),
+        (2000, BA, Weekday::Sat),
+        (2016, CB, Weekday::Fri),
+        (2004, DC, Weekday::Thu),
+        (2020, ED, Weekday::Wed),
+        (2008, FE, Weekday::Tue),
+        (2024, GF, Weekday::Mon),
+    ];
 
     #[test]
     #[cfg(feature = "rkyv-validation")]

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -27,7 +27,7 @@ use crate::naive::{IsoWeek, NaiveDateTime, NaiveTime};
 use crate::{expect, try_opt};
 use crate::{Datelike, TimeDelta, Weekday};
 
-use super::internals::{self, DateImpl, Mdf, Of, YearFlags};
+use super::internals::{self, Mdf, Of, YearFlags};
 use super::isoweek;
 
 const MAX_YEAR: i32 = internals::MAX_YEAR;
@@ -196,7 +196,7 @@ impl Days {
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub struct NaiveDate {
-    ymdf: DateImpl, // (year << 13) | of
+    ymdf: i32, // (year << 13) | of
 }
 
 /// The minimum possible `NaiveDate` (January 1, 262145 BCE).
@@ -233,7 +233,7 @@ impl NaiveDate {
         }
         debug_assert!(YearFlags::from_year(year).0 == flags.0);
         match Of::new(ordinal, flags) {
-            Some(of) => Some(NaiveDate { ymdf: (year << 13) | (of.inner() as DateImpl) }),
+            Some(of) => Some(NaiveDate { ymdf: (year << 13) | (of.inner() as i32) }),
             None => None, // Invalid: Ordinal outside of the nr of days in a year with those flags.
         }
     }
@@ -245,7 +245,7 @@ impl NaiveDate {
             return None; // Out-of-range
         }
         match mdf.to_of() {
-            Some(of) => Some(NaiveDate { ymdf: (year << 13) | (of.inner() as DateImpl) }),
+            Some(of) => Some(NaiveDate { ymdf: (year << 13) | (of.inner() as i32) }),
             None => None, // Non-existing date
         }
     }
@@ -1058,7 +1058,7 @@ impl NaiveDate {
     /// Does not check if the year flags match the year.
     #[inline]
     const fn with_of(&self, of: Of) -> NaiveDate {
-        NaiveDate { ymdf: (self.ymdf & !0b1_1111_1111_1111) | of.inner() as DateImpl }
+        NaiveDate { ymdf: (self.ymdf & !0b1_1111_1111_1111) | of.inner() as i32 }
     }
 
     /// Makes a new `NaiveDate` for the next calendar date.

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -38,7 +38,6 @@ use crate::{expect, try_opt};
 use crate::{Datelike, TimeDelta, Weekday};
 
 use super::internals::{self, Mdf, Of, YearFlags};
-use super::isoweek;
 
 /// A week represented by a [`NaiveDate`] and a [`Weekday`] which is the first
 /// day of the week.
@@ -1689,7 +1688,7 @@ impl Datelike for NaiveDate {
 
     #[inline]
     fn iso_week(&self) -> IsoWeek {
-        isoweek::iso_week_from_yof(self.year(), self.of())
+        IsoWeek::from_yof(self.year(), self.of())
     }
 
     /// Makes a new `NaiveDate` with the year number changed, while keeping the same month and day.

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -2,6 +2,16 @@
 // See README.md and LICENSE.txt for details.
 
 //! ISO 8601 calendar date without timezone.
+//!
+//! The implementation is optimized for determining year, month, day and day of week.
+//!
+//! Format of `NaiveDate`:
+//! `YYYY_YYYY_YYYY_YYYY_YYYO_OOOO_OOOO_LWWW`
+//! `Y`: Year
+//! `O`: Ordinal
+//! `L`: leap year flag (1 = common year, 0 is leap year)
+//! `W`: weekday before the first day of the year
+//! `LWWW`: will also be referred to as the year flags (`F`)
 
 #[cfg(feature = "alloc")]
 use core::borrow::Borrow;

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -303,11 +303,6 @@ impl Of {
         }
     }
 
-    #[inline]
-    pub(super) const fn flags(&self) -> YearFlags {
-        YearFlags((self.0 & 0b1111) as u8)
-    }
-
     #[cfg_attr(feature = "cargo-clippy", allow(clippy::wrong_self_convention))]
     #[inline]
     pub(super) const fn to_mdf(&self) -> Mdf {

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -346,13 +346,6 @@ impl Of {
         Mdf::from_of(*self)
     }
 
-    /// Returns an `Of` with the next day, or `None` if this is the last day of the year.
-    #[inline]
-    pub(super) const fn succ(&self) -> Option<Of> {
-        let of = Of(self.0 + (1 << 4));
-        of.validate()
-    }
-
     /// Returns an `Of` with the previous day, or `None` if this is the first day of the year.
     #[inline]
     pub(super) const fn pred(&self) -> Option<Of> {
@@ -866,10 +859,6 @@ mod tests {
         assert!(Of::from_mdf(Mdf::new(2, 29, regular_year).unwrap()).is_none());
         assert!(Of::from_mdf(Mdf::new(2, 29, leap_year).unwrap()).is_some());
         assert!(Of::from_mdf(Mdf::new(2, 28, regular_year).unwrap()).is_some());
-
-        assert!(Of::new(365, regular_year).unwrap().succ().is_none());
-        assert!(Of::new(365, leap_year).unwrap().succ().is_some());
-        assert!(Of::new(366, leap_year).unwrap().succ().is_none());
 
         assert!(Of::new(1, regular_year).unwrap().pred().is_none());
         assert!(Of::new(1, leap_year).unwrap().pred().is_none());

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -402,6 +402,20 @@ impl Mdf {
     pub(super) const fn to_of(&self) -> Option<Of> {
         Of::from_mdf(*self)
     }
+
+    #[inline]
+    pub(super) const fn ordinal(&self) -> Option<u32> {
+        let mdl = self.0 >> 3;
+        match MDL_TO_OL[mdl as usize] {
+            XX => None,
+            v => Some((mdl - v as i32 as u32) >> 1),
+        }
+    }
+
+    #[inline]
+    pub(super) const fn year_flags(&self) -> YearFlags {
+        YearFlags((self.0 & 0b1111) as u8)
+    }
 }
 
 impl fmt::Debug for Mdf {

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -15,7 +15,6 @@
 
 #![cfg_attr(feature = "__internal_bench", allow(missing_docs))]
 
-use crate::Weekday;
 use core::fmt;
 
 /// The year flags (aka the dominical letter).
@@ -315,12 +314,6 @@ impl Of {
         YearFlags((self.0 & 0b1111) as u8)
     }
 
-    #[inline]
-    pub(super) const fn weekday(&self) -> Weekday {
-        let Of(of) = *self;
-        weekday_from_u32_mod7((of >> 4) + (of & 0b111))
-    }
-
     #[cfg_attr(feature = "cargo-clippy", allow(clippy::wrong_self_convention))]
     #[inline]
     pub(super) const fn to_mdf(&self) -> Mdf {
@@ -446,27 +439,10 @@ impl fmt::Debug for Mdf {
     }
 }
 
-/// Create a `Weekday` from an `u32`, with Monday = 0.
-/// Infallible, takes any `n` and applies `% 7`.
-#[inline]
-const fn weekday_from_u32_mod7(n: u32) -> Weekday {
-    match n % 7 {
-        0 => Weekday::Mon,
-        1 => Weekday::Tue,
-        2 => Weekday::Wed,
-        3 => Weekday::Thu,
-        4 => Weekday::Fri,
-        5 => Weekday::Sat,
-        _ => Weekday::Sun,
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::weekday_from_u32_mod7;
     use super::{Mdf, Of};
     use super::{YearFlags, A, AG, B, BA, C, CB, D, DC, E, ED, F, FE, G, GF};
-    use crate::Weekday;
 
     const NONLEAP_FLAGS: [YearFlags; 7] = [A, B, C, D, E, F, G];
     const LEAP_FLAGS: [YearFlags; 7] = [AG, BA, CB, DC, ED, FE, GF];
@@ -635,34 +611,6 @@ mod tests {
     }
 
     #[test]
-    fn test_of_weekday() {
-        assert_eq!(Of::new(1, A).unwrap().weekday(), Weekday::Sun);
-        assert_eq!(Of::new(1, B).unwrap().weekday(), Weekday::Sat);
-        assert_eq!(Of::new(1, C).unwrap().weekday(), Weekday::Fri);
-        assert_eq!(Of::new(1, D).unwrap().weekday(), Weekday::Thu);
-        assert_eq!(Of::new(1, E).unwrap().weekday(), Weekday::Wed);
-        assert_eq!(Of::new(1, F).unwrap().weekday(), Weekday::Tue);
-        assert_eq!(Of::new(1, G).unwrap().weekday(), Weekday::Mon);
-        assert_eq!(Of::new(1, AG).unwrap().weekday(), Weekday::Sun);
-        assert_eq!(Of::new(1, BA).unwrap().weekday(), Weekday::Sat);
-        assert_eq!(Of::new(1, CB).unwrap().weekday(), Weekday::Fri);
-        assert_eq!(Of::new(1, DC).unwrap().weekday(), Weekday::Thu);
-        assert_eq!(Of::new(1, ED).unwrap().weekday(), Weekday::Wed);
-        assert_eq!(Of::new(1, FE).unwrap().weekday(), Weekday::Tue);
-        assert_eq!(Of::new(1, GF).unwrap().weekday(), Weekday::Mon);
-
-        for &flags in FLAGS.iter() {
-            let mut prev = Of::new(1, flags).unwrap().weekday();
-            for ordinal in 2u32..=flags.ndays() {
-                let of = Of::new(ordinal, flags).unwrap();
-                let expected = prev.succ();
-                assert_eq!(of.weekday(), expected);
-                prev = expected;
-            }
-        }
-    }
-
-    #[test]
     fn test_mdf_fields() {
         for &flags in FLAGS.iter() {
             for month in 1u32..=12 {
@@ -787,13 +735,5 @@ mod tests {
         assert!(Of::from_mdf(Mdf::new(2, 29, regular_year).unwrap()).is_none());
         assert!(Of::from_mdf(Mdf::new(2, 29, leap_year).unwrap()).is_some());
         assert!(Of::from_mdf(Mdf::new(2, 28, regular_year).unwrap()).is_some());
-    }
-
-    #[test]
-    fn test_weekday_from_u32_mod7() {
-        for i in 0..=1000 {
-            assert_eq!(weekday_from_u32_mod7(i), Weekday::try_from((i % 7) as u8).unwrap());
-        }
-        assert_eq!(weekday_from_u32_mod7(u32::MAX), Weekday::Thu);
     }
 }

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -18,18 +18,15 @@
 use crate::Weekday;
 use core::fmt;
 
-/// The internal date representation: `year << 13 | Of`
-pub(super) type DateImpl = i32;
-
 /// MAX_YEAR is one year less than the type is capable of representing. Internally we may sometimes
 /// use the headroom, notably to handle cases where the offset of a `DateTime` constructed with
 /// `NaiveDate::MAX` pushes it beyond the valid, representable range.
-pub(super) const MAX_YEAR: DateImpl = (i32::MAX >> 13) - 1;
+pub(super) const MAX_YEAR: i32 = (i32::MAX >> 13) - 1;
 
 /// MIN_YEAR is one year more than the type is capable of representing. Internally we may sometimes
 /// use the headroom, notably to handle cases where the offset of a `DateTime` constructed with
 /// `NaiveDate::MIN` pushes it beyond the valid, representable range.
-pub(super) const MIN_YEAR: DateImpl = (i32::MIN >> 13) + 1;
+pub(super) const MIN_YEAR: i32 = (i32::MIN >> 13) + 1;
 
 /// The year flags (aka the dominical letter).
 ///
@@ -285,8 +282,8 @@ impl Of {
         of.validate()
     }
 
-    pub(super) const fn from_date_impl(date_impl: DateImpl) -> Of {
-        // We assume the value in the `DateImpl` is valid.
+    pub(super) const fn from_date_impl(date_impl: i32) -> Of {
+        // We assume the value in `date_impl` is valid.
         Of((date_impl & 0b1_1111_1111_1111) as u32)
     }
 

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -316,12 +316,6 @@ impl Of {
     }
 
     #[inline]
-    pub(super) const fn with_ordinal(&self, ordinal: u32) -> Option<Of> {
-        let of = Of((ordinal << 4) | (self.0 & 0b1111));
-        of.validate()
-    }
-
-    #[inline]
     pub(super) const fn flags(&self) -> YearFlags {
         YearFlags((self.0 & 0b1111) as u8)
     }
@@ -661,30 +655,6 @@ mod tests {
                     assert_eq!(of.ordinal(), ordinal);
                 }
             }
-        }
-    }
-
-    #[test]
-    fn test_of_with_fields() {
-        fn check(flags: YearFlags, ordinal: u32) {
-            let of = Of::new(ordinal, flags).unwrap();
-
-            for ordinal in 0u32..=1024 {
-                let of = of.with_ordinal(ordinal);
-                assert_eq!(of, Of::new(ordinal, flags));
-                if let Some(of) = of {
-                    assert_eq!(of.ordinal(), ordinal);
-                }
-            }
-        }
-
-        for &flags in NONLEAP_FLAGS.iter() {
-            check(flags, 1);
-            check(flags, 365);
-        }
-        for &flags in LEAP_FLAGS.iter() {
-            check(flags, 1);
-            check(flags, 366);
         }
     }
 

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -321,14 +321,6 @@ impl Of {
         weekday_from_u32_mod7((of >> 4) + (of & 0b111))
     }
 
-    #[inline]
-    pub(super) fn isoweekdate_raw(&self) -> (u32, Weekday) {
-        // week ordinal = ordinal + delta
-        let Of(of) = *self;
-        let weekord = (of >> 4).wrapping_add(self.flags().isoweek_delta());
-        (weekord / 7, weekday_from_u32_mod7(weekord))
-    }
-
     #[cfg_attr(feature = "cargo-clippy", allow(clippy::wrong_self_convention))]
     #[inline]
     pub(super) const fn to_mdf(&self) -> Mdf {
@@ -736,15 +728,6 @@ mod tests {
             check(flags, 2, 29);
             check(flags, 2, 30);
             check(flags, 12, 31);
-        }
-    }
-
-    #[test]
-    fn test_of_isoweekdate_raw() {
-        for &flags in FLAGS.iter() {
-            // January 4 should be in the first week
-            let (week, _) = Of::new(4 /* January 4 */, flags).unwrap().isoweekdate_raw();
-            assert_eq!(week, 1);
         }
     }
 

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -311,11 +311,6 @@ impl Of {
     }
 
     #[inline]
-    pub(super) const fn ordinal(&self) -> u32 {
-        self.0 >> 4
-    }
-
-    #[inline]
     pub(super) const fn flags(&self) -> YearFlags {
         YearFlags((self.0 & 0b1111) as u8)
     }
@@ -644,17 +639,6 @@ mod tests {
             check(false, flags, u32::MAX, 0, u32::MAX, 1024);
             check(false, flags, 0, u32::MAX, 16, u32::MAX);
             check(false, flags, u32::MAX, u32::MAX, u32::MAX, u32::MAX);
-        }
-    }
-
-    #[test]
-    fn test_of_fields() {
-        for &flags in FLAGS.iter() {
-            for ordinal in 1u32..=366 {
-                if let Some(of) = Of::new(ordinal, flags) {
-                    assert_eq!(of.ordinal(), ordinal);
-                }
-            }
         }
     }
 

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -265,12 +265,6 @@ const OL_TO_MDL: &[u8; MAX_OL as usize + 1] = &[
 pub(super) struct Of(u32);
 
 impl Of {
-    #[inline]
-    pub(super) const fn new(ordinal: u32, YearFlags(flags): YearFlags) -> Option<Of> {
-        let of = Of((ordinal << 4) | flags as u32);
-        of.validate()
-    }
-
     pub(super) const fn from_date_impl(date_impl: i32) -> Of {
         // We assume the value in `date_impl` is valid.
         Of((date_impl & 0b1_1111_1111_1111) as u32)
@@ -484,42 +478,6 @@ mod tests {
     }
 
     #[test]
-    fn test_of() {
-        fn check(expected: bool, flags: YearFlags, ordinal1: u32, ordinal2: u32) {
-            for ordinal in ordinal1..=ordinal2 {
-                let of = match Of::new(ordinal, flags) {
-                    Some(of) => of,
-                    None if !expected => continue,
-                    None => panic!("Of::new({}, {:?}) returned None", ordinal, flags),
-                };
-
-                assert!(
-                    of.validate().is_some() == expected,
-                    "ordinal {} = {:?} should be {} for dominical year {:?}",
-                    ordinal,
-                    of,
-                    if expected { "valid" } else { "invalid" },
-                    flags
-                );
-            }
-        }
-
-        for &flags in NONLEAP_FLAGS.iter() {
-            check(false, flags, 0, 0);
-            check(true, flags, 1, 365);
-            check(false, flags, 366, 1024);
-            check(false, flags, u32::MAX, u32::MAX);
-        }
-
-        for &flags in LEAP_FLAGS.iter() {
-            check(false, flags, 0, 0);
-            check(true, flags, 1, 366);
-            check(false, flags, 367, 1024);
-            check(false, flags, u32::MAX, u32::MAX);
-        }
-    }
-
-    #[test]
     fn test_mdf_valid() {
         fn check(expected: bool, flags: YearFlags, month1: u32, day1: u32, month2: u32, day2: u32) {
             for month in month1..=month2 {
@@ -719,11 +677,6 @@ mod tests {
     fn test_invalid_returns_none() {
         let regular_year = YearFlags::from_year(2023);
         let leap_year = YearFlags::from_year(2024);
-        assert!(Of::new(0, regular_year).is_none());
-        assert!(Of::new(366, regular_year).is_none());
-        assert!(Of::new(366, leap_year).is_some());
-        assert!(Of::new(367, regular_year).is_none());
-
         assert!(Mdf::new(0, 1, regular_year).is_none());
         assert!(Mdf::new(13, 1, regular_year).is_none());
         assert!(Mdf::new(1, 0, regular_year).is_none());

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -18,16 +18,6 @@
 use crate::Weekday;
 use core::fmt;
 
-/// MAX_YEAR is one year less than the type is capable of representing. Internally we may sometimes
-/// use the headroom, notably to handle cases where the offset of a `DateTime` constructed with
-/// `NaiveDate::MAX` pushes it beyond the valid, representable range.
-pub(super) const MAX_YEAR: i32 = (i32::MAX >> 13) - 1;
-
-/// MIN_YEAR is one year more than the type is capable of representing. Internally we may sometimes
-/// use the headroom, notably to handle cases where the offset of a `DateTime` constructed with
-/// `NaiveDate::MIN` pushes it beyond the valid, representable range.
-pub(super) const MIN_YEAR: i32 = (i32::MIN >> 13) + 1;
-
 /// The year flags (aka the dominical letter).
 ///
 /// There are 14 possible classes of year in the Gregorian calendar:

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -345,15 +345,6 @@ impl Of {
     pub(super) const fn to_mdf(&self) -> Mdf {
         Mdf::from_of(*self)
     }
-
-    /// Returns an `Of` with the previous day, or `None` if this is the first day of the year.
-    #[inline]
-    pub(super) const fn pred(&self) -> Option<Of> {
-        match self.ordinal() {
-            1 => None,
-            _ => Some(Of(self.0 - (1 << 4))),
-        }
-    }
 }
 
 impl fmt::Debug for Of {
@@ -859,9 +850,6 @@ mod tests {
         assert!(Of::from_mdf(Mdf::new(2, 29, regular_year).unwrap()).is_none());
         assert!(Of::from_mdf(Mdf::new(2, 29, leap_year).unwrap()).is_some());
         assert!(Of::from_mdf(Mdf::new(2, 28, regular_year).unwrap()).is_some());
-
-        assert!(Of::new(1, regular_year).unwrap().pred().is_none());
-        assert!(Of::new(1, leap_year).unwrap().pred().is_none());
     }
 
     #[test]

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -5,7 +5,7 @@
 
 use core::fmt;
 
-use super::internals::{DateImpl, Of, YearFlags};
+use super::internals::{Of, YearFlags};
 
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
@@ -28,7 +28,7 @@ pub struct IsoWeek {
     // note that this allows for larger year range than `NaiveDate`.
     // this is crucial because we have an edge case for the first and last week supported,
     // which year number might not match the calendar year number.
-    ywf: DateImpl, // (year << 10) | (week << 4) | flag
+    ywf: i32, // (year << 10) | (week << 4) | flag
 }
 
 /// Returns the corresponding `IsoWeek` from the year and the `Of` internal value.
@@ -53,7 +53,7 @@ pub(super) fn iso_week_from_yof(year: i32, of: Of) -> IsoWeek {
         }
     };
     let flags = YearFlags::from_year(year);
-    IsoWeek { ywf: (year << 10) | (week << 4) as DateImpl | DateImpl::from(flags.0) }
+    IsoWeek { ywf: (year << 10) | (week << 4) as i32 | i32::from(flags.0) }
 }
 
 impl IsoWeek {

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -5,7 +5,7 @@
 
 use core::fmt;
 
-use super::internals::{Of, YearFlags};
+use super::internals::YearFlags;
 
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
@@ -38,14 +38,14 @@ impl IsoWeek {
     // because the year range for the week date and the calendar date do not match and
     // it is confusing to have a date that is out of range in one and not in another.
     // currently we sidestep this issue by making `IsoWeek` fully dependent of `Datelike`.
-    pub(super) fn from_yof(year: i32, of: Of) -> Self {
-        let (rawweek, _) = of.isoweekdate_raw();
+    pub(super) fn from_yof(year: i32, ordinal: u32, year_flags: YearFlags) -> Self {
+        let rawweek = (ordinal + year_flags.isoweek_delta()) / 7;
         let (year, week) = if rawweek < 1 {
             // previous year
             let prevlastweek = YearFlags::from_year(year - 1).nisoweeks();
             (year - 1, prevlastweek)
         } else {
-            let lastweek = of.flags().nisoweeks();
+            let lastweek = year_flags.nisoweeks();
             if rawweek > lastweek {
                 // next year
                 (year + 1, 1)

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -155,7 +155,7 @@ impl fmt::Debug for IsoWeek {
 mod tests {
     #[cfg(feature = "rkyv-validation")]
     use super::IsoWeek;
-    use crate::naive::{internals, NaiveDate};
+    use crate::naive::date::{self, NaiveDate};
     use crate::Datelike;
 
     #[test]
@@ -163,13 +163,13 @@ mod tests {
         let minweek = NaiveDate::MIN.iso_week();
         let maxweek = NaiveDate::MAX.iso_week();
 
-        assert_eq!(minweek.year(), internals::MIN_YEAR);
+        assert_eq!(minweek.year(), date::MIN_YEAR);
         assert_eq!(minweek.week(), 1);
         assert_eq!(minweek.week0(), 0);
         #[cfg(feature = "alloc")]
         assert_eq!(format!("{:?}", minweek), NaiveDate::MIN.format("%G-W%V").to_string());
 
-        assert_eq!(maxweek.year(), internals::MAX_YEAR + 1);
+        assert_eq!(maxweek.year(), date::MAX_YEAR + 1);
         assert_eq!(maxweek.week(), 1);
         assert_eq!(maxweek.week0(), 0);
         #[cfg(feature = "alloc")]

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -31,32 +31,32 @@ pub struct IsoWeek {
     ywf: i32, // (year << 10) | (week << 4) | flag
 }
 
-/// Returns the corresponding `IsoWeek` from the year and the `Of` internal value.
-//
-// internal use only. we don't expose the public constructor for `IsoWeek` for now,
-// because the year range for the week date and the calendar date do not match and
-// it is confusing to have a date that is out of range in one and not in another.
-// currently we sidestep this issue by making `IsoWeek` fully dependent of `Datelike`.
-pub(super) fn iso_week_from_yof(year: i32, of: Of) -> IsoWeek {
-    let (rawweek, _) = of.isoweekdate_raw();
-    let (year, week) = if rawweek < 1 {
-        // previous year
-        let prevlastweek = YearFlags::from_year(year - 1).nisoweeks();
-        (year - 1, prevlastweek)
-    } else {
-        let lastweek = of.flags().nisoweeks();
-        if rawweek > lastweek {
-            // next year
-            (year + 1, 1)
-        } else {
-            (year, rawweek)
-        }
-    };
-    let flags = YearFlags::from_year(year);
-    IsoWeek { ywf: (year << 10) | (week << 4) as i32 | i32::from(flags.0) }
-}
-
 impl IsoWeek {
+    /// Returns the corresponding `IsoWeek` from the year and the `Of` internal value.
+    //
+    // internal use only. we don't expose the public constructor for `IsoWeek` for now,
+    // because the year range for the week date and the calendar date do not match and
+    // it is confusing to have a date that is out of range in one and not in another.
+    // currently we sidestep this issue by making `IsoWeek` fully dependent of `Datelike`.
+    pub(super) fn from_yof(year: i32, of: Of) -> Self {
+        let (rawweek, _) = of.isoweekdate_raw();
+        let (year, week) = if rawweek < 1 {
+            // previous year
+            let prevlastweek = YearFlags::from_year(year - 1).nisoweeks();
+            (year - 1, prevlastweek)
+        } else {
+            let lastweek = of.flags().nisoweeks();
+            if rawweek > lastweek {
+                // next year
+                (year + 1, 1)
+            } else {
+                (year, rawweek)
+            }
+        };
+        let flags = YearFlags::from_year(year);
+        IsoWeek { ywf: (year << 10) | (week << 4) as i32 | i32::from(flags.0) }
+    }
+
     /// Returns the year number for this ISO week.
     ///
     /// # Example


### PR DESCRIPTION
As discussed in https://github.com/chronotope/chrono/pull/1207.

The main motivation was removing the `Of` type, because it is an abstraction that is more in the way than helping.
I also moved things around to make the files smaller.
And the construction of `IsoWeek` and to/from `Mdf` is changed to not access private fields.

A lot of stuff here, but I am happy with the clean separation this brings.