### PR TITLE
Do not depend on `android-tzdata` if the `clock` feature is not enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default = ["clock", "std", "oldtime", "wasmbind"]
 alloc = []
 libc = []
 std = []
-clock = ["std", "winapi", "iana-time-zone"]
+clock = ["std", "winapi", "iana-time-zone", "android-tzdata"]
 oldtime = ["time"]
 wasmbind = ["wasm-bindgen", "js-sys"]
 unstable-locales = ["pure-rust-locales", "alloc"]
@@ -50,7 +50,7 @@ winapi = { version = "0.3.0", features = ["std", "minwinbase", "minwindef", "tim
 iana-time-zone = { version = "0.1.45", optional = true, features = ["fallback"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-android-tzdata = "0.1.1"
+android-tzdata = { version = "0.1.1", optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1" }


### PR DESCRIPTION
All usages of `android-tzdata` types are within the `offset::local` module, [but such module is not built if the `clock` feature is not enabled](https://github.com/chronotope/chrono/blob/0be4e7c1d67614683f1e9345ed7d7df2643f6f0b/src/offset/mod.rs#L32-L33). Therefore, `android-tzdata` is effectively an unused dependency when the `clock` feature is disabled.

To avoid downloading unnecessary crates on build time, let's make the dependency on `android-tzdata` conditional on enabling the `clock` feature, as it was done with e.g. `iana-time-zone`.