### PR TITLE
test.yml set MSRV for test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, 0.4.x]
   pull_request:
 
+env:
+  MSRV: "1.57.0"
+
 jobs:
   timezones:
     strategy:
@@ -30,16 +33,21 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.57
+          toolchain: ${{ env.MSRV }}
+      - run: rustup override set ${{ env.MSRV }}
       - uses: Swatinem/rust-cache@v2
       # run --lib and --doc to avoid the long running integration tests
       # which are run elsewhere
       - run: |
+          set -eux
+          cargo --version
           cargo test --lib \
             --features \
             unstable-locales,wasmbind,oldtime,clock,rustc-serialize,winapi,serde \
             --color=always -- --color=always
       - run: |
+          set -eux
+          cargo --version
           cargo test --doc \
             --features \
             unstable-locales,wasmbind,oldtime,clock,rustc-serialize,winapi,serde \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.MSRV }}
-      - run: rustup override set ${{ env.MSRV }}
+      #- run: rustup override set ${{ env.MSRV }}
       - uses: Swatinem/rust-cache@v2
       # run --lib and --doc to avoid the long running integration tests
       # which are run elsewhere


### PR DESCRIPTION
Previously, the MSRV 1.57.0 was not actually being used to run the `cargo test`, the default rust was used (currently at 1.70.0).

### Thanks for contributing to chrono!

If your feature is semver-compatible, please target the 0.4.x branch;
the main branch will be used for 0.5.0 development going forward.

Please consider adding a test to ensure your bug fix/feature will not break in the future.
