### PR TITLE
Export `Archived*` types in `rkyv` module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ bincode = { version = "1.3.0" }
 wasm-bindgen-test = "0.3"
 
 [package.metadata.docs.rs]
-features = ["serde"]
+features = ["serde, rkyv"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -569,6 +569,26 @@ pub mod serde {
     pub use super::datetime::serde::*;
 }
 
+/// Zero-copy serialization/deserialization with rkyv.
+///
+/// This module re-exports the `Archived*` versions of chrono's types.
+#[cfg(feature = "rkyv")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rkyv")))]
+pub mod rkyv {
+    pub use crate::datetime::ArchivedDateTime;
+    pub use crate::duration::ArchivedDuration;
+    pub use crate::month::ArchivedMonth;
+    pub use crate::naive::date::ArchivedNaiveDate;
+    pub use crate::naive::datetime::ArchivedNaiveDateTime;
+    pub use crate::naive::isoweek::ArchivedIsoWeek;
+    pub use crate::naive::time::ArchivedNaiveTime;
+    pub use crate::offset::fixed::ArchivedFixedOffset;
+    #[cfg(feature = "clock")]
+    pub use crate::offset::local::ArchivedLocal;
+    pub use crate::offset::utc::ArchivedUtc;
+    pub use crate::weekday::ArchivedWeekday;
+}
+
 /// Out of range error type used in various converting APIs
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
 pub struct OutOfRange {

--- a/src/naive/mod.rs
+++ b/src/naive/mod.rs
@@ -4,11 +4,11 @@
 //! (e.g. [`TimeZone`](../offset/trait.TimeZone.html)),
 //! but can be also used for the simpler date and time handling.
 
-mod date;
+pub(crate) mod date;
 pub(crate) mod datetime;
 mod internals;
-mod isoweek;
-mod time;
+pub(crate) mod isoweek;
+pub(crate) mod time;
 
 pub use self::date::{Days, NaiveDate, NaiveDateDaysIterator, NaiveDateWeeksIterator, NaiveWeek};
 #[allow(deprecated)]

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -26,15 +26,15 @@ use crate::Weekday;
 #[allow(deprecated)]
 use crate::{Date, DateTime};
 
-mod fixed;
+pub(crate) mod fixed;
 pub use self::fixed::FixedOffset;
 
 #[cfg(feature = "clock")]
-mod local;
+pub(crate) mod local;
 #[cfg(feature = "clock")]
 pub use self::local::Local;
 
-mod utc;
+pub(crate) mod utc;
 pub use self::utc::Utc;
 
 /// The conversion result from the local time to the timezone-aware datetime types.


### PR DESCRIPTION
Without these the types can't be named and users can't see their documentation.

See https://github.com/chronotope/chrono/pull/1271#issuecomment-1729108510.