### PR TITLE
Add `NaiveDateTime::checked_(add|sub)_offset`

### DIFF
--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -1619,6 +1619,15 @@ impl AddAssign<Duration> for NaiveDateTime {
     }
 }
 
+impl Add<FixedOffset> for NaiveDateTime {
+    type Output = NaiveDateTime;
+
+    #[inline]
+    fn add(self, rhs: FixedOffset) -> NaiveDateTime {
+        self.checked_add_offset(rhs).unwrap()
+    }
+}
+
 impl Add<Months> for NaiveDateTime {
     type Output = NaiveDateTime;
 
@@ -1743,6 +1752,15 @@ impl SubAssign<Duration> for NaiveDateTime {
     #[inline]
     fn sub_assign(&mut self, rhs: Duration) {
         *self = self.sub(rhs);
+    }
+}
+
+impl Sub<FixedOffset> for NaiveDateTime {
+    type Output = NaiveDateTime;
+
+    #[inline]
+    fn sub(self, rhs: FixedOffset) -> NaiveDateTime {
+        self.checked_sub_offset(rhs).unwrap()
     }
 }
 

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -433,3 +433,60 @@ fn test_and_utc() {
     assert_eq!(dt_utc.naive_local(), ndt);
     assert_eq!(dt_utc.timezone(), Utc);
 }
+
+#[test]
+fn test_checked_add_offset() {
+    let ymdhmsm = |y, m, d, h, mn, s, mi| {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi)
+    };
+
+    let positive_offset = FixedOffset::east_opt(2 * 60 * 60).unwrap();
+    // regular date
+    let dt = ymdhmsm(2023, 5, 5, 20, 10, 0, 0).unwrap();
+    assert_eq!(dt.checked_add_offset(positive_offset), ymdhmsm(2023, 5, 5, 22, 10, 0, 0));
+    // leap second is preserved
+    let dt = ymdhmsm(2023, 6, 30, 23, 59, 59, 1_000).unwrap();
+    assert_eq!(dt.checked_add_offset(positive_offset), ymdhmsm(2023, 7, 1, 1, 59, 59, 1_000));
+    // out of range
+    assert!(NaiveDateTime::MAX.checked_add_offset(positive_offset).is_none());
+
+    let negative_offset = FixedOffset::west_opt(2 * 60 * 60).unwrap();
+    // regular date
+    let dt = ymdhmsm(2023, 5, 5, 20, 10, 0, 0).unwrap();
+    assert_eq!(dt.checked_add_offset(negative_offset), ymdhmsm(2023, 5, 5, 18, 10, 0, 0));
+    // leap second is preserved
+    let dt = ymdhmsm(2023, 6, 30, 23, 59, 59, 1_000).unwrap();
+    assert_eq!(dt.checked_add_offset(negative_offset), ymdhmsm(2023, 6, 30, 21, 59, 59, 1_000));
+    // out of range
+    assert!(NaiveDateTime::MIN.checked_add_offset(negative_offset).is_none());
+}
+
+#[test]
+fn test_checked_sub_offset() {
+    let ymdhmsm = |y, m, d, h, mn, s, mi| {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi)
+    };
+
+    let positive_offset = FixedOffset::east_opt(2 * 60 * 60).unwrap();
+    // regular date
+    let dt = ymdhmsm(2023, 5, 5, 20, 10, 0, 0).unwrap();
+    assert_eq!(dt.checked_sub_offset(positive_offset), ymdhmsm(2023, 5, 5, 18, 10, 0, 0));
+    // leap second is preserved
+    let dt = ymdhmsm(2023, 6, 30, 23, 59, 59, 1_000).unwrap();
+    assert_eq!(dt.checked_sub_offset(positive_offset), ymdhmsm(2023, 6, 30, 21, 59, 59, 1_000));
+    // out of range
+    assert!(NaiveDateTime::MIN.checked_sub_offset(positive_offset).is_none());
+
+    let negative_offset = FixedOffset::west_opt(2 * 60 * 60).unwrap();
+    // regular date
+    let dt = ymdhmsm(2023, 5, 5, 20, 10, 0, 0).unwrap();
+    assert_eq!(dt.checked_sub_offset(negative_offset), ymdhmsm(2023, 5, 5, 22, 10, 0, 0));
+    // leap second is preserved
+    let dt = ymdhmsm(2023, 6, 30, 23, 59, 59, 1_000).unwrap();
+    assert_eq!(dt.checked_sub_offset(negative_offset), ymdhmsm(2023, 7, 1, 1, 59, 59, 1_000));
+    // out of range
+    assert!(NaiveDateTime::MAX.checked_sub_offset(negative_offset).is_none());
+
+    assert_eq!(dt.checked_add_offset(positive_offset), Some(dt + positive_offset));
+    assert_eq!(dt.checked_sub_offset(positive_offset), Some(dt - positive_offset));
+}

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -204,7 +204,7 @@ impl Add<FixedOffset> for NaiveDateTime {
 
     #[inline]
     fn add(self, rhs: FixedOffset) -> NaiveDateTime {
-        add_with_leapsecond(&self, rhs.local_minus_utc)
+        self.checked_add_offset(rhs).unwrap()
     }
 }
 
@@ -213,7 +213,7 @@ impl Sub<FixedOffset> for NaiveDateTime {
 
     #[inline]
     fn sub(self, rhs: FixedOffset) -> NaiveDateTime {
-        add_with_leapsecond(&self, -rhs.local_minus_utc)
+        self.checked_sub_offset(rhs).unwrap()
     }
 }
 

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -199,24 +199,6 @@ where
     (lhs + OldDuration::seconds(i64::from(rhs))).with_nanosecond(nanos).unwrap()
 }
 
-impl Add<FixedOffset> for NaiveDateTime {
-    type Output = NaiveDateTime;
-
-    #[inline]
-    fn add(self, rhs: FixedOffset) -> NaiveDateTime {
-        self.checked_add_offset(rhs).unwrap()
-    }
-}
-
-impl Sub<FixedOffset> for NaiveDateTime {
-    type Output = NaiveDateTime;
-
-    #[inline]
-    fn sub(self, rhs: FixedOffset) -> NaiveDateTime {
-        self.checked_sub_offset(rhs).unwrap()
-    }
-}
-
 impl<Tz: TimeZone> Add<FixedOffset> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 


### PR DESCRIPTION
These methods are const and public so they can be used with https://github.com/chronotope/chrono/pull/1270.

Because the offset is never more than 24 hours, we can use `NaiveDate::pred_opt()` and `NaiveDate::succ_opt()` Instead of `NaiveDate::add_days`. This gives a nice little performance improvement for many methods on `DateTime` (benchmarks in https://github.com/chronotope/chrono/pull/1069#issuecomment-1732226078).

Most of all we can use these methods to avoid out of range panics when converting datetimes from UTC to local or back.

Split out from https://github.com/chronotope/chrono/pull/1069.