### PR TITLE
Format day in RFC 2822 without padding

### DIFF
--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -460,6 +460,10 @@ fn test_datetime_rfc2822() {
         Utc.with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap().to_rfc2822(),
         "Wed, 18 Feb 2015 23:16:09 +0000"
     );
+    assert_eq!(
+        Utc.with_ymd_and_hms(2015, 2, 1, 23, 16, 9).unwrap().to_rfc2822(),
+        "Sun, 1 Feb 2015 23:16:09 +0000"
+    );
     // timezone +05
     assert_eq!(
         edt.from_local_datetime(

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -637,7 +637,12 @@ fn write_rfc2822_inner(
 
     w.write_str(short_weekdays(locale)[d.weekday().num_days_from_sunday() as usize])?;
     w.write_str(", ")?;
-    write_hundreds(w, d.day() as u8)?;
+    let day = d.day();
+    if day < 10 {
+        w.write_char((b'0' + day as u8) as char)?;
+    } else {
+        write_hundreds(w, day as u8)?;
+    }
     w.write_char(' ')?;
     w.write_str(short_months(locale)[d.month0() as usize])?;
     w.write_char(' ')?;


### PR DESCRIPTION
`DateTime::to_rfc2822` would format the day value with space padding when https://github.com/chronotope/chrono/pull/249 was opened. https://github.com/chronotope/chrono/pull/844 changed it to zero padding, probably unintentionally. No padding at all seems more in line with the standard.

We had no test for this case.

Fixes https://github.com/chronotope/chrono/issues/1269.