### PR TITLE
Specify branch for GitHub Actions badge and fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![Chat][discord-image]][discord]
 [![codecov.io][codecov-img]][codecov-link]
 
-[gh-image]: https://github.com/chronotope/chrono/actions/workflows/test.yml/badge.svg
-[gh-checks]: https://github.com/chronotope/chrono/actions?query=workflow%3Atest
+[gh-image]: https://github.com/chronotope/chrono/actions/workflows/test.yml/badge.svg?branch=main
+[gh-checks]: https://github.com/chronotope/chrono/actions/workflows/test.yml?query=branch%3Amain
 [cratesio-image]: https://img.shields.io/crates/v/chrono.svg
 [cratesio]: https://crates.io/crates/chrono
 [docsrs-image]: https://docs.rs/chrono/badge.svg


### PR DESCRIPTION
I think it makes more sense for the GitHub Actions badge to match the latest run on the branch that that particular readme is on.
For the main branch I'll make it point to the `main` with the next merge.

This also fixes the link, that seems to have been broken for quite a while.