### PR TITLE
CI: run tests on `i686` and `wasm32-wasi`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,6 @@ jobs:
         os: [ubuntu-latest]
         target:
           [
-            wasm32-wasi,
             wasm32-unknown-emscripten,
             aarch64-apple-ios,
             aarch64-linux-android,
@@ -141,6 +140,27 @@ jobs:
       # The `TZ` and `NOW` variables are used to compare the results inside the WASM environment
       # with the host system.
       - run: TZ="$(date +%z)" NOW="$(date +%s)" wasm-pack test --node -- --features wasmbind
+
+  test_wasi:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        target:
+          - wasm32-wasi
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasi
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo install cargo-wasi
+      - uses: mwilliamson/setup-wasmtime-action@v2
+        with:
+          wasmtime-version: "12.0.1"
+      # We can't use `--all-features` because `rustc-serialize` doesn't support
+      # `wasm32-wasi`.
+      - run: cargo wasi test --features=serde,unstable-locales --color=always -- --color=always
 
   cross-targets:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,22 +6,10 @@ on:
   pull_request:
 
 jobs:
-  timezones_linux:
+  timezones:
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        tz: ["ACST-9:30", "EST4", "UTC0", "Asia/Katmandu"]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo test --all-features --color=always -- --color=always
-
-  timezones_other:
-    strategy:
-      matrix:
-        os: [macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         tz: ["ACST-9:30", "EST4", "UTC0", "Asia/Katmandu"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,7 +135,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-node@v3
       - uses: jetli/wasm-pack-action@v0.4.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,20 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cross check --target ${{ matrix.target }}
 
+  cross-tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - run: cargo install cross
+      - uses: Swatinem/rust-cache@v2
+      - run: cross test --lib --all-features --target i686-unknown-linux-gnu --color=always
+      - run: cross test --doc --all-features --target i686-unknown-linux-gnu --color=always
+      - run: cross test --lib --all-features --target i686-unknown-linux-musl --color=always
+      - run: cross test --doc --all-features --target i686-unknown-linux-musl --color=always
+
   check-docs:
     runs-on: ubuntu-latest
     steps:

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1185,8 +1185,11 @@ fn test_subsecond_part() {
     assert_eq!(1234567, datetime.timestamp_subsec_nanos());
 }
 
+// Some targets, such as `wasm32-wasi`, have a problematic definition of `SystemTime`, such as an
+// `i32` (year 2035 problem), or an `u64` (no values before `UNIX-EPOCH`).
+// See https://github.com/rust-lang/rust/issues/44394.
 #[test]
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(all(target_arch = "wasm32", target_os = "wasi"))))]
 fn test_from_system_time() {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 

--- a/src/offset/local/tz_info/timezone.rs
+++ b/src/offset/local/tz_info/timezone.rs
@@ -859,8 +859,12 @@ mod tests {
                 assert_eq!(time_zone_local, time_zone_local_1);
             }
 
-            let time_zone_utc = TimeZone::from_posix_tz("UTC")?;
-            assert_eq!(time_zone_utc.find_local_time_type(0)?.offset(), 0);
+            // `TimeZone::from_posix_tz("UTC")` will return `Error` if the environment does not have
+            // a time zone database, like for example some docker containers.
+            // In that case skip the test.
+            if let Ok(time_zone_utc) = TimeZone::from_posix_tz("UTC") {
+                assert_eq!(time_zone_utc.find_local_time_type(0)?.offset(), 0);
+            }
         }
 
         assert!(TimeZone::from_posix_tz("EST5EDT,0/0,J365/25").is_err());


### PR DESCRIPTION
Fixes https://github.com/chronotope/chrono/issues/352.