### PR TITLE
Remove `format::{format_localized, format_item_localized}`

### DIFF
--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -188,53 +188,6 @@ pub fn format_item(
     .fmt(w)
 }
 
-/// Tries to format given arguments with given formatting items.
-/// Internally used by `DelayedFormat`.
-#[cfg(all(feature = "unstable-locales", feature = "alloc"))]
-#[deprecated(since = "0.4.32", note = "Use DelayedFormat::fmt instead")]
-pub fn format_localized<'a, I, B>(
-    w: &mut fmt::Formatter,
-    date: Option<&NaiveDate>,
-    time: Option<&NaiveTime>,
-    off: Option<&(String, FixedOffset)>,
-    items: I,
-    locale: Locale,
-) -> fmt::Result
-where
-    I: Iterator<Item = B> + Clone,
-    B: Borrow<Item<'a>>,
-{
-    DelayedFormat {
-        date: date.copied(),
-        time: time.copied(),
-        off: off.cloned(),
-        items,
-        locale: Some(locale),
-    }
-    .fmt(w)
-}
-
-/// Formats single formatting item
-#[cfg(all(feature = "unstable-locales", feature = "alloc"))]
-#[deprecated(since = "0.4.32", note = "Use DelayedFormat::fmt instead")]
-pub fn format_item_localized(
-    w: &mut fmt::Formatter,
-    date: Option<&NaiveDate>,
-    time: Option<&NaiveTime>,
-    off: Option<&(String, FixedOffset)>,
-    item: &Item<'_>,
-    locale: Locale,
-) -> fmt::Result {
-    DelayedFormat {
-        date: date.copied(),
-        time: time.copied(),
-        off: off.cloned(),
-        items: [item].into_iter(),
-        locale: Some(locale),
-    }
-    .fmt(w)
-}
-
 #[cfg(feature = "alloc")]
 fn format_inner(
     w: &mut impl Write,

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -61,9 +61,6 @@ pub(crate) use formatting::write_rfc3339;
 #[cfg(feature = "alloc")]
 #[allow(deprecated)]
 pub use formatting::{format, format_item, DelayedFormat};
-#[cfg(all(feature = "unstable-locales", feature = "alloc"))]
-#[allow(deprecated)]
-pub use formatting::{format_item_localized, format_localized};
 #[cfg(feature = "unstable-locales")]
 pub use locales::Locale;
 pub(crate) use parse::parse_rfc3339;


### PR DESCRIPTION
I forgot that in https://github.com/chronotope/chrono/pull/1306 `format::{format_localized, format_item_localized}` are behind the `unstable-locales` feature. Instead of deprecating I think we can just removed them.
That is what it did in the PR the commit was based on, but I messed up.