### PR TITLE
Use `overflowing_naive_local` in `DateTime::checked_add*`

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -436,13 +436,17 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// # Errors
     ///
     /// Returns `None` if:
-    /// - The resulting date would be out of range.
     /// - The local time at the resulting date does not exist or is ambiguous, for example during a
     ///   daylight saving time transition.
+    /// - The resulting UTC datetime would be out of range.
+    /// - The resulting local datetime would be out of range (unless `months` is zero).
     #[must_use]
-    pub fn checked_add_months(self, rhs: Months) -> Option<DateTime<Tz>> {
-        self.naive_local()
-            .checked_add_months(rhs)?
+    pub fn checked_add_months(self, months: Months) -> Option<DateTime<Tz>> {
+        // `NaiveDate::checked_add_months` has a fast path for `Months(0)` that does not validate
+        // the resulting date, with which we can return `Some` even for an out of range local
+        // datetime.
+        self.overflowing_naive_local()
+            .checked_add_months(months)?
             .and_local_timezone(Tz::from_offset(&self.offset))
             .single()
     }
@@ -469,13 +473,17 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// # Errors
     ///
     /// Returns `None` if:
-    /// - The resulting date would be out of range.
     /// - The local time at the resulting date does not exist or is ambiguous, for example during a
     ///   daylight saving time transition.
+    /// - The resulting UTC datetime would be out of range.
+    /// - The resulting local datetime would be out of range (unless `months` is zero).
     #[must_use]
-    pub fn checked_sub_months(self, rhs: Months) -> Option<DateTime<Tz>> {
-        self.naive_local()
-            .checked_sub_months(rhs)?
+    pub fn checked_sub_months(self, months: Months) -> Option<DateTime<Tz>> {
+        // `NaiveDate::checked_sub_months` has a fast path for `Months(0)` that does not validate
+        // the resulting date, with which we can return `Some` even for an out of range local
+        // datetime.
+        self.overflowing_naive_local()
+            .checked_sub_months(months)?
             .and_local_timezone(Tz::from_offset(&self.offset))
             .single()
     }

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1099,12 +1099,15 @@ impl<Tz: TimeZone> Datelike for DateTime<Tz> {
     /// # Errors
     ///
     /// Returns `None` if:
-    /// - The resulting date does not exist.
-    /// - When the `NaiveDateTime` would be out of range.
     /// - The local time at the resulting date does not exist or is ambiguous, for example during a
     ///   daylight saving time transition.
+    /// - The resulting UTC datetime would be out of range.
+    /// - The resulting local datetime would be out of range (unless the year remains the same).
     fn with_year(&self, year: i32) -> Option<DateTime<Tz>> {
-        map_local(self, |datetime| datetime.with_year(year))
+        map_local(self, |dt| match dt.year() == year {
+            true => Some(dt),
+            false => dt.with_year(year),
+        })
     }
 
     /// Makes a new `DateTime` with the month number (starting from 1) changed.

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1462,6 +1462,31 @@ fn test_min_max_setters() {
 }
 
 #[test]
+fn test_min_max_add_days() {
+    let offset_min = FixedOffset::west_opt(2 * 60 * 60).unwrap();
+    let beyond_min = offset_min.from_utc_datetime(&NaiveDateTime::MIN);
+    let offset_max = FixedOffset::east_opt(2 * 60 * 60).unwrap();
+    let beyond_max = offset_max.from_utc_datetime(&NaiveDateTime::MAX);
+    let max_time = NaiveTime::from_hms_nano_opt(23, 59, 59, 999_999_999).unwrap();
+
+    assert_eq!(beyond_min.checked_add_days(Days::new(0)), Some(beyond_min));
+    assert_eq!(
+        beyond_min.checked_add_days(Days::new(1)),
+        Some(offset_min.from_utc_datetime(&(NaiveDate::MIN + Days(1)).and_time(NaiveTime::MIN)))
+    );
+    assert_eq!(beyond_min.checked_sub_days(Days::new(0)), Some(beyond_min));
+    assert_eq!(beyond_min.checked_sub_days(Days::new(1)), None);
+
+    assert_eq!(beyond_max.checked_add_days(Days::new(0)), Some(beyond_max));
+    assert_eq!(beyond_max.checked_add_days(Days::new(1)), None);
+    assert_eq!(beyond_max.checked_sub_days(Days::new(0)), Some(beyond_max));
+    assert_eq!(
+        beyond_max.checked_sub_days(Days::new(1)),
+        Some(offset_max.from_utc_datetime(&(NaiveDate::MAX - Days(1)).and_time(max_time)))
+    );
+}
+
+#[test]
 fn test_min_max_add_months() {
     let offset_min = FixedOffset::west_opt(2 * 60 * 60).unwrap();
     let beyond_min = offset_min.from_utc_datetime(&NaiveDateTime::MIN);

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1462,6 +1462,31 @@ fn test_min_max_setters() {
 }
 
 #[test]
+fn test_min_max_add_months() {
+    let offset_min = FixedOffset::west_opt(2 * 60 * 60).unwrap();
+    let beyond_min = offset_min.from_utc_datetime(&NaiveDateTime::MIN);
+    let offset_max = FixedOffset::east_opt(2 * 60 * 60).unwrap();
+    let beyond_max = offset_max.from_utc_datetime(&NaiveDateTime::MAX);
+    let max_time = NaiveTime::from_hms_nano_opt(23, 59, 59, 999_999_999).unwrap();
+
+    assert_eq!(beyond_min.checked_add_months(Months::new(0)), Some(beyond_min));
+    assert_eq!(
+        beyond_min.checked_add_months(Months::new(1)),
+        Some(offset_min.from_utc_datetime(&(NaiveDate::MIN + Months(1)).and_time(NaiveTime::MIN)))
+    );
+    assert_eq!(beyond_min.checked_sub_months(Months::new(0)), Some(beyond_min));
+    assert_eq!(beyond_min.checked_sub_months(Months::new(1)), None);
+
+    assert_eq!(beyond_max.checked_add_months(Months::new(0)), Some(beyond_max));
+    assert_eq!(beyond_max.checked_add_months(Months::new(1)), None);
+    assert_eq!(beyond_max.checked_sub_months(Months::new(0)), Some(beyond_max));
+    assert_eq!(
+        beyond_max.checked_sub_months(Months::new(1)),
+        Some(offset_max.from_utc_datetime(&(NaiveDate::MAX - Months(1)).and_time(max_time)))
+    );
+}
+
+#[test]
 #[should_panic]
 fn test_local_beyond_min_datetime() {
     let min = FixedOffset::west_opt(2 * 60 * 60).unwrap().from_utc_datetime(&NaiveDateTime::MIN);

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1421,6 +1421,7 @@ fn test_min_max_setters() {
     let beyond_max = offset_max.from_utc_datetime(&NaiveDateTime::MAX);
 
     assert_eq!(beyond_min.with_year(2020).unwrap().year(), 2020);
+    assert_eq!(beyond_min.with_year(beyond_min.year()), Some(beyond_min));
     assert_eq!(beyond_min.with_month(beyond_min.month()), Some(beyond_min));
     assert_eq!(beyond_min.with_month(3), None);
     assert_eq!(beyond_min.with_month0(beyond_min.month0()), Some(beyond_min));
@@ -1441,6 +1442,7 @@ fn test_min_max_setters() {
     assert_eq!(beyond_min.with_nanosecond(0), Some(beyond_min));
 
     assert_eq!(beyond_max.with_year(2020).unwrap().year(), 2020);
+    assert_eq!(beyond_max.with_year(beyond_max.year()), Some(beyond_max));
     assert_eq!(beyond_max.with_month(beyond_max.month()), Some(beyond_max));
     assert_eq!(beyond_max.with_month(3), None);
     assert_eq!(beyond_max.with_month0(beyond_max.month0()), Some(beyond_max));

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -699,10 +699,14 @@ impl NaiveDate {
 
     /// Add a duration of `i32` days to the date.
     pub(crate) const fn add_days(self, days: i32) -> Option<Self> {
-        // fast path if the result is within the same year
+        // Fast path if the result is within the same year.
+        // Also `DateTime::checked_(add|sub)_days` relies on this path, because if the value remains
+        // within the year it doesn't do a check if the year is in range.
+        // This way `DateTime:checked_(add|sub)_days(Days::new(0))` can be a no-op on dates were the
+        // local datetime is beyond `NaiveDate::{MIN, MAX}.
         const ORDINAL_MASK: i32 = 0b1_1111_1111_0000;
         if let Some(ordinal) = ((self.yof() & ORDINAL_MASK) >> 4).checked_add(days) {
-            if ordinal > 0 && ordinal <= 365 {
+            if ordinal > 0 && ordinal <= (365 + self.leap_year() as i32) {
                 let year_and_flags = self.yof() & !ORDINAL_MASK;
                 return Some(NaiveDate::from_yof(year_and_flags | (ordinal << 4)));
             }


### PR DESCRIPTION
The final part of https://github.com/chronotope/chrono/pull/1048.

Using `overflowing_naive_local` in `DateTime::checked_(add|sub)_days` and `DateTime::checked_(add|sub)_months` prevents panics.

I thought it would be good if users can rely on another property: that a clear no-op works as a no-op. I.e.`DateTime::checked_add_days(Days::new(0))` should always return the original value.
To do that, `checked_(add|sub)_days` and `checked_(add|sub)_months` have a fast path that returns `Some(self)` if it is a no-op.
They already had a fast path anyway, we just start relying on it.

`with_year` gains a fast path to have the same property.

What we can't promise is that you can add or subtract and create a value that is just out of range for the local time but still in range for the UTC value. That would require alternative methods on `NaiveDate` for `add_days`, `checked_*_months` and `with_year` that have a different bound checks. It just doesn't seem worth it to me.