### PR TITLE
test.yml remove errant `with: node-version`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,8 +120,6 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
-        with:
-          node-version: "12"
       - run: cargo build --target ${{ matrix.target }}  --color=always
 
   test_wasm:


### PR DESCRIPTION
This `with: node-version` parameter is not specified by [`Swatinem/rust-cache@v2`](https://github.com/marketplace/actions/rust-cache). Currently causing warnings for github Actions

<img width="757" alt="Screenshot 2023-11-05 193129" src="https://github.com/chronotope/chrono/assets/815261/98260975-9894-41bc-b815-961088f61106">

https://github.com/chronotope/chrono/actions/runs/6757025993