### PR TITLE
Expose rkyv features as features for chrono users.

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,9 @@
 name: codecov
+
+env:
+  # It's really `--all-features`, but not adding the mutually exclusive features from rkyv
+  ALL_NON_EXCLUSIVE_FEATURES: --features "default unstable-locales rkyv-64 rkyv-validation rustc-serialize serde arbitrary"
+
 on:
   push:
     branches: [main, 0.4.x]
@@ -18,7 +23,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo +nightly llvm-cov --all-features --workspace --lcov --doctests --output-path lcov.info
+        run: cargo +nightly llvm-cov ${{ env.ALL_NON_EXCLUSIVE_FEATURES }} --workspace --lcov --doctests --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,9 @@
 name: lint
 
+env:
+  # It's really `--all-features`, but not adding the mutually exclusive features from rkyv
+  ALL_NON_EXCLUSIVE_FEATURES: --features "default unstable-locales rkyv-64 rkyv-validation rustc-serialize serde arbitrary"
+
 on:
   push:
     branches: [main, 0.4.x]
@@ -19,7 +23,7 @@ jobs:
       - run: cargo fmt --check --manifest-path fuzz/Cargo.toml
       - run: cargo fmt --check --manifest-path bench/Cargo.toml
       - run: |
-          cargo clippy --all-features --all-targets --color=always \
+          cargo clippy ${{ env.ALL_NON_EXCLUSIVE_FEATURES }} --all-targets --color=always \
             -- -D warnings
       - run: |
           cargo clippy --manifest-path fuzz/Cargo.toml --color=always \
@@ -50,8 +54,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo install cargo-deadlinks
-      - run: cargo deadlinks -- --all-features
-      - run: cargo doc --all-features --no-deps
+      - run: cargo deadlinks -- ${{ env.ALL_NON_EXCLUSIVE_FEATURES }}
+      - run: cargo doc ${{ env.ALL_NON_EXCLUSIVE_FEATURES }} --no-deps
         env:
           RUSTDOCFLAGS: -Dwarnings
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: All Tests and Builds
 
+env:
+  # It's really `--all-features`, but not adding the mutually exclusive features from rkyv
+  ALL_NON_EXCLUSIVE_FEATURES: --features "default unstable-locales rkyv-32 rkyv-validation rustc-serialize serde arbitrary"
+
 on:
   push:
     branches: [main, 0.4.x]
@@ -16,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --all-features --color=always -- --color=always
+      - run: cargo test ${{ env.ALL_NON_EXCLUSIVE_FEATURES }} --color=always -- --color=always
 
   # later this may be able to be included with the below
   # kept separate for now as the following don't compile on 1.60
@@ -61,8 +65,8 @@ jobs:
       - run: cargo check --manifest-path fuzz/Cargo.toml --all-targets
       # run --lib and --doc to avoid the long running integration tests
       # which are run elsewhere
-      - run: cargo test --lib --all-features --color=always -- --color=always
-      - run: cargo test --doc --all-features --color=always -- --color=always
+      - run: cargo test --lib ${{ env.ALL_NON_EXCLUSIVE_FEATURES }} --color=always -- --color=always
+      - run: cargo test --doc ${{ env.ALL_NON_EXCLUSIVE_FEATURES }} --color=always -- --color=always
 
   features_check:
     strategy:
@@ -76,7 +80,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: |
           cargo hack check --feature-powerset --optional-deps serde \
-            --skip __internal_bench,iana-time-zone,pure-rust-locales,libc,winapi \
+            --skip __internal_bench,iana-time-zone,pure-rust-locales,libc,winapi,rkyv-16,rkyv-64,rkyv-validation \
             --all-targets
         # run using `bash` on all platforms for consistent
         # line-continuation marks
@@ -182,16 +186,16 @@ jobs:
       - uses: actions/checkout@v4
       - run: cargo install cross
       - uses: Swatinem/rust-cache@v2
-      - run: cross test --lib --all-features --target i686-unknown-linux-gnu --color=always
-      - run: cross test --doc --all-features --target i686-unknown-linux-gnu --color=always
-      - run: cross test --lib --all-features --target i686-unknown-linux-musl --color=always
-      - run: cross test --doc --all-features --target i686-unknown-linux-musl --color=always
+      - run: cross test --lib ${{ env.ALL_NON_EXCLUSIVE_FEATURES }} --target i686-unknown-linux-gnu --color=always
+      - run: cross test --doc ${{ env.ALL_NON_EXCLUSIVE_FEATURES }} --target i686-unknown-linux-gnu --color=always
+      - run: cross test --lib ${{ env.ALL_NON_EXCLUSIVE_FEATURES }} --target i686-unknown-linux-musl --color=always
+      - run: cross test --doc ${{ env.ALL_NON_EXCLUSIVE_FEATURES }} --target i686-unknown-linux-musl --color=always
 
   check-docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo +nightly doc --all-features --no-deps
