### PR TITLE
Add `NaiveTime::overflowing_(add|sub)_offset`

### DIFF
--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -1180,6 +1180,15 @@ impl AddAssign<Duration> for NaiveTime {
     }
 }
 
+impl Add<FixedOffset> for NaiveTime {
+    type Output = NaiveTime;
+
+    #[inline]
+    fn add(self, rhs: FixedOffset) -> NaiveTime {
+        self.overflowing_add_offset(rhs).0
+    }
+}
+
 /// A subtraction of `Duration` from `NaiveTime` wraps around and never overflows or underflows.
 /// In particular the addition ignores integral number of days.
 /// It is the same as the addition with a negated `Duration`.
@@ -1259,6 +1268,15 @@ impl SubAssign<Duration> for NaiveTime {
         let rhs = OldDuration::from_std(rhs)
             .expect("overflow converting from core::time::Duration to chrono::Duration");
         *self -= rhs;
+    }
+}
+
+impl Sub<FixedOffset> for NaiveTime {
+    type Output = NaiveTime;
+
+    #[inline]
+    fn sub(self, rhs: FixedOffset) -> NaiveTime {
+        self.overflowing_sub_offset(rhs).0
     }
 }
 

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -13,7 +13,7 @@ use rkyv::{Archive, Deserialize, Serialize};
 use super::{LocalResult, Offset, TimeZone};
 use crate::duration::Duration as OldDuration;
 use crate::format::{scan, OUT_OF_RANGE};
-use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
+use crate::naive::{NaiveDate, NaiveDateTime};
 use crate::{DateTime, ParseError, Timelike};
 
 /// The time zone with fixed offset, from UTC-23:59:59 to UTC+23:59:59.
@@ -197,24 +197,6 @@ where
     let nanos = lhs.nanosecond();
     let lhs = lhs.with_nanosecond(0).unwrap();
     (lhs + OldDuration::seconds(i64::from(rhs))).with_nanosecond(nanos).unwrap()
-}
-
-impl Add<FixedOffset> for NaiveTime {
-    type Output = NaiveTime;
-
-    #[inline]
-    fn add(self, rhs: FixedOffset) -> NaiveTime {
-        self.overflowing_add_offset(rhs).0
-    }
-}
-
-impl Sub<FixedOffset> for NaiveTime {
-    type Output = NaiveTime;
-
-    #[inline]
-    fn sub(self, rhs: FixedOffset) -> NaiveTime {
-        self.overflowing_sub_offset(rhs).0
-    }
 }
 
 impl Add<FixedOffset> for NaiveDateTime {

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -204,7 +204,7 @@ impl Add<FixedOffset> for NaiveTime {
 
     #[inline]
     fn add(self, rhs: FixedOffset) -> NaiveTime {
-        add_with_leapsecond(&self, rhs.local_minus_utc)
+        self.overflowing_add_offset(rhs).0
     }
 }
 
@@ -213,7 +213,7 @@ impl Sub<FixedOffset> for NaiveTime {
 
     #[inline]
     fn sub(self, rhs: FixedOffset) -> NaiveTime {
-        add_with_leapsecond(&self, -rhs.local_minus_utc)
+        self.overflowing_sub_offset(rhs).0
     }
 }
 


### PR DESCRIPTION
On its own these methods are not that useful. We need them to nicely implement `NaiveDateTime::checked_(add|sub)_offset`.
It does make the existing `Add` and `Sub` implementations simpler.

Split out from https://github.com/chronotope/chrono/pull/1069.