### PR TITLE
Workaround for Windows local time prior to 1601

### DIFF
--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1267,6 +1267,17 @@ fn test_datetime_from_timestamp_millis() {
 
 #[test]
 #[cfg(feature = "clock")]
+fn test_datetime_before_windows_api_limits() {
+    // dt corresponds to `FILETIME = 147221225472` from issue 651.
+    // This used to fail on Windows for timezones with an offset of -5:00 or greater.
+    // The API limits years to 1601..=30827.
+    let dt = NaiveDate::from_ymd_opt(1601, 1, 1).unwrap().and_hms_milli_opt(4, 5, 22, 122).unwrap();
+    let local_dt = Local.from_utc_datetime(&dt);
+    dbg!(local_dt);
+}
+
+#[test]
+#[cfg(feature = "clock")]
 fn test_years_elapsed() {
     const WEEKS_PER_YEAR: f32 = 52.1775;
 

--- a/src/offset/local/win_bindings.rs
+++ b/src/offset/local/win_bindings.rs
@@ -5,6 +5,7 @@
 ::windows_targets::link!("kernel32.dll" "system" fn SystemTimeToTzSpecificLocalTime(lptimezoneinformation : *const TIME_ZONE_INFORMATION, lpuniversaltime : *const SYSTEMTIME, lplocaltime : *mut SYSTEMTIME) -> BOOL);
 ::windows_targets::link!("kernel32.dll" "system" fn TzSpecificLocalTimeToSystemTime(lptimezoneinformation : *const TIME_ZONE_INFORMATION, lplocaltime : *const SYSTEMTIME, lpuniversaltime : *mut SYSTEMTIME) -> BOOL);
 pub type BOOL = i32;
+pub const ERROR_INVALID_PARAMETER: WIN32_ERROR = 87u32;
 #[repr(C)]
 pub struct FILETIME {
     pub dwLowDateTime: u32,
@@ -49,3 +50,4 @@ impl ::core::clone::Clone for TIME_ZONE_INFORMATION {
         *self
     }
 }
+pub type WIN32_ERROR = u32;

--- a/src/offset/local/win_bindings.txt
+++ b/src/offset/local/win_bindings.txt
@@ -1,6 +1,7 @@
 --out src/offset/local/win_bindings.rs
 --config flatten sys
 --filter
+    Windows.Win32.Foundation.ERROR_INVALID_PARAMETER
     Windows.Win32.System.Time.SystemTimeToFileTime
     Windows.Win32.System.Time.SystemTimeToTzSpecificLocalTime
     Windows.Win32.System.Time.TzSpecificLocalTimeToSystemTime


### PR DESCRIPTION
This PR makes the minimum necessary changes to workaround #1364. It's not a full fix but it will allow people to use chrono to get the local time of files with a creation time of zero. I believe this to be worthwhile in the interim until a better patch lands.

If getting the offset for 1601 fails with `ERROR_INVALID_PARAMETER` then this patch instead calculates the offset for 1602. This works only because the 1600's are long enough ago that dynamic timezones aren't a concern and negative timezone offsets will always be much less than a year (typically a few hours).