### PR TITLE
Fix `*_DAYS_FROM_YEAR_0` calculation

### DIFF
--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -2405,13 +2405,14 @@ mod tests {
         let calculated_max = NaiveDate::from_ymd_opt(MAX_YEAR, 12, 31).unwrap();
         assert!(
             NaiveDate::MIN == calculated_min,
-            "`NaiveDate::MIN` should have a year flag {:?}",
+            "`NaiveDate::MIN` should have year flag {:?}",
             calculated_min.of().flags()
         );
         assert!(
             NaiveDate::MAX == calculated_max,
-            "`NaiveDate::MAX` should have a year flag {:?}",
-            calculated_max.of().flags()
+            "`NaiveDate::MAX` should have year flag {:?} and ordinal {}",
+            calculated_max.of().flags(),
+            calculated_max.of().ordinal()
         );
 
         // let's also check that the entire range do not exceed 2^44 seconds

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -3235,22 +3235,16 @@ mod tests {
     }
 
     //   MAX_YEAR-12-31 minus 0000-01-01
-    // = ((MAX_YEAR+1)-01-01 minus 0001-01-01) + (0001-01-01 minus 0000-01-01) - 1 day
-    // = ((MAX_YEAR+1)-01-01 minus 0001-01-01) + 365 days
-    // = MAX_YEAR * 365 + (# of leap years from 0001 to MAX_YEAR) + 365 days
+    // = (MAX_YEAR-12-31 minus 0000-12-31) + (0000-12-31 - 0000-01-01)
+    // = MAX_YEAR * 365 + (# of leap years from 0001 to MAX_YEAR) + 365
+    // = (MAX_YEAR + 1) * 365 + (# of leap years from 0001 to MAX_YEAR)
     const MAX_DAYS_FROM_YEAR_0: i32 =
-        MAX_YEAR * 365 + MAX_YEAR / 4 - MAX_YEAR / 100 + MAX_YEAR / 400 + 365;
+        (MAX_YEAR + 1) * 365 + MAX_YEAR / 4 - MAX_YEAR / 100 + MAX_YEAR / 400;
 
     //   MIN_YEAR-01-01 minus 0000-01-01
-    // = (MIN_YEAR+400n+1)-01-01 minus (400n+1)-01-01
-    // = ((MIN_YEAR+400n+1)-01-01 minus 0001-01-01) - ((400n+1)-01-01 minus 0001-01-01)
-    // = ((MIN_YEAR+400n+1)-01-01 minus 0001-01-01) - 146097n days
-    //
-    // n is set to 1000 for convenience.
-    const MIN_DAYS_FROM_YEAR_0: i32 = (MIN_YEAR + 400_000) * 365 + (MIN_YEAR + 400_000) / 4
-        - (MIN_YEAR + 400_000) / 100
-        + (MIN_YEAR + 400_000) / 400
-        - 146_097_000;
+    // = MIN_YEAR * 365 + (# of leap years from MIN_YEAR to 0000)
+    const MIN_DAYS_FROM_YEAR_0: i32 =
+        MIN_YEAR * 365 + MIN_YEAR / 4 - MIN_YEAR / 100 + MIN_YEAR / 400;
 
     // only used for testing, but duplicated in naive::datetime
     const MAX_BITS: usize = 44;


### PR DESCRIPTION
The `MIN_DAYS_FROM_YEAR_0` and `MAX_DAYS_FROM_YEAR_0` constants are only used in tests.

As described in https://github.com/chronotope/chrono/pull/1048 there is something subtly wrong in the derivation of them. But I was not smart enough to put my finger on it :smile:.

The formula was only correct if `MIN_YEAR` was a leap year. I changed it to a correct formula that tries to be less smart, and tested it to be correct for all possible years.

`test_date_bounds` helps to verify `NaiveDate::MIN` and `NaiveDate::MAX` are correct. I changed it a little to also report the last ordinal day in `NaiveDate::MAX`.

Split out from https://github.com/chronotope/chrono/pull/1048.