### PR TITLE
Bump version to 0.4.30

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ cff-version: 1.2.0
 message: Please cite this crate using these information.
 
 # Version information.
-date-released: 2023-09-05
-version: 0.4.29
+date-released: 2023-09-07
+version: 0.4.30
 
 # Project information.
 abstract: Date and time library for Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono"
-version = "0.4.29"
+version = "0.4.30"
 description = "Date and time library for Rust"
 homepage = "https://github.com/chronotope/chrono"
 documentation = "https://docs.rs/chrono/"


### PR DESCRIPTION
Do we also want to include https://github.com/chronotope/chrono/pull/1246?