### PR TITLE
Move benchmarks to a separate crate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,11 +17,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo fmt --check -- --color=always
       - run: cargo fmt --check --manifest-path fuzz/Cargo.toml
+      - run: cargo fmt --check --manifest-path bench/Cargo.toml
       - run: |
           cargo clippy --all-features --all-targets --color=always \
             -- -D warnings
       - run: |
           cargo clippy --manifest-path fuzz/Cargo.toml --color=always \
+            -- -D warnings
+      - run: |
+          cargo clippy --manifest-path bench/Cargo.toml --color=always \
             -- -D warnings
         env:
           RUSTFLAGS: "-Dwarnings"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           toolchain: ${{ matrix.rust_version }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo check --benches
+      - run: cargo check --manifest-path bench/Cargo.toml --benches
       - run: cargo check --manifest-path fuzz/Cargo.toml --all-targets
       # run --lib and --doc to avoid the long running integration tests
       # which are run elsewhere

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ clock = ["std", "winapi", "iana-time-zone", "android-tzdata"]
 oldtime = ["time"]
 wasmbind = ["wasm-bindgen", "js-sys"]
 unstable-locales = ["pure-rust-locales", "alloc"]
-__internal_bench = ["criterion"]
+__internal_bench = []
 __doctest = []
 
 [dependencies]
@@ -35,7 +35,6 @@ num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }
 serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.6", optional = true }
-criterion = { version = "0.4.0", optional = true }
 rkyv = { version = "0.7", optional = true }
 arbitrary = { version = "1.0.0", features = ["derive"], optional = true }
 
@@ -71,13 +70,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
 features = ["serde"]
-
-[[bench]]
-name = "chrono"
-required-features = ["__internal_bench"]
-harness = false
-
-[[bench]]
-name = "serde"
-required-features = ["__internal_bench", "serde"]
-harness = false

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "benches"
+version = "0.1.0"
+edition = "2021"
+
+# Even as a `dev-dependency` Criterion and its dependencies can affect the MSRV of chrono.
+# But not when it lives in a separate crate :-).
+# See https://github.com/chronotope/chrono/pull/1104.
+
+[lib]
+name = "benches"
+
+[dependencies]
+chrono = { path = "..", features = ["__internal_bench", "serde"] }
+
+[[bench]]
+name = "chrono"
+harness = false
+
+[[bench]]
+name = "serde"
+harness = false
+
+[dev-dependencies]
+criterion = "0.5.0"
+serde_json = "1"

--- a/bench/benches/chrono.rs
+++ b/bench/benches/chrono.rs
@@ -1,5 +1,4 @@
 //! Benchmarks for chrono that just depend on std
-#![cfg(feature = "__internal_bench")]
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 

--- a/bench/benches/serde.rs
+++ b/bench/benches/serde.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "__internal_bench")]
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use chrono::NaiveDateTime;

--- a/bench/src/lib.rs
+++ b/bench/src/lib.rs
@@ -1,0 +1,1 @@
+// This file only exists to make `benches` a valid crate.


### PR DESCRIPTION
As reported in https://github.com/chronotope/chrono/issues/1223 a security advisory for `atty` shows up when we resolve the one for time 0.1.

By moving the benchmarks to a separate crate criterion and its dependencies no longer affect our MSRV or can cause advisories, and criterion can be updated to 5.1.

~I needed a `lib.rs` file to have a valid crate, and we had a tiny one in `ci/core-test`. It seemed like a nice opportunity to merge them.~ Edit: doesn't work.

Fixes https://github.com/chronotope/chrono/issues/1223, alternative to https://github.com/chronotope/chrono/pull/1224.