### PR TITLE
Add `Weekday::days_since`.

### DIFF
--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -1152,9 +1152,9 @@ fn resolve_week_date(
 
     let first_day_of_year = NaiveDate::from_yo_opt(year, 1).ok_or(OUT_OF_RANGE)?;
     // Ordinal of the day at which week 1 starts.
-    let first_week_start = 1 + week_start_day.num_days_from(first_day_of_year.weekday()) as i32;
+    let first_week_start = 1 + week_start_day.days_since(first_day_of_year.weekday()) as i32;
     // Number of the `weekday`, which is 0 for the first day of the week.
-    let weekday = weekday.num_days_from(week_start_day) as i32;
+    let weekday = weekday.days_since(week_start_day) as i32;
     let ordinal = first_week_start + (week as i32 - 1) * 7 + weekday;
     if ordinal <= 0 {
         return Err(IMPOSSIBLE);

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -122,7 +122,7 @@ impl arbitrary::Arbitrary<'_> for NaiveDate {
 
 impl NaiveDate {
     pub(crate) fn weeks_from(&self, day: Weekday) -> i32 {
-        (self.ordinal() as i32 - self.weekday().num_days_from(day) as i32 + 6) / 7
+        (self.ordinal() as i32 - self.weekday().days_since(day) as i32 + 6) / 7
     }
 
     /// Makes a new `NaiveDate` from year, ordinal and flags.

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -101,7 +101,7 @@ impl Weekday {
     /// `w.number_from_monday()`: | 1     | 2     | 3     | 4     | 5     | 6     | 7
     #[inline]
     pub const fn number_from_monday(&self) -> u32 {
-        self.num_days_from(Weekday::Mon) + 1
+        self.days_since(Weekday::Mon) + 1
     }
 
     /// Returns a day-of-week number starting from Sunday = 1.
@@ -111,7 +111,7 @@ impl Weekday {
     /// `w.number_from_sunday()`: | 2     | 3     | 4     | 5     | 6     | 7     | 1
     #[inline]
     pub const fn number_from_sunday(&self) -> u32 {
-        self.num_days_from(Weekday::Sun) + 1
+        self.days_since(Weekday::Sun) + 1
     }
 
     /// Returns a day-of-week number starting from Monday = 0.
@@ -135,7 +135,7 @@ impl Weekday {
     /// ```
     #[inline]
     pub const fn num_days_from_monday(&self) -> u32 {
-        self.num_days_from(Weekday::Mon)
+        self.days_since(Weekday::Mon)
     }
 
     /// Returns a day-of-week number starting from Sunday = 0.
@@ -145,17 +145,27 @@ impl Weekday {
     /// `w.num_days_from_sunday()`: | 1     | 2     | 3     | 4     | 5     | 6     | 0
     #[inline]
     pub const fn num_days_from_sunday(&self) -> u32 {
-        self.num_days_from(Weekday::Sun)
+        self.days_since(Weekday::Sun)
     }
 
-    /// Returns a day-of-week number starting from the parameter `day` (D) = 0.
+    /// The number of days since the given day.
     ///
-    /// `w`:                        | `D`   | `D+1` | `D+2` | `D+3` | `D+4` | `D+5` | `D+6`
-    /// --------------------------- | ----- | ----- | ----- | ----- | ----- | ----- | -----
-    /// `w.num_days_from(wd)`:      | 0     | 1     | 2     | 3     | 4     | 5     | 6
-    #[inline]
-    pub(crate) const fn num_days_from(&self, day: Weekday) -> u32 {
-        (*self as u32 + 7 - day as u32) % 7
+    /// # Examples
+    ///
+    /// ```
+    /// use chrono::Weekday::*;
+    /// assert_eq!(Mon.days_since(Mon), 0);
+    /// assert_eq!(Sun.days_since(Tue), 5);
+    /// assert_eq!(Wed.days_since(Sun), 3);
+    /// ```
+    pub const fn days_since(&self, other: Weekday) -> u32 {
+        let lhs = *self as u32;
+        let rhs = other as u32;
+        if lhs < rhs {
+            7 + lhs - rhs
+        } else {
+            lhs - rhs
+        }
     }
 }
 
@@ -296,34 +306,28 @@ mod tests {
     use super::Weekday;
 
     #[test]
-    fn test_num_days_from() {
+    fn test_days_since() {
         for i in 0..7 {
             let base_day = Weekday::try_from(i).unwrap();
 
-            assert_eq!(base_day.num_days_from_monday(), base_day.num_days_from(Weekday::Mon));
-            assert_eq!(base_day.num_days_from_sunday(), base_day.num_days_from(Weekday::Sun));
+            assert_eq!(base_day.num_days_from_monday(), base_day.days_since(Weekday::Mon));
+            assert_eq!(base_day.num_days_from_sunday(), base_day.days_since(Weekday::Sun));
 
-            assert_eq!(base_day.num_days_from(base_day), 0);
+            assert_eq!(base_day.days_since(base_day), 0);
 
-            assert_eq!(base_day.num_days_from(base_day.pred()), 1);
-            assert_eq!(base_day.num_days_from(base_day.pred().pred()), 2);
-            assert_eq!(base_day.num_days_from(base_day.pred().pred().pred()), 3);
-            assert_eq!(base_day.num_days_from(base_day.pred().pred().pred().pred()), 4);
-            assert_eq!(base_day.num_days_from(base_day.pred().pred().pred().pred().pred()), 5);
-            assert_eq!(
-                base_day.num_days_from(base_day.pred().pred().pred().pred().pred().pred()),
-                6
-            );
+            assert_eq!(base_day.days_since(base_day.pred()), 1);
+            assert_eq!(base_day.days_since(base_day.pred().pred()), 2);
+            assert_eq!(base_day.days_since(base_day.pred().pred().pred()), 3);
+            assert_eq!(base_day.days_since(base_day.pred().pred().pred().pred()), 4);
+            assert_eq!(base_day.days_since(base_day.pred().pred().pred().pred().pred()), 5);
+            assert_eq!(base_day.days_since(base_day.pred().pred().pred().pred().pred().pred()), 6);
 
-            assert_eq!(base_day.num_days_from(base_day.succ()), 6);
-            assert_eq!(base_day.num_days_from(base_day.succ().succ()), 5);
-            assert_eq!(base_day.num_days_from(base_day.succ().succ().succ()), 4);
-            assert_eq!(base_day.num_days_from(base_day.succ().succ().succ().succ()), 3);
-            assert_eq!(base_day.num_days_from(base_day.succ().succ().succ().succ().succ()), 2);
-            assert_eq!(
-                base_day.num_days_from(base_day.succ().succ().succ().succ().succ().succ()),
-                1
-            );
+            assert_eq!(base_day.days_since(base_day.succ()), 6);
+            assert_eq!(base_day.days_since(base_day.succ().succ()), 5);
+            assert_eq!(base_day.days_since(base_day.succ().succ().succ()), 4);
+            assert_eq!(base_day.days_since(base_day.succ().succ().succ().succ()), 3);
+            assert_eq!(base_day.days_since(base_day.succ().succ().succ().succ().succ()), 2);
+            assert_eq!(base_day.days_since(base_day.succ().succ().succ().succ().succ().succ()), 1);
         }
     }
 


### PR DESCRIPTION
This resurrects the work in https://github.com/chronotope/chrono/pull/216 by @clarfonthey.

`WeekDay::days_since` doesn't offer any new functionality, but I quite like its API.

Fixes #201, #1560.