### PR TITLE
Inline `write_rfc2822_inner`, don't localize

### DIFF
--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -395,7 +395,7 @@ fn format_inner(
                 // same as `%a, %d %b %Y %H:%M:%S %z`
                 {
                     if let (Some(d), Some(t), Some(&(_, off))) = (date, time, off) {
-                        Some(write_rfc2822_inner(w, *d, *t, off, locale))
+                        Some(write_rfc2822(w, crate::NaiveDateTime::new(*d, *t), off))
                     } else {
                         None
                     }
@@ -576,45 +576,35 @@ pub(crate) fn write_rfc2822(
     dt: NaiveDateTime,
     off: FixedOffset,
 ) -> fmt::Result {
-    write_rfc2822_inner(w, dt.date(), dt.time(), off, default_locale())
-}
-
-#[cfg(feature = "alloc")]
-/// write datetimes like `Tue, 1 Jul 2003 10:52:37 +0200`, same as `%a, %d %b %Y %H:%M:%S %z`
-fn write_rfc2822_inner(
-    w: &mut impl Write,
-    d: NaiveDate,
-    t: NaiveTime,
-    off: FixedOffset,
-    locale: Locale,
-) -> fmt::Result {
-    let year = d.year();
+    let year = dt.year();
     // RFC2822 is only defined on years 0 through 9999
     if !(0..=9999).contains(&year) {
         return Err(fmt::Error);
     }
 
-    w.write_str(short_weekdays(locale)[d.weekday().num_days_from_sunday() as usize])?;
+    let english = default_locale();
+
+    w.write_str(short_weekdays(english)[dt.weekday().num_days_from_sunday() as usize])?;
     w.write_str(", ")?;
-    let day = d.day();
+    let day = dt.day();
     if day < 10 {
         w.write_char((b'0' + day as u8) as char)?;
     } else {
         write_hundreds(w, day as u8)?;
     }
     w.write_char(' ')?;
-    w.write_str(short_months(locale)[d.month0() as usize])?;
+    w.write_str(short_months(english)[dt.month0() as usize])?;
     w.write_char(' ')?;
     write_hundreds(w, (year / 100) as u8)?;
     write_hundreds(w, (year % 100) as u8)?;
     w.write_char(' ')?;
 
-    let (hour, min, sec) = t.hms();
+    let (hour, min, sec) = dt.time().hms();
     write_hundreds(w, hour as u8)?;
     w.write_char(':')?;
     write_hundreds(w, min as u8)?;
     w.write_char(':')?;
-    let sec = sec + t.nanosecond() / 1_000_000_000;
+    let sec = sec + dt.nanosecond() / 1_000_000_000;
     write_hundreds(w, sec as u8)?;
     w.write_char(' ')?;
     OffsetFormat {


### PR DESCRIPTION
As discussed in https://github.com/chronotope/chrono/pull/1144#discussion_r1313731594 we should not localize the day and month names in `write_rfc2822` with the `unstable-locales` feature, because the RFC requires English names.