### PR TITLE
Fix quotes in docs.rs feature list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ bincode = { version = "1.3.0" }
 wasm-bindgen-test = "0.3"
 
 [package.metadata.docs.rs]
-features = ["arbitrary, rkyv, serde, unstable-locales"]
+features = ["arbitrary", "rkyv", "serde", "unstable-locales"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]


### PR DESCRIPTION
I messed this up in both https://github.com/chronotope/chrono/pull/1304 and https://github.com/chronotope/chrono/pull/1305 😞.