### PR TITLE
Don't use deprecated method in `impl Arbitrary for DateTime`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
       - run: |
-          cargo hack check --feature-powerset --optional-deps serde \
+          cargo hack check --feature-powerset --optional-deps arbitrary,serde \
             --skip __internal_bench,iana-time-zone,pure-rust-locales,libc,winapi,rkyv-16,rkyv-64,rkyv-validation \
             --all-targets
         # run using `bash` on all platforms for consistent

--- a/src/date.rs
+++ b/src/date.rs
@@ -555,7 +555,7 @@ where
 
 // Note that implementation of Arbitrary cannot be automatically derived for Date<Tz>, due to
 // the nontrivial bound <Tz as TimeZone>::Offset: Arbitrary.
-#[cfg(feature = "arbitrary")]
+#[cfg(all(feature = "arbitrary", feature = "std"))]
 impl<'a, Tz> arbitrary::Arbitrary<'a> for Date<Tz>
 where
     Tz: TimeZone,

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1696,7 +1696,7 @@ impl From<DateTime<Utc>> for js_sys::Date {
 
 // Note that implementation of Arbitrary cannot be simply derived for DateTime<Tz>, due to
 // the nontrivial bound <Tz as TimeZone>::Offset: Arbitrary.
-#[cfg(feature = "arbitrary")]
+#[cfg(all(feature = "arbitrary", feature = "std"))]
 impl<'a, Tz> arbitrary::Arbitrary<'a> for DateTime<Tz>
 where
     Tz: TimeZone,

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1705,7 +1705,7 @@ where
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<DateTime<Tz>> {
         let datetime = NaiveDateTime::arbitrary(u)?;
         let offset = <Tz as TimeZone>::Offset::arbitrary(u)?;
-        Ok(DateTime::from_utc(datetime, offset))
+        Ok(DateTime::from_naive_utc_and_offset(datetime, offset))
     }
 }
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -506,7 +506,7 @@ const fn div_mod_floor_64(this: i64, other: i64) -> (i64, i64) {
     (this.div_euclid(other), this.rem_euclid(other))
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(all(feature = "arbitrary", feature = "std"))]
 impl arbitrary::Arbitrary<'_> for Duration {
     fn arbitrary(u: &mut arbitrary::Unstructured) -> arbitrary::Result<Duration> {
         const MIN_SECS: i64 = -i64::MAX / MILLIS_PER_SEC - 1;

--- a/src/month.rs
+++ b/src/month.rs
@@ -37,7 +37,7 @@ use crate::OutOfRange;
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(arbitrary::Arbitrary))]
 pub enum Month {
     /// January
     January = 0,
@@ -225,7 +225,7 @@ impl num_traits::FromPrimitive for Month {
 
 /// A duration in calendar months
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(arbitrary::Arbitrary))]
 pub struct Months(pub(crate) u32);
 
 impl Months {

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -207,7 +207,7 @@ pub const MIN_DATE: NaiveDate = NaiveDate::MIN;
 #[deprecated(since = "0.4.20", note = "Use NaiveDate::MAX instead")]
 pub const MAX_DATE: NaiveDate = NaiveDate::MAX;
 
-#[cfg(feature = "arbitrary")]
+#[cfg(all(feature = "arbitrary", feature = "std"))]
 impl arbitrary::Arbitrary<'_> for NaiveDate {
     fn arbitrary(u: &mut arbitrary::Unstructured) -> arbitrary::Result<NaiveDate> {
         let year = u.int_in_range(MIN_YEAR..=MAX_YEAR)?;

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -81,7 +81,7 @@ pub const MAX_DATETIME: NaiveDateTime = NaiveDateTime::MAX;
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(arbitrary::Arbitrary))]
 pub struct NaiveDateTime {
     date: NaiveDate,
     time: NaiveTime,

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -176,7 +176,7 @@ impl fmt::Display for FixedOffset {
     }
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(all(feature = "arbitrary", feature = "std"))]
 impl arbitrary::Arbitrary<'_> for FixedOffset {
     fn arbitrary(u: &mut arbitrary::Unstructured) -> arbitrary::Result<FixedOffset> {
         let secs = u.int_in_range(-86_399..=86_399)?;

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -48,7 +48,7 @@ use crate::{Date, DateTime};
     archive_attr(derive(Clone, Copy, PartialEq, Eq, Debug, Hash))
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(arbitrary::Arbitrary))]
 pub struct Utc;
 
 #[cfg(feature = "now")]

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -38,7 +38,7 @@ use crate::OutOfRange;
     archive_attr(derive(Clone, Copy, PartialEq, Eq, Debug, Hash))
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(arbitrary::Arbitrary))]
 pub enum Weekday {
     /// Monday.
     Mon = 0,


### PR DESCRIPTION
Missed in https://github.com/chronotope/chrono/pull/1175. I also modified the CI to check the `arbitrary` feature.