### PR TITLE
Backport documentation fixes

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1229,7 +1229,7 @@ where
 }
 
 /// Accepts a relaxed form of RFC3339.
-/// A space or a 'T' are acepted as the separator between the date and time
+/// A space or a 'T' are accepted as the separator between the date and time
 /// parts.
 ///
 /// All of these examples are equivalent:
@@ -1250,7 +1250,7 @@ impl str::FromStr for DateTime<Utc> {
 }
 
 /// Accepts a relaxed form of RFC3339.
-/// A space or a 'T' are acepted as the separator between the date and time
+/// A space or a 'T' are accepted as the separator between the date and time
 /// parts.
 ///
 /// All of these examples are equivalent:

--- a/src/oldtime.rs
+++ b/src/oldtime.rs
@@ -112,8 +112,8 @@ impl Duration {
     }
 
     /// Makes a new `Duration` with given number of seconds.
-    /// Panics when the duration is more than `i64::MAX` seconds
-    /// or less than `i64::MIN` seconds.
+    /// Panics when the duration is more than `i64::MAX` milliseconds
+    /// or less than `i64::MIN` milliseconds.
     #[inline]
     #[must_use]
     pub fn seconds(seconds: i64) -> Duration {


### PR DESCRIPTION
Includes https://github.com/chronotope/chrono/pull/1209 and the first commit from https://github.com/chronotope/chrono/pull/1221.