### PR TITLE
Backport #1240: Add Discord link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Chrono GitHub Actions][gh-image]][gh-checks]
 [![Chrono on crates.io][cratesio-image]][cratesio]
 [![Chrono on docs.rs][docsrs-image]][docsrs]
-[![Join the chat at https://gitter.im/chrono-rs/chrono][gitter-image]][gitter]
+[![Chat][discord-image]][discord]
 [![codecov.io][codecov-img]][codecov-link]
 
 [gh-image]: https://github.com/chronotope/chrono/actions/workflows/test.yml/badge.svg
@@ -13,8 +13,8 @@
 [cratesio]: https://crates.io/crates/chrono
 [docsrs-image]: https://docs.rs/chrono/badge.svg
 [docsrs]: https://docs.rs/chrono
-[gitter-image]: https://badges.gitter.im/chrono-rs/chrono.svg
-[gitter]: https://gitter.im/chrono-rs/chrono
+[discord-image]: https://img.shields.io/discord/976380008299917365?logo=discord
+[discord]: https://discord.gg/sXpav4PS7M
 [codecov-img]: https://img.shields.io/codecov/c/github/chronotope/chrono?logo=codecov
 [codecov-link]: https://codecov.io/gh/chronotope/chrono
 


### PR DESCRIPTION
See https://github.com/chronotope/chrono/pull/1240.