+      - run: cargo +nightly doc ${{ env.ALL_NON_EXCLUSIVE_FEATURES }} --no-deps
         env:
           RUSTDOCFLAGS: "-D warnings --cfg docsrs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ unstable-locales = ["pure-rust-locales"]
 rkyv-16 = ["rkyv", "rkyv?/size_16"]
 rkyv-32 = ["rkyv", "rkyv?/size_32"]
 rkyv-64 = ["rkyv", "rkyv?/size_64"]
-rkyv-validation = ["rkyv?/validation"]
+rkyv-validation = ["rkyv", "rkyv?/validation"]
 # Features for internal use only:
 __internal_bench = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ rust-version = "1.61.0"
 name = "chrono"
 
 [features]
+# Don't forget to adjust `ALL_NON_EXCLUSIVE_FEATURES` in CI scripts when adding a feature or an optional dependency.
 default = ["clock", "std", "oldtime", "wasmbind"]
 alloc = []
 libc = []
@@ -27,7 +28,12 @@ now = ["std"]
 oldtime = []
 wasmbind = ["wasm-bindgen", "js-sys"]
 unstable-locales = ["pure-rust-locales"]
-rkyv-validation = ["rkyv/validation"]
+# Note that rkyv-16, rkyv-32, and rkyv-64 are mutually exclusive.
+rkyv-16 = ["rkyv", "rkyv?/size_16"]
+rkyv-32 = ["rkyv", "rkyv?/size_32"]
+rkyv-64 = ["rkyv", "rkyv?/size_64"]
+rkyv-validation = ["rkyv?/validation"]
+# Features for internal use only:
 __internal_bench = []
 
 [dependencies]
@@ -35,7 +41,7 @@ num-traits = { version = "0.2", default-features = false }
 rustc-serialize = { version = "0.3.20", optional = true }
 serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.7", optional = true }
-rkyv = { version = "0.7.41", optional = true }
+rkyv = { version = "0.7.43", optional = true, default-features = false }
 arbitrary = { version = "1.0.0", features = ["derive"], optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]

--- a/src/month.rs
+++ b/src/month.rs
@@ -33,7 +33,7 @@ use crate::OutOfRange;
 #[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
 #[cfg_attr(
     feature = "rkyv",
-    archive(compare(PartialEq)),
+    archive(compare(PartialEq, PartialOrd)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -20,7 +20,7 @@ use rkyv::{Archive, Deserialize, Serialize};
 #[cfg_attr(feature = "rkyv", derive(Archive, Deserialize, Serialize))]
 #[cfg_attr(
     feature = "rkyv",
-    archive(compare(PartialEq)),
+    archive(compare(PartialEq, PartialOrd)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]


### PR DESCRIPTION
rkyv by default serializes usize as u32. This isn't ideal on most modern platforms and unfortunately is configured through a feature flag.

If we just set `default-features = false` in the rkyv Cargo dependency, the crate fails to compile because all the size features are mutually exclusive. On the other hand if we want to e.g., change the serialization of usize to 64-bit and we also want to use chrono this currently fails to compile because chrono always enables rkyv/size_32.

This re-exports the relevant rkyv features so users can choose which serialization to enable. The approach is similar to what the ordered-float crate does:

https://github.com/reem/rust-ordered-float/blob/8111b345372632893af0b8aa12152f3dc7278aba/Cargo.toml#L37



Note aside: rkyv with `default-features = false is what was recommended on the rkyv discord by the maintainer (see screenshot below). But it seems that the approach ordered-float took is better as it doesn't break backward compatibility (and compilation of chrono library without specifying any features).

![image](https://github.com/chronotope/chrono/assets/127654/45cd90fd-f157-4f13-ab3f-c0ce341711e1)



### Thanks for contributing to chrono!

If your feature is semver-compatible, please target the 0.4.x branch;
the main branch will be used for 0.5.0 development going forward.

Please consider adding a test to ensure your bug fix/feature will not break in the future.
