### PR TITLE
Expand `From` impls of `js_sys::Date`

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1412,11 +1412,11 @@ impl From<&js_sys::Date> for DateTime<Utc> {
         not(any(target_os = "emscripten", target_os = "wasi"))
     )))
 )]
-impl From<DateTime<Utc>> for js_sys::Date {
-    /// Converts a `DateTime<Utc>` to a JS `Date`. The resulting value may be lossy,
+impl<Tz: TimeZone> From<DateTime<Tz>> for js_sys::Date {
+    /// Converts a `DateTime<Tz>` to a JS `Date`. The resulting value may be lossy,
     /// any values that have a millisecond timestamp value greater/less than ±8,640,000,000,000,000
     /// (April 20, 271821 BCE ~ September 13, 275760 CE) will become invalid dates in JS.
-    fn from(date: DateTime<Utc>) -> js_sys::Date {
+    fn from(date: DateTime<Tz>) -> js_sys::Date {
         let js_millis = wasm_bindgen::JsValue::from_f64(date.timestamp_millis() as f64);
         js_sys::Date::new(&js_millis)
     }

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1366,14 +1366,6 @@ impl<Tz: TimeZone> From<DateTime<Tz>> for SystemTime {
     feature = "wasmbind",
     not(any(target_os = "emscripten", target_os = "wasi"))
 ))]
-#[cfg_attr(
-    docsrs,
-    doc(cfg(all(
-        target_arch = "wasm32",
-        feature = "wasmbind",
-        not(any(target_os = "emscripten", target_os = "wasi"))
-    )))
-)]
 impl From<js_sys::Date> for DateTime<Utc> {
     fn from(date: js_sys::Date) -> DateTime<Utc> {
         DateTime::<Utc>::from(&date)
@@ -1385,14 +1377,6 @@ impl From<js_sys::Date> for DateTime<Utc> {
     feature = "wasmbind",
     not(any(target_os = "emscripten", target_os = "wasi"))
 ))]
-#[cfg_attr(
-    docsrs,
-    doc(cfg(all(
-        target_arch = "wasm32",
-        feature = "wasmbind",
-        not(any(target_os = "emscripten", target_os = "wasi"))
-    )))
-)]
 impl From<&js_sys::Date> for DateTime<Utc> {
     fn from(date: &js_sys::Date) -> DateTime<Utc> {
         Utc.timestamp_millis_opt(date.get_time() as i64).unwrap()
@@ -1404,14 +1388,6 @@ impl From<&js_sys::Date> for DateTime<Utc> {
     feature = "wasmbind",
     not(any(target_os = "emscripten", target_os = "wasi"))
 ))]
-#[cfg_attr(
-    docsrs,
-    doc(cfg(all(
-        target_arch = "wasm32",
-        feature = "wasmbind",
-        not(any(target_os = "emscripten", target_os = "wasi"))
-    )))
-)]
 impl<Tz: TimeZone> From<DateTime<Tz>> for js_sys::Date {
     fn from(date: DateTime<Tz>) -> js_sys::Date {
         let js_millis = wasm_bindgen::JsValue::from_f64(date.timestamp_millis() as f64);

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1388,6 +1388,32 @@ impl From<&js_sys::Date> for DateTime<Utc> {
     feature = "wasmbind",
     not(any(target_os = "emscripten", target_os = "wasi"))
 ))]
+impl From<js_sys::Date> for DateTime<Local> {
+    fn from(date: js_sys::Date) -> DateTime<Local> {
+        DateTime::<Local>::from(&date)
+    }
+}
+
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "wasmbind",
+    not(any(target_os = "emscripten", target_os = "wasi"))
+))]
+impl From<&js_sys::Date> for DateTime<Local> {
+    fn from(date: &js_sys::Date) -> DateTime<Local> {
+        FixedOffset::west_opt((date.get_timezone_offset() as i32) * 60)
+            .unwrap()
+            .timestamp_millis_opt(date.get_time() as i64)
+            .unwrap()
+            .into()
+    }
+}
+
+#[cfg(all(
+    target_arch = "wasm32",
+    feature = "wasmbind",
+    not(any(target_os = "emscripten", target_os = "wasi"))
+))]
 impl<Tz: TimeZone> From<DateTime<Tz>> for js_sys::Date {
     fn from(date: DateTime<Tz>) -> js_sys::Date {
         let js_millis = wasm_bindgen::JsValue::from_f64(date.timestamp_millis() as f64);

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1413,9 +1413,6 @@ impl From<&js_sys::Date> for DateTime<Utc> {
     )))
 )]
 impl<Tz: TimeZone> From<DateTime<Tz>> for js_sys::Date {
-    /// Converts a `DateTime<Tz>` to a JS `Date`. The resulting value may be lossy,
-    /// any values that have a millisecond timestamp value greater/less than ±8,640,000,000,000,000
-    /// (April 20, 271821 BCE ~ September 13, 275760 CE) will become invalid dates in JS.
     fn from(date: DateTime<Tz>) -> js_sys::Date {
         let js_millis = wasm_bindgen::JsValue::from_f64(date.timestamp_millis() as f64);
         js_sys::Date::new(&js_millis)


### PR DESCRIPTION
While updating https://github.com/chronotope/chrono/pull/1040 I noticed our `From` impls of `js_sys::Date` are not as flexible as they could be.
The only allow converting from `DateTime<Utc>` instead of a generic `DateTime`.
And we had nothing to convert to `DateTime<Local>` and preserve the offset.

This does change type inference. Does that make it a problematic change?