### PR TITLE
Upgrade pure-rust-locales to 0.7.0 (main)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ __internal_bench = []
 
 [dependencies]
 serde = { version = "1.0.99", default-features = false, optional = true }
-pure-rust-locales = { version = "0.6", optional = true }
+pure-rust-locales = { version = "0.7", optional = true }
 rkyv = { version = "0.7", optional = true }
 arbitrary = { version = "1.0.0", features = ["derive"], optional = true }
 


### PR DESCRIPTION
This is an update for main branch. PR for main branch is #1288.

Context: https://github.com/cecton/pure-rust-locales/pull/7