### PR TITLE
De-blob serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ __doctest = []
 time = { version = "0.1.43", optional = true }
 num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }
-serde = { version = "1.0.99", default-features = false, optional = true }
+serde = { version = "1.0.99, <= 1.0.171", default-features = false, optional = true }
 pure-rust-locales = { version = "0.6", optional = true }
 criterion = { version = "0.4.0", optional = true }
 rkyv = { version = "0.7", optional = true }
@@ -54,7 +54,7 @@ android-tzdata = "0.1.1"
 
 [dev-dependencies]
 serde_json = { version = "1" }
-serde_derive = { version = "1", default-features = false }
+serde_derive = { version = "1.0.99, <= 1.0.171", default-features = false }
 bincode = { version = "1.3.0" }
 doc-comment = { version = "0.3" }
 


### PR DESCRIPTION
Fixes #1218 

I've been advocating to get serde to do the binary blobs opt-in basis but at best there will be opt-out at top bin level only :(

This will restrict the max version to ensure only serde without binary blobs gets pulled

Crates `time` and `rust-analyzer` have already done this and `rand` etc. may follow as well soon.
