### PR TITLE
Revert #806

### DIFF
--- a/bench/benches/chrono.rs
+++ b/bench/benches/chrono.rs
@@ -12,7 +12,7 @@ fn bench_datetime_parse_from_rfc2822(c: &mut Criterion) {
     c.bench_function("bench_datetime_parse_from_rfc2822", |b| {
         b.iter(|| {
             let str = black_box("Wed, 18 Feb 2015 23:16:09 +0000");
-            DateTime::<FixedOffset>::parse_from_rfc2822(str).unwrap()
+            DateTime::parse_from_rfc2822(str).unwrap()
         })
     });
 }
@@ -21,7 +21,7 @@ fn bench_datetime_parse_from_rfc3339(c: &mut Criterion) {
     c.bench_function("bench_datetime_parse_from_rfc3339", |b| {
         b.iter(|| {
             let str = black_box("2015-02-18T23:59:60.234567+05:00");
-            DateTime::<FixedOffset>::parse_from_rfc3339(str).unwrap()
+            DateTime::parse_from_rfc3339(str).unwrap()
         })
     });
 }

--- a/fuzz/fuzz_targets/fuzz_reader.rs
+++ b/fuzz/fuzz_targets/fuzz_reader.rs
@@ -4,7 +4,7 @@ use libfuzzer_sys::fuzz_target;
 fuzz_target!(|data: &[u8]| {
     use chrono::prelude::*;
     if let Ok(data) = std::str::from_utf8(data) {
-        let _ = DateTime::<FixedOffset>::parse_from_rfc2822(data);
-        let _ = DateTime::<FixedOffset>::parse_from_rfc3339(data);
+        let _ = DateTime::parse_from_rfc2822(data);
+        let _ = DateTime::parse_from_rfc3339(data);
     }
 });

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -677,7 +677,7 @@ impl DateTime<FixedOffset> {
     /// ```
     /// # use chrono::{DateTime, FixedOffset, TimeZone};
     /// assert_eq!(
-    ///     DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 GMT").unwrap(),
+    ///     DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 GMT").unwrap(),
     ///     FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap()
     /// );
     /// ```
@@ -727,7 +727,7 @@ impl DateTime<FixedOffset> {
     /// ```rust
     /// use chrono::{DateTime, FixedOffset, TimeZone, NaiveDate};
     ///
-    /// let dt = DateTime::<FixedOffset>::parse_from_str(
+    /// let dt = DateTime::parse_from_str(
     ///     "1983 Apr 13 12:09:14.274 +0000", "%Y %b %d %H:%M:%S%.3f %z");
     /// assert_eq!(dt, Ok(FixedOffset::east_opt(0).unwrap().from_local_datetime(&NaiveDate::from_ymd_opt(1983, 4, 13).unwrap().and_hms_milli_opt(12, 9, 14, 274).unwrap()).unwrap()));
     /// ```

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -773,60 +773,6 @@ impl DateTime<FixedOffset> {
 }
 
 impl DateTime<Utc> {
-    /// Parses an RFC 2822 date-and-time string into a `DateTime<Utc>` value.
-    ///
-    /// This parses valid RFC 2822 datetime values (such as `Tue, 1 Jul 2003 10:52:37 +0200`)
-    /// and returns a new `DateTime<Utc>` instance corresponding to the UTC date/time, accounting
-    /// for the difference between UTC and the parsed timezone, should they differ.
-    ///
-    /// RFC 2822 is the internet message standard that specifies the representation of times in HTTP
-    /// and email headers.
-    pub fn parse_from_rfc2822(s: &str) -> ParseResult<DateTime<Utc>> {
-        DateTime::<FixedOffset>::parse_from_rfc2822(s).map(|result| result.into())
-    }
-
-    /// Parses an RFC 3339 date-and-time string into a `DateTime<Utc>` value.
-    ///
-    /// Parses all valid RFC 3339 values (as well as the subset of valid ISO 8601 values that are
-    /// also valid RFC 3339 date-and-time values) and returns a new `DateTime<Utc>` instance
-    /// corresponding to the matching UTC date/time, accounting for the difference between UTC and
-    /// the parsed input's timezone, should they differ. While RFC 3339 values come in a wide
-    /// variety of shapes and sizes, `1996-12-19T16:39:57-08:00` is an example of the most commonly
-    /// encountered variety of RFC 3339 formats.
-    ///
-    /// Why isn't this named `parse_from_iso8601`? That's because ISO 8601 allows representing
-    /// values in a wide range of formats, only some of which represent actual date-and-time
-    /// instances (rather than periods, ranges, dates, or times). Some valid ISO 8601 values are
-    /// also simultaneously valid RFC 3339 values, but not all RFC 3339 values are valid ISO 8601
-    /// values (or the other way around).
-    pub fn parse_from_rfc3339(s: &str) -> ParseResult<DateTime<Utc>> {
-        DateTime::<FixedOffset>::parse_from_rfc3339(s).map(|result| result.into())
-    }
-
-    /// Parses a string from a user-specified format into a `DateTime<Utc>` value.
-    ///
-    /// Note that this method *requires a timezone* in the input string. See
-    /// [`NaiveDateTime::parse_from_str`](./naive/struct.NaiveDateTime.html#method.parse_from_str)
-    /// for a version that does not require a timezone in the to-be-parsed str. The returned
-    /// `DateTime<Utc>` value will reflect the difference in timezones between UTC and the parsed
-    /// time zone, should they differ.
-    ///
-    /// See the [`format::strftime` module](./format/strftime/index.html) for supported format
-    /// sequences.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use chrono::{DateTime, NaiveDate, Utc};
-    ///
-    /// let dt = DateTime::<Utc>::parse_from_str(
-    ///     "1983 Apr 13 12:09:14.274 +0100", "%Y %b %d %H:%M:%S%.3f %z");
-    /// assert_eq!(dt, Ok(NaiveDate::from_ymd_opt(1983, 4, 13).unwrap().and_hms_milli_opt(11, 9, 14, 274).unwrap().and_utc()));
-    /// ```
-    pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<DateTime<Utc>> {
-        DateTime::<FixedOffset>::parse_from_str(s, fmt).map(|result| result.into())
-    }
-
     /// The minimum possible `DateTime<Utc>`.
     pub const MIN_UTC: Self = DateTime { datetime: NaiveDateTime::MIN, offset: Utc };
     /// The maximum possible `DateTime<Utc>`.

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -472,7 +472,7 @@ fn test_datetime_rfc2822() {
         "Wed, 18 Feb 2015 23:16:09 +0500"
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:60 +0500"),
+        DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:60 +0500"),
         Ok(edt
             .from_local_datetime(
                 &NaiveDate::from_ymd_opt(2015, 2, 18)
@@ -482,9 +482,9 @@ fn test_datetime_rfc2822() {
             )
             .unwrap())
     );
-    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("31 DEC 262143 23:59 -2359").is_err());
+    assert!(DateTime::parse_from_rfc2822("31 DEC 262143 23:59 -2359").is_err());
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00"),
+        DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00"),
         Ok(edt
             .from_local_datetime(
                 &NaiveDate::from_ymd_opt(2015, 2, 18)
@@ -508,11 +508,11 @@ fn test_datetime_rfc2822() {
     );
 
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +0000"),
+        DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +0000"),
         Ok(FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 -0000"),
+        DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 -0000"),
         Ok(FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
     );
     assert_eq!(
@@ -520,24 +520,24 @@ fn test_datetime_rfc2822() {
         "Wed, 18 Feb 2015 23:59:60 +0500"
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:58 +0500"),
+        DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:58 +0500"),
         Ok(ymdhms(&edt, 2015, 2, 18, 23, 59, 58))
     );
     assert_ne!(
-        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:58 +0500"),
+        DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:58 +0500"),
         Ok(ymdhms_milli(&edt, 2015, 2, 18, 23, 59, 58, 500))
     );
 
     // many varying whitespace intermixed
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822(
+        DateTime::parse_from_rfc2822(
             "\t\t\tWed,\n\t\t18 \r\n\t\tFeb \u{3000} 2015\r\n\t\t\t23:59:58    \t+0500"
         ),
         Ok(ymdhms(&edt, 2015, 2, 18, 23, 59, 58))
     );
     // example from RFC 2822 Appendix A.5.
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822(
+        DateTime::parse_from_rfc2822(
             "Thu,\n\t13\n      Feb\n        1969\n    23:32\n             -0330 (Newfoundland Time)"
         ),
         Ok(
@@ -549,7 +549,7 @@ fn test_datetime_rfc2822() {
     );
     // example from RFC 2822 Appendix A.5. without trailing " (Newfoundland Time)"
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc2822(
+        DateTime::parse_from_rfc2822(
             "Thu,\n\t13\n      Feb\n        1969\n    23:32\n             -0330"
         ),
         Ok(
@@ -558,23 +558,17 @@ fn test_datetime_rfc2822() {
     );
 
     // bad year
-    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("31 DEC 262143 23:59 -2359").is_err());
+    assert!(DateTime::parse_from_rfc2822("31 DEC 262143 23:59 -2359").is_err());
     // wrong format
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +00:00").is_err()
-    );
+    assert!(DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +00:00").is_err());
     // full name day of week
-    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("Wednesday, 18 Feb 2015 23:16:09 +0000")
-        .is_err());
+    assert!(DateTime::parse_from_rfc2822("Wednesday, 18 Feb 2015 23:16:09 +0000").is_err());
     // full name day of week
-    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("Wednesday 18 Feb 2015 23:16:09 +0000")
-        .is_err());
+    assert!(DateTime::parse_from_rfc2822("Wednesday 18 Feb 2015 23:16:09 +0000").is_err());
     // wrong day of week separator '.'
-    assert!(DateTime::<FixedOffset>::parse_from_rfc2822("Wed. 18 Feb 2015 23:16:09 +0000").is_err());
+    assert!(DateTime::parse_from_rfc2822("Wed. 18 Feb 2015 23:16:09 +0000").is_err());
     // *trailing* space causes failure
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +0000   ").is_err()
-    );
+    assert!(DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +0000   ").is_err());
 }
 
 #[test]
@@ -611,19 +605,19 @@ fn test_datetime_rfc3339() {
         "2015-02-18T23:59:60.234567+05:00"
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:59.123+05:00"),
+        DateTime::parse_from_rfc3339("2015-02-18T23:59:59.123+05:00"),
         Ok(ymdhms_micro(&edt5, 2015, 2, 18, 23, 59, 59, 123_000))
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:59.123456+05:00"),
+        DateTime::parse_from_rfc3339("2015-02-18T23:59:59.123456+05:00"),
         Ok(ymdhms_micro(&edt5, 2015, 2, 18, 23, 59, 59, 123_456))
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:59.123456789+05:00"),
+        DateTime::parse_from_rfc3339("2015-02-18T23:59:59.123456789+05:00"),
         Ok(ymdhms_nano(&edt5, 2015, 2, 18, 23, 59, 59, 123_456_789))
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:16:09Z"),
+        DateTime::parse_from_rfc3339("2015-02-18T23:16:09Z"),
         Ok(ymdhms(&edt0, 2015, 2, 18, 23, 16, 9))
     );
 
@@ -636,49 +630,31 @@ fn test_datetime_rfc3339() {
         "2015-02-18T23:16:09.150+05:00"
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T00:00:00.234567+05:00"),
+        DateTime::parse_from_rfc3339("2015-02-18T00:00:00.234567+05:00"),
         Ok(ymdhms_micro(&edt5, 2015, 2, 18, 0, 0, 0, 234_567))
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:16:09Z"),
+        DateTime::parse_from_rfc3339("2015-02-18T23:16:09Z"),
         Ok(ymdhms(&edt0, 2015, 2, 18, 23, 16, 9))
     );
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18 23:59:60.234567+05:00"),
+        DateTime::parse_from_rfc3339("2015-02-18 23:59:60.234567+05:00"),
         Ok(ymdhms_micro(&edt5, 2015, 2, 18, 23, 59, 59, 1_234_567))
     );
     assert_eq!(ymdhms_utc(2015, 2, 18, 23, 16, 9).to_rfc3339(), "2015-02-18T23:16:09+00:00");
 
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567 +05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:059:60.234567+05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00PST").is_err()
-    );
-    assert!(DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+PST").is_err());
-    assert!(DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567PST").is_err());
-    assert!(DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+0500").is_err());
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567:+05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00 ").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339(" 2015-02-18T23:59:60.234567+05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015- 02-18T23:59:60.234567+05:00").is_err()
-    );
-    assert!(
-        DateTime::<FixedOffset>::parse_from_rfc3339("2015-02-18T23:59:60.234567A+05:00").is_err()
-    );
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567 +05:00").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:059:60.234567+05:00").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00PST").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+PST").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567PST").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+0500").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00:00").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567:+05:00").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00 ").is_err());
+    assert!(DateTime::parse_from_rfc3339(" 2015-02-18T23:59:60.234567+05:00").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015- 02-18T23:59:60.234567+05:00").is_err());
+    assert!(DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567A+05:00").is_err());
 }
 
 #[test]
@@ -922,18 +898,15 @@ fn test_parse_from_str() {
     let edt0 = FixedOffset::east_opt(0).unwrap();
     let wdt = FixedOffset::west_opt(10 * 3600).unwrap();
     assert_eq!(
-        DateTime::<FixedOffset>::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
+        DateTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
         Ok(ymdhms(&edt, 2014, 5, 7, 12, 34, 56))
     ); // ignore offset
-    assert!(DateTime::<FixedOffset>::parse_from_str("20140507000000", "%Y%m%d%H%M%S").is_err()); // no offset
-    assert!(DateTime::<FixedOffset>::parse_from_str(
-        "Fri, 09 Aug 2013 23:54:35 GMT",
-        "%a, %d %b %Y %H:%M:%S GMT"
-    )
-    .is_err());
+    assert!(DateTime::parse_from_str("20140507000000", "%Y%m%d%H%M%S").is_err()); // no offset
+    assert!(DateTime::parse_from_str("Fri, 09 Aug 2013 23:54:35 GMT", "%a, %d %b %Y %H:%M:%S GMT")
+        .is_err());
     assert_eq!(
-        DateTime::<Utc>::parse_from_str("0", "%s").unwrap(),
-        NaiveDateTime::from_timestamp_opt(0, 0).unwrap().and_utc().fixed_offset()
+        DateTime::parse_from_str("0", "%s").unwrap(),
+        NaiveDateTime::from_timestamp_opt(0, 0).unwrap().and_utc()
     );
 
     assert_eq!(
@@ -979,7 +952,7 @@ fn test_parse_from_str() {
 #[test]
 fn test_datetime_parse_from_str() {
     let dt = ymdhms(&FixedOffset::east_opt(-9 * 60 * 60).unwrap(), 2013, 8, 9, 23, 54, 35);
-    let parse = DateTime::<FixedOffset>::parse_from_str;
+    let parse = DateTime::parse_from_str;
 
     // timezone variations
 

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -1865,7 +1865,7 @@ mod tests {
 
         // Test against test data above
         for &(date, checkdate) in testdates.iter() {
-            let dt = DateTime::<FixedOffset>::parse_from_rfc3339(date);
+            let dt = DateTime::parse_from_rfc3339(date);
             if dt != checkdate {
                 // check for expected result
                 panic!(

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -743,18 +743,15 @@ mod tests {
         );
         assert_eq!(
             dt.with_timezone(&Utc),
-            DateTime::<FixedOffset>::parse_from_str("2001-07-07T15:04:60.026490708Z", "%+")
-                .unwrap()
+            DateTime::parse_from_str("2001-07-07T15:04:60.026490708Z", "%+").unwrap()
         );
         assert_eq!(
             dt.with_timezone(&Utc),
-            DateTime::<FixedOffset>::parse_from_str("2001-07-07T15:04:60.026490708UTC", "%+")
-                .unwrap()
+            DateTime::parse_from_str("2001-07-07T15:04:60.026490708UTC", "%+").unwrap()
         );
         assert_eq!(
             dt.with_timezone(&Utc),
-            DateTime::<FixedOffset>::parse_from_str("2001-07-07t15:04:60.026490708utc", "%+")
-                .unwrap()
+            DateTime::parse_from_str("2001-07-07t15:04:60.026490708utc", "%+").unwrap()
         );
 
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,18 +282,18 @@
 //! assert_eq!("2014-11-28T21:00:09+09:00".parse::<DateTime<FixedOffset>>(), Ok(fixed_dt.clone()));
 //!
 //! // method 2
-//! assert_eq!(DateTime::<FixedOffset>::parse_from_str("2014-11-28 21:00:09 +09:00", "%Y-%m-%d %H:%M:%S %z"),
+//! assert_eq!(DateTime::parse_from_str("2014-11-28 21:00:09 +09:00", "%Y-%m-%d %H:%M:%S %z"),
 //!            Ok(fixed_dt.clone()));
-//! assert_eq!(DateTime::<FixedOffset>::parse_from_rfc2822("Fri, 28 Nov 2014 21:00:09 +0900"),
+//! assert_eq!(DateTime::parse_from_rfc2822("Fri, 28 Nov 2014 21:00:09 +0900"),
 //!            Ok(fixed_dt.clone()));
-//! assert_eq!(DateTime::<FixedOffset>::parse_from_rfc3339("2014-11-28T21:00:09+09:00"), Ok(fixed_dt.clone()));
+//! assert_eq!(DateTime::parse_from_rfc3339("2014-11-28T21:00:09+09:00"), Ok(fixed_dt.clone()));
 //!
 //! // oops, the year is missing!
-//! assert!(DateTime::<FixedOffset>::parse_from_str("Fri Nov 28 12:00:09", "%a %b %e %T %Y").is_err());
+//! assert!(DateTime::parse_from_str("Fri Nov 28 12:00:09", "%a %b %e %T %Y").is_err());
 //! // oops, the format string does not include the year at all!
-//! assert!(DateTime::<FixedOffset>::parse_from_str("Fri Nov 28 12:00:09", "%a %b %e %T").is_err());
+//! assert!(DateTime::parse_from_str("Fri Nov 28 12:00:09", "%a %b %e %T").is_err());
 //! // oops, the weekday is incorrect!
-//! assert!(DateTime::<FixedOffset>::parse_from_str("Sat Nov 28 12:00:09 2014", "%a %b %e %T %Y").is_err());
+//! assert!(DateTime::parse_from_str("Sat Nov 28 12:00:09 2014", "%a %b %e %T %Y").is_err());
 //! ```
 //!
 //! Again : See [`format::strftime`](./format/strftime/index.html#specifiers)
@@ -313,14 +313,14 @@
 #![cfg_attr(not(feature = "std"), doc = "```ignore")]
 #![cfg_attr(feature = "std", doc = "```rust")]
 //! // We need the trait in scope to use Utc::timestamp().
-//! use chrono::{DateTime, FixedOffset, TimeZone, Utc};
+//! use chrono::{DateTime, TimeZone, Utc};
 //!
 //! // Construct a datetime from epoch:
 //! let dt = Utc.timestamp_opt(1_500_000_000, 0).unwrap();
 //! assert_eq!(dt.to_rfc2822(), "Fri, 14 Jul 2017 02:40:00 +0000");
 //!
 //! // Get epoch value from a datetime:
-//! let dt = DateTime::<FixedOffset>::parse_from_rfc2822("Fri, 14 Jul 2017 02:40:00 +0000").unwrap();
+//! let dt = DateTime::parse_from_rfc2822("Fri, 14 Jul 2017 02:40:00 +0000").unwrap();
 //! assert_eq!(dt.timestamp(), 1_500_000_000);
 //! ```
 //!

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -182,7 +182,7 @@ mod tests;
 ///
 /// let dt = Utc.with_ymd_and_hms(2015, 6, 30, 23, 56, 5).unwrap();
 /// assert_eq!(format!("{:?}", dt), "2015-06-30T23:56:05Z");
-/// assert_eq!(DateTime::<Utc>::parse_from_rfc3339("2015-06-30T23:56:05Z").unwrap(), dt);
+/// assert_eq!(DateTime::parse_from_rfc3339("2015-06-30T23:56:05Z").unwrap(), dt);
 /// ```
 ///
 /// Since Chrono alone cannot determine any existence of leap seconds,


### PR DESCRIPTION
https://github.com/chronotope/chrono/pull/806 conveniently adds parsing methods to `DateTime<Utc>`. I don't believe it was fully realized at the time how much of a change this is going to be for users.

All `parse_from_*` methods are going to need type annotations on 0.5. These are widely used methods. I think this makes the common use more annoying.

Parsing to `DateTime<FixedOffset>` is what I consider the regular case. It is the type that best matches the format strings of RFC 3339, RFC 2822, ISO 8601, and any manual string that can be parsed as a `DateTime`.
```rust
// 0.4.x
let dt = DateTime::parse_from_rfc3339("2015-06-30T23:56:05+02:00")?;
let dt: DateTime<Utc> = DateTime::parse_from_rfc3339("2015-06-30T23:56:05+02:00")?.into();

// with #806:
let dt = DateTime::<FixedOffset>::parse_from_rfc3339("2015-06-30T23:56:05+02:00")?;
let dt = DateTime::<Utc>::parse_from_rfc3339("2015-06-30T23:56:05+02:00")?;
```

Parsing to `DateTime<Utc>` folds the offset in the datetime value, essentially losing the offset information.
In https://github.com/chronotope/chrono/issues/1075 the discussion was to go in the opposite direction for 0.5: if we parse a value with fields that the target type can't hold, we should return an error.

So I would like to revert for two reasons: all the extra type annotations, and to make it an explicit choice for users to drop the offset information.

cc @mqudsi.