### PR TITLE
Fix `test_type_types` on 32-bit targets

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ message: Please cite this crate using these information.
 
 # Version information.
 date-released: 2023-08-29
-version: 0.4.27
+version: 0.4.28
 
 # Project information.
 abstract: Date and time library for Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono"
-version = "0.4.27"
+version = "0.4.28"
 description = "Date and time library for Rust"
 homepage = "https://github.com/chronotope/chrono"
 documentation = "https://docs.rs/chrono/"

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -906,11 +906,20 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "unstable-locales")]
+    #[cfg(all(feature = "unstable-locales", target_pointer_width = "64"))]
     fn test_type_sizes() {
         use core::mem::size_of;
         assert_eq!(size_of::<Item>(), 24);
         assert_eq!(size_of::<StrftimeItems>(), 56);
+        assert_eq!(size_of::<Locale>(), 2);
+    }
+
+    #[test]
+    #[cfg(all(feature = "unstable-locales", target_pointer_width = "32"))]
+    fn test_type_sizes() {
+        use core::mem::size_of;
+        assert_eq!(size_of::<Item>(), 12);
+        assert_eq!(size_of::<StrftimeItems>(), 28);
         assert_eq!(size_of::<Locale>(), 2);
     }
 }


### PR DESCRIPTION
It only fails with the `unstable-locales` feature.

Fixes https://github.com/chronotope/chrono/issues/1234.