### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-ChangeLog for Chrono
-====================
+Changelog
+=========
 
 This documents notable changes to [Chrono](https://github.com/chronotope/chrono)
 up to and including version 0.4.19. For later releases, please review the
@@ -11,18 +11,18 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
 
 ## [0.4.18] - 2020-09-26
 
-* Restore support for x86_64-fortanix-unknown-sgx
+* Restore support for `x86_64-fortanix-unknown-sgx`
 
 ## [0.4.17] - 2020-09-26
 
-* Fix a name resolution error in wasm-bindgen code introduced by removing the dependency on time
+* Fix a name resolution error in `wasm-bindgen` code introduced by removing the dependency on time
   v0.1
 
 ## [0.4.16] - 2020-09-25
 
 ### Features
 
-* Add %Z specifier to the `FromStr`, similar to the glibc strptime
+* Add %Z specifier to the `FromStr`, similar to the glibc `strptime`
   (does not set the offset from the timezone name)
 
 * Drop the dependency on time v0.1, which is deprecated, unless the `oldtime`
@@ -145,7 +145,7 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
 
 * Make Datetime arithmatic adjust their offsets after discovering their new
   timestamps (@quodlibetor #337)
-* Put wasm-bindgen related code and dependencies behind a `wasmbind` feature
+* Put `wasm-bindgen` related code and dependencies behind a `wasmbind` feature
   gate. (@quodlibetor #335)
 
 ## [0.4.8] - 2019-08-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -906,6 +906,107 @@ Language changes, updated documentations.
 
 The initial version that was available to `crates.io`.
 
+## Pre-crates.io
+
+Before `crates.io` was launched in november 2014 dependencies were specified as
+just git repositories. Chrono did not keep versions until then.
+
+### 2014-10-10
+
+Use a Cargoified version of libnum.
+
+### 2014-08-31
+
+Switches to `std::time::duration::Duration`.
+
+### 2014-08-29
+
+Added missing `.offset()` methods; UTC/FixedOffset now implement `Eq`.
+
+### 2014-08-19
+
+- language changes: an array size now needs to be uint.
+
+### 2014-07-31
+
+- added constructors from timestamp; added `UTC::{today,now}`.
+- added the `Local` offset implementation.
+- made `Time::fmt` to use the same decimal separator as `Duration::fmt`.
+- added `chrono::format` module and `format` methods.
+  this is a saner replacement for `time::strftime`; it does not allocate
+  the additional memory.
+
+### 2014-07-29
+
+- changed the internal representation of `TimeZ`.
+- made every type `Clone`able; added `and_*` constructors to `DateZ`.
+  it allows for, say, `DateZ::from_ymd(2014,1,2).and_hms(3,4,5)`.
+- fixed a bug on `DateTimeZ::add` with the negative fractional `Duration`.
+- initial `Offset` implementations.
+- mass renaming from `BlahBlahZ` to `NaiveBlahBlah`.
+
+### 2014-07-25
+
+- fixed erratic `fmt` behaviors with format specifiers. (rust-lang/rust#15934)
+
+- added docs to `Duration`; added `Duration::new_opt`; removed `{MIN,MAX}_{DAYS,YEAR}`.
+  the minimum and maximum for `DateZ` and `Duration` is now provided via
+  dedicated constants `{date,duration}::{MIN,MAX}`, much like built-in
+  `std::int` and others. they also now implements `std::num::Bounded`.
+  cf. rust-lang/rust#15934
+
+- changed the decimal point from `,` to `.`. (cf. rust-lang/rust#15934)
+  ISO 8601 allows for both but prefers `,`, which was a main reason
+  for its use in rust-chrono. but this is too alien given other usages of
+  decimal points in Rust, so I guess it is better to switch to `.`.
+
+- renamed `chrono::date::{MIN,MAX}` to `chrono::date::{MINZ,MAXZ}`.
+  this is because we are going to add `MIN` and `MAX` for timezone-aware `Date`s later.
+
+- renamed `n<foo>s` to `num_<foo>s` and changed their semantics.
+  `Duration` now has a `to_tuple` method which corresponds to
+  the original `(dur.ndays(), dur.nseconds(), dur.nnanoseconds())`.
+  new `num_*s()` methods in `Duration` always return the integral
+  number of specified units in the duration.
+
+- relicensed from MIT to dual MIT/APL2. closes #2.
+
+### 2014-07-19
+
+Major API surgeries.
+
+- added a new example.
+- reexported all public APIs in the crate root.
+- made all constructors fail on the invalid arguments by default;
+  `*_opt()` variants have been added for the original behavior.
+- same for `DateZ::{succ,pred}`.
+- fixed a missing overflow check from `TimeZ::from_hms_{milli,micro}`.
+- the public API now uses `i32`/`u32` instead of `int`/`uint` for integers.
+
+### 2014-07-12
+
+- added Cargo support and updated `.travis.yml`
+- language changes: `ToStr` -> `ToString.`
+
+### 2014-05-31
+
+- fixed an unintentionally overflowing `Duration` constructors; made tests valid on 32-bit platform.
+- language changes: `{,Total}{Eq,Ord}` -> `{Partial,}{Eq,Ord}`.
+- language changes: `to_owned()` on `&str` is being deprecated.
+- language changes: `std::fmt` is moved to core and now independent of std I/O.
+- language changes: `~"str"` -> `"str".to_owned()`.
+- language changes: `BenchHarness` -> `Bencher`.
+
+### 2014-04-06
+
+- added (not yet well-tested) mult/div ops for `Duration`.
+- language changes: priv tuple-like fields are now default as well.
+- `Duration::days` is now `i32` (not `int`), related methods apply the new limits for days.
+
+### 2014-04-03
+
+Initial version.
+
 [0.4.19]: https://github.com/chronotope/chrono/releases/tag/v0.4.19
 [0.4.18]: https://github.com/chronotope/chrono/releases/tag/v0.4.18
 [0.4.17]: https://github.com/chronotope/chrono/releases/tag/v0.4.17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,8 +183,6 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
 * Doc improvements -- improve README CI verification, external links
 * winapi upgrade to 0.3
 
-## Unreleased
-
 ### Features
 
 * Added `NaiveDate::from_weekday_of_month{,_opt}` for getting eg. the 2nd Friday of March 2017.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -443,6 +443,8 @@ This is the last version officially supports Rust 1.12.0 or older.
 (0.2.24 was accidentally uploaded without a proper check for warnings in the default state,
 and replaced by 0.2.25 very shortly. Duh.)
 
+## [0.2.24] - 2016-08-03
+
 ### Added
 
 - Serde 0.8 is now supported. 0.7 also remains supported. (#86)
@@ -520,6 +522,8 @@ and replaced by 0.2.25 very shortly. Duh.)
   up to 3, 6 or 9 decimal digits. This is a natural extension to the existing `%f`.
   Note that this is (not yet) generic, no other value of precision is supported. (#45)
 
+- Tons of supporting examples for the documentation have been added. More to come.
+
 ### Changed
 
 - Forbade unsized types from implementing `Datelike` and `Timelike`.
@@ -560,6 +564,11 @@ and replaced by 0.2.25 very shortly. Duh.)
 
 ## [0.2.13] - 2015-04-29
 
+This version is finally beta-compatible.
+
+This introduces a slight incompatibility, namely, due to the rewired reexport for `chrono::Duration`
+(which now comes from crates.io `time` crate).
+
 ### Added
 
 - The optional dependency on `rustc_serialize` and
@@ -570,6 +579,69 @@ and replaced by 0.2.25 very shortly. Duh.)
 
 - `chrono::Duration` reexport is changed to that of crates.io `time` crate.
   This enables Rust 1.0 beta compatibility.
+
+## [0.2.12] - 2015-04-24
+
+Language changes.
+
+- Many `std::num` traits are removed and replaced with
+  the external `num` crate. For time being, thus, Chrono will
+  require the dependency on `num`. This is expected to be temporary
+  however.
+
+## [0.2.11] - 2015-04-16
+
+Language changes.
+
+- Replaced `thread::scoped` with `thread::spawn` to cope with
+  a rare de-stabilization event.
+
+- `#[deprecated]` is (ironically) deprecated with user crates.
+  All uses of them have been replaced by doc comments.
+
+## [0.2.10] - 2015-04-04
+
+Language changes.
+
+- `Copy` requires `Clone`.
+
+## [0.2.9] - 2015-04-03
+
+Language changes.
+
+- `std::num::Int` is deprecated.
+
+- Removed one feature flag (`str_char`).
+
+## [0.2.8] - 2015-03-30
+
+Language changes.
+
+- Slice patterns are now feature gated.
+
+- Reformatted the `chrono::format::strftime` documentation
+  with a proper table (closes #31).
+
+## [0.2.7] - 2015-03-27
+
+Language changes.
+
+- Feature flags are now required on the doctests.
+
+- New lints for trivial casts. We are now not going to change
+  the internal implementation type for `NaiveDate`, so that's fine.
+
+## [0.2.6] - 2015-03-21
+
+Language changes and dependency updates.
+
+- `range` is now deprecated.
+
+- `str_char` feature gate is split out from `collections`.
+
+## [0.2.5] - 2015-03-05
+
+Language changes, mostly overflow changes.
 
 ## [0.2.4] - 2015-03-03
 
@@ -589,7 +661,15 @@ and replaced by 0.2.25 very shortly. Duh.)
 
 - `Local::from_utc_datetime` didn't set a correct offset. (#26)
 
+## [0.2.2] - 2015-02-26
+
+Language & docs changes.
+
+- `missing_docs` lint now checks for associated types.
+
 ## [0.2.1] - 2015-02-21
+
+- Language changes: `std::hash` has been renewed.
 
 ### Changed
 
@@ -667,13 +747,39 @@ and replaced by 0.2.25 very shortly. Duh.)
 - `with_offset` method has been removed. Use `with_timezone` method instead.
   (This is not deprecated since it is an integral part of offset reform.)
 
+## [0.1.18] - 2015-02-06
+
+Language changes.
+
+- Replaced remaining occurrences of `Show` with `Debug`.
+- Dependency upgrades.
+
+## [0.1.17] - 2015-01-29
+
+Language changes.
+
+- Many unstable stdlib parts require `#[feature]` flags as per Rust RFC #507.
+
+## [0.1.16] - 2015-01-29
+
+Dependency fixes due to language changes.
+
+## [0.1.15] - 2015-01-24
+
+Language changes.
+
+- `std::fmt::Show` is now `std::fmt::Debug`.
+- `std::fmt::String` is now `std::fmt::Display`.
+
 ## [0.1.14] - 2015-01-10
 
 ### Added
 
-- Added a missing `std::fmt::String` impl for `Local`.
+- Added a missing `std::fmt::String` impl for `Local` (thanks @daboross).
 
 ## [0.1.13] - 2015-01-10
+
+Language changes and `fmt::String` supports.
 
 ### Changed
 
@@ -686,12 +792,75 @@ and replaced by 0.2.25 very shortly. Duh.)
 
 ## [0.1.12] - 2015-01-08
 
+Language changes.
+
+- Feature flags used are all accepted.
+- Orphan check workaround is no longer required.
+
 ### Removed
 
 - `Duration + T` no longer works due to the updated impl reachability rules.
   Use `T + Duration` as a workaround.
 
+## [0.1.11] - 2025-01-06
+
+Language changes.
+
+- Boxed closures are gone; some unboxed closures require an explicit
+  annotation for kinds (`&:` in most cases).
+
+## [0.1.10] - 2025-01-06
+
+Language changes.
+
+- `std::str::SendStr` is now `std::string::CowString<'static>`.
+
+## [0.1.9] - 2025-01-05
+
+Language changes.
+
+- `Add` and `Sub` switches to associated types.
+
+## [0.1.8] - 2015-01-04
+
+Language changes.
+
+- `#[deriving]` is now `#[derive]`.
+- prelude no longer imports many items by default.
+- `[T, ..n]` is no longer valid.
+- a temporary fix for `#[derive(Hash)]` failing out.
+- the formatting error uses a dedicated type instead of `IoError`.
+
+## [0.1.7] - 2015-01-02
+
+Language changes.
+
+- `Eq` no longer accepts the reflexive type parameter.
+  (this doesn't change the actual interface, as `Eq` is simply
+   a marker for total ordering. `PartialEq` retains it.)
+
+## [0.1.6] - 2014-12-25
+
+Fixed tests per language changes and `.travis.yml`.
+
+This also switches to the crates.io dependency unconditionally.
+
+## [0.1.5] - 2014-12-17
+
+Language changes.
+
+- `Add` and `Sub` requires a value instead of a reference.
+- Tuple indexing is now ungated.
+
 ## [0.1.4] - 2014-12-13
+
+Language changes.
+
+- `Copy` is now opt-in. Every `Copy`able type is made to implement `Copy`. While unlikely, I haven't deeply thought about `Copy`ability so it might change in 0.2.
+
+### Added
+
+- Added a BIG (friendly) limitation section to the README.
 
 ### Fixed
 
@@ -725,6 +894,15 @@ and replaced by 0.2.25 very shortly. Duh.)
 ### Changed
 
 - Chrono no longer needs `num` dependency.
+- Removed unused `unsafe` checks.
+
+## [0.1.1] - 2014-11-21
+
+Language changes, updated documentations.
+
+- `std::fmt::WriteError` is now `std::fmt::Error`.
+- abandoned rust-ci for documentations (sorry, but it didn't work
+  nowdays ;_;), we are now publishing directly to Github pages.
 
 ## [0.1.0] - 2014-11-20
 
@@ -753,6 +931,7 @@ The initial version that was available to `crates.io`.
 [0.3.1]: https://github.com/chronotope/chrono/releases/tag/v0.3.1
 [0.3.0]: https://github.com/chronotope/chrono/releases/tag/v0.3.0
 [0.2.25]: https://github.com/chronotope/chrono/releases/tag/v0.2.25
+[0.2.24]: https://github.com/chronotope/chrono/releases/tag/v0.2.24
 [0.2.23]: https://github.com/chronotope/chrono/releases/tag/v0.2.23
 [0.2.22]: https://github.com/chronotope/chrono/releases/tag/v0.2.22
 [0.2.21]: https://github.com/chronotope/chrono/releases/tag/v0.2.21
@@ -764,14 +943,35 @@ The initial version that was available to `crates.io`.
 [0.2.15]: https://github.com/chronotope/chrono/releases/tag/v0.2.15
 [0.2.14]: https://github.com/chronotope/chrono/releases/tag/v0.2.14
 [0.2.13]: https://github.com/chronotope/chrono/releases/tag/v0.2.13
+[0.2.12]: https://github.com/chronotope/chrono/releases/tag/v0.2.12
+[0.2.11]: https://github.com/chronotope/chrono/releases/tag/v0.2.11
+[0.2.10]: https://github.com/chronotope/chrono/releases/tag/v0.2.10
+[0.2.9]: https://github.com/chronotope/chrono/releases/tag/v0.2.9
+[0.2.8]: https://github.com/chronotope/chrono/releases/tag/v0.2.8
+[0.2.7]: https://github.com/chronotope/chrono/releases/tag/v0.2.7
+[0.2.6]: https://github.com/chronotope/chrono/releases/tag/v0.2.6
+[0.2.5]: https://github.com/chronotope/chrono/releases/tag/v0.2.5
 [0.2.4]: https://github.com/chronotope/chrono/releases/tag/v0.2.4
 [0.2.3]: https://github.com/chronotope/chrono/releases/tag/v0.2.3
+[0.2.2]: https://github.com/chronotope/chrono/releases/tag/v0.2.2
 [0.2.1]: https://github.com/chronotope/chrono/releases/tag/v0.2.1
 [0.2.0]: https://github.com/chronotope/chrono/releases/tag/v0.2.0
+[0.1.18]: https://github.com/chronotope/chrono/releases/tag/v0.1.18
+[0.1.17]: https://github.com/chronotope/chrono/releases/tag/v0.1.17
+[0.1.16]: https://github.com/chronotope/chrono/releases/tag/v0.1.16
+[0.1.15]: https://github.com/chronotope/chrono/releases/tag/v0.1.15
 [0.1.14]: https://github.com/chronotope/chrono/releases/tag/v0.1.14
 [0.1.13]: https://github.com/chronotope/chrono/releases/tag/v0.1.13
 [0.1.12]: https://github.com/chronotope/chrono/releases/tag/v0.1.12
+[0.1.11]: https://github.com/chronotope/chrono/releases/tag/v0.1.11
+[0.1.10]: https://github.com/chronotope/chrono/releases/tag/v0.1.10
+[0.1.9]: https://github.com/chronotope/chrono/releases/tag/v0.1.9
+[0.1.8]: https://github.com/chronotope/chrono/releases/tag/v0.1.8
+[0.1.7]: https://github.com/chronotope/chrono/releases/tag/v0.1.7
+[0.1.6]: https://github.com/chronotope/chrono/releases/tag/v0.1.6
+[0.1.5]: https://github.com/chronotope/chrono/releases/tag/v0.1.5
 [0.1.4]: https://github.com/chronotope/chrono/releases/tag/v0.1.4
 [0.1.3]: https://github.com/chronotope/chrono/releases/tag/v0.1.3
 [0.1.2]: https://github.com/chronotope/chrono/releases/tag/v0.1.2
+[0.1.1]: https://github.com/chronotope/chrono/releases/tag/v0.1.1
 [0.1.0]: https://github.com/chronotope/chrono/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,20 @@ This documents notable changes to [Chrono](https://github.com/chronotope/chrono)
 up to and including version 0.4.19. For later releases, please review the
 release notes on [GitHub](https://github.com/chronotope/chrono/releases).
 
-## 0.4.19
+## [0.4.19] - 2020-09-30
 
 * Correct build on solaris/illumos
 
-## 0.4.18
+## [0.4.18] - 2020-09-26
 
 * Restore support for x86_64-fortanix-unknown-sgx
 
-## 0.4.17
+## [0.4.17] - 2020-09-26
 
 * Fix a name resolution error in wasm-bindgen code introduced by removing the dependency on time
   v0.1
 
-## 0.4.16
+## [0.4.16] - 2020-09-25
 
 ### Features
 
@@ -31,13 +31,13 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
   `time::Duration` should be switched to import `chrono::Duration` instead to
   avoid breakage.
 
-## 0.4.15
+## [0.4.15] - 2020-08-14
 
 ### Fixes
 
 * Correct usage of vec in specific feature combinations (@quodlibetor)
 
-## 0.4.14 **YANKED**
+## [0.4.14] - 2020-08-07 **YANKED**
 
 ### Features
 
@@ -51,7 +51,7 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
 
 * Added MIN and MAX values for `NaiveTime`, `NaiveDateTime` and `DateTime<Utc>`.
 
-## 0.4.13
+## [0.4.13] - 2020-07-06
 
 ### Features
 
@@ -61,7 +61,7 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
 
 * Code improvements to impl `From` for `js_sys` in wasm to reuse code (@schrieveslaach)
 
-## 0.4.12
+## [0.4.12] - 2020-08-02
 
 ### New Methods and impls
 
@@ -84,7 +84,7 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
 * Migrate to github actions from travis-ci, make the overall CI experience more comprehensible,
   significantly faster and more correct (#439 @quodlibetor)
 
-## 0.4.11
+## [0.4.11] - 2020-03-07
 
 ### Improvements
 
@@ -106,7 +106,7 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
 
 * Use Criterion for benchmarks (@quodlibetor)
 
-## 0.4.10
+## [0.4.10] - 2019-11-24
 
 ### Compatibility notes
 
@@ -139,7 +139,7 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
   deprecation warnings and has been stable since rustc 1.13.0
 * Deny dead code
 
-## 0.4.9
+## [0.4.9] - 2019-09-04
 
 ### Fixes
 
@@ -148,7 +148,7 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
 * Put wasm-bindgen related code and dependencies behind a `wasmbind` feature
   gate. (@quodlibetor #335)
 
-## 0.4.8
+## [0.4.8] - 2019-08-31
 
 ### Fixes
 
@@ -161,7 +161,7 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
   emscripten/`wasm-unknown-emscripten`). (finished by @evq in #331, initial
   work by @jjpe #287)
 
-## 0.4.7
+## [0.4.7] - 2019-06-25
 
 ### Fixes
 
@@ -176,7 +176,7 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
 * Add `timestamp_nanos` methods (@jean-airoldie #308)
 * Documentation improvements
 
-## 0.4.6
+## [0.4.6] - 2018-08-25
 
 ### Maintenance
 
@@ -189,7 +189,7 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
 
 * Added `NaiveDate::from_weekday_of_month{,_opt}` for getting eg. the 2nd Friday of March 2017.
 
-## 0.4.5
+## [0.4.5] - 2018-07-28
 
 ### Features
 
@@ -198,13 +198,13 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
 * Derive `Hash` on `FixedOffset` (@LuoZijun #254)
 * Improved docs (@storyfeet #261, @quodlibetor #252)
 
-## 0.4.4
+## [0.4.4] - 2018-06-23
 
 ### Features
 
 * Added support for parsing nanoseconds without the leading dot (@emschwartz #251)
 
-## 0.4.3
+## [0.4.3] - 2018-06-11
 
 ### Features
 
@@ -214,7 +214,7 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
 * Added "Permissive" timezone parsing which allows a numeric timezone to
   be specified without minutes. (@quodlibetor #242)
 
-## 0.4.2
+## [0.4.2] - 2018-04-07
 
 ### Deprecations
 
@@ -229,7 +229,7 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
 * Implement subtraction of two `Date`s, `Time`s, or `DateTime`s, returning a
   `Duration` (@tobz1000 #237)
 
-## 0.4.1
+## [0.4.1] - 2018-03-28
 
 ### Bug Fixes
 
@@ -251,7 +251,7 @@ release notes on [GitHub](https://github.com/chronotope/chrono/releases).
 * Docs! (@alatiera @kosta @quodlibetor @kennytm)
 * Run clippy and various fixes (@quodlibetor)
 
-## 0.4.0 (2017-06-22)
+## [0.4.0] - 2017-06-22
 
 This was originally planned as a minor release but was pushed to a major
 release due to the compatibility concern raised.
@@ -334,7 +334,7 @@ release due to the compatibility concern raised.
 
 - Various documentation fixes and goodies. (#92, #131, #136)
 
-## 0.3.1 (2017-05-02)
+## [0.3.1] - 2017-05-02
 
 ### Added
 
@@ -356,7 +356,7 @@ release due to the compatibility concern raised.
 - Fixed a bug that the leap second can be mapped wrongly in the local time zone.
   Only occurs when the local time zone is behind UTC. (#130)
 
-## 0.3.0 (2017-02-07)
+## [0.3.0] - 2017-02-07
 
 The project has moved to the [Chronotope](https://github.com/chronotope/) organization.
 
@@ -436,7 +436,7 @@ The project has moved to the [Chronotope](https://github.com/chronotope/) organi
 - `chrono::offset::add_with_leapsecond` has been removed.
   Use a direct addition with `FixedOffset` instead.
 
-## 0.2.25 (2016-08-04)
+## [0.2.25] - 2016-08-04
 
 This is the last version officially supports Rust 1.12.0 or older.
 
@@ -452,7 +452,7 @@ and replaced by 0.2.25 very shortly. Duh.)
 - The deserialization implementation for rustc-serialize now properly verifies the input.
   All serialization codes are also now thoroughly tested. (#42)
 
-## 0.2.23 (2016-08-03)
+## [0.2.23] - 2016-08-03
 
 ### Added
 
@@ -470,26 +470,26 @@ and replaced by 0.2.25 very shortly. Duh.)
   due to the long-standing libtime bug (dates back to mid-2015).
   Workaround has been implemented. (#85)
 
-## 0.2.22 (2016-04-22)
+## [0.2.22] - 2016-04-22
 
 ### Fixed
 
 - `%.6f` and `%.9f` used to print only three digits when the nanosecond part is zero. (#71)
 - The documentation for `%+` has been updated to reflect the current status. (#71)
 
-## 0.2.21 (2016-03-29)
+## [0.2.21] - 2016-03-29
 
 ### Fixed
 
 - `Fixed::LongWeekdayName` was unable to recognize `"sunday"` (whoops). (#66)
 
-## 0.2.20 (2016-03-06)
+## [0.2.20] - 2016-03-06
 
 ### Changed
 
 - `serde` dependency has been updated to 0.7. (#63, #64)
 
-## 0.2.19 (2016-02-05)
+## [0.2.19] - 2016-02-05
 
 ### Added
 
@@ -499,20 +499,20 @@ and replaced by 0.2.25 very shortly. Duh.)
 
 - `DateTime::date` had been wrong when the local date and the UTC date is in disagreement. (#61)
 
-## 0.2.18 (2016-01-23)
+## [0.2.18] - 2016-01-23
 
 ### Fixed
 
 - Chrono no longer pulls a superfluous `rand` dependency. (#57)
 
-## 0.2.17 (2015-11-22)
+## [0.2.17] - 2015-11-22
 
 ### Added
 
 - Naive date and time types and `DateTime` now have a `serde` support.
   They serialize as an ISO 8601 / RFC 3339 string just like `Debug`. (#51)
 
-## 0.2.16 (2015-09-06)
+## [0.2.16] - 2015-09-06
 
 ### Added
 
@@ -530,7 +530,7 @@ and replaced by 0.2.25 very shortly. Duh.)
 
 - Fixed a broken link in the `README.md`. (#41)
 
-## 0.2.15 (2015-07-05)
+## [0.2.15] - 2015-07-05
 
 ### Added
 
@@ -549,7 +549,7 @@ and replaced by 0.2.25 very shortly. Duh.)
 
 - Improved the documentation and associated tests for `strftime`.
 
-## 0.2.14 (2015-05-15)
+## [0.2.14] - 2015-05-15
 
 ### Fixed
 
@@ -558,7 +558,7 @@ and replaced by 0.2.25 very shortly. Duh.)
   This was caused by an underflow in the conversion from `Duration` to the parts;
   the lack of tests for this case allowed a bug. (#37)
 
-## 0.2.13 (2015-04-29)
+## [0.2.13] - 2015-04-29
 
 ### Added
 
@@ -571,14 +571,14 @@ and replaced by 0.2.25 very shortly. Duh.)
 - `chrono::Duration` reexport is changed to that of crates.io `time` crate.
   This enables Rust 1.0 beta compatibility.
 
-## 0.2.4 (2015-03-03)
+## [0.2.4] - 2015-03-03
 
 ### Fixed
 
 - Clarified the meaning of `Date<Tz>` and fixed unwanted conversion problem
   that only occurs with positive UTC offsets. (#27)
 
-## 0.2.3 (2015-02-27)
+## [0.2.3] - 2015-02-27
 
 ### Added
 
@@ -589,13 +589,13 @@ and replaced by 0.2.25 very shortly. Duh.)
 
 - `Local::from_utc_datetime` didn't set a correct offset. (#26)
 
-## 0.2.1 (2015-02-21)
+## [0.2.1] - 2015-02-21
 
 ### Changed
 
 - `DelayedFormat` no longer conveys a redundant lifetime.
 
-## 0.2.0 (2015-02-19)
+## [0.2.0] - 2015-02-19
 
 ### Added
 
@@ -667,13 +667,13 @@ and replaced by 0.2.25 very shortly. Duh.)
 - `with_offset` method has been removed. Use `with_timezone` method instead.
   (This is not deprecated since it is an integral part of offset reform.)
 
-## 0.1.14 (2015-01-10)
+## [0.1.14] - 2015-01-10
 
 ### Added
 
 - Added a missing `std::fmt::String` impl for `Local`.
 
-## 0.1.13 (2015-01-10)
+## [0.1.13] - 2015-01-10
 
 ### Changed
 
@@ -684,21 +684,21 @@ and replaced by 0.2.25 very shortly. Duh.)
 
 - `Offset::name` has been replaced by a `std::fmt::String` implementation to `Offset`.
 
-## 0.1.12 (2015-01-08)
+## [0.1.12] - 2015-01-08
 
 ### Removed
 
 - `Duration + T` no longer works due to the updated impl reachability rules.
   Use `T + Duration` as a workaround.
 
-## 0.1.4 (2014-12-13)
+## [0.1.4] - 2014-12-13
 
 ### Fixed
 
 - Fixed a bug that `Date::and_*` methods with an offset that can change the date are
   off by one day.
 
-## 0.1.3 (2014-11-28)
+## [0.1.3] - 2014-11-28
 
 ### Added
 
@@ -716,7 +716,7 @@ and replaced by 0.2.25 very shortly. Duh.)
 
 - `{Date,Time} - Duration` overloadings are now allowed.
 
-## 0.1.2 (2014-11-24)
+## [0.1.2] - 2014-11-24
 
 ### Added
 
@@ -726,6 +726,52 @@ and replaced by 0.2.25 very shortly. Duh.)
 
 - Chrono no longer needs `num` dependency.
 
-## 0.1.0 (2014-11-20)
+## [0.1.0] - 2014-11-20
 
 The initial version that was available to `crates.io`.
+
+[0.4.19]: https://github.com/chronotope/chrono/releases/tag/v0.4.19
+[0.4.18]: https://github.com/chronotope/chrono/releases/tag/v0.4.18
+[0.4.17]: https://github.com/chronotope/chrono/releases/tag/v0.4.17
+[0.4.16]: https://github.com/chronotope/chrono/releases/tag/v0.4.16
+[0.4.15]: https://github.com/chronotope/chrono/releases/tag/v0.4.15
+[0.4.14]: https://github.com/chronotope/chrono/releases/tag/v0.4.14
+[0.4.13]: https://github.com/chronotope/chrono/releases/tag/v0.4.13
+[0.4.12]: https://github.com/chronotope/chrono/releases/tag/v0.4.12
+[0.4.11]: https://github.com/chronotope/chrono/releases/tag/v0.4.11
+[0.4.10]: https://github.com/chronotope/chrono/releases/tag/v0.4.10
+[0.4.9]: https://github.com/chronotope/chrono/releases/tag/v0.4.9
+[0.4.8]: https://github.com/chronotope/chrono/releases/tag/v0.4.8
+[0.4.7]: https://github.com/chronotope/chrono/releases/tag/v0.4.7
+[0.4.6]: https://github.com/chronotope/chrono/releases/tag/v0.4.6
+[0.4.5]: https://github.com/chronotope/chrono/releases/tag/v0.4.5
+[0.4.4]: https://github.com/chronotope/chrono/releases/tag/v0.4.4
+[0.4.3]: https://github.com/chronotope/chrono/releases/tag/v0.4.3
+[0.4.2]: https://github.com/chronotope/chrono/releases/tag/v0.4.2
+[0.4.1]: https://github.com/chronotope/chrono/releases/tag/v0.4.1
+[0.4.0]: https://github.com/chronotope/chrono/releases/tag/v0.4.0
+[0.3.1]: https://github.com/chronotope/chrono/releases/tag/v0.3.1
+[0.3.0]: https://github.com/chronotope/chrono/releases/tag/v0.3.0
+[0.2.25]: https://github.com/chronotope/chrono/releases/tag/v0.2.25
+[0.2.23]: https://github.com/chronotope/chrono/releases/tag/v0.2.23
+[0.2.22]: https://github.com/chronotope/chrono/releases/tag/v0.2.22
+[0.2.21]: https://github.com/chronotope/chrono/releases/tag/v0.2.21
+[0.2.20]: https://github.com/chronotope/chrono/releases/tag/v0.2.20
+[0.2.19]: https://github.com/chronotope/chrono/releases/tag/v0.2.19
+[0.2.18]: https://github.com/chronotope/chrono/releases/tag/v0.2.18
+[0.2.17]: https://github.com/chronotope/chrono/releases/tag/v0.2.17
+[0.2.16]: https://github.com/chronotope/chrono/releases/tag/v0.2.16
+[0.2.15]: https://github.com/chronotope/chrono/releases/tag/v0.2.15
+[0.2.14]: https://github.com/chronotope/chrono/releases/tag/v0.2.14
+[0.2.13]: https://github.com/chronotope/chrono/releases/tag/v0.2.13
+[0.2.4]: https://github.com/chronotope/chrono/releases/tag/v0.2.4
+[0.2.3]: https://github.com/chronotope/chrono/releases/tag/v0.2.3
+[0.2.1]: https://github.com/chronotope/chrono/releases/tag/v0.2.1
+[0.2.0]: https://github.com/chronotope/chrono/releases/tag/v0.2.0
+[0.1.14]: https://github.com/chronotope/chrono/releases/tag/v0.1.14
+[0.1.13]: https://github.com/chronotope/chrono/releases/tag/v0.1.13
+[0.1.12]: https://github.com/chronotope/chrono/releases/tag/v0.1.12
+[0.1.4]: https://github.com/chronotope/chrono/releases/tag/v0.1.4
+[0.1.3]: https://github.com/chronotope/chrono/releases/tag/v0.1.3
+[0.1.2]: https://github.com/chronotope/chrono/releases/tag/v0.1.2
+[0.1.0]: https://github.com/chronotope/chrono/releases/tag/v0.1.0


### PR DESCRIPTION
Mostly because I like having a `CHANGELOG.md` file, and don't mind doing some simple busywork.

I included old releases that were skipped in the changelog but had release notes in the git commit of the version bump, and the newer releases that only had GitHub releases.

I also did some spelunking yesterday. Is it nice to include the history of the relation between chrono and time 0.1?
Including release notes in the changelog is a little out of place, but not too much I hope.