### PR TITLE
Add a feature and method to override `now`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rkyv-16 = ["dep:rkyv", "rkyv?/size_16"]
 rkyv-32 = ["dep:rkyv", "rkyv?/size_32"]
 rkyv-64 = ["dep:rkyv", "rkyv?/size_64"]
 rkyv-validation = ["rkyv?/validation"]
+test-override = []
 # Features for internal use only:
 __internal_bench = []
 
@@ -71,7 +72,7 @@ bincode = { version = "1.3.0" }
 wasm-bindgen-test = "0.3"
 
 [package.metadata.docs.rs]
-features = ["arbitrary", "rkyv", "serde", "unstable-locales"]
+features = ["arbitrary", "rkyv", "serde", "test-override", "unstable-locales"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -171,7 +171,6 @@ impl Local {
     /// use chrono::{Local, FixedOffset, TimeZone, Datelike};
     /// fn is_today_leap_day() -> bool {
     ///     let today = Local::now().date_naive();
-    /// dbg!(today);
     ///     today.month() == 2 && today.day() == 29
     /// }
     ///


### PR DESCRIPTION
Updated version of https://github.com/chronotope/chrono/pull/580. A comment in the related issue https://github.com/chronotope/chrono/issues/105#issuecomment-633260201 has collected 28 thumb ups in three years. This may be our most popular feature request.

The only method added is `Local::override_now(datetime: Option<DateTime<FixedOffset>>)`, and it affects `Local::now()` and `Utc::now()`. I made it a method on `Local` because it takes a datetime and an offset, while for `Utc` only a datetime would make sense.

The functionality is only available behind the `test-override` feature while running tests.