### PR TITLE
Don't have oldtime feature enabled by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.57.0"
 name = "chrono"
 
 [features]
-default = ["clock", "std", "oldtime", "wasmbind"]
+default = ["clock", "std", "wasmbind"]
 alloc = []
 libc = []
 winapi = ["windows-targets"]

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Optional features:
 * `serde`: Enable serialization/deserialization via serde.
 * `rkyv`: Enable serialization/deserialization via rkyv.
 * `rustc-serialize`: Enable serialization/deserialization via rustc-serialize (deprecated).
-* `old_time`: compatability with the `Duration` type of the `time` 0.1 crate (deprecated).
+* `oldtime`: compatability with the `Duration` type of the `time` 0.1 crate (deprecated).
 * `arbitrary`: construct arbitrary instances of a type with the Arbitrary crate.
 * `unstable-locales`: Enable localization. This adds various methods with a `_localized` suffix.
   The implementation and API may change or even be removed in a patch release. Feedback welcome.


### PR DESCRIPTION
Having the oldtime feature enabled by default causes packages depending on this to fail a [security audit](https://rustsec.org/advisories/RUSTSEC-2020-0071) if they leave default features on due to the dependency on time 0.1. Furthermore, the documentation on [docs.rs](https://github.com/chronotope/chrono/releases/tag/v0.4.28) and [crates.io](https://crates.io/crates/chrono/0.4.28) indicate that this is an optional and non-default feature. This PR brings the code in-sync with the documentation and also fixes a misspelling of that feature. It can still be enabled for those that need it and are able to ignore the audit.

Further background on this, it looks like this features was dropped on the [main](https://github.com/chronotope/chrono/commit/4c351b1e720a30a6e32068fe386293b36d0e86fd) branch about a year ago, however, from what I gather, that branch will not be ready for a release any time soon so this is an interim measure until then.