### PR TITLE
Make remaining methods const

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -27,6 +27,7 @@ use crate::naive::{Days, IsoWeek, NaiveDate, NaiveDateTime, NaiveTime};
 #[cfg(feature = "clock")]
 use crate::offset::Local;
 use crate::offset::{FixedOffset, Offset, TimeZone, Utc};
+use crate::try_opt;
 #[allow(deprecated)]
 use crate::Date;
 use crate::{Datelike, Months, Timelike, Weekday};
@@ -626,8 +627,11 @@ impl DateTime<Utc> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn from_timestamp(secs: i64, nsecs: u32) -> Option<Self> {
-        NaiveDateTime::from_timestamp_opt(secs, nsecs).as_ref().map(NaiveDateTime::and_utc)
+    pub const fn from_timestamp(secs: i64, nsecs: u32) -> Option<Self> {
+        Some(DateTime {
+            datetime: try_opt!(NaiveDateTime::from_timestamp_opt(secs, nsecs)),
+            offset: Utc,
+        })
     }
 
     /// Makes a new [`DateTime<Utc>`] from the number of non-leap milliseconds

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -1144,6 +1144,40 @@ mod tests {
     }
 
     #[test]
+    fn test_duration_const() {
+        const ONE_WEEK: Duration = Duration::weeks(1);
+        const ONE_DAY: Duration = Duration::days(1);
+        const ONE_HOUR: Duration = Duration::hours(1);
+        const ONE_MINUTE: Duration = Duration::minutes(1);
+        const ONE_SECOND: Duration = Duration::seconds(1);
+        const ONE_MILLI: Duration = Duration::milliseconds(1);
+        const ONE_MICRO: Duration = Duration::microseconds(1);
+        const ONE_NANO: Duration = Duration::nanoseconds(1);
+        let combo: Duration = ONE_WEEK
+            + ONE_DAY
+            + ONE_HOUR
+            + ONE_MINUTE
+            + ONE_SECOND
+            + ONE_MILLI
+            + ONE_MICRO
+            + ONE_NANO;
+
+        assert!(ONE_WEEK != Duration::zero());
+        assert!(ONE_DAY != Duration::zero());
+        assert!(ONE_HOUR != Duration::zero());
+        assert!(ONE_MINUTE != Duration::zero());
+        assert!(ONE_SECOND != Duration::zero());
+        assert!(ONE_MILLI != Duration::zero());
+        assert!(ONE_MICRO != Duration::zero());
+        assert!(ONE_NANO != Duration::zero());
+        assert_eq!(
+            combo,
+            Duration::seconds(86400 * 7 + 86400 + 3600 + 60 + 1)
+                + Duration::nanoseconds(1 + 1_000 + 1_000_000)
+        );
+    }
+
+    #[test]
     #[cfg(feature = "rkyv-validation")]
     fn test_rkyv_validation() {
         let duration = Duration::seconds(1);

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -75,6 +75,23 @@ pub(crate) const MAX: Duration = Duration {
 };
 
 impl Duration {
+    /// Makes a new `Duration` with given number of seconds and nanoseconds.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` when the duration is out of bounds, or if `nanos` ≥ 1,000,000,000.
+    pub(crate) const fn new(secs: i64, nanos: u32) -> Option<Duration> {
+        if secs < MIN.secs
+            || secs > MAX.secs
+            || nanos > 1_000_000_000
+            || (secs == MAX.secs && nanos > MAX.nanos as u32)
+            || (secs == MIN.secs && nanos < MIN.nanos as u32)
+        {
+            return None;
+        }
+        Some(Duration { secs, nanos: nanos as i32 })
+    }
+
     /// Makes a new `Duration` with the given number of weeks.
     ///
     /// Equivalent to `Duration::seconds(weeks * 7 * 24 * 60 * 60)` with

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -435,6 +435,15 @@ impl Duration {
         }
         Ok(StdDuration::new(self.secs as u64, self.nanos as u32))
     }
+
+    /// This duplicates `Neg::neg` because trait methods can't be const yet.
+    pub(crate) const fn neg(self) -> Duration {
+        let (secs_diff, nanos) = match self.nanos {
+            0 => (0, 0),
+            nanos => (1, NANOS_PER_SEC - nanos),
+        };
+        Duration { secs: -self.secs - secs_diff, nanos }
+    }
 }
 
 impl Neg for Duration {
@@ -442,11 +451,11 @@ impl Neg for Duration {
 
     #[inline]
     fn neg(self) -> Duration {
-        if self.nanos == 0 {
-            Duration { secs: -self.secs, nanos: 0 }
-        } else {
-            Duration { secs: -self.secs - 1, nanos: NANOS_PER_SEC - self.nanos }
-        }
+        let (secs_diff, nanos) = match self.nanos {
+            0 => (0, 0),
+            nanos => (1, NANOS_PER_SEC - nanos),
+        };
+        Duration { secs: -self.secs - secs_diff, nanos }
     }
 }
 

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -16,6 +16,8 @@ use core::{fmt, i64};
 #[cfg(feature = "std")]
 use std::error::Error;
 
+use crate::try_opt;
+
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
@@ -37,15 +39,6 @@ const SECS_PER_HOUR: i64 = 3600;
 const SECS_PER_DAY: i64 = 86_400;
 /// The number of (non-leap) seconds in a week.
 const SECS_PER_WEEK: i64 = 604_800;
-
-macro_rules! try_opt {
-    ($e:expr) => {
-        match $e {
-            Some(v) => v,
-            None => return None,
-        }
-    };
-}
 
 /// ISO 8601 time duration with nanosecond precision.
 ///

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1155,9 +1155,12 @@ impl NaiveDate {
     /// assert_eq!(NaiveDate::MAX.checked_add_signed(Duration::days(1)), None);
     /// ```
     #[must_use]
-    pub fn checked_add_signed(self, rhs: OldDuration) -> Option<NaiveDate> {
-        let days = i32::try_from(rhs.num_days()).ok()?;
-        self.add_days(days)
+    pub const fn checked_add_signed(self, rhs: OldDuration) -> Option<NaiveDate> {
+        let days = rhs.num_days();
+        if days < i32::MIN as i64 || days > i32::MAX as i64 {
+            return None;
+        }
+        self.add_days(days as i32)
     }
 
     /// Subtracts the number of whole days in the given `Duration` from the current date.
@@ -1181,9 +1184,12 @@ impl NaiveDate {
     /// assert_eq!(NaiveDate::MIN.checked_sub_signed(Duration::days(1)), None);
     /// ```
     #[must_use]
-    pub fn checked_sub_signed(self, rhs: OldDuration) -> Option<NaiveDate> {
-        let days = i32::try_from(-rhs.num_days()).ok()?;
-        self.add_days(days)
+    pub const fn checked_sub_signed(self, rhs: OldDuration) -> Option<NaiveDate> {
+        let days = -rhs.num_days();
+        if days < i32::MIN as i64 || days > i32::MAX as i64 {
+            return None;
+        }
+        self.add_days(days as i32)
     }
 
     /// Subtracts another `NaiveDate` from the current date.
@@ -1209,7 +1215,7 @@ impl NaiveDate {
     /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(1614, 1, 1)), Duration::days(365*400 + 97));
     /// ```
     #[must_use]
-    pub fn signed_duration_since(self, rhs: NaiveDate) -> OldDuration {
+    pub const fn signed_duration_since(self, rhs: NaiveDate) -> OldDuration {
         let year1 = self.year();
         let year2 = rhs.year();
         let (year1_div_400, year1_mod_400) = div_mod_floor(year1, 400);

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -61,14 +61,14 @@ impl NaiveWeek {
     /// ```
     #[inline]
     #[must_use]
-    pub fn first_day(&self) -> NaiveDate {
+    pub const fn first_day(&self) -> NaiveDate {
         let start = self.start.num_days_from_monday() as i32;
         let ref_day = self.date.weekday().num_days_from_monday() as i32;
         // Calculate the number of days to subtract from `self.date`.
         // Do not construct an intermediate date beyond `self.date`, because that may be out of
         // range if `date` is close to `NaiveDate::MAX`.
         let days = start - ref_day - if start > ref_day { 7 } else { 0 };
-        self.date.add_days(days).unwrap()
+        expect!(self.date.add_days(days), "first weekday out of range for `NaiveDate`")
     }
 
     /// Returns a date representing the last day of the week.
@@ -89,14 +89,14 @@ impl NaiveWeek {
     /// ```
     #[inline]
     #[must_use]
-    pub fn last_day(&self) -> NaiveDate {
+    pub const fn last_day(&self) -> NaiveDate {
         let end = self.start.pred().num_days_from_monday() as i32;
         let ref_day = self.date.weekday().num_days_from_monday() as i32;
         // Calculate the number of days to add to `self.date`.
         // Do not construct an intermediate date before `self.date` (like with `first_day()`),
         // because that may be out of range if `date` is close to `NaiveDate::MIN`.
         let days = end - ref_day + if end < ref_day { 7 } else { 0 };
-        self.date.add_days(days).unwrap()
+        expect!(self.date.add_days(days), "last weekday out of range for `NaiveDate`")
     }
 
     /// Returns a [`RangeInclusive<T>`] representing the whole week bounded by
@@ -119,7 +119,7 @@ impl NaiveWeek {
     /// ```
     #[inline]
     #[must_use]
-    pub fn days(&self) -> RangeInclusive<NaiveDate> {
+    pub const fn days(&self) -> RangeInclusive<NaiveDate> {
         self.first_day()..=self.last_day()
     }
 }

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -639,8 +639,8 @@ impl NaiveTime {
     /// ```
     #[inline]
     #[must_use]
-    pub fn overflowing_sub_signed(&self, rhs: OldDuration) -> (NaiveTime, i64) {
-        let (time, rhs) = self.overflowing_add_signed(-rhs);
+    pub const fn overflowing_sub_signed(&self, rhs: OldDuration) -> (NaiveTime, i64) {
+        let (time, rhs) = self.overflowing_add_signed(rhs.neg());
         (time, -rhs) // safe to negate, rhs is within +/- (2^63 / 1000)
     }
 

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -1196,7 +1196,7 @@ impl Add<Duration> for NaiveTime {
         // overflow during the conversion to `chrono::Duration`.
         // But we limit to double that just in case `self` is a leap-second.
         let secs = rhs.as_secs() % (2 * 24 * 60 * 60);
-        let d = OldDuration::from_std(Duration::new(secs, rhs.subsec_nanos())).unwrap();
+        let d = OldDuration::new(secs as i64, rhs.subsec_nanos()).unwrap();
         self.overflowing_add_signed(d).0
     }
 }
@@ -1306,7 +1306,7 @@ impl Sub<Duration> for NaiveTime {
         // overflow during the conversion to `chrono::Duration`.
         // But we limit to double that just in case `self` is a leap-second.
         let secs = rhs.as_secs() % (2 * 24 * 60 * 60);
-        let d = OldDuration::from_std(Duration::new(secs, rhs.subsec_nanos())).unwrap();
+        let d = OldDuration::new(secs as i64, rhs.subsec_nanos()).unwrap();
         self.overflowing_sub_signed(d).0
     }
 }


### PR DESCRIPTION
Depends on https://github.com/chronotope/chrono/pull/1137.

This finishes the work to make all methods const where possible.
Where it is not possible is parsing and formatting, and anything that involves traits including `DateTime<tz>`.
