### PR TITLE
Remove workaround for Rust < 1.61

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -93,7 +93,10 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     #[inline]
     #[must_use]
-    pub fn from_naive_utc_and_offset(datetime: NaiveDateTime, offset: Tz::Offset) -> DateTime<Tz> {
+    pub const fn from_naive_utc_and_offset(
+        datetime: NaiveDateTime,
+        offset: Tz::Offset,
+    ) -> DateTime<Tz> {
         DateTime { datetime, offset }
     }
 
@@ -653,14 +656,6 @@ impl DateTime<Utc> {
     #[must_use]
     pub fn from_timestamp_millis(millis: i64) -> Option<Self> {
         NaiveDateTime::from_timestamp_millis(millis).as_ref().map(NaiveDateTime::and_utc)
-    }
-
-    // FIXME: remove when our MSRV is 1.61+
-    // This method is used by `NaiveDateTime::and_utc` because `DateTime::from_naive_utc_and_offset`
-    // can't be made const yet.
-    // Trait bounds in const function / implementation blocks were not supported until 1.61.
-    pub(crate) const fn from_naive_utc(datetime: NaiveDateTime) -> Self {
-        DateTime { datetime, offset: Utc }
     }
 
     /// The Unix Epoch, 1970-01-01 00:00:00 UTC.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -1066,8 +1066,7 @@ impl NaiveDateTime {
     /// ```
     #[must_use]
     pub const fn and_utc(&self) -> DateTime<Utc> {
-        // FIXME: use `DateTime::from_naive_utc_and_offset` when our MSRV is 1.61+.
-        DateTime::from_naive_utc(*self)
+        DateTime::from_naive_utc_and_offset(*self, Utc)
     }
 
     /// The minimum possible `NaiveDateTime`.


### PR DESCRIPTION
Introduced in https://github.com/chronotope/chrono/pull/1286 but no longer needed as our MSRV is now 1.61.