### PR TITLE
Make methods on `NaiveDateTime` const where possible

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -622,6 +622,14 @@ impl DateTime<Utc> {
         NaiveDateTime::from_timestamp_opt(secs, nsecs).as_ref().map(NaiveDateTime::and_utc)
     }
 
+    // FIXME: remove when our MSRV is 1.61+
+    // This method is used by `NaiveDateTime::and_utc` because `DateTime::from_naive_utc_and_offset`
+    // can't be made const yet.
+    // Trait bounds in const function / implementation blocks were not supported until 1.61.
+    pub(crate) const fn from_naive_utc(datetime: NaiveDateTime) -> Self {
+        DateTime { datetime, offset: Utc }
+    }
+
     /// The Unix Epoch, 1970-01-01 00:00:00 UTC.
     pub const UNIX_EPOCH: Self = Self { datetime: NaiveDateTime::UNIX_EPOCH, offset: Utc };
 }

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -1030,8 +1030,9 @@ impl NaiveDateTime {
     /// assert_eq!(dt.timezone(), Utc);
     /// ```
     #[must_use]
-    pub fn and_utc(&self) -> DateTime<Utc> {
-        Utc.from_utc_datetime(self)
+    pub const fn and_utc(&self) -> DateTime<Utc> {
+        // FIXME: use `DateTime::from_naive_utc_and_offset` when our MSRV is 1.61+.
+        DateTime::from_naive_utc(*self)
     }
 
     /// The minimum possible `NaiveDateTime`.

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -868,6 +868,21 @@ impl NaiveTime {
         (hour, min, sec)
     }
 
+    /// Returns the number of non-leap seconds past the last midnight.
+    // This duplicates `Timelike::num_seconds_from_midnight()`, because trait methods can't be const
+    // yet.
+    #[inline]
+    pub(crate) const fn num_seconds_from_midnight(&self) -> u32 {
+        self.secs
+    }
+
+    /// Returns the number of nanoseconds since the whole non-leap second.
+    // This duplicates `Timelike::nanosecond()`, because trait methods can't be const yet.
+    #[inline]
+    pub(crate) const fn nanosecond(&self) -> u32 {
+        self.frac
+    }
+
     /// The earliest possible `NaiveTime`
     pub const MIN: Self = Self { secs: 0, frac: 0 };
     pub(super) const MAX: Self = Self { secs: 23 * 3600 + 59 * 60 + 59, frac: 999_999_999 };


### PR DESCRIPTION
I had to copy a few methods from the `Datelike` and `Timelike` traits to const methods on `NaiveDate` and `NaiveTime`, to make use of them in const methods on `NaiveDateTime`.

Otherwise the changes are fairly straightforward.

Only `DateTime<Tz>` to go after this (and a handful of methods that depend on `Duration`).