### PR TITLE
Bump criterion from 0.4.0 to 0.5.1.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ __doctest = []
 [dependencies]
 serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.6", optional = true }
-criterion = { version = "0.4.0", optional = true }
+criterion = { version = "0.5.1", optional = true }
 rkyv = { version = "0.7", optional = true }
 arbitrary = { version = "1.0.0", features = ["derive"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 exclude = ["/ci/*"]
 edition = "2021"
-rust-version = "1.57.0"
+rust-version = "1.60.0"
 
 [lib]
 name = "chrono"


### PR DESCRIPTION
As part of #1223 . This PR fixes this security advisory 

```
Crate:     atty
Version:   0.2.14
Warning:   unsound
Title:     Potential unaligned read
Date:      2021-07-04
ID:        RUSTSEC-2021-0145
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0145
Dependency tree:
atty 0.2.14
└── criterion 0.4.0
    └── chrono 0.5.0-alpha.1
```