### PR TITLE
Add From<NaiveDate> for NaiveDateTime

### DIFF
--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -1048,6 +1048,22 @@ impl NaiveDateTime {
         expect!(NaiveDate::from_ymd_opt(1970, 1, 1), "").and_time(NaiveTime::MIN);
 }
 
+impl From<NaiveDate> for NaiveDateTime {
+    /// Converts a `NaiveDate` to a `NaiveDateTime` of the same date but at midnight.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use chrono::{NaiveDate, NaiveDateTime};
+    ///
+    /// let nd = NaiveDate::from_ymd_opt(2016, 5, 28).unwrap();
+    /// let ndt = NaiveDate::from_ymd_opt(2016, 5, 28).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    /// assert_eq!(ndt, NaiveDateTime::from(nd));
+    fn from(date: NaiveDate) -> Self {
+        date.and_hms_opt(0, 0, 0).unwrap()
+    }
+}
+
 impl Datelike for NaiveDateTime {
     /// Returns the year number in the [calendar date](./struct.NaiveDate.html#calendar-date).
     ///


### PR DESCRIPTION
This PR implements `From<NaiveDate>` to `NaiveDateTime` to facilitate more flexible APIs.

### Motivation

Some users of the `chrono` library may want to create functions that can take both `NaiveDate` and `NaiveDateTime`. Without this trait that is not necessarily possible. Currently `NaiveDate` implements `From<NaiveDateTime>` so they could build an API that takes `NaiveDateTime`s and converts them `NaiveDate`s but the reverse is not possible.

Currently only this is possible:

```
fn use_as_naive_date<D>(date: D) -> NaiveDate
where
    D: Into<NaiveDate>,
{
    date.into()
}
```

The function above can handle `NaiveDate` or `NaiveDateTime` input where the body can use the input to get a `NaiveDate`.
With my changes, this will be possible as well:

```
fn use_as_naive_datetime<D>(date: D) -> NaiveDateTime
where
    D: Into<NaiveDateTime>,
{
    date.into()
}
```

Here the use has created a function that can take `NaiveDate` or `NaiveDateTime` and get a `NaiveDateTime`. While ostensibly a small change, it gives chrono users the ability to create more powerful and flexible APIs.

Thank you for considering my pull request.

