### PR TITLE
Correct documentation for FromStr for Weekday and Month

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -455,7 +455,7 @@ const BAD_FORMAT: ParseError = ParseError(ParseErrorKind::BadFormat);
 
 // this implementation is here only because we need some private code from `scan`
 
-/// Parsing a `str` into a `Weekday` uses the format [`%W`](./format/strftime/index.html).
+/// Parsing a `str` into a `Weekday` uses the format [`%A`](./format/strftime/index.html).
 ///
 /// # Example
 ///
@@ -491,7 +491,7 @@ impl FromStr for Weekday {
     }
 }
 
-/// Parsing a `str` into a `Month` uses the format [`%W`](./format/strftime/index.html).
+/// Parsing a `str` into a `Month` uses the format [`%B`](./format/strftime/index.html).
 ///
 /// # Example
 ///


### PR DESCRIPTION
The described parsing specifiers were wrong. Not that it actually uses those in the code, but their effect would be the same.

Relevant part of strftime docs:
| Spec. | Example  | Description                                                                |
|-------|----------|----------------------------------------------------------------------------|
| `%B`  | `July`   | Full month name. Also accepts corresponding abbreviation in parsing.       |
| `%A`  | `Sunday` | Full weekday name. Also accepts corresponding abbreviation in parsing.     |
| `%W`  | `27`     | Same as `%U`, but week 1 starts with the first Monday in that year instead.|   