### PR TITLE
Upgrade pure-rust-locales to 0.7.0 (0.4.x)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ __internal_bench = []
 num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }
 serde = { version = "1.0.99", default-features = false, optional = true }
-pure-rust-locales = { version = "0.6", optional = true }
+pure-rust-locales = { version = "0.7", optional = true }
 rkyv = { version = "0.7", optional = true }
 arbitrary = { version = "1.0.0", features = ["derive"], optional = true }
 


### PR DESCRIPTION
This is an update for v4. PR for main branch is #1287.

Context: https://github.com/cecton/pure-rust-locales/pull/7