### PR TITLE
Add `.github/codecov.yml` and set threshold to 1%

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%


### PR DESCRIPTION
According to https://github.com/codecov/codecov-action/issues/554 we need to put a `codecov.yml` file with a threshold in the top-level directory, `dev/`, or `.github`.

I have set it to 5%, which will basically never fail.