### PR TITLE
Deprecate standalone `format` functions

### DIFF
--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -7,8 +7,9 @@
 use alloc::string::{String, ToString};
 #[cfg(any(feature = "alloc", feature = "std"))]
 use core::borrow::Borrow;
-use core::fmt;
-use core::fmt::Write;
+#[cfg(any(feature = "alloc", feature = "std"))]
+use core::fmt::Display;
+use core::fmt::{self, Write};
 
 #[cfg(any(
     feature = "alloc",
@@ -87,7 +88,7 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
         items: I,
     ) -> DelayedFormat<I>
     where
-        Off: Offset + fmt::Display,
+        Off: Offset + Display,
     {
         let name_and_diff = (offset.to_string(), offset.fix());
         DelayedFormat {
@@ -123,7 +124,7 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
         locale: Locale,
     ) -> DelayedFormat<I>
     where
-        Off: Offset + fmt::Display,
+        Off: Offset + Display,
     {
         let name_and_diff = (offset.to_string(), offset.fix());
         DelayedFormat { date, time, off: Some(name_and_diff), items, locale: Some(locale) }
@@ -131,7 +132,7 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
 }
 
 #[cfg(any(feature = "alloc", feature = "std"))]
-impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> fmt::Display for DelayedFormat<I> {
+impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> Display for DelayedFormat<I> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         #[cfg(feature = "unstable-locales")]
         {

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -135,20 +135,22 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
 impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> Display for DelayedFormat<I> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         #[cfg(feature = "unstable-locales")]
-        {
-            if let Some(locale) = self.locale {
-                return format_localized(
-                    f,
-                    self.date.as_ref(),
-                    self.time.as_ref(),
-                    self.off.as_ref(),
-                    self.items.clone(),
-                    locale,
-                );
-            }
-        }
+        let locale = self.locale;
+        #[cfg(not(feature = "unstable-locales"))]
+        let locale = None;
 
-        format(f, self.date.as_ref(), self.time.as_ref(), self.off.as_ref(), self.items.clone())
+        let mut result = String::new();
+        for item in self.items.clone() {
+            format_inner(
+                &mut result,
+                self.date.as_ref(),
+                self.time.as_ref(),
+                self.off.as_ref(),
+                item.borrow(),
+                locale,
+            )?;
+        }
+        f.pad(&result)
     }
 }
 
@@ -166,12 +168,17 @@ where
     I: Iterator<Item = B> + Clone,
     B: Borrow<Item<'a>>,
 {
-    let mut result = String::new();
-    for item in items {
-        format_inner(&mut result, date, time, off, item.borrow(), None)?;
+    DelayedFormat {
+        date: date.copied(),
+        time: time.copied(),
+        off: off.cloned(),
+        items,
+        #[cfg(feature = "unstable-locales")]
+        locale: None,
     }
-    w.pad(&result)
+    .fmt(w)
 }
+
 /// Formats single formatting item
 #[cfg(any(feature = "alloc", feature = "std"))]
 pub fn format_item(
@@ -181,9 +188,15 @@ pub fn format_item(
     off: Option<&(String, FixedOffset)>,
     item: &Item<'_>,
 ) -> fmt::Result {
-    let mut result = String::new();
-    format_inner(&mut result, date, time, off, item, None)?;
-    w.pad(&result)
+    DelayedFormat {
+        date: date.copied(),
+        time: time.copied(),
+        off: off.cloned(),
+        items: [item].into_iter(),
+        #[cfg(feature = "unstable-locales")]
+        locale: None,
+    }
+    .fmt(w)
 }
 
 /// Tries to format given arguments with given formatting items.
@@ -201,11 +214,14 @@ where
     I: Iterator<Item = B> + Clone,
     B: Borrow<Item<'a>>,
 {
-    let mut result = String::new();
-    for item in items {
-        format_inner(&mut result, date, time, off, item.borrow(), Some(locale))?;
+    DelayedFormat {
+        date: date.copied(),
+        time: time.copied(),
+        off: off.cloned(),
+        items,
+        locale: Some(locale),
     }
-    w.pad(&result)
+    .fmt(w)
 }
 
 /// Formats single formatting item
@@ -218,9 +234,14 @@ pub fn format_item_localized(
     item: &Item<'_>,
     locale: Locale,
 ) -> fmt::Result {
-    let mut result = String::new();
-    format_inner(&mut result, date, time, off, item, Some(locale))?;
-    w.pad(&result)
+    DelayedFormat {
+        date: date.copied(),
+        time: time.copied(),
+        off: off.cloned(),
+        items: [item].into_iter(),
+        locale: Some(locale),
+    }
+    .fmt(w)
 }
 
 #[cfg(any(feature = "alloc", feature = "std"))]

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -157,6 +157,7 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> Display for Delayed
 /// Tries to format given arguments with given formatting items.
 /// Internally used by `DelayedFormat`.
 #[cfg(any(feature = "alloc", feature = "std"))]
+#[deprecated(since = "0.4.32", note = "Use DelayedFormat::fmt instead")]
 pub fn format<'a, I, B>(
     w: &mut fmt::Formatter,
     date: Option<&NaiveDate>,
@@ -181,6 +182,7 @@ where
 
 /// Formats single formatting item
 #[cfg(any(feature = "alloc", feature = "std"))]
+#[deprecated(since = "0.4.32", note = "Use DelayedFormat::fmt instead")]
 pub fn format_item(
     w: &mut fmt::Formatter,
     date: Option<&NaiveDate>,
@@ -202,6 +204,7 @@ pub fn format_item(
 /// Tries to format given arguments with given formatting items.
 /// Internally used by `DelayedFormat`.
 #[cfg(feature = "unstable-locales")]
+#[deprecated(since = "0.4.32", note = "Use DelayedFormat::fmt instead")]
 pub fn format_localized<'a, I, B>(
     w: &mut fmt::Formatter,
     date: Option<&NaiveDate>,
@@ -226,6 +229,7 @@ where
 
 /// Formats single formatting item
 #[cfg(feature = "unstable-locales")]
+#[deprecated(since = "0.4.32", note = "Use DelayedFormat::fmt instead")]
 pub fn format_item_localized(
     w: &mut fmt::Formatter,
     date: Option<&NaiveDate>,

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -62,8 +62,10 @@ pub(crate) use formatting::write_rfc2822;
 ))]
 pub(crate) use formatting::write_rfc3339;
 #[cfg(any(feature = "alloc", feature = "std"))]
+#[allow(deprecated)]
 pub use formatting::{format, format_item, DelayedFormat};
 #[cfg(feature = "unstable-locales")]
+#[allow(deprecated)]
 pub use formatting::{format_item_localized, format_localized};
 #[cfg(all(feature = "unstable-locales", any(feature = "alloc", feature = "std")))]
 pub use locales::Locale;


### PR DESCRIPTION
Split out from https://github.com/chronotope/chrono/pull/1163.

In the `format` module we have 4 standalone [`format*` functions](https://docs.rs/chrono/latest/chrono/format/index.html#functions). I don't think they were ever intended to be public.
They need an `&mut Formatter<'_>` as argument, which can't be constructed outside of a `Display` implementation.

To deprecated these methods I inlined them in `DelayedFormat::Display`, and made the methods wrappers around that.