### PR TITLE
tests calling date command set env LC_ALL

### DIFF
--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -121,6 +121,7 @@ fn verify_against_date_command_format_local(path: &'static str, dt: NaiveDateTim
 
     let output = process::Command::new(path)
         .env("LANG", "c")
+        .env("LC_ALL", "c")
         .arg("-d")
         .arg(format!(
             "{}-{:02}-{:02} {:02}:{:02}:{:02}",


### PR DESCRIPTION
For tests calling `date` Unix tool, also set
environment variable `LC_ALL=c` to make more sure to avoid locality problems.

On systems with environment variable and value `LC_ALL=en_US.utf8` set then the test `try_verify_against_date_command_format` may fail.

```text
$ LC_ALL=en_US.utf8 cargo test
...
test try_verify_against_date_command_format ... FAILED
test try_verify_against_date_command ... ok

failures:

---- try_verify_against_date_command_format stdout ----
LANG: "en_US.UTF-8"
command: "/usr/bin/date" --version
stdout: "date (GNU coreutils) 8.32\nCopyright (C) 2020 Free Software Foundation, Inc.\nLicense GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.\nThis is free software: you are free to change and redistribute it.\nThere is NO WARRANTY, to the extent permitted by law.\n\nWritten by David MacKenzie.\n"
stderr: ""
thread 'try_verify_against_date_command_format' panicked at 'assertion failed: `(left == right)`
  left: `"d01 D01/01/70 F1970-01-01 H12 I12 j001 k12 l12 m01 M11 S13 T12:11:13 u4 U00 w4 W00 X12:11:13 PM y70 Y1970 z-08:00\n"`,
 right: `"d01 D01/01/70 F1970-01-01 H12 I12 j001 k12 l12 m01 M11 S13 T12:11:13 u4 U00 w4 W00 X12:11:13 y70 Y1970 z-08:00\n"`', tests/dateutils.rs:144:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This failure occurred on Ubuntu 22.04, rust 1.72.0, `date` _date (GNU coreutils) 8.32_.

PR #1090 sets environment variable `LANG=c`. Apparently that is not always sufficient.

Relates to Issue #1060, PR #1090