### PR TITLE
CI: fail on warnings in `features-check`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,8 +88,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: |
           cargo hack check --feature-powerset --optional-deps serde,rkyv \
-            --skip default --skip __internal_bench --skip __doctest \
-            --skip iana-time-zone --skip pure-rust-locales
+            --skip __internal_bench,__doctest,iana-time-zone,pure-rust-locales,libc
         # run using `bash` on all platforms for consistent
         # line-continuation marks
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,8 @@ jobs:
         # run using `bash` on all platforms for consistent
         # line-continuation marks
         shell: bash
+        env:
+          RUSTFLAGS: "-D warnings"
       - run: cargo test --no-default-features
       - run: cargo test --no-default-features --features=alloc
       - run: cargo test --no-default-features --features=unstable-locales

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: |
           cargo hack check --feature-powerset --optional-deps serde,rkyv \
-            --skip __internal_bench,__doctest,iana-time-zone,pure-rust-locales,libc
+            --skip __internal_bench,__doctest,iana-time-zone,pure-rust-locales,libc \
+            --all-targets
         # run using `bash` on all platforms for consistent
         # line-continuation marks
         shell: bash

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -10,17 +10,37 @@ use core::borrow::Borrow;
 use core::fmt;
 use core::fmt::Write;
 
+#[cfg(any(
+    feature = "alloc",
+    feature = "std",
+    feature = "serde",
+    feature = "rustc-serialize"
+))]
 use crate::datetime::SecondsFormat;
 #[cfg(any(feature = "alloc", feature = "std"))]
 use crate::offset::Offset;
+#[cfg(any(
+    feature = "alloc",
+    feature = "std",
+    feature = "serde",
+    feature = "rustc-serialize"
+))]
 use crate::{Datelike, FixedOffset, NaiveDateTime, Timelike};
 #[cfg(any(feature = "alloc", feature = "std"))]
 use crate::{NaiveDate, NaiveTime, Weekday};
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 use super::locales;
+#[cfg(any(
+    feature = "alloc",
+    feature = "std",
+    feature = "serde",
+    feature = "rustc-serialize"
+))]
 use super::{Colons, OffsetFormat, OffsetPrecision, Pad};
 #[cfg(any(feature = "alloc", feature = "std"))]
 use super::{Fixed, InternalFixed, InternalInternal, Item, Locale, Numeric};
+#[cfg(any(feature = "alloc", feature = "std"))]
 use locales::*;
 
 /// A *temporary* object which can be used as an argument to `format!` or others.
@@ -445,6 +465,7 @@ fn format_inner(
     }
 }
 
+#[cfg(any(feature = "alloc", feature = "std", feature = "serde", feature = "rustc-serialize"))]
 impl OffsetFormat {
     /// Writes an offset from UTC with the format defined by `self`.
     fn format(&self, w: &mut impl Write, off: FixedOffset) -> fmt::Result {
@@ -526,6 +547,7 @@ impl OffsetFormat {
 
 /// Writes the date, time and offset to the string. same as `%Y-%m-%dT%H:%M:%S%.f%:z`
 #[inline]
+#[cfg(any(feature = "alloc", feature = "std", feature = "serde", feature = "rustc-serialize"))]
 pub(crate) fn write_rfc3339(
     w: &mut impl Write,
     dt: NaiveDateTime,

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -48,19 +48,26 @@ pub(crate) mod scan;
 
 pub mod strftime;
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub(crate) mod locales;
 
 pub(crate) use formatting::write_hundreds;
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub(crate) use formatting::write_rfc2822;
+#[cfg(any(
+    feature = "alloc",
+    feature = "std",
+    feature = "serde",
+    feature = "rustc-serialize"
+))]
 pub(crate) use formatting::write_rfc3339;
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub use formatting::{format, format_item, DelayedFormat};
 #[cfg(feature = "unstable-locales")]
 pub use formatting::{format_item_localized, format_localized};
-#[cfg(feature = "unstable-locales")]
+#[cfg(all(feature = "unstable-locales", any(feature = "alloc", feature = "std")))]
 pub use locales::Locale;
-#[cfg(not(feature = "unstable-locales"))]
+#[cfg(all(not(feature = "unstable-locales"), any(feature = "alloc", feature = "std")))]
 pub(crate) use locales::Locale;
 pub use parse::{parse, parse_and_remainder};
 pub use parsed::Parsed;


### PR DESCRIPTION
Edit:
In https://github.com/chronotope/chrono/pull/1198 and https://github.com/chronotope/chrono/pull/1200 I did not get the feature gates completely right, and they would give warnings for some combination of features. But the CI did not complain.

This changes the `features-check` job to deny warnings.

I also removed the unused `libc` feature from the combinations `cargo hack` checks. This reduced the combinations from 384 to 156, which should shave ca. 5 minutes off our CI time.