### PR TITLE
Remove `__doctest` feature and `doc_comment` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ oldtime = []
 wasmbind = ["wasm-bindgen", "js-sys"]
 unstable-locales = ["pure-rust-locales", "alloc"]
 __internal_bench = []
-__doctest = []
 
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
@@ -58,7 +57,6 @@ android-tzdata = { version = "0.1.1", optional = true }
 serde_json = { version = "1" }
 serde_derive = { version = "1", default-features = false }
 bincode = { version = "1.3.0" }
-doc-comment = { version = "0.3" }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,14 +481,6 @@ pub use duration::OutOfRangeError;
 
 use core::fmt;
 
-#[cfg(feature = "__doctest")]
-#[cfg_attr(feature = "__doctest", cfg(doctest))]
-use doc_comment::doctest;
-
-#[cfg(feature = "__doctest")]
-#[cfg_attr(feature = "__doctest", cfg(doctest))]
-doctest!("../README.md");
-
 /// A convenience module appropriate for glob imports (`use chrono::prelude::*;`).
 pub mod prelude {
     #[doc(no_inline)]


### PR DESCRIPTION
The `__doctest` feature and `doc_comment` dependency where added in https://github.com/chronotope/chrono/pull/316 to test the examples in `README.md`. But we no longer use it for testing, and don't have examples in the README.

I propose to just remove this feature. The `__doctest` name should have made it pretty clear this was not mean to be a feature other crates should rely on.