### PR TITLE
Optimize `NaiveDate::add_days` for small values

### DIFF
--- a/bench/benches/chrono.rs
+++ b/bench/benches/chrono.rs
@@ -6,7 +6,7 @@ use chrono::format::StrftimeItems;
 use chrono::prelude::*;
 #[cfg(feature = "unstable-locales")]
 use chrono::Locale;
-use chrono::{DateTime, FixedOffset, Local, Utc, __BenchYearFlags};
+use chrono::{DateTime, Duration, FixedOffset, Local, Utc, __BenchYearFlags};
 
 fn bench_datetime_parse_from_rfc2822(c: &mut Criterion) {
     c.bench_function("bench_datetime_parse_from_rfc2822", |b| {
@@ -195,6 +195,15 @@ fn bench_format_manual(c: &mut Criterion) {
         })
     });
 }
+
+fn bench_naivedate_add_signed(c: &mut Criterion) {
+    let date = NaiveDate::from_ymd_opt(2023, 7, 29).unwrap();
+    let extra = Duration::days(25);
+    c.bench_function("bench_naivedate_add_signed", |b| {
+        b.iter(|| black_box(date).checked_add_signed(extra).unwrap())
+    });
+}
+
 criterion_group!(
     benches,
     bench_datetime_parse_from_rfc2822,
@@ -210,6 +219,7 @@ criterion_group!(
     bench_format,
     bench_format_with_items,
     bench_format_manual,
+    bench_naivedate_add_signed,
 );
 
 #[cfg(feature = "unstable-locales")]


### PR DESCRIPTION
I expect this method to be used much more often with small values than with values that end up an *x* number of years into the past or future. So I would like to add a fast path.

In the common case where the result of `add_checked_signed` and similar ends up within the same year we can avoid a couple of divisions and lookups and just change the ordinal.

Before:
```
bench_naivedate_add_signed
                        time:   [32.797 ns 34.745 ns 36.560 ns]
Found 13 outliers among 100 measurements (13.00%)
  13 (13.00%) high severe
```

After:
```
bench_naivedate_add_signed
                        time:   [12.886 ns 13.422 ns 13.855 ns]
                        change: [-65.054% -63.390% -61.655%] (p = 0.00 < 0.05)
                        Performance has improved.
```