### PR TITLE
Fixed typo in Duration::hours() exception

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -116,7 +116,7 @@ impl Duration {
     #[inline]
     #[must_use]
     pub fn hours(hours: i64) -> Duration {
-        Duration::try_hours(hours).expect("Duration::hours ouf of bounds")
+        Duration::try_hours(hours).expect("Duration::hours out of bounds")
     }
 
     /// Makes a new `Duration` with given number of hours.


### PR DESCRIPTION
# Summary of changes

This PR simply fixes a typo found in the exception message thrown from `Duration::hours()` when the value is out of range.

# Points of note

## Tests

There are no current tests that use the exception message, and so none have been updated. All tests pass.

## Branch point

The branch point chosen has been the latest tagged release, with the PR targeting the `0.4.x` branch. 