### PR TITLE
Add Months::num_months() and num_years()

### DIFF
--- a/src/month.rs
+++ b/src/month.rs
@@ -230,14 +230,8 @@ impl Months {
 
     /// Returns the total number of months in the `Months` instance.
     #[inline]
-    pub const fn num_months(&self) -> u32 {
+    pub const fn as_u32(&self) -> u32 {
         self.0
-    }
-
-    /// Returns the total number of whole years in the `Months` instance.
-    #[inline]
-    pub const fn num_years(&self) -> u32 {
-        self.0 / 12
     }
 }
 
@@ -366,21 +360,10 @@ mod tests {
     }
 
     #[test]
-    fn test_months_num_months() {
-        assert_eq!(Months::new(0).num_months(), 0);
-        assert_eq!(Months::new(1).num_months(), 1);
-        assert_eq!(Months::new(u32::MAX).num_months(), u32::MAX);
-    }
-
-    #[test]
-    fn test_months_num_years() {
-        assert_eq!(Months::new(0).num_years(), 0);
-        assert_eq!(Months::new(1).num_years(), 0);
-        assert_eq!(Months::new(11).num_years(), 0);
-        assert_eq!(Months::new(12).num_years(), 1);
-        assert_eq!(Months::new(23).num_years(), 1);
-        assert_eq!(Months::new(24).num_years(), 2);
-        assert_eq!(Months::new(u32::MAX).num_years(), u32::MAX / 12);
+    fn test_months_as_u32() {
+        assert_eq!(Months::new(0).as_u32(), 0);
+        assert_eq!(Months::new(1).as_u32(), 1);
+        assert_eq!(Months::new(u32::MAX).as_u32(), u32::MAX);
     }
 
     #[test]

--- a/src/month.rs
+++ b/src/month.rs
@@ -227,6 +227,18 @@ impl Months {
     pub const fn new(num: u32) -> Self {
         Self(num)
     }
+
+    /// Returns the total number of months in the `Months` instance.
+    #[inline]
+    pub const fn num_months(&self) -> u32 {
+        self.0
+    }
+
+    /// Returns the total number of whole years in the `Months` instance.
+    #[inline]
+    pub const fn num_years(&self) -> u32 {
+        self.0 / 12
+    }
 }
 
 /// An error resulting from reading `<Month>` value with `FromStr`.
@@ -298,7 +310,7 @@ mod month_serde {
 #[cfg(test)]
 mod tests {
     use super::Month;
-    use crate::{Datelike, OutOfRange, TimeZone, Utc};
+    use crate::{Datelike, Months, OutOfRange, TimeZone, Utc};
 
     #[test]
     fn test_month_enum_try_from() {
@@ -351,6 +363,24 @@ mod tests {
         assert!(Month::January < Month::December);
         assert!(Month::July >= Month::May);
         assert!(Month::September > Month::March);
+    }
+
+    #[test]
+    fn test_months_num_months() {
+        assert_eq!(Months::new(0).num_months(), 0);
+        assert_eq!(Months::new(1).num_months(), 1);
+        assert_eq!(Months::new(u32::MAX).num_months(), u32::MAX);
+    }
+
+    #[test]
+    fn test_months_num_years() {
+        assert_eq!(Months::new(0).num_years(), 0);
+        assert_eq!(Months::new(1).num_years(), 0);
+        assert_eq!(Months::new(11).num_years(), 0);
+        assert_eq!(Months::new(12).num_years(), 1);
+        assert_eq!(Months::new(23).num_years(), 1);
+        assert_eq!(Months::new(24).num_years(), 2);
+        assert_eq!(Months::new(u32::MAX).num_years(), u32::MAX / 12);
     }
 
     #[test]


### PR DESCRIPTION
# Summary of changes

The changes in this PR are extremely simple and trivial: to present two new functions that provide general ease and compatibility in using `Months`, in similar fashion to `Duration`.

The problem being solved is that the `Months` type is a one-way black box. Once created, it is impossible to verify what it contains. Although its primary purpose is to provide a vector for effecting changes, without being able to inspect its value it is impossible to verify in tests, or support in a wider context. Additionally, extending the type from an external perspective will not help with this.

Therefore, this PR simply adds two new methods to `Months`:

  - `Months::num_months()` - This returns the number of months represented by the type, and is the primary objective of the PR.
  - `Months::num_years()` - This is a convenience function that is added to fit with the functions provided elsewhere.

The naming of the functions follows those provided by `Duration`, as this is the most similar type.

# Questions and points of note

## Constants

There is no readily-available `MONTHS_PER_YEAR` or similar - there is one in `src/offset/local/tz_info/rule.rs`, but nothing usable. Please advise if one should be added instead of using the magic number `12` - in which case, should it be local to the module, and private, or would Chrono benefit from a more public one?

## Annotations

Observing the code elsewhere, for instance in `Duration`, some functions are annotated as `inline`, and some as `must_use`, but not entirely consistently. In an attempt to fit with the codebase as well as possible, the two new functions have been annotated as `inline`, but not as `must_use`. Please advise as to what the general Chrono preference is in this regard.

## Tests

Tests have been added to try to satisfy what seems sensible and appropriate to check, in a manner that fits in with the other Chrono tests. Hopefully they have been placed in an acceptable location.

## Branch point

The branch point chosen has been the latest tagged release, with the PR targeting the 0.4.x branch. Hopefully that is correct.