### PR TITLE
Add `DateTime::to_utc`

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -379,6 +379,14 @@ impl<Tz: TimeZone> DateTime<Tz> {
         self.with_timezone(&self.offset().fix())
     }
 
+    /// Turn this `DateTime` into a `DateTime<Utc>`, dropping the offset and associated timezone
+    /// information.
+    #[inline]
+    #[must_use]
+    pub fn to_utc(&self) -> DateTime<Utc> {
+        DateTime { datetime: self.datetime, offset: Utc }
+    }
+
     /// Adds given `Duration` to the current date and time.
     ///
     /// # Errors

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1429,6 +1429,14 @@ fn test_datetime_fixed_offset() {
 }
 
 #[test]
+fn test_datetime_to_utc() {
+    let dt =
+        FixedOffset::east_opt(3600).unwrap().with_ymd_and_hms(2020, 2, 22, 23, 24, 25).unwrap();
+    let dt_utc: DateTime<Utc> = dt.to_utc();
+    assert_eq!(dt, dt_utc);
+}
+
+#[test]
 fn test_add_sub_months() {
     let utc_dt = Utc.with_ymd_and_hms(2018, 9, 5, 23, 58, 0).unwrap();
     assert_eq!(utc_dt + Months::new(15), Utc.with_ymd_and_hms(2019, 12, 5, 23, 58, 0).unwrap());


### PR DESCRIPTION
To have an easy way to convert any `DateTime<Tz>` to `DateTime<Utc>`.

As discussed in https://github.com/chronotope/chrono/pull/1318.