### PR TITLE
Fix arbitrary string slicing in `parse_rfc3339_relaxed`

### DIFF
--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -804,6 +804,7 @@ fn test_datetime_from_str() {
             .unwrap())
     );
     assert!("2015-2-18T23:16:9.15".parse::<DateTime<Utc>>().is_err());
+    assert!("2015-02-18T23:16:9.15øøø".parse::<DateTime<Utc>>().is_err());
 
     // no test for `DateTime<Local>`, we cannot verify that much.
 }

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -586,7 +586,7 @@ fn parse_rfc3339_relaxed<'a>(parsed: &mut Parsed, mut s: &'a str) -> ParseResult
         Ok(_) => return Err(NOT_ENOUGH),
     };
     s = s.trim_start();
-    let (s, offset) = if s.len() >= 3 && "UTC".eq_ignore_ascii_case(&s[..3]) {
+    let (s, offset) = if s.len() >= 3 && "UTC".as_bytes().eq_ignore_ascii_case(&s.as_bytes()[..3]) {
         (&s[3..], 0)
     } else {
         scan::timezone_offset(s, scan::colon_or_space, true, false, true)?


### PR DESCRIPTION
Introduced in https://github.com/chronotope/chrono/pull/1145.

Fixes https://github.com/chronotope/chrono/issues/1253.