### PR TITLE
Revert "add test_issue_866"

### DIFF
--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -257,12 +257,4 @@ mod tests {
             );
         }
     }
-
-    /// Test Issue #866
-    #[test]
-    fn test_issue_866() {
-        #[allow(deprecated)]
-        let local_20221106 = Local.ymd(2022, 11, 6);
-        let _dt_20221106 = local_20221106.and_hms_milli_opt(1, 2, 59, 1000).unwrap();
-    }
 }


### PR DESCRIPTION
The test added in https://github.com/chronotope/chrono/pull/1077 is pretty much guaranteed to cause trouble.

We don't know if any arbitrary `DateTime<Local>` will exist, such as `2022-11-06T01:02:60` in that test. It may fall in a DST transition and not exist or be ambiguous.

The fix for https://github.com/chronotope/chrono/issues/866 in https://github.com/chronotope/chrono/pull/1064 took this into account, and https://github.com/chronotope/chrono/pull/1077 added the failure mode right back :smile:.

Fixes https://github.com/chronotope/chrono/issues/1236.