### PR TITLE
0.5.x: Remove everything deprecated

### DIFF
--- a/bench/benches/chrono.rs
+++ b/bench/benches/chrono.rs
@@ -37,7 +37,7 @@ fn bench_datetime_from_str(c: &mut Criterion) {
 }
 
 fn bench_datetime_to_rfc2822(c: &mut Criterion) {
-    let pst = FixedOffset::east_opt(8 * 60 * 60).unwrap();
+    let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
             &NaiveDate::from_ymd_opt(2018, 1, 11)
@@ -50,7 +50,7 @@ fn bench_datetime_to_rfc2822(c: &mut Criterion) {
 }
 
 fn bench_datetime_to_rfc3339(c: &mut Criterion) {
-    let pst = FixedOffset::east_opt(8 * 60 * 60).unwrap();
+    let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
             &NaiveDate::from_ymd_opt(2018, 1, 11)
@@ -63,7 +63,7 @@ fn bench_datetime_to_rfc3339(c: &mut Criterion) {
 }
 
 fn bench_datetime_to_rfc3339_opts(c: &mut Criterion) {
-    let pst = FixedOffset::east_opt(8 * 60 * 60).unwrap();
+    let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
             &NaiveDate::from_ymd_opt(2018, 1, 11)
@@ -205,7 +205,7 @@ fn bench_naivedate_add_signed(c: &mut Criterion) {
 }
 
 fn bench_datetime_with(c: &mut Criterion) {
-    let dt = FixedOffset::east_opt(3600).unwrap().with_ymd_and_hms(2023, 9, 23, 7, 36, 0).unwrap();
+    let dt = FixedOffset::east(3600).unwrap().with_ymd_and_hms(2023, 9, 23, 7, 36, 0).unwrap();
     c.bench_function("bench_datetime_with", |b| {
         b.iter(|| black_box(black_box(dt).with_hour(12)).unwrap())
     });

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -268,7 +268,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     #[inline]
     #[must_use]
     pub fn timestamp_nanos_opt(&self) -> Option<i64> {
-        self.datetime.timestamp_nanos_opt()
+        self.datetime.timestamp_nanos()
     }
 
     /// Returns the number of milliseconds since the last second boundary.
@@ -597,7 +597,7 @@ impl DateTime<Utc> {
     #[must_use]
     pub const fn from_timestamp(secs: i64, nsecs: u32) -> Option<Self> {
         Some(DateTime {
-            datetime: try_opt!(NaiveDateTime::from_timestamp_opt(secs, nsecs)),
+            datetime: try_opt!(NaiveDateTime::from_timestamp(secs, nsecs)),
             offset: Utc,
         })
     }

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -102,7 +102,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// use chrono::prelude::*;
     ///
     /// let date: DateTime<Utc> = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
-    /// let other: DateTime<FixedOffset> = FixedOffset::east_opt(23).unwrap().with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+    /// let other: DateTime<FixedOffset> = FixedOffset::east(23).unwrap().with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
     /// assert_eq!(date.date_naive(), other.date_naive());
     /// ```
     #[inline]
@@ -493,7 +493,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Secs, true),
     ///            "2018-01-26T18:30:09Z");
     ///
-    /// let pst = FixedOffset::east_opt(8 * 60 * 60).unwrap();
+    /// let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     /// let dt = pst.from_local_datetime(&NaiveDate::from_ymd_opt(2018, 1, 26).unwrap().and_hms_micro_opt(10, 30, 9, 453_829).unwrap()).unwrap();
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Secs, true),
     ///            "2018-01-26T10:30:09+08:00");
@@ -594,7 +594,7 @@ impl Default for DateTime<Local> {
 
 impl Default for DateTime<FixedOffset> {
     fn default() -> Self {
-        FixedOffset::west_opt(0).unwrap().from_utc_datetime(&NaiveDateTime::default())
+        FixedOffset::west(0).unwrap().from_utc_datetime(&NaiveDateTime::default())
     }
 }
 
@@ -605,7 +605,7 @@ impl From<DateTime<Utc>> for DateTime<FixedOffset> {
     /// Conversion is done via [`DateTime::with_timezone`]. Note that the converted value returned by
     /// this will be created with a fixed timezone offset of 0.
     fn from(src: DateTime<Utc>) -> Self {
-        src.with_timezone(&FixedOffset::east_opt(0).unwrap())
+        src.with_timezone(&FixedOffset::east(0).unwrap())
     }
 }
 
@@ -707,7 +707,7 @@ impl DateTime<FixedOffset> {
     /// # use chrono::{DateTime, FixedOffset, TimeZone};
     /// assert_eq!(
     ///     DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 GMT").unwrap(),
-    ///     FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap()
+    ///     FixedOffset::east(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap()
     /// );
     /// ```
     pub fn parse_from_rfc2822(s: &str) -> ParseResult<DateTime<FixedOffset>> {
@@ -758,7 +758,7 @@ impl DateTime<FixedOffset> {
     ///
     /// let dt = DateTime::parse_from_str(
     ///     "1983 Apr 13 12:09:14.274 +0000", "%Y %b %d %H:%M:%S%.3f %z");
-    /// assert_eq!(dt, Ok(FixedOffset::east_opt(0).unwrap().from_local_datetime(&NaiveDate::from_ymd_opt(1983, 4, 13).unwrap().and_hms_milli_opt(12, 9, 14, 274).unwrap()).unwrap()));
+    /// assert_eq!(dt, Ok(FixedOffset::east(0).unwrap().from_local_datetime(&NaiveDate::from_ymd_opt(1983, 4, 13).unwrap().and_hms_milli_opt(12, 9, 14, 274).unwrap()).unwrap()));
     /// ```
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<DateTime<FixedOffset>> {
         let mut parsed = Parsed::new();
@@ -787,7 +787,7 @@ impl DateTime<FixedOffset> {
     ///     "2015-02-18 23:16:09 +0200 trailing text", "%Y-%m-%d %H:%M:%S %z").unwrap();
     /// assert_eq!(
     ///     datetime,
-    ///     FixedOffset::east_opt(2*3600).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap()
+    ///     FixedOffset::east(2*3600).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap()
     /// );
     /// assert_eq!(remainder, " trailing text");
     /// ```
@@ -1137,8 +1137,8 @@ impl<Tz: TimeZone, Tz2: TimeZone> PartialOrd<DateTime<Tz2>> for DateTime<Tz> {
     /// ```
     /// use chrono::prelude::*;
     ///
-    /// let earlier = Utc.with_ymd_and_hms(2015, 5, 15, 2, 0, 0).unwrap().with_timezone(&FixedOffset::west_opt(1 * 3600).unwrap());
-    /// let later   = Utc.with_ymd_and_hms(2015, 5, 15, 3, 0, 0).unwrap().with_timezone(&FixedOffset::west_opt(5 * 3600).unwrap());
+    /// let earlier = Utc.with_ymd_and_hms(2015, 5, 15, 2, 0, 0).unwrap().with_timezone(&FixedOffset::west(1 * 3600).unwrap());
+    /// let later   = Utc.with_ymd_and_hms(2015, 5, 15, 3, 0, 0).unwrap().with_timezone(&FixedOffset::west(5 * 3600).unwrap());
     ///
     /// assert_eq!(earlier.to_string(), "2015-05-15 01:00:00 -01:00");
     /// assert_eq!(later.to_string(), "2015-05-14 22:00:00 -05:00");
@@ -1645,14 +1645,14 @@ where
 
     assert_eq!(
         to_string_fixed(
-            &FixedOffset::east_opt(3660).unwrap().with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
+            &FixedOffset::east(3660).unwrap().with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
         )
         .ok(),
         Some(r#""2014-07-24T12:34:06+01:01""#.into())
     );
     assert_eq!(
         to_string_fixed(
-            &FixedOffset::east_opt(3650).unwrap().with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
+            &FixedOffset::east(3650).unwrap().with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
         )
         .ok(),
         // An offset with seconds is not allowed by RFC 3339, so we round it to the nearest minute.
@@ -1689,13 +1689,13 @@ fn test_decodable_json<FUtc, FFixed, FLocal, E>(
     assert_eq!(
         norm(&fixed_from_str(r#""2014-07-24T12:34:06Z""#).ok()),
         norm(&Some(
-            FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
+            FixedOffset::east(0).unwrap().with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
         ))
     );
     assert_eq!(
         norm(&fixed_from_str(r#""2014-07-24T13:57:06+01:23""#).ok()),
         norm(&Some(
-            FixedOffset::east_opt(60 * 60 + 23 * 60)
+            FixedOffset::east(60 * 60 + 23 * 60)
                 .unwrap()
                 .with_ymd_and_hms(2014, 7, 24, 13, 57, 6)
                 .unwrap()

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -123,7 +123,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// (aka "UNIX timestamp").
     ///
     /// The reverse operation of creating a [`DateTime`] from a timestamp can be performed
-    /// using [`from_timestamp`](DateTime::from_timestamp) or [`TimeZone::timestamp_opt`].
+    /// using [`from_timestamp`](DateTime::from_timestamp) or [`TimeZone::timestamp`].
     ///
     /// ```
     /// use chrono::{DateTime, TimeZone, Utc};
@@ -517,7 +517,7 @@ impl DateTime<Utc> {
     /// [`timestamp_subsec_nanos`](DateTime::timestamp_subsec_nanos).
     ///
     /// If you need to create a `DateTime` with a [`TimeZone`] different from [`Utc`], use
-    /// [`TimeZone::timestamp_opt`] or [`DateTime::with_timezone`].
+    /// [`TimeZone::timestamp`] or [`DateTime::with_timezone`].
     ///
     /// The nanosecond part can exceed 1,000,000,000 in order to represent a
     /// [leap second](NaiveTime#leap-second-handling), but only when `secs % 60 == 59`.
@@ -553,7 +553,7 @@ impl DateTime<Utc> {
     /// This is guaranteed to round-trip with regard to [`timestamp_millis`](DateTime::timestamp_millis).
     ///
     /// If you need to create a `DateTime` with a [`TimeZone`] different from [`Utc`], use
-    /// [`TimeZone::timestamp_millis_opt`] or [`DateTime::with_timezone`].
+    /// [`TimeZone::timestamp_millis`] or [`DateTime::with_timezone`].
     ///
     /// # Errors
     ///
@@ -1554,7 +1554,7 @@ impl From<SystemTime> for DateTime<Utc> {
                 }
             }
         };
-        Utc.timestamp_opt(sec, nsec).unwrap()
+        Utc.timestamp(sec, nsec).unwrap()
     }
 }
 
@@ -1597,7 +1597,7 @@ impl From<js_sys::Date> for DateTime<Utc> {
 ))]
 impl From<&js_sys::Date> for DateTime<Utc> {
     fn from(date: &js_sys::Date) -> DateTime<Utc> {
-        Utc.timestamp_millis_opt(date.get_time() as i64).unwrap()
+        Utc.timestamp_millis(date.get_time() as i64).unwrap()
     }
 }
 

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -56,13 +56,6 @@ pub struct DateTime<Tz: TimeZone> {
     offset: Tz::Offset,
 }
 
-/// The minimum possible `DateTime<Utc>`.
-#[deprecated(since = "0.4.20", note = "Use DateTime::MIN_UTC instead")]
-pub const MIN_DATETIME: DateTime<Utc> = DateTime::<Utc>::MIN_UTC;
-/// The maximum possible `DateTime<Utc>`.
-#[deprecated(since = "0.4.20", note = "Use DateTime::MAX_UTC instead")]
-pub const MAX_DATETIME: DateTime<Utc> = DateTime::<Utc>::MAX_UTC;
-
 impl<Tz: TimeZone> DateTime<Tz> {
     /// Makes a new `DateTime` from its components: a `NaiveDateTime` in UTC and an `Offset`.
     ///
@@ -93,37 +86,6 @@ impl<Tz: TimeZone> DateTime<Tz> {
         offset: Tz::Offset,
     ) -> DateTime<Tz> {
         DateTime { datetime, offset }
-    }
-
-    /// Makes a new `DateTime` from its components: a `NaiveDateTime` in UTC and an `Offset`.
-    #[inline]
-    #[must_use]
-    #[deprecated(
-        since = "0.4.27",
-        note = "Use TimeZone::from_utc_datetime() or DateTime::from_naive_utc_and_offset instead"
-    )]
-    pub fn from_utc(datetime: NaiveDateTime, offset: Tz::Offset) -> DateTime<Tz> {
-        DateTime { datetime, offset }
-    }
-
-    /// Makes a new `DateTime` from a `NaiveDateTime` in *local* time and an `Offset`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the local datetime can't be converted to UTC because it would be out of range.
-    ///
-    /// This can happen if `datetime` is near the end of the representable range of `NaiveDateTime`,
-    /// and the offset from UTC pushes it beyond that.
-    #[inline]
-    #[must_use]
-    #[deprecated(
-        since = "0.4.27",
-        note = "Use TimeZone::from_local_datetime() or NaiveDateTime::and_local_timezone instead"
-    )]
-    pub fn from_local(datetime: NaiveDateTime, offset: Tz::Offset) -> DateTime<Tz> {
-        let datetime_utc = datetime - offset.fix();
-
-        DateTime { datetime: datetime_utc, offset }
     }
 
     /// Retrieves the date without an associated timezone.
@@ -213,23 +175,6 @@ impl<Tz: TimeZone> DateTime<Tz> {
     #[must_use]
     pub fn timestamp_micros(&self) -> i64 {
         self.datetime.timestamp_micros()
-    }
-
-    /// Returns the number of non-leap-nanoseconds since January 1, 1970 UTC.
-    ///
-    /// # Panics
-    ///
-    /// An `i64` with nanosecond precision can span a range of ~584 years. This function panics on
-    /// an out of range `DateTime`.
-    ///
-    /// The dates that can be represented as nanoseconds are between 1677-09-21T00:12:43.145224192
-    /// and 2262-04-11T23:47:16.854775807.
-    #[deprecated(since = "0.4.31", note = "use `timestamp_nanos_opt()` instead")]
-    #[inline]
-    #[must_use]
-    pub fn timestamp_nanos(&self) -> i64 {
-        self.timestamp_nanos_opt()
-            .expect("value can not be represented in a timestamp with nanosecond precision.")
     }
 
     /// Returns the number of non-leap-nanoseconds since January 1, 1970 UTC.

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -193,26 +193,26 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// use chrono::{Utc, NaiveDate};
     ///
     /// let dt = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_nano_opt(0, 0, 1, 444).unwrap().and_local_timezone(Utc).unwrap();
-    /// assert_eq!(dt.timestamp_nanos_opt(), Some(1_000_000_444));
+    /// assert_eq!(dt.timestamp_nanos(), Some(1_000_000_444));
     ///
     /// let dt = NaiveDate::from_ymd_opt(2001, 9, 9).unwrap().and_hms_nano_opt(1, 46, 40, 555).unwrap().and_local_timezone(Utc).unwrap();
-    /// assert_eq!(dt.timestamp_nanos_opt(), Some(1_000_000_000_000_000_555));
+    /// assert_eq!(dt.timestamp_nanos(), Some(1_000_000_000_000_000_555));
     ///
     /// let dt = NaiveDate::from_ymd_opt(1677, 9, 21).unwrap().and_hms_nano_opt(0, 12, 43, 145_224_192).unwrap().and_local_timezone(Utc).unwrap();
-    /// assert_eq!(dt.timestamp_nanos_opt(), Some(-9_223_372_036_854_775_808));
+    /// assert_eq!(dt.timestamp_nanos(), Some(-9_223_372_036_854_775_808));
     ///
     /// let dt = NaiveDate::from_ymd_opt(2262, 4, 11).unwrap().and_hms_nano_opt(23, 47, 16, 854_775_807).unwrap().and_local_timezone(Utc).unwrap();
-    /// assert_eq!(dt.timestamp_nanos_opt(), Some(9_223_372_036_854_775_807));
+    /// assert_eq!(dt.timestamp_nanos(), Some(9_223_372_036_854_775_807));
     ///
     /// let dt = NaiveDate::from_ymd_opt(1677, 9, 21).unwrap().and_hms_nano_opt(0, 12, 43, 145_224_191).unwrap().and_local_timezone(Utc).unwrap();
-    /// assert_eq!(dt.timestamp_nanos_opt(), None);
+    /// assert_eq!(dt.timestamp_nanos(), None);
     ///
     /// let dt = NaiveDate::from_ymd_opt(2262, 4, 11).unwrap().and_hms_nano_opt(23, 47, 16, 854_775_808).unwrap().and_local_timezone(Utc).unwrap();
-    /// assert_eq!(dt.timestamp_nanos_opt(), None);
+    /// assert_eq!(dt.timestamp_nanos(), None);
     /// ```
     #[inline]
     #[must_use]
-    pub fn timestamp_nanos_opt(&self) -> Option<i64> {
+    pub fn timestamp_nanos(&self) -> Option<i64> {
         self.datetime.timestamp_nanos()
     }
 

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -191,10 +191,10 @@ pub mod ts_nanoseconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1526522699, 918355733).unwrap() });
+    /// assert_eq!(my_s, S { time: Utc.timestamp(1526522699, 918355733).unwrap() });
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp_opt(-1, 999_999_999).unwrap() });
+    /// assert_eq!(my_s, S { time: Utc.timestamp(-1, 999_999_999).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
@@ -219,7 +219,7 @@ pub mod ts_nanoseconds {
             E: de::Error,
         {
             serde_from(
-                Utc.timestamp_opt(
+                Utc.timestamp(
                     value.div_euclid(1_000_000_000),
                     (value.rem_euclid(1_000_000_000)) as u32,
                 ),
@@ -233,7 +233,7 @@ pub mod ts_nanoseconds {
             E: de::Error,
         {
             serde_from(
-                Utc.timestamp_opt((value / 1_000_000_000) as i64, (value % 1_000_000_000) as u32),
+                Utc.timestamp((value / 1_000_000_000) as i64, (value % 1_000_000_000) as u32),
                 &value,
             )
         }
@@ -335,7 +335,7 @@ pub mod ts_nanoseconds_option {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1526522699, 918355733).single() });
+    /// assert_eq!(my_s, S { time: Utc.timestamp(1526522699, 918355733).single() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
@@ -462,10 +462,10 @@ pub mod ts_microseconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1526522699, 918355000).unwrap() });
+    /// assert_eq!(my_s, S { time: Utc.timestamp(1526522699, 918355000).unwrap() });
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp_opt(-1, 999_999_000).unwrap() });
+    /// assert_eq!(my_s, S { time: Utc.timestamp(-1, 999_999_000).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
@@ -490,7 +490,7 @@ pub mod ts_microseconds {
             E: de::Error,
         {
             serde_from(
-                Utc.timestamp_opt(
+                Utc.timestamp(
                     value.div_euclid(1_000_000),
                     (value.rem_euclid(1_000_000) * 1_000) as u32,
                 ),
@@ -504,7 +504,7 @@ pub mod ts_microseconds {
             E: de::Error,
         {
             serde_from(
-                Utc.timestamp_opt((value / 1_000_000) as i64, ((value % 1_000_000) * 1_000) as u32),
+                Utc.timestamp((value / 1_000_000) as i64, ((value % 1_000_000) * 1_000) as u32),
                 &value,
             )
         }
@@ -595,7 +595,7 @@ pub mod ts_microseconds_option {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1526522699, 918355000).single() });
+    /// assert_eq!(my_s, S { time: Utc.timestamp(1526522699, 918355000).single() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
@@ -722,10 +722,10 @@ pub mod ts_milliseconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1526522699, 918000000).unwrap() });
+    /// assert_eq!(my_s, S { time: Utc.timestamp(1526522699, 918000000).unwrap() });
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp_opt(-1, 999_000_000).unwrap() });
+    /// assert_eq!(my_s, S { time: Utc.timestamp(-1, 999_000_000).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
@@ -749,7 +749,7 @@ pub mod ts_milliseconds {
         where
             E: de::Error,
         {
-            serde_from(Utc.timestamp_millis_opt(value), &value)
+            serde_from(Utc.timestamp_millis(value), &value)
         }
 
         /// Deserialize a timestamp in milliseconds since the epoch
@@ -758,7 +758,7 @@ pub mod ts_milliseconds {
             E: de::Error,
         {
             serde_from(
-                Utc.timestamp_opt((value / 1000) as i64, ((value % 1000) * 1_000_000) as u32),
+                Utc.timestamp((value / 1000) as i64, ((value % 1000) * 1_000_000) as u32),
                 &value,
             )
         }
@@ -856,7 +856,7 @@ pub mod ts_milliseconds_option {
     /// }
     ///
     /// let my_s: E<S> = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
-    /// assert_eq!(my_s, E::V(S { time: Some(Utc.timestamp_opt(1526522699, 918000000).unwrap()) }));
+    /// assert_eq!(my_s, E::V(S { time: Some(Utc.timestamp(1526522699, 918000000).unwrap()) }));
     /// let s: E<S> = serde_json::from_str(r#"{ "time": null }"#)?;
     /// assert_eq!(s, E::V(S { time: None }));
     /// let t: E<S> = serde_json::from_str(r#"{}"#)?;
@@ -987,7 +987,7 @@ pub mod ts_seconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1431684000, 0).unwrap() });
+    /// assert_eq!(my_s, S { time: Utc.timestamp(1431684000, 0).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
@@ -1011,7 +1011,7 @@ pub mod ts_seconds {
         where
             E: de::Error,
         {
-            serde_from(Utc.timestamp_opt(value, 0), &value)
+            serde_from(Utc.timestamp(value, 0), &value)
         }
 
         /// Deserialize a timestamp in seconds since the epoch
@@ -1023,7 +1023,7 @@ pub mod ts_seconds {
                 if value > i64::MAX as u64 {
                     LocalResult::None
                 } else {
-                    Utc.timestamp_opt(value as i64, 0)
+                    Utc.timestamp(value as i64, 0)
                 },
                 &value,
             )
@@ -1115,7 +1115,7 @@ pub mod ts_seconds_option {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp_opt(1431684000, 0).single() });
+    /// assert_eq!(my_s, S { time: Utc.timestamp(1431684000, 0).single() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -1225,7 +1225,7 @@ mod tests {
         }
         impl Offset for TestTimeZone {
             fn fix(&self) -> FixedOffset {
-                FixedOffset::east_opt(15 * 60 * 60).unwrap()
+                FixedOffset::east(15 * 60 * 60).unwrap()
             }
         }
 

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -169,7 +169,7 @@ pub mod ts_nanoseconds {
     where
         S: ser::Serializer,
     {
-        serializer.serialize_i64(dt.timestamp_nanos_opt().ok_or(ser::Error::custom(
+        serializer.serialize_i64(dt.timestamp_nanos().ok_or(ser::Error::custom(
             "value out of range for a timestamp with nanosecond precision",
         ))?)
     }
@@ -311,7 +311,7 @@ pub mod ts_nanoseconds_option {
         S: ser::Serializer,
     {
         match *opt {
-            Some(ref dt) => serializer.serialize_some(&dt.timestamp_nanos_opt().ok_or(
+            Some(ref dt) => serializer.serialize_some(&dt.timestamp_nanos().ok_or(
                 ser::Error::custom("value out of range for a timestamp with nanosecond precision"),
             )?),
             None => serializer.serialize_none(),

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1606,7 +1606,7 @@ fn nano_roundrip() {
     ] {
         println!("nanos: {}", nanos);
         let dt = Utc.timestamp_nanos(nanos);
-        let nanos2 = dt.timestamp_nanos_opt().expect("value roundtrips");
+        let nanos2 = dt.timestamp_nanos().expect("value roundtrips");
         assert_eq!(nanos, nanos2);
     }
 }

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -903,7 +903,7 @@ fn test_parse_from_str() {
         .is_err());
     assert_eq!(
         DateTime::parse_from_str("0", "%s").unwrap(),
-        NaiveDateTime::from_timestamp_opt(0, 0).unwrap().and_utc()
+        NaiveDateTime::from_timestamp(0, 0).unwrap().and_utc()
     );
 
     assert_eq!(

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -10,10 +10,10 @@ struct DstTester;
 
 impl DstTester {
     fn winter_offset() -> FixedOffset {
-        FixedOffset::east_opt(8 * 60 * 60).unwrap()
+        FixedOffset::east(8 * 60 * 60).unwrap()
     }
     fn summer_offset() -> FixedOffset {
-        FixedOffset::east_opt(9 * 60 * 60).unwrap()
+        FixedOffset::east(9 * 60 * 60).unwrap()
     }
 
     const TO_WINTER_MONTH_DAY: (u32, u32) = (4, 15);
@@ -117,8 +117,8 @@ impl TimeZone for DstTester {
 
 #[test]
 fn test_datetime_add_days() {
-    let est = FixedOffset::west_opt(5 * 60 * 60).unwrap();
-    let kst = FixedOffset::east_opt(9 * 60 * 60).unwrap();
+    let est = FixedOffset::west(5 * 60 * 60).unwrap();
+    let kst = FixedOffset::east(9 * 60 * 60).unwrap();
 
     assert_eq!(
         format!("{}", est.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Days::new(5)),
@@ -159,8 +159,8 @@ fn test_datetime_add_days() {
 
 #[test]
 fn test_datetime_sub_days() {
-    let est = FixedOffset::west_opt(5 * 60 * 60).unwrap();
-    let kst = FixedOffset::east_opt(9 * 60 * 60).unwrap();
+    let est = FixedOffset::west(5 * 60 * 60).unwrap();
+    let kst = FixedOffset::east(9 * 60 * 60).unwrap();
 
     assert_eq!(
         format!("{}", est.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Days::new(5)),
@@ -183,8 +183,8 @@ fn test_datetime_sub_days() {
 
 #[test]
 fn test_datetime_add_months() {
-    let est = FixedOffset::west_opt(5 * 60 * 60).unwrap();
-    let kst = FixedOffset::east_opt(9 * 60 * 60).unwrap();
+    let est = FixedOffset::west(5 * 60 * 60).unwrap();
+    let kst = FixedOffset::east(9 * 60 * 60).unwrap();
 
     assert_eq!(
         format!("{}", est.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Months::new(1)),
@@ -207,8 +207,8 @@ fn test_datetime_add_months() {
 
 #[test]
 fn test_datetime_sub_months() {
-    let est = FixedOffset::west_opt(5 * 60 * 60).unwrap();
-    let kst = FixedOffset::east_opt(9 * 60 * 60).unwrap();
+    let est = FixedOffset::west(5 * 60 * 60).unwrap();
+    let kst = FixedOffset::east(9 * 60 * 60).unwrap();
 
     assert_eq!(
         format!("{}", est.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Months::new(1)),
@@ -326,9 +326,9 @@ fn ymdhms_milli_utc(
 
 #[test]
 fn test_datetime_offset() {
-    let est = FixedOffset::west_opt(5 * 60 * 60).unwrap();
-    let edt = FixedOffset::west_opt(4 * 60 * 60).unwrap();
-    let kst = FixedOffset::east_opt(9 * 60 * 60).unwrap();
+    let est = FixedOffset::west(5 * 60 * 60).unwrap();
+    let edt = FixedOffset::west(4 * 60 * 60).unwrap();
+    let kst = FixedOffset::east(9 * 60 * 60).unwrap();
 
     assert_eq!(
         format!("{}", Utc.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap()),
@@ -414,17 +414,17 @@ fn signed_duration_since_autoref() {
 
 #[test]
 fn test_datetime_date_and_time() {
-    let tz = FixedOffset::east_opt(5 * 60 * 60).unwrap();
+    let tz = FixedOffset::east(5 * 60 * 60).unwrap();
     let d = tz.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap();
     assert_eq!(d.time(), NaiveTime::from_hms(7, 8, 9).unwrap());
     assert_eq!(d.date_naive(), NaiveDate::from_ymd_opt(2014, 5, 6).unwrap());
 
-    let tz = FixedOffset::east_opt(4 * 60 * 60).unwrap();
+    let tz = FixedOffset::east(4 * 60 * 60).unwrap();
     let d = tz.with_ymd_and_hms(2016, 5, 4, 3, 2, 1).unwrap();
     assert_eq!(d.time(), NaiveTime::from_hms(3, 2, 1).unwrap());
     assert_eq!(d.date_naive(), NaiveDate::from_ymd_opt(2016, 5, 4).unwrap());
 
-    let tz = FixedOffset::west_opt(13 * 60 * 60).unwrap();
+    let tz = FixedOffset::west(13 * 60 * 60).unwrap();
     let d = tz.with_ymd_and_hms(2017, 8, 9, 12, 34, 56).unwrap();
     assert_eq!(d.time(), NaiveTime::from_hms(12, 34, 56).unwrap());
     assert_eq!(d.date_naive(), NaiveDate::from_ymd_opt(2017, 8, 9).unwrap());
@@ -445,7 +445,7 @@ fn test_datetime_with_timezone() {
 #[test]
 #[cfg(feature = "alloc")]
 fn test_datetime_rfc2822() {
-    let edt = FixedOffset::east_opt(5 * 60 * 60).unwrap();
+    let edt = FixedOffset::east(5 * 60 * 60).unwrap();
 
     // timezone 0
     assert_eq!(
@@ -506,11 +506,11 @@ fn test_datetime_rfc2822() {
 
     assert_eq!(
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +0000"),
-        Ok(FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
+        Ok(FixedOffset::east(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
     );
     assert_eq!(
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 -0000"),
-        Ok(FixedOffset::east_opt(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
+        Ok(FixedOffset::east(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
     );
     assert_eq!(
         ymdhms_micro(&edt, 2015, 2, 18, 23, 59, 59, 1_234_567).to_rfc2822(),
@@ -539,7 +539,7 @@ fn test_datetime_rfc2822() {
         ),
         Ok(
             ymdhms(
-                &FixedOffset::east_opt(-3 * 60 * 60 - 30 * 60).unwrap(),
+                &FixedOffset::east(-3 * 60 * 60 - 30 * 60).unwrap(),
                 1969, 2, 13, 23, 32, 0,
             )
         )
@@ -549,9 +549,7 @@ fn test_datetime_rfc2822() {
         DateTime::parse_from_rfc2822(
             "Thu,\n\t13\n      Feb\n        1969\n    23:32\n             -0330"
         ),
-        Ok(
-            ymdhms(&FixedOffset::east_opt(-3 * 60 * 60 - 30 * 60).unwrap(), 1969, 2, 13, 23, 32, 0,)
-        )
+        Ok(ymdhms(&FixedOffset::east(-3 * 60 * 60 - 30 * 60).unwrap(), 1969, 2, 13, 23, 32, 0,))
     );
 
     // bad year
@@ -571,8 +569,8 @@ fn test_datetime_rfc2822() {
 #[test]
 #[cfg(feature = "alloc")]
 fn test_datetime_rfc3339() {
-    let edt5 = FixedOffset::east_opt(5 * 60 * 60).unwrap();
-    let edt0 = FixedOffset::east_opt(0).unwrap();
+    let edt5 = FixedOffset::east(5 * 60 * 60).unwrap();
+    let edt0 = FixedOffset::east(0).unwrap();
 
     // timezone 0
     assert_eq!(
@@ -658,7 +656,7 @@ fn test_datetime_rfc3339() {
 #[cfg(feature = "alloc")]
 fn test_rfc3339_opts() {
     use crate::SecondsFormat::*;
-    let pst = FixedOffset::east_opt(8 * 60 * 60).unwrap();
+    let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
             &NaiveDate::from_ymd_opt(2018, 1, 11)
@@ -688,7 +686,7 @@ fn test_rfc3339_opts() {
 fn test_datetime_from_str() {
     assert_eq!(
         "2015-02-18T23:16:9.15Z".parse::<DateTime<FixedOffset>>(),
-        Ok(FixedOffset::east_opt(0)
+        Ok(FixedOffset::east(0)
             .unwrap()
             .from_local_datetime(
                 &NaiveDate::from_ymd_opt(2015, 2, 18)
@@ -745,7 +743,7 @@ fn test_datetime_from_str() {
 
     assert_eq!(
         "2015-2-18T23:16:9.15Z".parse::<DateTime<FixedOffset>>(),
-        Ok(FixedOffset::east_opt(0)
+        Ok(FixedOffset::east(0)
             .unwrap()
             .from_local_datetime(
                 &NaiveDate::from_ymd_opt(2015, 2, 18)
@@ -757,7 +755,7 @@ fn test_datetime_from_str() {
     );
     assert_eq!(
         "2015-2-18T13:16:9.15-10:00".parse::<DateTime<FixedOffset>>(),
-        Ok(FixedOffset::west_opt(10 * 3600)
+        Ok(FixedOffset::west(10 * 3600)
             .unwrap()
             .from_local_datetime(
                 &NaiveDate::from_ymd_opt(2015, 2, 18)
@@ -891,9 +889,9 @@ fn test_parse_datetime_utc() {
 
 #[test]
 fn test_parse_from_str() {
-    let edt = FixedOffset::east_opt(570 * 60).unwrap();
-    let edt0 = FixedOffset::east_opt(0).unwrap();
-    let wdt = FixedOffset::west_opt(10 * 3600).unwrap();
+    let edt = FixedOffset::east(570 * 60).unwrap();
+    let edt0 = FixedOffset::east(0).unwrap();
+    let wdt = FixedOffset::west(10 * 3600).unwrap();
     assert_eq!(
         DateTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
         Ok(ymdhms(&edt, 2014, 5, 7, 12, 34, 56))
@@ -948,7 +946,7 @@ fn test_parse_from_str() {
 
 #[test]
 fn test_datetime_parse_from_str() {
-    let dt = ymdhms(&FixedOffset::east_opt(-9 * 60 * 60).unwrap(), 2013, 8, 9, 23, 54, 35);
+    let dt = ymdhms(&FixedOffset::east(-9 * 60 * 60).unwrap(), 2013, 8, 9, 23, 54, 35);
     let parse = DateTime::parse_from_str;
 
     // timezone variations
@@ -1094,10 +1092,10 @@ fn test_to_string_round_trip() {
     let dt = Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap();
     let _dt: DateTime<Utc> = dt.to_string().parse().unwrap();
 
-    let ndt_fixed = dt.with_timezone(&FixedOffset::east_opt(3600).unwrap());
+    let ndt_fixed = dt.with_timezone(&FixedOffset::east(3600).unwrap());
     let _dt: DateTime<FixedOffset> = ndt_fixed.to_string().parse().unwrap();
 
-    let ndt_fixed = dt.with_timezone(&FixedOffset::east_opt(0).unwrap());
+    let ndt_fixed = dt.with_timezone(&FixedOffset::east(0).unwrap());
     let _dt: DateTime<FixedOffset> = ndt_fixed.to_string().parse().unwrap();
 }
 
@@ -1207,11 +1205,11 @@ fn test_from_system_time() {
         assert_eq!(SystemTime::from(epoch.with_timezone(&Local)), UNIX_EPOCH);
     }
     assert_eq!(
-        SystemTime::from(epoch.with_timezone(&FixedOffset::east_opt(32400).unwrap())),
+        SystemTime::from(epoch.with_timezone(&FixedOffset::east(32400).unwrap())),
         UNIX_EPOCH
     );
     assert_eq!(
-        SystemTime::from(epoch.with_timezone(&FixedOffset::west_opt(28800).unwrap())),
+        SystemTime::from(epoch.with_timezone(&FixedOffset::west(28800).unwrap())),
         UNIX_EPOCH
     );
 }
@@ -1257,13 +1255,13 @@ fn test_datetime_add_assign() {
     datetime_add += TimeDelta::seconds(60);
     assert_eq!(datetime_add, datetime + TimeDelta::seconds(60));
 
-    let timezone = FixedOffset::east_opt(60 * 60).unwrap();
+    let timezone = FixedOffset::east(60 * 60).unwrap();
     let datetime = datetime.with_timezone(&timezone);
     let datetime_add = datetime_add.with_timezone(&timezone);
 
     assert_eq!(datetime_add, datetime + TimeDelta::seconds(60));
 
-    let timezone = FixedOffset::west_opt(2 * 60 * 60).unwrap();
+    let timezone = FixedOffset::west(2 * 60 * 60).unwrap();
     let datetime = datetime.with_timezone(&timezone);
     let datetime_add = datetime_add.with_timezone(&timezone);
 
@@ -1294,13 +1292,13 @@ fn test_datetime_sub_assign() {
     datetime_sub -= TimeDelta::minutes(90);
     assert_eq!(datetime_sub, datetime - TimeDelta::minutes(90));
 
-    let timezone = FixedOffset::east_opt(60 * 60).unwrap();
+    let timezone = FixedOffset::east(60 * 60).unwrap();
     let datetime = datetime.with_timezone(&timezone);
     let datetime_sub = datetime_sub.with_timezone(&timezone);
 
     assert_eq!(datetime_sub, datetime - TimeDelta::minutes(90));
 
-    let timezone = FixedOffset::west_opt(2 * 60 * 60).unwrap();
+    let timezone = FixedOffset::west(2 * 60 * 60).unwrap();
     let datetime = datetime.with_timezone(&timezone);
     let datetime_sub = datetime_sub.with_timezone(&timezone);
 
@@ -1309,9 +1307,9 @@ fn test_datetime_sub_assign() {
 
 #[test]
 fn test_min_max_getters() {
-    let offset_min = FixedOffset::west_opt(2 * 60 * 60).unwrap();
+    let offset_min = FixedOffset::west(2 * 60 * 60).unwrap();
     let beyond_min = offset_min.from_utc_datetime(&NaiveDateTime::MIN);
-    let offset_max = FixedOffset::east_opt(2 * 60 * 60).unwrap();
+    let offset_max = FixedOffset::east(2 * 60 * 60).unwrap();
     let beyond_max = offset_max.from_utc_datetime(&NaiveDateTime::MAX);
 
     assert_eq!(format!("{:?}", beyond_min), "-262144-12-31T22:00:00-02:00");
@@ -1367,9 +1365,9 @@ fn test_min_max_getters() {
 
 #[test]
 fn test_min_max_setters() {
-    let offset_min = FixedOffset::west_opt(2 * 60 * 60).unwrap();
+    let offset_min = FixedOffset::west(2 * 60 * 60).unwrap();
     let beyond_min = offset_min.from_utc_datetime(&NaiveDateTime::MIN);
-    let offset_max = FixedOffset::east_opt(2 * 60 * 60).unwrap();
+    let offset_max = FixedOffset::east(2 * 60 * 60).unwrap();
     let beyond_max = offset_max.from_utc_datetime(&NaiveDateTime::MAX);
 
     assert_eq!(beyond_min.with_year(2020).unwrap().year(), 2020);
@@ -1416,14 +1414,14 @@ fn test_min_max_setters() {
 #[test]
 #[should_panic]
 fn test_local_beyond_min_datetime() {
-    let min = FixedOffset::west_opt(2 * 60 * 60).unwrap().from_utc_datetime(&NaiveDateTime::MIN);
+    let min = FixedOffset::west(2 * 60 * 60).unwrap().from_utc_datetime(&NaiveDateTime::MIN);
     let _ = min.naive_local();
 }
 
 #[test]
 #[should_panic]
 fn test_local_beyond_max_datetime() {
-    let max = FixedOffset::east_opt(2 * 60 * 60).unwrap().from_utc_datetime(&NaiveDateTime::MAX);
+    let max = FixedOffset::east(2 * 60 * 60).unwrap().from_utc_datetime(&NaiveDateTime::MAX);
     let _ = max.naive_local();
 }
 
@@ -1516,18 +1514,17 @@ fn test_datetime_fixed_offset() {
     let naivedatetime = NaiveDate::from_ymd_opt(2023, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
 
     let datetime = Utc.from_utc_datetime(&naivedatetime);
-    let fixed_utc = FixedOffset::east_opt(0).unwrap();
+    let fixed_utc = FixedOffset::east(0).unwrap();
     assert_eq!(datetime.fixed_offset(), fixed_utc.from_local_datetime(&naivedatetime).unwrap());
 
-    let fixed_offset = FixedOffset::east_opt(3600).unwrap();
+    let fixed_offset = FixedOffset::east(3600).unwrap();
     let datetime_fixed = fixed_offset.from_local_datetime(&naivedatetime).unwrap();
     assert_eq!(datetime_fixed.fixed_offset(), datetime_fixed);
 }
 
 #[test]
 fn test_datetime_to_utc() {
-    let dt =
-        FixedOffset::east_opt(3600).unwrap().with_ymd_and_hms(2020, 2, 22, 23, 24, 25).unwrap();
+    let dt = FixedOffset::east(3600).unwrap().with_ymd_and_hms(2020, 2, 22, 23, 24, 25).unwrap();
     let dt_utc: DateTime<Utc> = dt.to_utc();
     assert_eq!(dt, dt_utc);
 }
@@ -1552,10 +1549,8 @@ fn test_add_sub_months() {
 #[test]
 fn test_auto_conversion() {
     let utc_dt = Utc.with_ymd_and_hms(2018, 9, 5, 23, 58, 0).unwrap();
-    let cdt_dt = FixedOffset::west_opt(5 * 60 * 60)
-        .unwrap()
-        .with_ymd_and_hms(2018, 9, 5, 18, 58, 0)
-        .unwrap();
+    let cdt_dt =
+        FixedOffset::west(5 * 60 * 60).unwrap().with_ymd_and_hms(2018, 9, 5, 18, 58, 0).unwrap();
     let utc_dt2: DateTime<Utc> = cdt_dt.into();
     assert_eq!(utc_dt, utc_dt2);
 }

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -20,7 +20,7 @@ impl DstTester {
     const TO_SUMMER_MONTH_DAY: (u32, u32) = (9, 15);
 
     fn transition_start_local() -> NaiveTime {
-        NaiveTime::from_hms_opt(2, 0, 0).unwrap()
+        NaiveTime::from_hms(2, 0, 0).unwrap()
     }
 }
 
@@ -416,17 +416,17 @@ fn signed_duration_since_autoref() {
 fn test_datetime_date_and_time() {
     let tz = FixedOffset::east_opt(5 * 60 * 60).unwrap();
     let d = tz.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap();
-    assert_eq!(d.time(), NaiveTime::from_hms_opt(7, 8, 9).unwrap());
+    assert_eq!(d.time(), NaiveTime::from_hms(7, 8, 9).unwrap());
     assert_eq!(d.date_naive(), NaiveDate::from_ymd_opt(2014, 5, 6).unwrap());
 
     let tz = FixedOffset::east_opt(4 * 60 * 60).unwrap();
     let d = tz.with_ymd_and_hms(2016, 5, 4, 3, 2, 1).unwrap();
-    assert_eq!(d.time(), NaiveTime::from_hms_opt(3, 2, 1).unwrap());
+    assert_eq!(d.time(), NaiveTime::from_hms(3, 2, 1).unwrap());
     assert_eq!(d.date_naive(), NaiveDate::from_ymd_opt(2016, 5, 4).unwrap());
 
     let tz = FixedOffset::west_opt(13 * 60 * 60).unwrap();
     let d = tz.with_ymd_and_hms(2017, 8, 9, 12, 34, 56).unwrap();
-    assert_eq!(d.time(), NaiveTime::from_hms_opt(12, 34, 56).unwrap());
+    assert_eq!(d.time(), NaiveTime::from_hms(12, 34, 56).unwrap());
     assert_eq!(d.date_naive(), NaiveDate::from_ymd_opt(2017, 8, 9).unwrap());
 
     let utc_d = Utc.with_ymd_and_hms(2017, 8, 9, 12, 34, 56).unwrap();

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1217,30 +1217,6 @@ fn test_from_system_time() {
 }
 
 #[test]
-#[allow(deprecated)]
-fn test_datetime_from_local() {
-    // 2000-01-12T02:00:00Z
-    let naivedatetime_utc =
-        NaiveDate::from_ymd_opt(2000, 1, 12).unwrap().and_hms_opt(2, 0, 0).unwrap();
-    let datetime_utc = DateTime::<Utc>::from_utc(naivedatetime_utc, Utc);
-
-    // 2000-01-12T10:00:00+8:00:00
-    let timezone_east = FixedOffset::east_opt(8 * 60 * 60).unwrap();
-    let naivedatetime_east =
-        NaiveDate::from_ymd_opt(2000, 1, 12).unwrap().and_hms_opt(10, 0, 0).unwrap();
-    let datetime_east = DateTime::<FixedOffset>::from_local(naivedatetime_east, timezone_east);
-
-    // 2000-01-11T19:00:00-7:00:00
-    let timezone_west = FixedOffset::west_opt(7 * 60 * 60).unwrap();
-    let naivedatetime_west =
-        NaiveDate::from_ymd_opt(2000, 1, 11).unwrap().and_hms_opt(19, 0, 0).unwrap();
-    let datetime_west = DateTime::<FixedOffset>::from_local(naivedatetime_west, timezone_west);
-
-    assert_eq!(datetime_east, datetime_utc.with_timezone(&timezone_east));
-    assert_eq!(datetime_west, datetime_utc.with_timezone(&timezone_west));
-}
-
-#[test]
 fn test_datetime_from_timestamp_millis() {
     // 2000-01-12T01:02:03:004Z
     let naive_dt =
@@ -1582,19 +1558,6 @@ fn test_auto_conversion() {
         .unwrap();
     let utc_dt2: DateTime<Utc> = cdt_dt.into();
     assert_eq!(utc_dt, utc_dt2);
-}
-
-#[test]
-#[cfg(feature = "clock")]
-#[allow(deprecated)]
-fn test_test_deprecated_from_offset() {
-    let now = Local::now();
-    let naive = now.naive_local();
-    let utc = now.naive_utc();
-    let offset: FixedOffset = *now.offset();
-
-    assert_eq!(DateTime::<Local>::from_local(naive, offset), now);
-    assert_eq!(DateTime::<Local>::from_utc(utc, offset), now);
 }
 
 #[test]

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -724,15 +724,12 @@ mod tests {
         assert_eq!(t.format("%S,%f,%.f").to_string(), "07,210000000,.210");
         assert_eq!(t.format("%.3f,%.6f,%.9f").to_string(), ".210,.210000,.210000000");
 
-        let t = NaiveTime::from_hms_opt(3, 5, 7).unwrap();
+        let t = NaiveTime::from_hms(3, 5, 7).unwrap();
         assert_eq!(t.format("%S,%f,%.f").to_string(), "07,000000000,");
         assert_eq!(t.format("%.3f,%.6f,%.9f").to_string(), ".000,.000000,.000000000");
 
         // corner cases
-        assert_eq!(
-            NaiveTime::from_hms_opt(13, 57, 9).unwrap().format("%r").to_string(),
-            "01:57:09 PM"
-        );
+        assert_eq!(NaiveTime::from_hms(13, 57, 9).unwrap().format("%r").to_string(), "01:57:09 PM");
         assert_eq!(
             NaiveTime::from_hms_milli_opt(23, 59, 59, 1_000).unwrap().format("%X").to_string(),
             "23:59:60"

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -706,7 +706,7 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test_time_format() {
-        let t = NaiveTime::from_hms_nano_opt(3, 5, 7, 98765432).unwrap();
+        let t = NaiveTime::from_hms_nano(3, 5, 7, 98765432).unwrap();
         assert_eq!(t.format("%H,%k,%I,%l,%P,%p").to_string(), "03, 3,03, 3,am,AM");
         assert_eq!(t.format("%M").to_string(), "05");
         assert_eq!(t.format("%S,%f,%.f").to_string(), "07,098765432,.098765432");

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -716,7 +716,7 @@ mod tests {
         assert_eq!(t.format("%r").to_string(), "03:05:07 AM");
         assert_eq!(t.format("%t%n%%%n%t").to_string(), "\t\n%\n\t");
 
-        let t = NaiveTime::from_hms_micro_opt(3, 5, 7, 432100).unwrap();
+        let t = NaiveTime::from_hms_micro(3, 5, 7, 432100).unwrap();
         assert_eq!(t.format("%S,%f,%.f").to_string(), "07,432100000,.432100");
         assert_eq!(t.format("%.3f,%.6f,%.9f").to_string(), ".432,.432100,.432100000");
 

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -812,13 +812,13 @@ mod tests {
             }
             // +03:45, -03:30, +11:00, -11:00:22, +02:34:26, -12:34:30, +00:00
             let offsets = [
-                FixedOffset::east_opt(13_500).unwrap(),
-                FixedOffset::east_opt(-12_600).unwrap(),
-                FixedOffset::east_opt(39_600).unwrap(),
-                FixedOffset::east_opt(-39_622).unwrap(),
-                FixedOffset::east_opt(9266).unwrap(),
-                FixedOffset::east_opt(-45270).unwrap(),
-                FixedOffset::east_opt(0).unwrap(),
+                FixedOffset::east(13_500).unwrap(),
+                FixedOffset::east(-12_600).unwrap(),
+                FixedOffset::east(39_600).unwrap(),
+                FixedOffset::east(-39_622).unwrap(),
+                FixedOffset::east(9266).unwrap(),
+                FixedOffset::east(-45270).unwrap(),
+                FixedOffset::east(0).unwrap(),
             ];
             check(precision, Colons::Colon, Pad::Zero, false, offsets, expected[0]);
             check(precision, Colons::Colon, Pad::Zero, true, offsets, expected[1]);

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -139,53 +139,6 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> Display for Delayed
     }
 }
 
-/// Tries to format given arguments with given formatting items.
-/// Internally used by `DelayedFormat`.
-#[cfg(feature = "alloc")]
-#[deprecated(since = "0.4.32", note = "Use DelayedFormat::fmt instead")]
-pub fn format<'a, I, B>(
-    w: &mut fmt::Formatter,
-    date: Option<&NaiveDate>,
-    time: Option<&NaiveTime>,
-    off: Option<&(String, FixedOffset)>,
-    items: I,
-) -> fmt::Result
-where
-    I: Iterator<Item = B> + Clone,
-    B: Borrow<Item<'a>>,
-{
-    DelayedFormat {
-        date: date.copied(),
-        time: time.copied(),
-        off: off.cloned(),
-        items,
-        #[cfg(feature = "unstable-locales")]
-        locale: None,
-    }
-    .fmt(w)
-}
-
-/// Formats single formatting item
-#[cfg(feature = "alloc")]
-#[deprecated(since = "0.4.32", note = "Use DelayedFormat::fmt instead")]
-pub fn format_item(
-    w: &mut fmt::Formatter,
-    date: Option<&NaiveDate>,
-    time: Option<&NaiveTime>,
-    off: Option<&(String, FixedOffset)>,
-    item: &Item<'_>,
-) -> fmt::Result {
-    DelayedFormat {
-        date: date.copied(),
-        time: time.copied(),
-        off: off.cloned(),
-        items: [item].into_iter(),
-        #[cfg(feature = "unstable-locales")]
-        locale: None,
-    }
-    .fmt(w)
-}
-
 #[cfg(feature = "alloc")]
 fn format_inner(
     w: &mut impl Write,

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -720,7 +720,7 @@ mod tests {
         assert_eq!(t.format("%S,%f,%.f").to_string(), "07,432100000,.432100");
         assert_eq!(t.format("%.3f,%.6f,%.9f").to_string(), ".432,.432100,.432100000");
 
-        let t = NaiveTime::from_hms_milli_opt(3, 5, 7, 210).unwrap();
+        let t = NaiveTime::from_hms_milli(3, 5, 7, 210).unwrap();
         assert_eq!(t.format("%S,%f,%.f").to_string(), "07,210000000,.210");
         assert_eq!(t.format("%.3f,%.6f,%.9f").to_string(), ".210,.210000,.210000000");
 
@@ -731,7 +731,7 @@ mod tests {
         // corner cases
         assert_eq!(NaiveTime::from_hms(13, 57, 9).unwrap().format("%r").to_string(), "01:57:09 PM");
         assert_eq!(
-            NaiveTime::from_hms_milli_opt(23, 59, 59, 1_000).unwrap().format("%X").to_string(),
+            NaiveTime::from_hms_milli(23, 59, 59, 1_000).unwrap().format("%X").to_string(),
             "23:59:60"
         );
     }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -58,10 +58,9 @@ pub(crate) use formatting::write_hundreds;
 pub(crate) use formatting::write_rfc2822;
 #[cfg(any(feature = "alloc", feature = "serde", feature = "rustc-serialize"))]
 pub(crate) use formatting::write_rfc3339;
-pub use formatting::SecondsFormat;
 #[cfg(feature = "alloc")]
-#[allow(deprecated)]
-pub use formatting::{format, format_item, DelayedFormat};
+pub use formatting::DelayedFormat;
+pub use formatting::SecondsFormat;
 #[cfg(feature = "unstable-locales")]
 pub use locales::Locale;
 pub(crate) use parse::parse_rfc3339;

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -1629,7 +1629,7 @@ mod tests {
     #[test]
     fn test_rfc2822() {
         let ymd_hmsn = |y, m, d, h, n, s, nano, off| {
-            FixedOffset::east_opt(off * 60 * 60)
+            FixedOffset::east(off * 60 * 60)
                 .unwrap()
                 .with_ymd_and_hms(y, m, d, h, n, s)
                 .unwrap()
@@ -1794,7 +1794,7 @@ mod tests {
     #[test]
     fn test_rfc3339() {
         let ymd_hmsn = |y, m, d, h, n, s, nano, off| {
-            FixedOffset::east_opt(off * 60 * 60)
+            FixedOffset::east(off * 60 * 60)
                 .unwrap()
                 .with_ymd_and_hms(y, m, d, h, n, s)
                 .unwrap()

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -526,7 +526,7 @@ impl Parsed {
             None => 0,
         };
 
-        NaiveTime::from_hms_nano_opt(hour, minute, second, nano).ok_or(OUT_OF_RANGE)
+        NaiveTime::from_hms_nano(hour, minute, second, nano).ok_or(OUT_OF_RANGE)
     }
 
     /// Returns a parsed naive date and time out of given fields,
@@ -967,7 +967,7 @@ mod tests {
         }
 
         let hms = |h, m, s| Ok(NaiveTime::from_hms(h, m, s).unwrap());
-        let hmsn = |h, m, s, n| Ok(NaiveTime::from_hms_nano_opt(h, m, s, n).unwrap());
+        let hmsn = |h, m, s, n| Ok(NaiveTime::from_hms_nano(h, m, s, n).unwrap());
 
         // omission of fields
         assert_eq!(parse!(), Err(NOT_ENOUGH));

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -610,7 +610,7 @@ impl Parsed {
 
     /// Returns a parsed fixed time zone offset out of given fields.
     pub fn to_fixed_offset(&self) -> ParseResult<FixedOffset> {
-        self.offset.and_then(FixedOffset::east_opt).ok_or(OUT_OF_RANGE)
+        self.offset.and_then(FixedOffset::east).ok_or(OUT_OF_RANGE)
     }
 
     /// Returns a parsed timezone-aware date and time out of given fields.
@@ -627,7 +627,7 @@ impl Parsed {
             (None, None) => return Err(NOT_ENOUGH),
         };
         let datetime = self.to_naive_datetime_with_offset(offset)?;
-        let offset = FixedOffset::east_opt(offset).ok_or(OUT_OF_RANGE)?;
+        let offset = FixedOffset::east(offset).ok_or(OUT_OF_RANGE)?;
 
         match offset.from_local_datetime(&datetime) {
             LocalResult::None => Err(IMPOSSIBLE),
@@ -1176,7 +1176,7 @@ mod tests {
         }
 
         let ymdhmsn = |y, m, d, h, n, s, nano, off| {
-            Ok(FixedOffset::east_opt(off)
+            Ok(FixedOffset::east(off)
                 .unwrap()
                 .from_local_datetime(
                     &NaiveDate::from_ymd_opt(y, m, d)
@@ -1244,16 +1244,16 @@ mod tests {
             Err(IMPOSSIBLE)
         );
         assert_eq!(
-            parse!(FixedOffset::east_opt(32400).unwrap();
+            parse!(FixedOffset::east(32400).unwrap();
                           year: 2014, ordinal: 365, hour_div_12: 0, hour_mod_12: 4,
                           minute: 26, second: 40, nanosecond: 12_345_678, offset: 0),
             Err(IMPOSSIBLE)
         );
         assert_eq!(
-            parse!(FixedOffset::east_opt(32400).unwrap();
+            parse!(FixedOffset::east(32400).unwrap();
                           year: 2014, ordinal: 365, hour_div_12: 1, hour_mod_12: 1,
                           minute: 26, second: 40, nanosecond: 12_345_678, offset: 32400),
-            Ok(FixedOffset::east_opt(32400)
+            Ok(FixedOffset::east(32400)
                 .unwrap()
                 .from_local_datetime(
                     &NaiveDate::from_ymd_opt(2014, 12, 31)
@@ -1271,12 +1271,12 @@ mod tests {
         );
         assert_eq!(parse!(Utc; timestamp: 1_420_000_000, offset: 32400), Err(IMPOSSIBLE));
         assert_eq!(
-            parse!(FixedOffset::east_opt(32400).unwrap(); timestamp: 1_420_000_000, offset: 0),
+            parse!(FixedOffset::east(32400).unwrap(); timestamp: 1_420_000_000, offset: 0),
             Err(IMPOSSIBLE)
         );
         assert_eq!(
-            parse!(FixedOffset::east_opt(32400).unwrap(); timestamp: 1_420_000_000, offset: 32400),
-            Ok(FixedOffset::east_opt(32400)
+            parse!(FixedOffset::east(32400).unwrap(); timestamp: 1_420_000_000, offset: 32400),
+            Ok(FixedOffset::east(32400)
                 .unwrap()
                 .with_ymd_and_hms(2014, 12, 31, 13, 26, 40)
                 .unwrap())

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -966,7 +966,7 @@ mod tests {
             )
         }
 
-        let hms = |h, m, s| Ok(NaiveTime::from_hms_opt(h, m, s).unwrap());
+        let hms = |h, m, s| Ok(NaiveTime::from_hms(h, m, s).unwrap());
         let hmsn = |h, m, s, n| Ok(NaiveTime::from_hms_nano_opt(h, m, s, n).unwrap());
 
         // omission of fields

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -569,7 +569,7 @@ impl Parsed {
 
             // reconstruct date and time fields from timestamp
             let ts = timestamp.checked_add(i64::from(offset)).ok_or(OUT_OF_RANGE)?;
-            let datetime = NaiveDateTime::from_timestamp_opt(ts, 0);
+            let datetime = NaiveDateTime::from_timestamp(ts, 0);
             let mut datetime = datetime.ok_or(OUT_OF_RANGE)?;
 
             // fill year, ordinal, hour, minute and second fields from timestamp.
@@ -652,7 +652,7 @@ impl Parsed {
             // make a naive `DateTime` from given timestamp and (if any) nanosecond.
             // an empty `nanosecond` is always equal to zero, so missing nanosecond is fine.
             let nanosecond = self.nanosecond.unwrap_or(0);
-            let dt = NaiveDateTime::from_timestamp_opt(timestamp, nanosecond);
+            let dt = NaiveDateTime::from_timestamp(timestamp, nanosecond);
             let dt = dt.ok_or(OUT_OF_RANGE)?;
             guessed_offset = tz.offset_from_utc_datetime(&dt).fix().local_minus_utc();
         }

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -664,7 +664,7 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test_strftime_docs() {
-        let dt = FixedOffset::east_opt(34200)
+        let dt = FixedOffset::east(34200)
             .unwrap()
             .from_local_datetime(
                 &NaiveDate::from_ymd_opt(2001, 7, 8)
@@ -775,7 +775,7 @@ mod tests {
     #[test]
     #[cfg(all(feature = "unstable-locales", feature = "alloc"))]
     fn test_strftime_docs_localized() {
-        let dt = FixedOffset::east_opt(34200)
+        let dt = FixedOffset::east(34200)
             .unwrap()
             .with_ymd_and_hms(2001, 7, 8, 0, 34, 59)
             .unwrap()
@@ -832,7 +832,7 @@ mod tests {
         use crate::{FixedOffset, TimeZone};
         use std::fmt::Write;
 
-        let dt = FixedOffset::east_opt(34200)
+        let dt = FixedOffset::east(34200)
             .unwrap()
             .from_local_datetime(
                 &NaiveDate::from_ymd_opt(2001, 7, 8)
@@ -849,7 +849,7 @@ mod tests {
     #[test]
     #[cfg(all(feature = "unstable-locales", feature = "alloc"))]
     fn test_strftime_localized_korean() {
-        let dt = FixedOffset::east_opt(34200)
+        let dt = FixedOffset::east(34200)
             .unwrap()
             .with_ymd_and_hms(2001, 7, 8, 0, 34, 59)
             .unwrap()
@@ -878,7 +878,7 @@ mod tests {
     #[test]
     #[cfg(all(feature = "unstable-locales", feature = "alloc"))]
     fn test_strftime_localized_japanese() {
-        let dt = FixedOffset::east_opt(34200)
+        let dt = FixedOffset::east(34200)
             .unwrap()
             .with_ymd_and_hms(2001, 7, 8, 0, 34, 59)
             .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,9 +477,6 @@ pub mod prelude {
 
 mod datetime;
 pub use datetime::DateTime;
-#[allow(deprecated)]
-#[doc(no_inline)]
-pub use datetime::{MAX_DATETIME, MIN_DATETIME};
 
 pub mod format;
 /// L10n locales.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@
 //! // other time zone objects can be used to construct a local datetime.
 //! // obviously, `local_dt` is normally different from `dt`, but `fixed_dt` should be identical.
 //! let local_dt = Local.from_local_datetime(&NaiveDate::from_ymd_opt(2014, 7, 8).unwrap().and_hms_milli_opt(9, 10, 11, 12).unwrap()).unwrap();
-//! let fixed_dt = FixedOffset::east_opt(9 * 3600).unwrap().from_local_datetime(&NaiveDate::from_ymd_opt(2014, 7, 8).unwrap().and_hms_milli_opt(18, 10, 11, 12).unwrap()).unwrap();
+//! let fixed_dt = FixedOffset::east(9 * 3600).unwrap().from_local_datetime(&NaiveDate::from_ymd_opt(2014, 7, 8).unwrap().and_hms_milli_opt(18, 10, 11, 12).unwrap()).unwrap();
 //! assert_eq!(dt, fixed_dt);
 //! # let _ = local_dt;
 //! # }
@@ -169,7 +169,7 @@
 //! use chrono::TimeDelta;
 //!
 //! // assume this returned `2014-11-28T21:45:59.324310806+09:00`:
-//! let dt = FixedOffset::east_opt(9*3600).unwrap().from_local_datetime(&NaiveDate::from_ymd_opt(2014, 11, 28).unwrap().and_hms_nano_opt(21, 45, 59, 324310806).unwrap()).unwrap();
+//! let dt = FixedOffset::east(9*3600).unwrap().from_local_datetime(&NaiveDate::from_ymd_opt(2014, 11, 28).unwrap().and_hms_nano_opt(21, 45, 59, 324310806).unwrap()).unwrap();
 //!
 //! // property accessors
 //! assert_eq!((dt.year(), dt.month(), dt.day()), (2014, 11, 28));
@@ -182,7 +182,7 @@
 //!
 //! // time zone accessor and manipulation
 //! assert_eq!(dt.offset().fix().local_minus_utc(), 9 * 3600);
-//! assert_eq!(dt.timezone(), FixedOffset::east_opt(9 * 3600).unwrap());
+//! assert_eq!(dt.timezone(), FixedOffset::east(9 * 3600).unwrap());
 //! assert_eq!(dt.with_timezone(&Utc), NaiveDate::from_ymd_opt(2014, 11, 28).unwrap().and_hms_nano_opt(12, 45, 59, 324310806).unwrap().and_local_timezone(Utc).unwrap());
 //!
 //! // a sample of property manipulations (validates dynamically)
@@ -277,7 +277,7 @@
 //! use chrono::prelude::*;
 //!
 //! let dt = Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap();
-//! let fixed_dt = dt.with_timezone(&FixedOffset::east_opt(9*3600).unwrap());
+//! let fixed_dt = dt.with_timezone(&FixedOffset::east(9*3600).unwrap());
 //!
 //! // method 1
 //! assert_eq!("2014-11-28T12:00:09Z".parse::<DateTime<Utc>>(), Ok(dt.clone()));

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -864,7 +864,7 @@ impl NaiveDate {
     #[inline]
     #[must_use]
     pub const fn and_hms_opt(&self, hour: u32, min: u32, sec: u32) -> Option<NaiveDateTime> {
-        let time = try_opt!(NaiveTime::from_hms_opt(hour, min, sec));
+        let time = try_opt!(NaiveTime::from_hms(hour, min, sec));
         Some(self.and_time(time))
     }
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1028,7 +1028,7 @@ impl NaiveDate {
         sec: u32,
         nano: u32,
     ) -> Option<NaiveDateTime> {
-        let time = try_opt!(NaiveTime::from_hms_nano_opt(hour, min, sec, nano));
+        let time = try_opt!(NaiveTime::from_hms_nano(hour, min, sec, nano));
         Some(self.and_time(time))
     }
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -199,13 +199,6 @@ pub struct NaiveDate {
     ymdf: DateImpl, // (year << 13) | of
 }
 
-/// The minimum possible `NaiveDate` (January 1, 262145 BCE).
-#[deprecated(since = "0.4.20", note = "Use NaiveDate::MIN instead")]
-pub const MIN_DATE: NaiveDate = NaiveDate::MIN;
-/// The maximum possible `NaiveDate` (December 31, 262143 CE).
-#[deprecated(since = "0.4.20", note = "Use NaiveDate::MAX instead")]
-pub const MAX_DATE: NaiveDate = NaiveDate::MAX;
-
 #[cfg(all(feature = "arbitrary", feature = "std"))]
 impl arbitrary::Arbitrary<'_> for NaiveDate {
     fn arbitrary(u: &mut arbitrary::Unstructured) -> arbitrary::Result<NaiveDate> {
@@ -253,19 +246,6 @@ impl NaiveDate {
     /// Makes a new `NaiveDate` from the [calendar date](#calendar-date)
     /// (year, month and day).
     ///
-    /// # Panics
-    ///
-    /// Panics if the specified calendar day does not exist, on invalid values for `month` or `day`,
-    /// or if `year` is out of range for `NaiveDate`.
-    #[deprecated(since = "0.4.23", note = "use `from_ymd_opt()` instead")]
-    #[must_use]
-    pub const fn from_ymd(year: i32, month: u32, day: u32) -> NaiveDate {
-        expect!(NaiveDate::from_ymd_opt(year, month, day), "invalid or out-of-range date")
-    }
-
-    /// Makes a new `NaiveDate` from the [calendar date](#calendar-date)
-    /// (year, month and day).
-    ///
     /// # Errors
     ///
     /// Returns `None` if:
@@ -301,19 +281,6 @@ impl NaiveDate {
     /// Makes a new `NaiveDate` from the [ordinal date](#ordinal-date)
     /// (year and day of the year).
     ///
-    /// # Panics
-    ///
-    /// Panics if the specified ordinal day does not exist, on invalid values for `ordinal`, or if
-    /// `year` is out of range for `NaiveDate`.
-    #[deprecated(since = "0.4.23", note = "use `from_yo_opt()` instead")]
-    #[must_use]
-    pub const fn from_yo(year: i32, ordinal: u32) -> NaiveDate {
-        expect!(NaiveDate::from_yo_opt(year, ordinal), "invalid or out-of-range date")
-    }
-
-    /// Makes a new `NaiveDate` from the [ordinal date](#ordinal-date)
-    /// (year and day of the year).
-    ///
     /// # Errors
     ///
     /// Returns `None` if:
@@ -340,20 +307,6 @@ impl NaiveDate {
     pub const fn from_yo_opt(year: i32, ordinal: u32) -> Option<NaiveDate> {
         let flags = YearFlags::from_year(year);
         NaiveDate::from_ordinal_and_flags(year, ordinal, flags)
-    }
-
-    /// Makes a new `NaiveDate` from the [ISO week date](#week-date)
-    /// (year, week number and day of the week).
-    /// The resulting `NaiveDate` may have a different year from the input year.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the specified week does not exist in that year, on invalid values for `week`, or
-    /// if the resulting date is out of range for `NaiveDate`.
-    #[deprecated(since = "0.4.23", note = "use `from_isoywd_opt()` instead")]
-    #[must_use]
-    pub const fn from_isoywd(year: i32, week: u32, weekday: Weekday) -> NaiveDate {
-        expect!(NaiveDate::from_isoywd_opt(year, week, weekday), "invalid or out-of-range date")
     }
 
     /// Makes a new `NaiveDate` from the [ISO week date](#week-date)
@@ -441,19 +394,6 @@ impl NaiveDate {
     /// Makes a new `NaiveDate` from a day's number in the proleptic Gregorian calendar, with
     /// January 1, 1 being day 1.
     ///
-    /// # Panics
-    ///
-    /// Panics if the date is out of range.
-    #[deprecated(since = "0.4.23", note = "use `from_num_days_from_ce_opt()` instead")]
-    #[inline]
-    #[must_use]
-    pub const fn from_num_days_from_ce(days: i32) -> NaiveDate {
-        expect!(NaiveDate::from_num_days_from_ce_opt(days), "out-of-range date")
-    }
-
-    /// Makes a new `NaiveDate` from a day's number in the proleptic Gregorian calendar, with
-    /// January 1, 1 being day 1.
-    ///
     /// # Errors
     ///
     /// Returns `None` if the date is out of range.
@@ -481,27 +421,6 @@ impl NaiveDate {
         let (year_mod_400, ordinal) = internals::cycle_to_yo(cycle as u32);
         let flags = YearFlags::from_year_mod_400(year_mod_400 as i32);
         NaiveDate::from_ordinal_and_flags(year_div_400 * 400 + year_mod_400 as i32, ordinal, flags)
-    }
-
-    /// Makes a new `NaiveDate` by counting the number of occurrences of a particular day-of-week
-    /// since the beginning of the given month. For instance, if you want the 2nd Friday of March
-    /// 2017, you would use `NaiveDate::from_weekday_of_month(2017, 3, Weekday::Fri, 2)`.
-    ///
-    /// `n` is 1-indexed.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the specified day does not exist in that month, on invalid values for `month` or
-    /// `n`, or if `year` is out of range for `NaiveDate`.
-    #[deprecated(since = "0.4.23", note = "use `from_weekday_of_month_opt()` instead")]
-    #[must_use]
-    pub const fn from_weekday_of_month(
-        year: i32,
-        month: u32,
-        weekday: Weekday,
-        n: u8,
-    ) -> NaiveDate {
-        expect!(NaiveDate::from_weekday_of_month_opt(year, month, weekday, n), "out-of-range date")
     }
 
     /// Makes a new `NaiveDate` by counting the number of occurrences of a particular day-of-week
@@ -829,21 +748,6 @@ impl NaiveDate {
     /// Makes a new `NaiveDateTime` from the current date, hour, minute and second.
     ///
     /// No [leap second](./struct.NaiveTime.html#leap-second-handling) is allowed here;
-    /// use `NaiveDate::and_hms_*` methods with a subsecond parameter instead.
-    ///
-    /// # Panics
-    ///
-    /// Panics on invalid hour, minute and/or second.
-    #[deprecated(since = "0.4.23", note = "use `and_hms_opt()` instead")]
-    #[inline]
-    #[must_use]
-    pub const fn and_hms(&self, hour: u32, min: u32, sec: u32) -> NaiveDateTime {
-        expect!(self.and_hms_opt(hour, min, sec), "invalid time")
-    }
-
-    /// Makes a new `NaiveDateTime` from the current date, hour, minute and second.
-    ///
-    /// No [leap second](./struct.NaiveTime.html#leap-second-handling) is allowed here;
     /// use `NaiveDate::and_hms_*_opt` methods with a subsecond parameter instead.
     ///
     /// # Errors
@@ -866,21 +770,6 @@ impl NaiveDate {
     pub const fn and_hms_opt(&self, hour: u32, min: u32, sec: u32) -> Option<NaiveDateTime> {
         let time = try_opt!(NaiveTime::from_hms(hour, min, sec));
         Some(self.and_time(time))
-    }
-
-    /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and millisecond.
-    ///
-    /// The millisecond part is allowed to exceed 1,000,000,000 in order to represent a [leap second](
-    /// ./struct.NaiveTime.html#leap-second-handling), but only when `sec == 59`.
-    ///
-    /// # Panics
-    ///
-    /// Panics on invalid hour, minute, second and/or millisecond.
-    #[deprecated(since = "0.4.23", note = "use `and_hms_milli_opt()` instead")]
-    #[inline]
-    #[must_use]
-    pub const fn and_hms_milli(&self, hour: u32, min: u32, sec: u32, milli: u32) -> NaiveDateTime {
-        expect!(self.and_hms_milli_opt(hour, min, sec, milli), "invalid time")
     }
 
     /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and millisecond.
@@ -923,35 +812,6 @@ impl NaiveDate {
     /// The microsecond part is allowed to exceed 1,000,000,000 in order to represent a [leap second](
     /// ./struct.NaiveTime.html#leap-second-handling), but only when `sec == 59`.
     ///
-    /// # Panics
-    ///
-    /// Panics on invalid hour, minute, second and/or microsecond.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use chrono::{NaiveDate, NaiveDateTime, Datelike, Timelike, Weekday};
-    ///
-    /// let d = NaiveDate::from_ymd_opt(2015, 6, 3).unwrap();
-    ///
-    /// let dt: NaiveDateTime = d.and_hms_micro_opt(12, 34, 56, 789_012).unwrap();
-    /// assert_eq!(dt.year(), 2015);
-    /// assert_eq!(dt.weekday(), Weekday::Wed);
-    /// assert_eq!(dt.second(), 56);
-    /// assert_eq!(dt.nanosecond(), 789_012_000);
-    /// ```
-    #[deprecated(since = "0.4.23", note = "use `and_hms_micro_opt()` instead")]
-    #[inline]
-    #[must_use]
-    pub const fn and_hms_micro(&self, hour: u32, min: u32, sec: u32, micro: u32) -> NaiveDateTime {
-        expect!(self.and_hms_micro_opt(hour, min, sec, micro), "invalid time")
-    }
-
-    /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and microsecond.
-    ///
-    /// The microsecond part is allowed to exceed 1,000,000,000 in order to represent a [leap second](
-    /// ./struct.NaiveTime.html#leap-second-handling), but only when `sec == 59`.
-    ///
     /// # Errors
     ///
     /// Returns `None` on invalid hour, minute, second and/or microsecond.
@@ -980,21 +840,6 @@ impl NaiveDate {
     ) -> Option<NaiveDateTime> {
         let time = try_opt!(NaiveTime::from_hms_micro(hour, min, sec, micro));
         Some(self.and_time(time))
-    }
-
-    /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and nanosecond.
-    ///
-    /// The nanosecond part is allowed to exceed 1,000,000,000 in order to represent a [leap second](
-    /// ./struct.NaiveTime.html#leap-second-handling), but only when `sec == 59`.
-    ///
-    /// # Panics
-    ///
-    /// Panics on invalid hour, minute, second and/or nanosecond.
-    #[deprecated(since = "0.4.23", note = "use `and_hms_nano_opt()` instead")]
-    #[inline]
-    #[must_use]
-    pub const fn and_hms_nano(&self, hour: u32, min: u32, sec: u32, nano: u32) -> NaiveDateTime {
-        expect!(self.and_hms_nano_opt(hour, min, sec, nano), "invalid time")
     }
 
     /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and nanosecond.
@@ -1063,18 +908,6 @@ impl NaiveDate {
 
     /// Makes a new `NaiveDate` for the next calendar date.
     ///
-    /// # Panics
-    ///
-    /// Panics when `self` is the last representable date.
-    #[deprecated(since = "0.4.23", note = "use `succ_opt()` instead")]
-    #[inline]
-    #[must_use]
-    pub const fn succ(&self) -> NaiveDate {
-        expect!(self.succ_opt(), "out of bound")
-    }
-
-    /// Makes a new `NaiveDate` for the next calendar date.
-    ///
     /// # Errors
     ///
     /// Returns `None` when `self` is the last representable date.
@@ -1095,18 +928,6 @@ impl NaiveDate {
             Some(of) => Some(self.with_of(of)),
             None => NaiveDate::from_ymd_opt(self.year() + 1, 1, 1),
         }
-    }
-
-    /// Makes a new `NaiveDate` for the previous calendar date.
-    ///
-    /// # Panics
-    ///
-    /// Panics when `self` is the first representable date.
-    #[deprecated(since = "0.4.23", note = "use `pred_opt()` instead")]
-    #[inline]
-    #[must_use]
-    pub const fn pred(&self) -> NaiveDate {
-        expect!(self.pred_opt(), "out of bound")
     }
 
     /// Makes a new `NaiveDate` for the previous calendar date.

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -978,7 +978,7 @@ impl NaiveDate {
         sec: u32,
         micro: u32,
     ) -> Option<NaiveDateTime> {
-        let time = try_opt!(NaiveTime::from_hms_micro_opt(hour, min, sec, micro));
+        let time = try_opt!(NaiveTime::from_hms_micro(hour, min, sec, micro));
         Some(self.and_time(time))
     }
 

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -814,7 +814,7 @@ impl NaiveDate {
     /// use chrono::{NaiveDate, NaiveTime, NaiveDateTime};
     ///
     /// let d = NaiveDate::from_ymd_opt(2015, 6, 3).unwrap();
-    /// let t = NaiveTime::from_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let t = NaiveTime::from_hms_milli(12, 34, 56, 789).unwrap();
     ///
     /// let dt: NaiveDateTime = d.and_time(t);
     /// assert_eq!(dt.date(), d);
@@ -914,7 +914,7 @@ impl NaiveDate {
         sec: u32,
         milli: u32,
     ) -> Option<NaiveDateTime> {
-        let time = try_opt!(NaiveTime::from_hms_milli_opt(hour, min, sec, milli));
+        let time = try_opt!(NaiveTime::from_hms_milli(hour, min, sec, milli));
         Some(self.and_time(time))
     }
 

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -129,7 +129,7 @@ impl NaiveDateTime {
     pub const fn from_timestamp_millis(millis: i64) -> Option<NaiveDateTime> {
         let secs = millis.div_euclid(1000);
         let nsecs = millis.rem_euclid(1000) as u32 * 1_000_000;
-        NaiveDateTime::from_timestamp_opt(secs, nsecs)
+        NaiveDateTime::from_timestamp(secs, nsecs)
     }
 
     /// Creates a new [NaiveDateTime] from microseconds since the UNIX epoch.
@@ -161,7 +161,7 @@ impl NaiveDateTime {
     pub const fn from_timestamp_micros(micros: i64) -> Option<NaiveDateTime> {
         let secs = micros.div_euclid(1_000_000);
         let nsecs = micros.rem_euclid(1_000_000) as u32 * 1000;
-        NaiveDateTime::from_timestamp_opt(secs, nsecs)
+        NaiveDateTime::from_timestamp(secs, nsecs)
     }
 
     /// Creates a new [NaiveDateTime] from nanoseconds since the UNIX epoch.
@@ -180,13 +180,13 @@ impl NaiveDateTime {
     /// let timestamp_nanos: i64 = 1662921288_000_000_000; //Sunday, September 11, 2022 6:34:48 PM
     /// let naive_datetime = NaiveDateTime::from_timestamp_nanos(timestamp_nanos);
     /// assert!(naive_datetime.is_some());
-    /// assert_eq!(timestamp_nanos, naive_datetime.unwrap().timestamp_nanos_opt().unwrap());
+    /// assert_eq!(timestamp_nanos, naive_datetime.unwrap().timestamp_nanos().unwrap());
     ///
     /// // Negative timestamps (before the UNIX epoch) are supported as well.
     /// let timestamp_nanos: i64 = -2208936075_000_000_000; //Mon Jan 01 1900 14:38:45 GMT+0000
     /// let naive_datetime = NaiveDateTime::from_timestamp_nanos(timestamp_nanos);
     /// assert!(naive_datetime.is_some());
-    /// assert_eq!(timestamp_nanos, naive_datetime.unwrap().timestamp_nanos_opt().unwrap());
+    /// assert_eq!(timestamp_nanos, naive_datetime.unwrap().timestamp_nanos().unwrap());
     /// ```
     #[inline]
     #[must_use]
@@ -194,7 +194,7 @@ impl NaiveDateTime {
         let secs = nanos.div_euclid(NANOS_PER_SEC as i64);
         let nsecs = nanos.rem_euclid(NANOS_PER_SEC as i64) as u32;
 
-        NaiveDateTime::from_timestamp_opt(secs, nsecs)
+        NaiveDateTime::from_timestamp(secs, nsecs)
     }
 
     /// Makes a new `NaiveDateTime` corresponding to a UTC date and time,
@@ -218,18 +218,18 @@ impl NaiveDateTime {
     /// use chrono::NaiveDateTime;
     /// use std::i64;
     ///
-    /// let from_timestamp_opt = NaiveDateTime::from_timestamp_opt;
+    /// let from_timestamp = NaiveDateTime::from_timestamp;
     ///
-    /// assert!(from_timestamp_opt(0, 0).is_some());
-    /// assert!(from_timestamp_opt(0, 999_999_999).is_some());
-    /// assert!(from_timestamp_opt(0, 1_500_000_000).is_none()); // invalid leap second
-    /// assert!(from_timestamp_opt(59, 1_500_000_000).is_some()); // leap second
-    /// assert!(from_timestamp_opt(59, 2_000_000_000).is_none());
-    /// assert!(from_timestamp_opt(i64::MAX, 0).is_none());
+    /// assert!(from_timestamp(0, 0).is_some());
+    /// assert!(from_timestamp(0, 999_999_999).is_some());
+    /// assert!(from_timestamp(0, 1_500_000_000).is_none()); // invalid leap second
+    /// assert!(from_timestamp(59, 1_500_000_000).is_some()); // leap second
+    /// assert!(from_timestamp(59, 2_000_000_000).is_none());
+    /// assert!(from_timestamp(i64::MAX, 0).is_none());
     /// ```
     #[inline]
     #[must_use]
-    pub const fn from_timestamp_opt(secs: i64, nsecs: u32) -> Option<NaiveDateTime> {
+    pub const fn from_timestamp(secs: i64, nsecs: u32) -> Option<NaiveDateTime> {
         let days = secs.div_euclid(86_400);
         let secs = secs.rem_euclid(86_400);
         if days < i32::MIN as i64 || days > i32::MAX as i64 {
@@ -475,21 +475,21 @@ impl NaiveDateTime {
     /// use chrono::{NaiveDate, NaiveDateTime};
     ///
     /// let dt = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_nano_opt(0, 0, 1, 444).unwrap();
-    /// assert_eq!(dt.timestamp_nanos_opt(), Some(1_000_000_444));
+    /// assert_eq!(dt.timestamp_nanos(), Some(1_000_000_444));
     ///
     /// let dt = NaiveDate::from_ymd_opt(2001, 9, 9).unwrap().and_hms_nano_opt(1, 46, 40, 555).unwrap();
     ///
     /// const A_BILLION: i64 = 1_000_000_000;
-    /// let nanos = dt.timestamp_nanos_opt().unwrap();
+    /// let nanos = dt.timestamp_nanos().unwrap();
     /// assert_eq!(nanos, 1_000_000_000_000_000_555);
     /// assert_eq!(
     ///     Some(dt),
-    ///     NaiveDateTime::from_timestamp_opt(nanos / A_BILLION, (nanos % A_BILLION) as u32)
+    ///     NaiveDateTime::from_timestamp(nanos / A_BILLION, (nanos % A_BILLION) as u32)
     /// );
     /// ```
     #[inline]
     #[must_use]
-    pub const fn timestamp_nanos_opt(&self) -> Option<i64> {
+    pub const fn timestamp_nanos(&self) -> Option<i64> {
         let mut timestamp = self.timestamp();
         let mut timestamp_subsec_nanos = self.timestamp_subsec_nanos() as i64;
 
@@ -2099,11 +2099,11 @@ impl str::FromStr for NaiveDateTime {
 /// use chrono::NaiveDateTime;
 ///
 /// let default_date = NaiveDateTime::default();
-/// assert_eq!(Some(default_date), NaiveDateTime::from_timestamp_opt(0, 0));
+/// assert_eq!(Some(default_date), NaiveDateTime::from_timestamp(0, 0));
 /// ```
 impl Default for NaiveDateTime {
     fn default() -> Self {
-        NaiveDateTime::from_timestamp_opt(0, 0).unwrap()
+        NaiveDateTime::from_timestamp(0, 0).unwrap()
     }
 }
 

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -369,7 +369,7 @@ impl NaiveDateTime {
     /// use chrono::{NaiveDate, NaiveTime};
     ///
     /// let dt = NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_opt(9, 10, 11).unwrap();
-    /// assert_eq!(dt.time(), NaiveTime::from_hms_opt(9, 10, 11).unwrap());
+    /// assert_eq!(dt.time(), NaiveTime::from_hms(9, 10, 11).unwrap());
     /// ```
     #[inline]
     pub const fn time(&self) -> NaiveTime {

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -237,7 +237,7 @@ impl NaiveDateTime {
         }
         let date =
             NaiveDate::from_num_days_from_ce_opt(try_opt!((days as i32).checked_add(719_163)));
-        let time = NaiveTime::from_num_seconds_from_midnight_opt(secs as u32, nsecs);
+        let time = NaiveTime::from_num_seconds_from_midnight(secs as u32, nsecs);
         match (date, time) {
             (Some(date), Some(time)) => Some(NaiveDateTime { date, time }),
             (_, _) => None,

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -89,7 +89,7 @@ impl NaiveDateTime {
     /// use chrono::{NaiveDate, NaiveTime, NaiveDateTime};
     ///
     /// let d = NaiveDate::from_ymd_opt(2015, 6, 3).unwrap();
-    /// let t = NaiveTime::from_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let t = NaiveTime::from_hms_milli(12, 34, 56, 789).unwrap();
     ///
     /// let dt = NaiveDateTime::new(d, t);
     /// assert_eq!(dt.date(), d);

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -40,13 +40,6 @@ mod tests;
 /// touching that call when we are already sure that it WILL overflow...
 const MAX_SECS_BITS: usize = 44;
 
-/// The minimum possible `NaiveDateTime`.
-#[deprecated(since = "0.4.20", note = "Use NaiveDateTime::MIN instead")]
-pub const MIN_DATETIME: NaiveDateTime = NaiveDateTime::MIN;
-/// The maximum possible `NaiveDateTime`.
-#[deprecated(since = "0.4.20", note = "Use NaiveDateTime::MAX instead")]
-pub const MAX_DATETIME: NaiveDateTime = NaiveDateTime::MAX;
-
 /// ISO 8601 combined date and time without timezone.
 ///
 /// # Example
@@ -105,30 +98,6 @@ impl NaiveDateTime {
     #[inline]
     pub const fn new(date: NaiveDate, time: NaiveTime) -> NaiveDateTime {
         NaiveDateTime { date, time }
-    }
-
-    /// Makes a new `NaiveDateTime` corresponding to a UTC date and time,
-    /// from the number of non-leap seconds
-    /// since the midnight UTC on January 1, 1970 (aka "UNIX timestamp")
-    /// and the number of nanoseconds since the last whole non-leap second.
-    ///
-    /// For a non-naive version of this function see [`TimeZone::timestamp`].
-    ///
-    /// The nanosecond part can exceed 1,000,000,000 in order to represent a
-    /// [leap second](NaiveTime#leap-second-handling), but only when `secs % 60 == 59`.
-    /// (The true "UNIX timestamp" cannot represent a leap second unambiguously.)
-    ///
-    /// # Panics
-    ///
-    /// Panics if the number of seconds would be out of range for a `NaiveDateTime` (more than
-    /// ca. 262,000 years away from common era), and panics on an invalid nanosecond (2 seconds or
-    /// more).
-    #[deprecated(since = "0.4.23", note = "use `from_timestamp_opt()` instead")]
-    #[inline]
-    #[must_use]
-    pub const fn from_timestamp(secs: i64, nsecs: u32) -> NaiveDateTime {
-        let datetime = NaiveDateTime::from_timestamp_opt(secs, nsecs);
-        expect!(datetime, "invalid or out-of-range datetime")
     }
 
     /// Creates a new [NaiveDateTime] from milliseconds since the UNIX epoch.
@@ -485,28 +454,6 @@ impl NaiveDateTime {
     pub const fn timestamp_micros(&self) -> i64 {
         let as_us = self.timestamp() * 1_000_000;
         as_us + self.timestamp_subsec_micros() as i64
-    }
-
-    /// Returns the number of non-leap *nanoseconds* since midnight on January 1, 1970.
-    ///
-    /// Note that this does *not* account for the timezone!
-    /// The true "UNIX timestamp" would count seconds since the midnight *UTC* on the epoch.
-    ///
-    /// # Panics
-    ///
-    /// An `i64` with nanosecond precision can span a range of ~584 years. This function panics on
-    /// an out of range `NaiveDateTime`.
-    ///
-    /// The dates that can be represented as nanoseconds are between 1677-09-21T00:12:43.145224192
-    /// and 2262-04-11T23:47:16.854775807.
-    #[deprecated(since = "0.4.31", note = "use `timestamp_nanos_opt()` instead")]
-    #[inline]
-    #[must_use]
-    pub const fn timestamp_nanos(&self) -> i64 {
-        expect!(
-            self.timestamp_nanos_opt(),
-            "value can not be represented in a timestamp with nanosecond precision."
-        )
     }
 
     /// Returns the number of non-leap *nanoseconds* since midnight on January 1, 1970.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -998,7 +998,7 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, FixedOffset};
     /// let hour = 3600;
-    /// let tz = FixedOffset::east_opt(5 * hour).unwrap();
+    /// let tz = FixedOffset::east(5 * hour).unwrap();
     /// let dt = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap().and_local_timezone(tz).unwrap();
     /// assert_eq!(dt.timezone(), tz);
     /// ```

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -940,8 +940,7 @@ pub mod ts_seconds {
         where
             E: de::Error,
         {
-            NaiveDateTime::from_timestamp(value, 0)
-                .ok_or_else(|| E::custom(ne_timestamp(value)))
+            NaiveDateTime::from_timestamp(value, 0).ok_or_else(|| E::custom(ne_timestamp(value)))
         }
 
         fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -120,7 +120,7 @@ pub mod ts_nanoseconds {
     where
         S: ser::Serializer,
     {
-        serializer.serialize_i64(dt.timestamp_nanos_opt().ok_or(ser::Error::custom(
+        serializer.serialize_i64(dt.timestamp_nanos().ok_or(ser::Error::custom(
             "value out of range for a timestamp with nanosecond precision",
         ))?)
     }
@@ -142,10 +142,10 @@ pub mod ts_nanoseconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
-    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918355733).unwrap() });
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp(1526522699, 918355733).unwrap() });
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
-    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(-1, 999_999_999).unwrap() });
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp(-1, 999_999_999).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
@@ -168,7 +168,7 @@ pub mod ts_nanoseconds {
         where
             E: de::Error,
         {
-            NaiveDateTime::from_timestamp_opt(
+            NaiveDateTime::from_timestamp(
                 value.div_euclid(1_000_000_000),
                 (value.rem_euclid(1_000_000_000)) as u32,
             )
@@ -179,7 +179,7 @@ pub mod ts_nanoseconds {
         where
             E: de::Error,
         {
-            NaiveDateTime::from_timestamp_opt(
+            NaiveDateTime::from_timestamp(
                 (value / 1_000_000_000) as i64,
                 (value % 1_000_000_000) as u32,
             )
@@ -258,7 +258,7 @@ pub mod ts_nanoseconds_option {
         S: ser::Serializer,
     {
         match *opt {
-            Some(ref dt) => serializer.serialize_some(&dt.timestamp_nanos_opt().ok_or(
+            Some(ref dt) => serializer.serialize_some(&dt.timestamp_nanos().ok_or(
                 ser::Error::custom("value out of range for a timestamp with nanosecond precision"),
             )?),
             None => serializer.serialize_none(),
@@ -282,10 +282,10 @@ pub mod ts_nanoseconds_option {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
-    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918355733) });
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp(1526522699, 918355733) });
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
-    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(-1, 999_999_999) });
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp(-1, 999_999_999) });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
@@ -409,10 +409,10 @@ pub mod ts_microseconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
-    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918355000).unwrap() });
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp(1526522699, 918355000).unwrap() });
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
-    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(-1, 999_999_000).unwrap() });
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp(-1, 999_999_000).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
@@ -443,7 +443,7 @@ pub mod ts_microseconds {
         where
             E: de::Error,
         {
-            NaiveDateTime::from_timestamp_opt(
+            NaiveDateTime::from_timestamp(
                 (value / 1_000_000) as i64,
                 ((value % 1_000_000) * 1_000) as u32,
             )
@@ -536,10 +536,10 @@ pub mod ts_microseconds_option {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
-    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918355000) });
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp(1526522699, 918355000) });
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
-    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(-1, 999_999_000) });
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp(-1, 999_999_000) });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
@@ -663,10 +663,10 @@ pub mod ts_milliseconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
-    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918000000).unwrap() });
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp(1526522699, 918000000).unwrap() });
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
-    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(-1, 999_000_000).unwrap() });
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp(-1, 999_000_000).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
@@ -697,7 +697,7 @@ pub mod ts_milliseconds {
         where
             E: de::Error,
         {
-            NaiveDateTime::from_timestamp_opt(
+            NaiveDateTime::from_timestamp(
                 (value / 1000) as i64,
                 ((value % 1000) * 1_000_000) as u32,
             )
@@ -790,10 +790,10 @@ pub mod ts_milliseconds_option {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
-    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1526522699, 918000000) });
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp(1526522699, 918000000) });
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
-    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(-1, 999_000_000) });
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp(-1, 999_000_000) });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>
@@ -917,7 +917,7 @@ pub mod ts_seconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
-    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1431684000, 0).unwrap() });
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp(1431684000, 0).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<NaiveDateTime, D::Error>
@@ -940,7 +940,7 @@ pub mod ts_seconds {
         where
             E: de::Error,
         {
-            NaiveDateTime::from_timestamp_opt(value, 0)
+            NaiveDateTime::from_timestamp(value, 0)
                 .ok_or_else(|| E::custom(ne_timestamp(value)))
         }
 
@@ -948,7 +948,7 @@ pub mod ts_seconds {
         where
             E: de::Error,
         {
-            NaiveDateTime::from_timestamp_opt(value as i64, 0)
+            NaiveDateTime::from_timestamp(value as i64, 0)
                 .ok_or_else(|| E::custom(ne_timestamp(value)))
         }
     }
@@ -1038,7 +1038,7 @@ pub mod ts_seconds_option {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
-    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp_opt(1431684000, 0) });
+    /// assert_eq!(my_s, S { time: NaiveDateTime::from_timestamp(1431684000, 0) });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<NaiveDateTime>, D::Error>

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -35,7 +35,7 @@ fn test_datetime_from_timestamp_millis() {
     for secs in secs_test.iter().cloned() {
         assert_eq!(
             NaiveDateTime::from_timestamp_millis(secs * 1000),
-            NaiveDateTime::from_timestamp_opt(secs, 0)
+            NaiveDateTime::from_timestamp(secs, 0)
         );
     }
 }
@@ -73,7 +73,7 @@ fn test_datetime_from_timestamp_micros() {
     for secs in secs_test.iter().copied() {
         assert_eq!(
             NaiveDateTime::from_timestamp_micros(secs * 1_000_000),
-            NaiveDateTime::from_timestamp_opt(secs, 0)
+            NaiveDateTime::from_timestamp(secs, 0)
         );
     }
 }
@@ -95,7 +95,7 @@ fn test_datetime_from_timestamp_nanos() {
 
     for (timestamp_nanos, _formatted) in valid_map.iter().copied() {
         let naive_datetime = NaiveDateTime::from_timestamp_nanos(timestamp_nanos).unwrap();
-        assert_eq!(timestamp_nanos, naive_datetime.timestamp_nanos_opt().unwrap());
+        assert_eq!(timestamp_nanos, naive_datetime.timestamp_nanos().unwrap());
         #[cfg(feature = "alloc")]
         assert_eq!(naive_datetime.format("%F %T%.9f").to_string(), _formatted);
     }
@@ -104,18 +104,18 @@ fn test_datetime_from_timestamp_nanos() {
     // Maximum datetime in nanoseconds
     let maximum = "2262-04-11T23:47:16.854775804";
     let parsed: NaiveDateTime = maximum.parse().unwrap();
-    let nanos = parsed.timestamp_nanos_opt().unwrap();
+    let nanos = parsed.timestamp_nanos().unwrap();
     assert_eq!(
         NaiveDateTime::from_timestamp_nanos(nanos).unwrap(),
-        NaiveDateTime::from_timestamp_opt(nanos / A_BILLION, (nanos % A_BILLION) as u32).unwrap()
+        NaiveDateTime::from_timestamp(nanos / A_BILLION, (nanos % A_BILLION) as u32).unwrap()
     );
     // Minimum datetime in nanoseconds
     let minimum = "1677-09-21T00:12:44.000000000";
     let parsed: NaiveDateTime = minimum.parse().unwrap();
-    let nanos = parsed.timestamp_nanos_opt().unwrap();
+    let nanos = parsed.timestamp_nanos().unwrap();
     assert_eq!(
         NaiveDateTime::from_timestamp_nanos(nanos).unwrap(),
-        NaiveDateTime::from_timestamp_opt(nanos / A_BILLION, (nanos % A_BILLION) as u32).unwrap()
+        NaiveDateTime::from_timestamp(nanos / A_BILLION, (nanos % A_BILLION) as u32).unwrap()
     );
 
     // Test that the result of `from_timestamp_nanos` compares equal to
@@ -124,14 +124,14 @@ fn test_datetime_from_timestamp_nanos() {
     for secs in secs_test.iter().copied() {
         assert_eq!(
             NaiveDateTime::from_timestamp_nanos(secs * 1_000_000_000),
-            NaiveDateTime::from_timestamp_opt(secs, 0)
+            NaiveDateTime::from_timestamp(secs, 0)
         );
     }
 }
 
 #[test]
 fn test_datetime_from_timestamp() {
-    let from_timestamp = |secs| NaiveDateTime::from_timestamp_opt(secs, 0);
+    let from_timestamp = |secs| NaiveDateTime::from_timestamp(secs, 0);
     let ymdhms =
         |y, m, d, h, n, s| NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
     assert_eq!(from_timestamp(-1), Some(ymdhms(1969, 12, 31, 23, 59, 59)));
@@ -457,31 +457,31 @@ fn test_nanosecond_range() {
     const A_BILLION: i64 = 1_000_000_000;
     let maximum = "2262-04-11T23:47:16.854775804";
     let parsed: NaiveDateTime = maximum.parse().unwrap();
-    let nanos = parsed.timestamp_nanos_opt().unwrap();
+    let nanos = parsed.timestamp_nanos().unwrap();
     assert_eq!(
         parsed,
-        NaiveDateTime::from_timestamp_opt(nanos / A_BILLION, (nanos % A_BILLION) as u32).unwrap()
+        NaiveDateTime::from_timestamp(nanos / A_BILLION, (nanos % A_BILLION) as u32).unwrap()
     );
 
     let minimum = "1677-09-21T00:12:44.000000000";
     let parsed: NaiveDateTime = minimum.parse().unwrap();
-    let nanos = parsed.timestamp_nanos_opt().unwrap();
+    let nanos = parsed.timestamp_nanos().unwrap();
     assert_eq!(
         parsed,
-        NaiveDateTime::from_timestamp_opt(nanos / A_BILLION, (nanos % A_BILLION) as u32).unwrap()
+        NaiveDateTime::from_timestamp(nanos / A_BILLION, (nanos % A_BILLION) as u32).unwrap()
     );
 
     // Just beyond range
     let maximum = "2262-04-11T23:47:16.854775804";
     let parsed: NaiveDateTime = maximum.parse().unwrap();
     let beyond_max = parsed + TimeDelta::milliseconds(300);
-    assert!(beyond_max.timestamp_nanos_opt().is_none());
+    assert!(beyond_max.timestamp_nanos().is_none());
 
     // Far beyond range
     let maximum = "2262-04-11T23:47:16.854775804";
     let parsed: NaiveDateTime = maximum.parse().unwrap();
     let beyond_max = parsed + TimeDelta::days(365);
-    assert!(beyond_max.timestamp_nanos_opt().is_none());
+    assert!(beyond_max.timestamp_nanos().is_none());
 }
 
 #[test]

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -491,7 +491,7 @@ fn test_and_local_timezone() {
     assert_eq!(dt_utc.naive_local(), ndt);
     assert_eq!(dt_utc.timezone(), Utc);
 
-    let offset_tz = FixedOffset::west_opt(4 * 3600).unwrap();
+    let offset_tz = FixedOffset::west(4 * 3600).unwrap();
     let dt_offset = ndt.and_local_timezone(offset_tz).unwrap();
     assert_eq!(dt_offset.naive_local(), ndt);
     assert_eq!(dt_offset.timezone(), offset_tz);
@@ -511,7 +511,7 @@ fn test_checked_add_offset() {
         NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi)
     };
 
-    let positive_offset = FixedOffset::east_opt(2 * 60 * 60).unwrap();
+    let positive_offset = FixedOffset::east(2 * 60 * 60).unwrap();
     // regular date
     let dt = ymdhmsm(2023, 5, 5, 20, 10, 0, 0).unwrap();
     assert_eq!(dt.checked_add_offset(positive_offset), ymdhmsm(2023, 5, 5, 22, 10, 0, 0));
@@ -521,7 +521,7 @@ fn test_checked_add_offset() {
     // out of range
     assert!(NaiveDateTime::MAX.checked_add_offset(positive_offset).is_none());
 
-    let negative_offset = FixedOffset::west_opt(2 * 60 * 60).unwrap();
+    let negative_offset = FixedOffset::west(2 * 60 * 60).unwrap();
     // regular date
     let dt = ymdhmsm(2023, 5, 5, 20, 10, 0, 0).unwrap();
     assert_eq!(dt.checked_add_offset(negative_offset), ymdhmsm(2023, 5, 5, 18, 10, 0, 0));
@@ -538,7 +538,7 @@ fn test_checked_sub_offset() {
         NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi)
     };
 
-    let positive_offset = FixedOffset::east_opt(2 * 60 * 60).unwrap();
+    let positive_offset = FixedOffset::east(2 * 60 * 60).unwrap();
     // regular date
     let dt = ymdhmsm(2023, 5, 5, 20, 10, 0, 0).unwrap();
     assert_eq!(dt.checked_sub_offset(positive_offset), ymdhmsm(2023, 5, 5, 18, 10, 0, 0));
@@ -548,7 +548,7 @@ fn test_checked_sub_offset() {
     // out of range
     assert!(NaiveDateTime::MIN.checked_sub_offset(positive_offset).is_none());
 
-    let negative_offset = FixedOffset::west_opt(2 * 60 * 60).unwrap();
+    let negative_offset = FixedOffset::west(2 * 60 * 60).unwrap();
     // regular date
     let dt = ymdhmsm(2023, 5, 5, 20, 10, 0, 0).unwrap();
     assert_eq!(dt.checked_sub_offset(negative_offset), ymdhmsm(2023, 5, 5, 22, 10, 0, 0));
@@ -567,7 +567,7 @@ fn test_overflowing_add_offset() {
     let ymdhmsm = |y, m, d, h, mn, s, mi| {
         NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi).unwrap()
     };
-    let positive_offset = FixedOffset::east_opt(2 * 60 * 60).unwrap();
+    let positive_offset = FixedOffset::east(2 * 60 * 60).unwrap();
     // regular date
     let dt = ymdhmsm(2023, 5, 5, 20, 10, 0, 0);
     assert_eq!(dt.overflowing_add_offset(positive_offset), ymdhmsm(2023, 5, 5, 22, 10, 0, 0));
@@ -577,7 +577,7 @@ fn test_overflowing_add_offset() {
     // out of range
     assert!(NaiveDateTime::MAX.overflowing_add_offset(positive_offset) > NaiveDateTime::MAX);
 
-    let negative_offset = FixedOffset::west_opt(2 * 60 * 60).unwrap();
+    let negative_offset = FixedOffset::west(2 * 60 * 60).unwrap();
     // regular date
     let dt = ymdhmsm(2023, 5, 5, 20, 10, 0, 0);
     assert_eq!(dt.overflowing_add_offset(negative_offset), ymdhmsm(2023, 5, 5, 18, 10, 0, 0));
@@ -592,7 +592,7 @@ fn test_overflowing_add_offset() {
 fn test_and_timezone_min_max_dates() {
     for offset_hour in -23..=23 {
         dbg!(offset_hour);
-        let offset = FixedOffset::east_opt(offset_hour * 60 * 60).unwrap();
+        let offset = FixedOffset::east(offset_hour * 60 * 60).unwrap();
 
         let local_max = NaiveDateTime::MAX.and_local_timezone(offset);
         if offset_hour >= 0 {

--- a/src/naive/mod.rs
+++ b/src/naive/mod.rs
@@ -13,8 +13,7 @@ pub(crate) mod time;
 pub use self::date::{Days, NaiveDate, NaiveDateDaysIterator, NaiveDateWeeksIterator, NaiveWeek};
 #[allow(deprecated)]
 pub use self::date::{MAX_DATE, MIN_DATE};
-#[allow(deprecated)]
-pub use self::datetime::{NaiveDateTime, MAX_DATETIME, MIN_DATETIME};
+pub use self::datetime::NaiveDateTime;
 pub use self::isoweek::IsoWeek;
 pub use self::time::NaiveTime;
 

--- a/src/naive/mod.rs
+++ b/src/naive/mod.rs
@@ -11,8 +11,6 @@ pub(crate) mod isoweek;
 pub(crate) mod time;
 
 pub use self::date::{Days, NaiveDate, NaiveDateDaysIterator, NaiveDateWeeksIterator, NaiveWeek};
-#[allow(deprecated)]
-pub use self::date::{MAX_DATE, MIN_DATE};
 pub use self::datetime::NaiveDateTime;
 pub use self::isoweek::IsoWeek;
 pub use self::time::NaiveTime;

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -180,7 +180,7 @@ mod tests;
 /// ```
 /// use chrono::{FixedOffset, NaiveDate, TimeZone};
 ///
-/// let paramaribo_pre1945 = FixedOffset::east_opt(-13236).unwrap(); // -03:40:36
+/// let paramaribo_pre1945 = FixedOffset::east(-13236).unwrap(); // -03:40:36
 /// let leap_sec_2015 =
 ///     NaiveDate::from_ymd_opt(2015, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_000).unwrap();
 /// let dt1 = paramaribo_pre1945.from_utc_datetime(&leap_sec_2015);

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -230,21 +230,6 @@ impl arbitrary::Arbitrary<'_> for NaiveTime {
 impl NaiveTime {
     /// Makes a new `NaiveTime` from hour, minute and second.
     ///
-    /// No [leap second](#leap-second-handling) is allowed here;
-    /// use `NaiveTime::from_hms_*` methods with a subsecond parameter instead.
-    ///
-    /// # Panics
-    ///
-    /// Panics on invalid hour, minute and/or second.
-    #[deprecated(since = "0.4.23", note = "use `from_hms_opt()` instead")]
-    #[inline]
-    #[must_use]
-    pub const fn from_hms(hour: u32, min: u32, sec: u32) -> NaiveTime {
-        expect!(NaiveTime::from_hms_opt(hour, min, sec), "invalid time")
-    }
-
-    /// Makes a new `NaiveTime` from hour, minute and second.
-    ///
     /// The millisecond part is allowed to exceed 1,000,000,000 in order to represent a
     /// [leap second](#leap-second-handling), but only when `sec == 59`.
     ///
@@ -269,21 +254,6 @@ impl NaiveTime {
     #[must_use]
     pub const fn from_hms_opt(hour: u32, min: u32, sec: u32) -> Option<NaiveTime> {
         NaiveTime::from_hms_nano_opt(hour, min, sec, 0)
-    }
-
-    /// Makes a new `NaiveTime` from hour, minute, second and millisecond.
-    ///
-    /// The millisecond part can exceed 1,000
-    /// in order to represent the [leap second](#leap-second-handling).
-    ///
-    /// # Panics
-    ///
-    /// Panics on invalid hour, minute, second and/or millisecond.
-    #[deprecated(since = "0.4.23", note = "use `from_hms_milli_opt()` instead")]
-    #[inline]
-    #[must_use]
-    pub const fn from_hms_milli(hour: u32, min: u32, sec: u32, milli: u32) -> NaiveTime {
-        expect!(NaiveTime::from_hms_milli_opt(hour, min, sec, milli), "invalid time")
     }
 
     /// Makes a new `NaiveTime` from hour, minute, second and millisecond.
@@ -327,21 +297,6 @@ impl NaiveTime {
     /// The microsecond part is allowed to exceed 1,000,000,000 in order to represent a
     /// [leap second](#leap-second-handling), but only when `sec == 59`.
     ///
-    /// # Panics
-    ///
-    /// Panics on invalid hour, minute, second and/or microsecond.
-    #[deprecated(since = "0.4.23", note = "use `from_hms_micro_opt()` instead")]
-    #[inline]
-    #[must_use]
-    pub const fn from_hms_micro(hour: u32, min: u32, sec: u32, micro: u32) -> NaiveTime {
-        expect!(NaiveTime::from_hms_micro_opt(hour, min, sec, micro), "invalid time")
-    }
-
-    /// Makes a new `NaiveTime` from hour, minute, second and microsecond.
-    ///
-    /// The microsecond part is allowed to exceed 1,000,000,000 in order to represent a
-    /// [leap second](#leap-second-handling), but only when `sec == 59`.
-    ///
     /// # Errors
     ///
     /// Returns `None` on invalid hour, minute, second and/or microsecond.
@@ -371,21 +326,6 @@ impl NaiveTime {
     ) -> Option<NaiveTime> {
         let nano = try_opt!(micro.checked_mul(1_000));
         NaiveTime::from_hms_nano_opt(hour, min, sec, nano)
-    }
-
-    /// Makes a new `NaiveTime` from hour, minute, second and nanosecond.
-    ///
-    /// The nanosecond part is allowed to exceed 1,000,000,000 in order to represent a
-    /// [leap second](#leap-second-handling), but only when `sec == 59`.
-    ///
-    /// # Panics
-    ///
-    /// Panics on invalid hour, minute, second and/or nanosecond.
-    #[deprecated(since = "0.4.23", note = "use `from_hms_nano_opt()` instead")]
-    #[inline]
-    #[must_use]
-    pub const fn from_hms_nano(hour: u32, min: u32, sec: u32, nano: u32) -> NaiveTime {
-        expect!(NaiveTime::from_hms_nano_opt(hour, min, sec, nano), "invalid time")
     }
 
     /// Makes a new `NaiveTime` from hour, minute, second and nanosecond.
@@ -423,21 +363,6 @@ impl NaiveTime {
         }
         let secs = hour * 3600 + min * 60 + sec;
         Some(NaiveTime { secs, frac: nano })
-    }
-
-    /// Makes a new `NaiveTime` from the number of seconds since midnight and nanosecond.
-    ///
-    /// The nanosecond part is allowed to exceed 1,000,000,000 in order to represent a
-    /// [leap second](#leap-second-handling), but only when `secs % 60 == 59`.
-    ///
-    /// # Panics
-    ///
-    /// Panics on invalid number of seconds and/or nanosecond.
-    #[deprecated(since = "0.4.23", note = "use `from_num_seconds_from_midnight_opt()` instead")]
-    #[inline]
-    #[must_use]
-    pub const fn from_num_seconds_from_midnight(secs: u32, nano: u32) -> NaiveTime {
-        expect!(NaiveTime::from_num_seconds_from_midnight_opt(secs, nano), "invalid time")
     }
 
     /// Makes a new `NaiveTime` from the number of seconds since midnight and nanosecond.

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -75,7 +75,7 @@ mod tests;
 /// ```
 /// use chrono::{NaiveDate, NaiveTime, Utc};
 ///
-/// let t = NaiveTime::from_hms_milli_opt(8, 59, 59, 1_000).unwrap();
+/// let t = NaiveTime::from_hms_milli(8, 59, 59, 1_000).unwrap();
 ///
 /// let dt1 = NaiveDate::from_ymd_opt(2015, 7, 1).unwrap().and_hms_micro_opt(8, 59, 59, 1_000_000).unwrap();
 ///
@@ -270,7 +270,7 @@ impl NaiveTime {
     /// ```
     /// use chrono::NaiveTime;
     ///
-    /// let from_hmsm_opt = NaiveTime::from_hms_milli_opt;
+    /// let from_hmsm_opt = NaiveTime::from_hms_milli;
     ///
     /// assert!(from_hmsm_opt(0, 0, 0, 0).is_some());
     /// assert!(from_hmsm_opt(23, 59, 59, 999).is_some());
@@ -282,12 +282,7 @@ impl NaiveTime {
     /// ```
     #[inline]
     #[must_use]
-    pub const fn from_hms_milli_opt(
-        hour: u32,
-        min: u32,
-        sec: u32,
-        milli: u32,
-    ) -> Option<NaiveTime> {
+    pub const fn from_hms_milli(hour: u32, min: u32, sec: u32, milli: u32) -> Option<NaiveTime> {
         let nano = try_opt!(milli.checked_mul(1_000_000));
         NaiveTime::from_hms_nano_opt(hour, min, sec, nano)
     }
@@ -430,7 +425,7 @@ impl NaiveTime {
     /// # use chrono::NaiveTime;
     /// # let parse_from_str = NaiveTime::parse_from_str;
     /// assert_eq!(parse_from_str("08:59:60.123", "%H:%M:%S%.f"),
-    ///            Ok(NaiveTime::from_hms_milli_opt(8, 59, 59, 1_123).unwrap()));
+    ///            Ok(NaiveTime::from_hms_milli(8, 59, 59, 1_123).unwrap()));
     /// ```
     ///
     /// Missing seconds are assumed to be zero,
@@ -580,7 +575,7 @@ impl NaiveTime {
     /// ```
     /// use chrono::{TimeDelta, NaiveTime};
     ///
-    /// let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli_opt(h, m, s, milli).unwrap() };
+    /// let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
     /// let since = NaiveTime::signed_duration_since;
     ///
     /// assert_eq!(since(from_hmsm(3, 5, 7, 900), from_hmsm(3, 5, 7, 900)),
@@ -606,7 +601,7 @@ impl NaiveTime {
     ///
     /// ```
     /// # use chrono::{TimeDelta, NaiveTime};
-    /// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli_opt(h, m, s, milli).unwrap() };
+    /// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
     /// # let since = NaiveTime::signed_duration_since;
     /// assert_eq!(since(from_hmsm(3, 0, 59, 1_000), from_hmsm(3, 0, 59, 0)),
     ///            TimeDelta::seconds(1));
@@ -830,7 +825,7 @@ impl Timelike for NaiveTime {
     #[cfg_attr(not(feature = "std"), doc = "```ignore")]
     #[cfg_attr(feature = "std", doc = "```")]
     /// # use chrono::{NaiveTime, Timelike};
-    /// let leap = NaiveTime::from_hms_milli_opt(23, 59, 59, 1_000).unwrap();
+    /// let leap = NaiveTime::from_hms_milli(23, 59, 59, 1_000).unwrap();
     /// assert_eq!(leap.second(), 59);
     /// assert_eq!(leap.format("%H:%M:%S").to_string(), "23:59:60");
     /// ```
@@ -859,7 +854,7 @@ impl Timelike for NaiveTime {
     #[cfg_attr(not(feature = "std"), doc = "```ignore")]
     #[cfg_attr(feature = "std", doc = "```")]
     /// # use chrono::{NaiveTime, Timelike};
-    /// let leap = NaiveTime::from_hms_milli_opt(23, 59, 59, 1_000).unwrap();
+    /// let leap = NaiveTime::from_hms_milli(23, 59, 59, 1_000).unwrap();
     /// assert_eq!(leap.nanosecond(), 1_000_000_000);
     /// assert_eq!(leap.format("%H:%M:%S%.9f").to_string(), "23:59:60.000000000");
     /// ```
@@ -993,7 +988,7 @@ impl Timelike for NaiveTime {
     ///            3723);
     /// assert_eq!(NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap().num_seconds_from_midnight(),
     ///            86164);
-    /// assert_eq!(NaiveTime::from_hms_milli_opt(23, 59, 59, 1_000).unwrap().num_seconds_from_midnight(),
+    /// assert_eq!(NaiveTime::from_hms_milli(23, 59, 59, 1_000).unwrap().num_seconds_from_midnight(),
     ///            86399);
     /// ```
     #[inline]
@@ -1016,7 +1011,7 @@ impl Timelike for NaiveTime {
 /// ```
 /// use chrono::{TimeDelta, NaiveTime};
 ///
-/// let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli_opt(h, m, s, milli).unwrap() };
+/// let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
 ///
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::zero(),                  from_hmsm(3, 5, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::seconds(1),              from_hmsm(3, 5, 8, 0));
@@ -1032,7 +1027,7 @@ impl Timelike for NaiveTime {
 ///
 /// ```
 /// # use chrono::{TimeDelta, NaiveTime};
-/// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli_opt(h, m, s, milli).unwrap() };
+/// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::seconds(22*60*60), from_hmsm(1, 5, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::seconds(-8*60*60), from_hmsm(19, 5, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::days(800),         from_hmsm(3, 5, 7, 0));
@@ -1042,7 +1037,7 @@ impl Timelike for NaiveTime {
 ///
 /// ```
 /// # use chrono::{TimeDelta, NaiveTime};
-/// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli_opt(h, m, s, milli).unwrap() };
+/// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
 /// let leap = from_hmsm(3, 5, 59, 1_300);
 /// assert_eq!(leap + TimeDelta::zero(),             from_hmsm(3, 5, 59, 1_300));
 /// assert_eq!(leap + TimeDelta::milliseconds(-500), from_hmsm(3, 5, 59, 800));
@@ -1131,7 +1126,7 @@ impl Add<FixedOffset> for NaiveTime {
 /// ```
 /// use chrono::{TimeDelta, NaiveTime};
 ///
-/// let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli_opt(h, m, s, milli).unwrap() };
+/// let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
 ///
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::zero(),                  from_hmsm(3, 5, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::seconds(1),              from_hmsm(3, 5, 6, 0));
@@ -1145,7 +1140,7 @@ impl Add<FixedOffset> for NaiveTime {
 ///
 /// ```
 /// # use chrono::{TimeDelta, NaiveTime};
-/// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli_opt(h, m, s, milli).unwrap() };
+/// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::seconds(8*60*60), from_hmsm(19, 5, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::days(800),        from_hmsm(3, 5, 7, 0));
 /// ```
@@ -1154,7 +1149,7 @@ impl Add<FixedOffset> for NaiveTime {
 ///
 /// ```
 /// # use chrono::{TimeDelta, NaiveTime};
-/// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli_opt(h, m, s, milli).unwrap() };
+/// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
 /// let leap = from_hmsm(3, 5, 59, 1_300);
 /// assert_eq!(leap - TimeDelta::zero(),            from_hmsm(3, 5, 59, 1_300));
 /// assert_eq!(leap - TimeDelta::milliseconds(200), from_hmsm(3, 5, 59, 1_100));
@@ -1244,7 +1239,7 @@ impl Sub<FixedOffset> for NaiveTime {
 /// ```
 /// use chrono::{TimeDelta, NaiveTime};
 ///
-/// let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli_opt(h, m, s, milli).unwrap() };
+/// let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
 ///
 /// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 7, 900), TimeDelta::zero());
 /// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 7, 875), TimeDelta::milliseconds(25));
@@ -1262,7 +1257,7 @@ impl Sub<FixedOffset> for NaiveTime {
 ///
 /// ```
 /// # use chrono::{TimeDelta, NaiveTime};
-/// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli_opt(h, m, s, milli).unwrap() };
+/// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
 /// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(3, 0, 59, 0), TimeDelta::seconds(1));
 /// assert_eq!(from_hmsm(3, 0, 59, 1_500) - from_hmsm(3, 0, 59, 0),
 ///            TimeDelta::milliseconds(1500));
@@ -1297,7 +1292,7 @@ impl Sub<NaiveTime> for NaiveTime {
 /// use chrono::NaiveTime;
 ///
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms(23, 56, 4).unwrap()),              "23:56:04");
-/// assert_eq!(format!("{:?}", NaiveTime::from_hms_milli_opt(23, 56, 4, 12).unwrap()),    "23:56:04.012");
+/// assert_eq!(format!("{:?}", NaiveTime::from_hms_milli(23, 56, 4, 12).unwrap()),    "23:56:04.012");
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms_micro_opt(23, 56, 4, 1234).unwrap()),  "23:56:04.001234");
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms_nano_opt(23, 56, 4, 123456).unwrap()), "23:56:04.000123456");
 /// ```
@@ -1306,7 +1301,7 @@ impl Sub<NaiveTime> for NaiveTime {
 ///
 /// ```
 /// # use chrono::NaiveTime;
-/// assert_eq!(format!("{:?}", NaiveTime::from_hms_milli_opt(6, 59, 59, 1_500).unwrap()), "06:59:60.500");
+/// assert_eq!(format!("{:?}", NaiveTime::from_hms_milli(6, 59, 59, 1_500).unwrap()), "06:59:60.500");
 /// ```
 impl fmt::Debug for NaiveTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -1353,7 +1348,7 @@ impl fmt::Debug for NaiveTime {
 /// use chrono::NaiveTime;
 ///
 /// assert_eq!(format!("{}", NaiveTime::from_hms(23, 56, 4).unwrap()),              "23:56:04");
-/// assert_eq!(format!("{}", NaiveTime::from_hms_milli_opt(23, 56, 4, 12).unwrap()),    "23:56:04.012");
+/// assert_eq!(format!("{}", NaiveTime::from_hms_milli(23, 56, 4, 12).unwrap()),    "23:56:04.012");
 /// assert_eq!(format!("{}", NaiveTime::from_hms_micro_opt(23, 56, 4, 1234).unwrap()),  "23:56:04.001234");
 /// assert_eq!(format!("{}", NaiveTime::from_hms_nano_opt(23, 56, 4, 123456).unwrap()), "23:56:04.000123456");
 /// ```
@@ -1362,7 +1357,7 @@ impl fmt::Debug for NaiveTime {
 ///
 /// ```
 /// # use chrono::NaiveTime;
-/// assert_eq!(format!("{}", NaiveTime::from_hms_milli_opt(6, 59, 59, 1_500).unwrap()), "06:59:60.500");
+/// assert_eq!(format!("{}", NaiveTime::from_hms_milli(6, 59, 59, 1_500).unwrap()), "06:59:60.500");
 /// ```
 impl fmt::Display for NaiveTime {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -1448,11 +1443,11 @@ where
         Some(r#""00:00:00""#.into())
     );
     assert_eq!(
-        to_string(&NaiveTime::from_hms_milli_opt(0, 0, 0, 950).unwrap()).ok(),
+        to_string(&NaiveTime::from_hms_milli(0, 0, 0, 950).unwrap()).ok(),
         Some(r#""00:00:00.950""#.into())
     );
     assert_eq!(
-        to_string(&NaiveTime::from_hms_milli_opt(0, 0, 59, 1_000).unwrap()).ok(),
+        to_string(&NaiveTime::from_hms_milli(0, 0, 59, 1_000).unwrap()).ok(),
         Some(r#""00:00:60""#.into())
     );
     assert_eq!(
@@ -1487,15 +1482,15 @@ where
     assert_eq!(from_str(r#""0:0:0""#).ok(), Some(NaiveTime::from_hms(0, 0, 0).unwrap()));
     assert_eq!(
         from_str(r#""00:00:00.950""#).ok(),
-        Some(NaiveTime::from_hms_milli_opt(0, 0, 0, 950).unwrap())
+        Some(NaiveTime::from_hms_milli(0, 0, 0, 950).unwrap())
     );
     assert_eq!(
         from_str(r#""0:0:0.95""#).ok(),
-        Some(NaiveTime::from_hms_milli_opt(0, 0, 0, 950).unwrap())
+        Some(NaiveTime::from_hms_milli(0, 0, 0, 950).unwrap())
     );
     assert_eq!(
         from_str(r#""00:00:60""#).ok(),
-        Some(NaiveTime::from_hms_milli_opt(0, 0, 59, 1_000).unwrap())
+        Some(NaiveTime::from_hms_milli(0, 0, 59, 1_000).unwrap())
     );
     assert_eq!(from_str(r#""00:01:02""#).ok(), Some(NaiveTime::from_hms(0, 1, 2).unwrap()));
     assert_eq!(

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -221,7 +221,7 @@ impl arbitrary::Arbitrary<'_> for NaiveTime {
             secs = 59;
             nano += 1_000_000_000;
         }
-        let time = NaiveTime::from_num_seconds_from_midnight_opt(mins * 60 + secs, nano)
+        let time = NaiveTime::from_num_seconds_from_midnight(mins * 60 + secs, nano)
             .expect("Could not generate a valid chrono::NaiveTime. It looks like implementation of Arbitrary for NaiveTime is erroneous.");
         Ok(time)
     }
@@ -369,7 +369,7 @@ impl NaiveTime {
     /// ```
     /// use chrono::NaiveTime;
     ///
-    /// let from_nsecs_opt = NaiveTime::from_num_seconds_from_midnight_opt;
+    /// let from_nsecs_opt = NaiveTime::from_num_seconds_from_midnight;
     ///
     /// assert!(from_nsecs_opt(0, 0).is_some());
     /// assert!(from_nsecs_opt(86399, 999_999_999).is_some());
@@ -379,7 +379,7 @@ impl NaiveTime {
     /// ```
     #[inline]
     #[must_use]
-    pub const fn from_num_seconds_from_midnight_opt(secs: u32, nano: u32) -> Option<NaiveTime> {
+    pub const fn from_num_seconds_from_midnight(secs: u32, nano: u32) -> Option<NaiveTime> {
         if secs >= 86_400 || nano >= 2_000_000_000 || (nano >= 1_000_000_000 && secs % 60 != 59) {
             return None;
         }

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -301,7 +301,7 @@ impl NaiveTime {
     /// ```
     /// use chrono::NaiveTime;
     ///
-    /// let from_hmsu_opt = NaiveTime::from_hms_micro_opt;
+    /// let from_hmsu_opt = NaiveTime::from_hms_micro;
     ///
     /// assert!(from_hmsu_opt(0, 0, 0, 0).is_some());
     /// assert!(from_hmsu_opt(23, 59, 59, 999_999).is_some());
@@ -313,12 +313,7 @@ impl NaiveTime {
     /// ```
     #[inline]
     #[must_use]
-    pub const fn from_hms_micro_opt(
-        hour: u32,
-        min: u32,
-        sec: u32,
-        micro: u32,
-    ) -> Option<NaiveTime> {
+    pub const fn from_hms_micro(hour: u32, min: u32, sec: u32, micro: u32) -> Option<NaiveTime> {
         let nano = try_opt!(micro.checked_mul(1_000));
         NaiveTime::from_hms_nano_opt(hour, min, sec, nano)
     }
@@ -405,7 +400,7 @@ impl NaiveTime {
     /// assert_eq!(parse_from_str("23:56:04", "%H:%M:%S"),
     ///            Ok(NaiveTime::from_hms(23, 56, 4).unwrap()));
     /// assert_eq!(parse_from_str("pm012345.6789", "%p%I%M%S%.f"),
-    ///            Ok(NaiveTime::from_hms_micro_opt(13, 23, 45, 678_900).unwrap()));
+    ///            Ok(NaiveTime::from_hms_micro(13, 23, 45, 678_900).unwrap()));
     /// ```
     ///
     /// Date and offset is ignored for the purpose of parsing.
@@ -1293,7 +1288,7 @@ impl Sub<NaiveTime> for NaiveTime {
 ///
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms(23, 56, 4).unwrap()),              "23:56:04");
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms_milli(23, 56, 4, 12).unwrap()),    "23:56:04.012");
-/// assert_eq!(format!("{:?}", NaiveTime::from_hms_micro_opt(23, 56, 4, 1234).unwrap()),  "23:56:04.001234");
+/// assert_eq!(format!("{:?}", NaiveTime::from_hms_micro(23, 56, 4, 1234).unwrap()),  "23:56:04.001234");
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms_nano_opt(23, 56, 4, 123456).unwrap()), "23:56:04.000123456");
 /// ```
 ///
@@ -1349,7 +1344,7 @@ impl fmt::Debug for NaiveTime {
 ///
 /// assert_eq!(format!("{}", NaiveTime::from_hms(23, 56, 4).unwrap()),              "23:56:04");
 /// assert_eq!(format!("{}", NaiveTime::from_hms_milli(23, 56, 4, 12).unwrap()),    "23:56:04.012");
-/// assert_eq!(format!("{}", NaiveTime::from_hms_micro_opt(23, 56, 4, 1234).unwrap()),  "23:56:04.001234");
+/// assert_eq!(format!("{}", NaiveTime::from_hms_micro(23, 56, 4, 1234).unwrap()),  "23:56:04.001234");
 /// assert_eq!(format!("{}", NaiveTime::from_hms_nano_opt(23, 56, 4, 123456).unwrap()), "23:56:04.000123456");
 /// ```
 ///
@@ -1463,7 +1458,7 @@ where
         Some(r#""07:08:09""#.into())
     );
     assert_eq!(
-        to_string(&NaiveTime::from_hms_micro_opt(12, 34, 56, 789).unwrap()).ok(),
+        to_string(&NaiveTime::from_hms_micro(12, 34, 56, 789).unwrap()).ok(),
         Some(r#""12:34:56.000789""#.into())
     );
     assert_eq!(
@@ -1500,7 +1495,7 @@ where
     assert_eq!(from_str(r#""07:08:09""#).ok(), Some(NaiveTime::from_hms(7, 8, 9).unwrap()));
     assert_eq!(
         from_str(r#""12:34:56.000789""#).ok(),
-        Some(NaiveTime::from_hms_micro_opt(12, 34, 56, 789).unwrap())
+        Some(NaiveTime::from_hms_micro(12, 34, 56, 789).unwrap())
     );
     assert_eq!(
         from_str(r#""23:59:60.999999999""#).ok(),

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -242,17 +242,17 @@ impl NaiveTime {
     /// ```
     /// use chrono::NaiveTime;
     ///
-    /// let from_hms_opt = NaiveTime::from_hms_opt;
+    /// let from_hms = NaiveTime::from_hms;
     ///
-    /// assert!(from_hms_opt(0, 0, 0).is_some());
-    /// assert!(from_hms_opt(23, 59, 59).is_some());
-    /// assert!(from_hms_opt(24, 0, 0).is_none());
-    /// assert!(from_hms_opt(23, 60, 0).is_none());
-    /// assert!(from_hms_opt(23, 59, 60).is_none());
+    /// assert!(from_hms(0, 0, 0).is_some());
+    /// assert!(from_hms(23, 59, 59).is_some());
+    /// assert!(from_hms(24, 0, 0).is_none());
+    /// assert!(from_hms(23, 60, 0).is_none());
+    /// assert!(from_hms(23, 59, 60).is_none());
     /// ```
     #[inline]
     #[must_use]
-    pub const fn from_hms_opt(hour: u32, min: u32, sec: u32) -> Option<NaiveTime> {
+    pub const fn from_hms(hour: u32, min: u32, sec: u32) -> Option<NaiveTime> {
         NaiveTime::from_hms_nano_opt(hour, min, sec, 0)
     }
 
@@ -408,7 +408,7 @@ impl NaiveTime {
     /// let parse_from_str = NaiveTime::parse_from_str;
     ///
     /// assert_eq!(parse_from_str("23:56:04", "%H:%M:%S"),
-    ///            Ok(NaiveTime::from_hms_opt(23, 56, 4).unwrap()));
+    ///            Ok(NaiveTime::from_hms(23, 56, 4).unwrap()));
     /// assert_eq!(parse_from_str("pm012345.6789", "%p%I%M%S%.f"),
     ///            Ok(NaiveTime::from_hms_micro_opt(13, 23, 45, 678_900).unwrap()));
     /// ```
@@ -419,7 +419,7 @@ impl NaiveTime {
     /// # use chrono::NaiveTime;
     /// # let parse_from_str = NaiveTime::parse_from_str;
     /// assert_eq!(parse_from_str("2014-5-17T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
-    ///            Ok(NaiveTime::from_hms_opt(12, 34, 56).unwrap()));
+    ///            Ok(NaiveTime::from_hms(12, 34, 56).unwrap()));
     /// ```
     ///
     /// [Leap seconds](#leap-second-handling) are correctly handled by
@@ -440,7 +440,7 @@ impl NaiveTime {
     /// # use chrono::NaiveTime;
     /// # let parse_from_str = NaiveTime::parse_from_str;
     /// assert_eq!(parse_from_str("7:15", "%H:%M"),
-    ///            Ok(NaiveTime::from_hms_opt(7, 15, 0).unwrap()));
+    ///            Ok(NaiveTime::from_hms(7, 15, 0).unwrap()));
     ///
     /// assert!(parse_from_str("04m33s", "%Mm%Ss").is_err());
     /// assert!(parse_from_str("12", "%H").is_err());
@@ -476,7 +476,7 @@ impl NaiveTime {
     /// # use chrono::{NaiveTime};
     /// let (time, remainder) = NaiveTime::parse_and_remainder(
     ///     "3h4m33s trailing text", "%-Hh%-Mm%-Ss").unwrap();
-    /// assert_eq!(time, NaiveTime::from_hms_opt(3, 4, 33).unwrap());
+    /// assert_eq!(time, NaiveTime::from_hms(3, 4, 33).unwrap());
     /// assert_eq!(remainder, " trailing text");
     /// ```
     pub fn parse_and_remainder<'a>(s: &'a str, fmt: &str) -> ParseResult<(NaiveTime, &'a str)> {
@@ -493,7 +493,7 @@ impl NaiveTime {
     /// ```
     /// use chrono::{TimeDelta, NaiveTime};
     ///
-    /// let from_hms = |h, m, s| { NaiveTime::from_hms_opt(h, m, s).unwrap() };
+    /// let from_hms = |h, m, s| { NaiveTime::from_hms(h, m, s).unwrap() };
     ///
     /// assert_eq!(from_hms(3, 4, 5).overflowing_add_signed(TimeDelta::hours(11)),
     ///            (from_hms(14, 4, 5), 0));
@@ -549,7 +549,7 @@ impl NaiveTime {
     /// ```
     /// use chrono::{TimeDelta, NaiveTime};
     ///
-    /// let from_hms = |h, m, s| { NaiveTime::from_hms_opt(h, m, s).unwrap() };
+    /// let from_hms = |h, m, s| { NaiveTime::from_hms(h, m, s).unwrap() };
     ///
     /// assert_eq!(from_hms(3, 4, 5).overflowing_sub_signed(TimeDelta::hours(2)),
     ///            (from_hms(1, 4, 5), 0));
@@ -686,7 +686,7 @@ impl NaiveTime {
     /// use chrono::format::strftime::StrftimeItems;
     ///
     /// let fmt = StrftimeItems::new("%H:%M:%S");
-    /// let t = NaiveTime::from_hms_opt(23, 56, 4).unwrap();
+    /// let t = NaiveTime::from_hms(23, 56, 4).unwrap();
     /// assert_eq!(t.format_with_items(fmt.clone()).to_string(), "23:56:04");
     /// assert_eq!(t.format("%H:%M:%S").to_string(),             "23:56:04");
     /// ```
@@ -697,7 +697,7 @@ impl NaiveTime {
     /// # use chrono::NaiveTime;
     /// # use chrono::format::strftime::StrftimeItems;
     /// # let fmt = StrftimeItems::new("%H:%M:%S").clone();
-    /// # let t = NaiveTime::from_hms_opt(23, 56, 4).unwrap();
+    /// # let t = NaiveTime::from_hms(23, 56, 4).unwrap();
     /// assert_eq!(format!("{}", t.format_with_items(fmt)), "23:56:04");
     /// ```
     #[cfg(feature = "alloc")]
@@ -789,7 +789,7 @@ impl Timelike for NaiveTime {
     /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
-    /// assert_eq!(NaiveTime::from_hms_opt(0, 0, 0).unwrap().hour(), 0);
+    /// assert_eq!(NaiveTime::from_hms(0, 0, 0).unwrap().hour(), 0);
     /// assert_eq!(NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap().hour(), 23);
     /// ```
     #[inline]
@@ -804,7 +804,7 @@ impl Timelike for NaiveTime {
     /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
-    /// assert_eq!(NaiveTime::from_hms_opt(0, 0, 0).unwrap().minute(), 0);
+    /// assert_eq!(NaiveTime::from_hms(0, 0, 0).unwrap().minute(), 0);
     /// assert_eq!(NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap().minute(), 56);
     /// ```
     #[inline]
@@ -819,7 +819,7 @@ impl Timelike for NaiveTime {
     /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
-    /// assert_eq!(NaiveTime::from_hms_opt(0, 0, 0).unwrap().second(), 0);
+    /// assert_eq!(NaiveTime::from_hms(0, 0, 0).unwrap().second(), 0);
     /// assert_eq!(NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap().second(), 4);
     /// ```
     ///
@@ -848,7 +848,7 @@ impl Timelike for NaiveTime {
     /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
-    /// assert_eq!(NaiveTime::from_hms_opt(0, 0, 0).unwrap().nanosecond(), 0);
+    /// assert_eq!(NaiveTime::from_hms(0, 0, 0).unwrap().nanosecond(), 0);
     /// assert_eq!(NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap().nanosecond(), 12_345_678);
     /// ```
     ///
@@ -989,7 +989,7 @@ impl Timelike for NaiveTime {
     /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
-    /// assert_eq!(NaiveTime::from_hms_opt(1, 2, 3).unwrap().num_seconds_from_midnight(),
+    /// assert_eq!(NaiveTime::from_hms(1, 2, 3).unwrap().num_seconds_from_midnight(),
     ///            3723);
     /// assert_eq!(NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap().num_seconds_from_midnight(),
     ///            86164);
@@ -1296,7 +1296,7 @@ impl Sub<NaiveTime> for NaiveTime {
 /// ```
 /// use chrono::NaiveTime;
 ///
-/// assert_eq!(format!("{:?}", NaiveTime::from_hms_opt(23, 56, 4).unwrap()),              "23:56:04");
+/// assert_eq!(format!("{:?}", NaiveTime::from_hms(23, 56, 4).unwrap()),              "23:56:04");
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms_milli_opt(23, 56, 4, 12).unwrap()),    "23:56:04.012");
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms_micro_opt(23, 56, 4, 1234).unwrap()),  "23:56:04.001234");
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms_nano_opt(23, 56, 4, 123456).unwrap()), "23:56:04.000123456");
@@ -1352,7 +1352,7 @@ impl fmt::Debug for NaiveTime {
 /// ```
 /// use chrono::NaiveTime;
 ///
-/// assert_eq!(format!("{}", NaiveTime::from_hms_opt(23, 56, 4).unwrap()),              "23:56:04");
+/// assert_eq!(format!("{}", NaiveTime::from_hms(23, 56, 4).unwrap()),              "23:56:04");
 /// assert_eq!(format!("{}", NaiveTime::from_hms_milli_opt(23, 56, 4, 12).unwrap()),    "23:56:04.012");
 /// assert_eq!(format!("{}", NaiveTime::from_hms_micro_opt(23, 56, 4, 1234).unwrap()),  "23:56:04.001234");
 /// assert_eq!(format!("{}", NaiveTime::from_hms_nano_opt(23, 56, 4, 123456).unwrap()), "23:56:04.000123456");
@@ -1378,7 +1378,7 @@ impl fmt::Display for NaiveTime {
 /// ```
 /// use chrono::NaiveTime;
 ///
-/// let t = NaiveTime::from_hms_opt(23, 56, 4).unwrap();
+/// let t = NaiveTime::from_hms(23, 56, 4).unwrap();
 /// assert_eq!("23:56:04".parse::<NaiveTime>(), Ok(t));
 ///
 /// let t = NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap();
@@ -1388,7 +1388,7 @@ impl fmt::Display for NaiveTime {
 /// assert_eq!("23:59:60.23456789".parse::<NaiveTime>(), Ok(t));
 ///
 /// // Seconds are optional
-/// let t = NaiveTime::from_hms_opt(23, 56, 0).unwrap();
+/// let t = NaiveTime::from_hms(23, 56, 0).unwrap();
 /// assert_eq!("23:56".parse::<NaiveTime>(), Ok(t));
 ///
 /// assert!("foo".parse::<NaiveTime>().is_err());
@@ -1429,11 +1429,11 @@ impl str::FromStr for NaiveTime {
 /// use chrono::NaiveTime;
 ///
 /// let default_time = NaiveTime::default();
-/// assert_eq!(default_time, NaiveTime::from_hms_opt(0, 0, 0).unwrap());
+/// assert_eq!(default_time, NaiveTime::from_hms(0, 0, 0).unwrap());
 /// ```
 impl Default for NaiveTime {
     fn default() -> Self {
-        NaiveTime::from_hms_opt(0, 0, 0).unwrap()
+        NaiveTime::from_hms(0, 0, 0).unwrap()
     }
 }
 
@@ -1444,7 +1444,7 @@ where
     E: ::std::fmt::Debug,
 {
     assert_eq!(
-        to_string(&NaiveTime::from_hms_opt(0, 0, 0).unwrap()).ok(),
+        to_string(&NaiveTime::from_hms(0, 0, 0).unwrap()).ok(),
         Some(r#""00:00:00""#.into())
     );
     assert_eq!(
@@ -1456,7 +1456,7 @@ where
         Some(r#""00:00:60""#.into())
     );
     assert_eq!(
-        to_string(&NaiveTime::from_hms_opt(0, 1, 2).unwrap()).ok(),
+        to_string(&NaiveTime::from_hms(0, 1, 2).unwrap()).ok(),
         Some(r#""00:01:02""#.into())
     );
     assert_eq!(
@@ -1464,7 +1464,7 @@ where
         Some(r#""03:05:07.098765432""#.into())
     );
     assert_eq!(
-        to_string(&NaiveTime::from_hms_opt(7, 8, 9).unwrap()).ok(),
+        to_string(&NaiveTime::from_hms(7, 8, 9).unwrap()).ok(),
         Some(r#""07:08:09""#.into())
     );
     assert_eq!(
@@ -1483,8 +1483,8 @@ where
     F: Fn(&str) -> Result<NaiveTime, E>,
     E: ::std::fmt::Debug,
 {
-    assert_eq!(from_str(r#""00:00:00""#).ok(), Some(NaiveTime::from_hms_opt(0, 0, 0).unwrap()));
-    assert_eq!(from_str(r#""0:0:0""#).ok(), Some(NaiveTime::from_hms_opt(0, 0, 0).unwrap()));
+    assert_eq!(from_str(r#""00:00:00""#).ok(), Some(NaiveTime::from_hms(0, 0, 0).unwrap()));
+    assert_eq!(from_str(r#""0:0:0""#).ok(), Some(NaiveTime::from_hms(0, 0, 0).unwrap()));
     assert_eq!(
         from_str(r#""00:00:00.950""#).ok(),
         Some(NaiveTime::from_hms_milli_opt(0, 0, 0, 950).unwrap())
@@ -1497,12 +1497,12 @@ where
         from_str(r#""00:00:60""#).ok(),
         Some(NaiveTime::from_hms_milli_opt(0, 0, 59, 1_000).unwrap())
     );
-    assert_eq!(from_str(r#""00:01:02""#).ok(), Some(NaiveTime::from_hms_opt(0, 1, 2).unwrap()));
+    assert_eq!(from_str(r#""00:01:02""#).ok(), Some(NaiveTime::from_hms(0, 1, 2).unwrap()));
     assert_eq!(
         from_str(r#""03:05:07.098765432""#).ok(),
         Some(NaiveTime::from_hms_nano_opt(3, 5, 7, 98765432).unwrap())
     );
-    assert_eq!(from_str(r#""07:08:09""#).ok(), Some(NaiveTime::from_hms_opt(7, 8, 9).unwrap()));
+    assert_eq!(from_str(r#""07:08:09""#).ok(), Some(NaiveTime::from_hms(7, 8, 9).unwrap()));
     assert_eq!(
         from_str(r#""12:34:56.000789""#).ok(),
         Some(NaiveTime::from_hms_micro_opt(12, 34, 56, 789).unwrap())

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -253,7 +253,7 @@ impl NaiveTime {
     #[inline]
     #[must_use]
     pub const fn from_hms(hour: u32, min: u32, sec: u32) -> Option<NaiveTime> {
-        NaiveTime::from_hms_nano_opt(hour, min, sec, 0)
+        NaiveTime::from_hms_nano(hour, min, sec, 0)
     }
 
     /// Makes a new `NaiveTime` from hour, minute, second and millisecond.
@@ -284,7 +284,7 @@ impl NaiveTime {
     #[must_use]
     pub const fn from_hms_milli(hour: u32, min: u32, sec: u32, milli: u32) -> Option<NaiveTime> {
         let nano = try_opt!(milli.checked_mul(1_000_000));
-        NaiveTime::from_hms_nano_opt(hour, min, sec, nano)
+        NaiveTime::from_hms_nano(hour, min, sec, nano)
     }
 
     /// Makes a new `NaiveTime` from hour, minute, second and microsecond.
@@ -315,7 +315,7 @@ impl NaiveTime {
     #[must_use]
     pub const fn from_hms_micro(hour: u32, min: u32, sec: u32, micro: u32) -> Option<NaiveTime> {
         let nano = try_opt!(micro.checked_mul(1_000));
-        NaiveTime::from_hms_nano_opt(hour, min, sec, nano)
+        NaiveTime::from_hms_nano(hour, min, sec, nano)
     }
 
     /// Makes a new `NaiveTime` from hour, minute, second and nanosecond.
@@ -332,7 +332,7 @@ impl NaiveTime {
     /// ```
     /// use chrono::NaiveTime;
     ///
-    /// let from_hmsn_opt = NaiveTime::from_hms_nano_opt;
+    /// let from_hmsn_opt = NaiveTime::from_hms_nano;
     ///
     /// assert!(from_hmsn_opt(0, 0, 0, 0).is_some());
     /// assert!(from_hmsn_opt(23, 59, 59, 999_999_999).is_some());
@@ -344,7 +344,7 @@ impl NaiveTime {
     /// ```
     #[inline]
     #[must_use]
-    pub const fn from_hms_nano_opt(hour: u32, min: u32, sec: u32, nano: u32) -> Option<NaiveTime> {
+    pub const fn from_hms_nano(hour: u32, min: u32, sec: u32, nano: u32) -> Option<NaiveTime> {
         if (hour >= 24 || min >= 60 || sec >= 60)
             || (nano >= 1_000_000_000 && sec != 59)
             || nano >= 2_000_000_000
@@ -720,7 +720,7 @@ impl NaiveTime {
     /// ```
     /// use chrono::NaiveTime;
     ///
-    /// let t = NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap();
+    /// let t = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap();
     /// assert_eq!(t.format("%H:%M:%S").to_string(), "23:56:04");
     /// assert_eq!(t.format("%H:%M:%S%.6f").to_string(), "23:56:04.012345");
     /// assert_eq!(t.format("%-I:%M %p").to_string(), "11:56 PM");
@@ -730,7 +730,7 @@ impl NaiveTime {
     ///
     /// ```
     /// # use chrono::NaiveTime;
-    /// # let t = NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap();
+    /// # let t = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap();
     /// assert_eq!(format!("{}", t.format("%H:%M:%S")), "23:56:04");
     /// assert_eq!(format!("{}", t.format("%H:%M:%S%.6f")), "23:56:04.012345");
     /// assert_eq!(format!("{}", t.format("%-I:%M %p")), "11:56 PM");
@@ -780,7 +780,7 @@ impl Timelike for NaiveTime {
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// assert_eq!(NaiveTime::from_hms(0, 0, 0).unwrap().hour(), 0);
-    /// assert_eq!(NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap().hour(), 23);
+    /// assert_eq!(NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap().hour(), 23);
     /// ```
     #[inline]
     fn hour(&self) -> u32 {
@@ -795,7 +795,7 @@ impl Timelike for NaiveTime {
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// assert_eq!(NaiveTime::from_hms(0, 0, 0).unwrap().minute(), 0);
-    /// assert_eq!(NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap().minute(), 56);
+    /// assert_eq!(NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap().minute(), 56);
     /// ```
     #[inline]
     fn minute(&self) -> u32 {
@@ -810,7 +810,7 @@ impl Timelike for NaiveTime {
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// assert_eq!(NaiveTime::from_hms(0, 0, 0).unwrap().second(), 0);
-    /// assert_eq!(NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap().second(), 4);
+    /// assert_eq!(NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap().second(), 4);
     /// ```
     ///
     /// This method never returns 60 even when it is a leap second.
@@ -839,7 +839,7 @@ impl Timelike for NaiveTime {
     /// use chrono::{NaiveTime, Timelike};
     ///
     /// assert_eq!(NaiveTime::from_hms(0, 0, 0).unwrap().nanosecond(), 0);
-    /// assert_eq!(NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap().nanosecond(), 12_345_678);
+    /// assert_eq!(NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap().nanosecond(), 12_345_678);
     /// ```
     ///
     /// Leap seconds may have seemingly out-of-range return values.
@@ -869,8 +869,8 @@ impl Timelike for NaiveTime {
     /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
-    /// let dt = NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap();
-    /// assert_eq!(dt.with_hour(7), Some(NaiveTime::from_hms_nano_opt(7, 56, 4, 12_345_678).unwrap()));
+    /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap();
+    /// assert_eq!(dt.with_hour(7), Some(NaiveTime::from_hms_nano(7, 56, 4, 12_345_678).unwrap()));
     /// assert_eq!(dt.with_hour(24), None);
     /// ```
     #[inline]
@@ -893,8 +893,8 @@ impl Timelike for NaiveTime {
     /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
-    /// let dt = NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap();
-    /// assert_eq!(dt.with_minute(45), Some(NaiveTime::from_hms_nano_opt(23, 45, 4, 12_345_678).unwrap()));
+    /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap();
+    /// assert_eq!(dt.with_minute(45), Some(NaiveTime::from_hms_nano(23, 45, 4, 12_345_678).unwrap()));
     /// assert_eq!(dt.with_minute(60), None);
     /// ```
     #[inline]
@@ -920,8 +920,8 @@ impl Timelike for NaiveTime {
     /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
-    /// let dt = NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap();
-    /// assert_eq!(dt.with_second(17), Some(NaiveTime::from_hms_nano_opt(23, 56, 17, 12_345_678).unwrap()));
+    /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap();
+    /// assert_eq!(dt.with_second(17), Some(NaiveTime::from_hms_nano(23, 56, 17, 12_345_678).unwrap()));
     /// assert_eq!(dt.with_second(60), None);
     /// ```
     #[inline]
@@ -947,9 +947,9 @@ impl Timelike for NaiveTime {
     /// ```
     /// use chrono::{NaiveTime, Timelike};
     ///
-    /// let dt = NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap();
+    /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap();
     /// assert_eq!(dt.with_nanosecond(333_333_333),
-    ///            Some(NaiveTime::from_hms_nano_opt(23, 56, 4, 333_333_333).unwrap()));
+    ///            Some(NaiveTime::from_hms_nano(23, 56, 4, 333_333_333).unwrap()));
     /// assert_eq!(dt.with_nanosecond(2_000_000_000), None);
     /// ```
     ///
@@ -960,7 +960,7 @@ impl Timelike for NaiveTime {
     ///
     /// ```
     /// # use chrono::{NaiveTime, Timelike};
-    /// let dt = NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap();
+    /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap();
     /// let strange_leap_second = dt.with_nanosecond(1_333_333_333).unwrap();
     /// assert_eq!(strange_leap_second.nanosecond(), 1_333_333_333);
     /// ```
@@ -981,7 +981,7 @@ impl Timelike for NaiveTime {
     ///
     /// assert_eq!(NaiveTime::from_hms(1, 2, 3).unwrap().num_seconds_from_midnight(),
     ///            3723);
-    /// assert_eq!(NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap().num_seconds_from_midnight(),
+    /// assert_eq!(NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap().num_seconds_from_midnight(),
     ///            86164);
     /// assert_eq!(NaiveTime::from_hms_milli(23, 59, 59, 1_000).unwrap().num_seconds_from_midnight(),
     ///            86399);
@@ -1289,7 +1289,7 @@ impl Sub<NaiveTime> for NaiveTime {
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms(23, 56, 4).unwrap()),              "23:56:04");
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms_milli(23, 56, 4, 12).unwrap()),    "23:56:04.012");
 /// assert_eq!(format!("{:?}", NaiveTime::from_hms_micro(23, 56, 4, 1234).unwrap()),  "23:56:04.001234");
-/// assert_eq!(format!("{:?}", NaiveTime::from_hms_nano_opt(23, 56, 4, 123456).unwrap()), "23:56:04.000123456");
+/// assert_eq!(format!("{:?}", NaiveTime::from_hms_nano(23, 56, 4, 123456).unwrap()), "23:56:04.000123456");
 /// ```
 ///
 /// Leap seconds may also be used.
@@ -1345,7 +1345,7 @@ impl fmt::Debug for NaiveTime {
 /// assert_eq!(format!("{}", NaiveTime::from_hms(23, 56, 4).unwrap()),              "23:56:04");
 /// assert_eq!(format!("{}", NaiveTime::from_hms_milli(23, 56, 4, 12).unwrap()),    "23:56:04.012");
 /// assert_eq!(format!("{}", NaiveTime::from_hms_micro(23, 56, 4, 1234).unwrap()),  "23:56:04.001234");
-/// assert_eq!(format!("{}", NaiveTime::from_hms_nano_opt(23, 56, 4, 123456).unwrap()), "23:56:04.000123456");
+/// assert_eq!(format!("{}", NaiveTime::from_hms_nano(23, 56, 4, 123456).unwrap()), "23:56:04.000123456");
 /// ```
 ///
 /// Leap seconds may also be used.
@@ -1371,10 +1371,10 @@ impl fmt::Display for NaiveTime {
 /// let t = NaiveTime::from_hms(23, 56, 4).unwrap();
 /// assert_eq!("23:56:04".parse::<NaiveTime>(), Ok(t));
 ///
-/// let t = NaiveTime::from_hms_nano_opt(23, 56, 4, 12_345_678).unwrap();
+/// let t = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap();
 /// assert_eq!("23:56:4.012345678".parse::<NaiveTime>(), Ok(t));
 ///
-/// let t = NaiveTime::from_hms_nano_opt(23, 59, 59, 1_234_567_890).unwrap(); // leap second
+/// let t = NaiveTime::from_hms_nano(23, 59, 59, 1_234_567_890).unwrap(); // leap second
 /// assert_eq!("23:59:60.23456789".parse::<NaiveTime>(), Ok(t));
 ///
 /// // Seconds are optional
@@ -1450,7 +1450,7 @@ where
         Some(r#""00:01:02""#.into())
     );
     assert_eq!(
-        to_string(&NaiveTime::from_hms_nano_opt(3, 5, 7, 98765432).unwrap()).ok(),
+        to_string(&NaiveTime::from_hms_nano(3, 5, 7, 98765432).unwrap()).ok(),
         Some(r#""03:05:07.098765432""#.into())
     );
     assert_eq!(
@@ -1462,7 +1462,7 @@ where
         Some(r#""12:34:56.000789""#.into())
     );
     assert_eq!(
-        to_string(&NaiveTime::from_hms_nano_opt(23, 59, 59, 1_999_999_999).unwrap()).ok(),
+        to_string(&NaiveTime::from_hms_nano(23, 59, 59, 1_999_999_999).unwrap()).ok(),
         Some(r#""23:59:60.999999999""#.into())
     );
 }
@@ -1490,7 +1490,7 @@ where
     assert_eq!(from_str(r#""00:01:02""#).ok(), Some(NaiveTime::from_hms(0, 1, 2).unwrap()));
     assert_eq!(
         from_str(r#""03:05:07.098765432""#).ok(),
-        Some(NaiveTime::from_hms_nano_opt(3, 5, 7, 98765432).unwrap())
+        Some(NaiveTime::from_hms_nano(3, 5, 7, 98765432).unwrap())
     );
     assert_eq!(from_str(r#""07:08:09""#).ok(), Some(NaiveTime::from_hms(7, 8, 9).unwrap()));
     assert_eq!(
@@ -1499,11 +1499,11 @@ where
     );
     assert_eq!(
         from_str(r#""23:59:60.999999999""#).ok(),
-        Some(NaiveTime::from_hms_nano_opt(23, 59, 59, 1_999_999_999).unwrap())
+        Some(NaiveTime::from_hms_nano(23, 59, 59, 1_999_999_999).unwrap())
     );
     assert_eq!(
         from_str(r#""23:59:60.9999999999997""#).ok(), // excess digits are ignored
-        Some(NaiveTime::from_hms_nano_opt(23, 59, 59, 1_999_999_999).unwrap())
+        Some(NaiveTime::from_hms_nano(23, 59, 59, 1_999_999_999).unwrap())
     );
 
     // bad formats

--- a/src/naive/time/serde.rs
+++ b/src/naive/time/serde.rs
@@ -61,7 +61,7 @@ mod tests {
         // it is not self-describing.
         use bincode::{deserialize, serialize};
 
-        let t = NaiveTime::from_hms_nano_opt(3, 5, 7, 98765432).unwrap();
+        let t = NaiveTime::from_hms_nano(3, 5, 7, 98765432).unwrap();
         let encoded = serialize(&t).unwrap();
         let decoded: NaiveTime = deserialize(&encoded).unwrap();
         assert_eq!(t, decoded);

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -4,20 +4,20 @@ use crate::{FixedOffset, TimeDelta, Timelike};
 #[test]
 fn test_time_from_hms_milli() {
     assert_eq!(
-        NaiveTime::from_hms_milli_opt(3, 5, 7, 0),
+        NaiveTime::from_hms_milli(3, 5, 7, 0),
         Some(NaiveTime::from_hms_nano_opt(3, 5, 7, 0).unwrap())
     );
     assert_eq!(
-        NaiveTime::from_hms_milli_opt(3, 5, 7, 777),
+        NaiveTime::from_hms_milli(3, 5, 7, 777),
         Some(NaiveTime::from_hms_nano_opt(3, 5, 7, 777_000_000).unwrap())
     );
     assert_eq!(
-        NaiveTime::from_hms_milli_opt(3, 5, 59, 1_999),
+        NaiveTime::from_hms_milli(3, 5, 59, 1_999),
         Some(NaiveTime::from_hms_nano_opt(3, 5, 59, 1_999_000_000).unwrap())
     );
-    assert_eq!(NaiveTime::from_hms_milli_opt(3, 5, 59, 2_000), None);
-    assert_eq!(NaiveTime::from_hms_milli_opt(3, 5, 59, 5_000), None); // overflow check
-    assert_eq!(NaiveTime::from_hms_milli_opt(3, 5, 59, u32::MAX), None);
+    assert_eq!(NaiveTime::from_hms_milli(3, 5, 59, 2_000), None);
+    assert_eq!(NaiveTime::from_hms_milli(3, 5, 59, 5_000), None); // overflow check
+    assert_eq!(NaiveTime::from_hms_milli(3, 5, 59, u32::MAX), None);
 }
 
 #[test]
@@ -91,7 +91,7 @@ fn test_time_add() {
         }};
     }
 
-    let hmsm = |h, m, s, ms| NaiveTime::from_hms_milli_opt(h, m, s, ms).unwrap();
+    let hmsm = |h, m, s, ms| NaiveTime::from_hms_milli(h, m, s, ms).unwrap();
 
     check!(hmsm(3, 5, 59, 900), TimeDelta::zero(), hmsm(3, 5, 59, 900));
     check!(hmsm(3, 5, 59, 900), TimeDelta::milliseconds(100), hmsm(3, 6, 0, 0));
@@ -114,7 +114,7 @@ fn test_time_add() {
 
 #[test]
 fn test_time_overflowing_add() {
-    let hmsm = |h, m, s, ms| NaiveTime::from_hms_milli_opt(h, m, s, ms).unwrap();
+    let hmsm = |h, m, s, ms| NaiveTime::from_hms_milli(h, m, s, ms).unwrap();
 
     assert_eq!(
         hmsm(3, 4, 5, 678).overflowing_add_signed(TimeDelta::hours(11)),
@@ -170,7 +170,7 @@ fn test_time_sub() {
         }};
     }
 
-    let hmsm = |h, m, s, ms| NaiveTime::from_hms_milli_opt(h, m, s, ms).unwrap();
+    let hmsm = |h, m, s, ms| NaiveTime::from_hms_milli(h, m, s, ms).unwrap();
 
     check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 900), TimeDelta::zero());
     check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 600), TimeDelta::milliseconds(300));
@@ -210,16 +210,10 @@ fn test_core_duration_ops() {
 
 #[test]
 fn test_time_fmt() {
+    assert_eq!(format!("{}", NaiveTime::from_hms_milli(23, 59, 59, 999).unwrap()), "23:59:59.999");
+    assert_eq!(format!("{}", NaiveTime::from_hms_milli(23, 59, 59, 1_000).unwrap()), "23:59:60");
     assert_eq!(
-        format!("{}", NaiveTime::from_hms_milli_opt(23, 59, 59, 999).unwrap()),
-        "23:59:59.999"
-    );
-    assert_eq!(
-        format!("{}", NaiveTime::from_hms_milli_opt(23, 59, 59, 1_000).unwrap()),
-        "23:59:60"
-    );
-    assert_eq!(
-        format!("{}", NaiveTime::from_hms_milli_opt(23, 59, 59, 1_001).unwrap()),
+        format!("{}", NaiveTime::from_hms_milli(23, 59, 59, 1_001).unwrap()),
         "23:59:60.001"
     );
     assert_eq!(
@@ -232,10 +226,7 @@ fn test_time_fmt() {
     );
 
     // the format specifier should have no effect on `NaiveTime`
-    assert_eq!(
-        format!("{:30}", NaiveTime::from_hms_milli_opt(3, 5, 7, 9).unwrap()),
-        "03:05:07.009"
-    );
+    assert_eq!(format!("{:30}", NaiveTime::from_hms_milli(3, 5, 7, 9).unwrap()), "03:05:07.009");
 }
 
 #[test]
@@ -360,7 +351,7 @@ fn test_time_parse_from_str() {
 
 #[test]
 fn test_overflowing_offset() {
-    let hmsm = |h, m, s, n| NaiveTime::from_hms_milli_opt(h, m, s, n).unwrap();
+    let hmsm = |h, m, s, n| NaiveTime::from_hms_milli(h, m, s, n).unwrap();
 
     let positive_offset = FixedOffset::east_opt(4 * 60 * 60).unwrap();
     // regular time

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -45,41 +45,41 @@ fn test_time_from_hms_micro() {
 
 #[test]
 fn test_time_hms() {
-    assert_eq!(NaiveTime::from_hms_opt(3, 5, 7).unwrap().hour(), 3);
+    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().hour(), 3);
     assert_eq!(
-        NaiveTime::from_hms_opt(3, 5, 7).unwrap().with_hour(0),
-        Some(NaiveTime::from_hms_opt(0, 5, 7).unwrap())
+        NaiveTime::from_hms(3, 5, 7).unwrap().with_hour(0),
+        Some(NaiveTime::from_hms(0, 5, 7).unwrap())
     );
     assert_eq!(
-        NaiveTime::from_hms_opt(3, 5, 7).unwrap().with_hour(23),
-        Some(NaiveTime::from_hms_opt(23, 5, 7).unwrap())
+        NaiveTime::from_hms(3, 5, 7).unwrap().with_hour(23),
+        Some(NaiveTime::from_hms(23, 5, 7).unwrap())
     );
-    assert_eq!(NaiveTime::from_hms_opt(3, 5, 7).unwrap().with_hour(24), None);
-    assert_eq!(NaiveTime::from_hms_opt(3, 5, 7).unwrap().with_hour(u32::MAX), None);
+    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().with_hour(24), None);
+    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().with_hour(u32::MAX), None);
 
-    assert_eq!(NaiveTime::from_hms_opt(3, 5, 7).unwrap().minute(), 5);
+    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().minute(), 5);
     assert_eq!(
-        NaiveTime::from_hms_opt(3, 5, 7).unwrap().with_minute(0),
-        Some(NaiveTime::from_hms_opt(3, 0, 7).unwrap())
+        NaiveTime::from_hms(3, 5, 7).unwrap().with_minute(0),
+        Some(NaiveTime::from_hms(3, 0, 7).unwrap())
     );
     assert_eq!(
-        NaiveTime::from_hms_opt(3, 5, 7).unwrap().with_minute(59),
-        Some(NaiveTime::from_hms_opt(3, 59, 7).unwrap())
+        NaiveTime::from_hms(3, 5, 7).unwrap().with_minute(59),
+        Some(NaiveTime::from_hms(3, 59, 7).unwrap())
     );
-    assert_eq!(NaiveTime::from_hms_opt(3, 5, 7).unwrap().with_minute(60), None);
-    assert_eq!(NaiveTime::from_hms_opt(3, 5, 7).unwrap().with_minute(u32::MAX), None);
+    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().with_minute(60), None);
+    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().with_minute(u32::MAX), None);
 
-    assert_eq!(NaiveTime::from_hms_opt(3, 5, 7).unwrap().second(), 7);
+    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().second(), 7);
     assert_eq!(
-        NaiveTime::from_hms_opt(3, 5, 7).unwrap().with_second(0),
-        Some(NaiveTime::from_hms_opt(3, 5, 0).unwrap())
+        NaiveTime::from_hms(3, 5, 7).unwrap().with_second(0),
+        Some(NaiveTime::from_hms(3, 5, 0).unwrap())
     );
     assert_eq!(
-        NaiveTime::from_hms_opt(3, 5, 7).unwrap().with_second(59),
-        Some(NaiveTime::from_hms_opt(3, 5, 59).unwrap())
+        NaiveTime::from_hms(3, 5, 7).unwrap().with_second(59),
+        Some(NaiveTime::from_hms(3, 5, 59).unwrap())
     );
-    assert_eq!(NaiveTime::from_hms_opt(3, 5, 7).unwrap().with_second(60), None);
-    assert_eq!(NaiveTime::from_hms_opt(3, 5, 7).unwrap().with_second(u32::MAX), None);
+    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().with_second(60), None);
+    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().with_second(u32::MAX), None);
 }
 
 #[test]
@@ -142,7 +142,7 @@ fn test_time_overflowing_add() {
 
 #[test]
 fn test_time_addassignment() {
-    let hms = |h, m, s| NaiveTime::from_hms_opt(h, m, s).unwrap();
+    let hms = |h, m, s| NaiveTime::from_hms(h, m, s).unwrap();
     let mut time = hms(12, 12, 12);
     time += TimeDelta::hours(10);
     assert_eq!(time, hms(22, 12, 12));
@@ -152,7 +152,7 @@ fn test_time_addassignment() {
 
 #[test]
 fn test_time_subassignment() {
-    let hms = |h, m, s| NaiveTime::from_hms_opt(h, m, s).unwrap();
+    let hms = |h, m, s| NaiveTime::from_hms(h, m, s).unwrap();
     let mut time = hms(12, 12, 12);
     time -= TimeDelta::hours(10);
     assert_eq!(time, hms(2, 12, 12));
@@ -197,15 +197,15 @@ fn test_time_sub() {
 fn test_core_duration_ops() {
     use core::time::Duration;
 
-    let mut t = NaiveTime::from_hms_opt(11, 34, 23).unwrap();
+    let mut t = NaiveTime::from_hms(11, 34, 23).unwrap();
     let same = t + Duration::ZERO;
     assert_eq!(t, same);
 
     t += Duration::new(3600, 0);
-    assert_eq!(t, NaiveTime::from_hms_opt(12, 34, 23).unwrap());
+    assert_eq!(t, NaiveTime::from_hms(12, 34, 23).unwrap());
 
     t -= Duration::new(7200, 0);
-    assert_eq!(t, NaiveTime::from_hms_opt(10, 34, 23).unwrap());
+    assert_eq!(t, NaiveTime::from_hms(10, 34, 23).unwrap());
 }
 
 #[test]
@@ -340,7 +340,7 @@ fn test_time_from_str() {
 
 #[test]
 fn test_time_parse_from_str() {
-    let hms = |h, m, s| NaiveTime::from_hms_opt(h, m, s).unwrap();
+    let hms = |h, m, s| NaiveTime::from_hms(h, m, s).unwrap();
     assert_eq!(
         NaiveTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
         Ok(hms(12, 34, 56))

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -5,15 +5,15 @@ use crate::{FixedOffset, TimeDelta, Timelike};
 fn test_time_from_hms_milli() {
     assert_eq!(
         NaiveTime::from_hms_milli(3, 5, 7, 0),
-        Some(NaiveTime::from_hms_nano_opt(3, 5, 7, 0).unwrap())
+        Some(NaiveTime::from_hms_nano(3, 5, 7, 0).unwrap())
     );
     assert_eq!(
         NaiveTime::from_hms_milli(3, 5, 7, 777),
-        Some(NaiveTime::from_hms_nano_opt(3, 5, 7, 777_000_000).unwrap())
+        Some(NaiveTime::from_hms_nano(3, 5, 7, 777_000_000).unwrap())
     );
     assert_eq!(
         NaiveTime::from_hms_milli(3, 5, 59, 1_999),
-        Some(NaiveTime::from_hms_nano_opt(3, 5, 59, 1_999_000_000).unwrap())
+        Some(NaiveTime::from_hms_nano(3, 5, 59, 1_999_000_000).unwrap())
     );
     assert_eq!(NaiveTime::from_hms_milli(3, 5, 59, 2_000), None);
     assert_eq!(NaiveTime::from_hms_milli(3, 5, 59, 5_000), None); // overflow check
@@ -24,19 +24,19 @@ fn test_time_from_hms_milli() {
 fn test_time_from_hms_micro() {
     assert_eq!(
         NaiveTime::from_hms_micro(3, 5, 7, 0),
-        Some(NaiveTime::from_hms_nano_opt(3, 5, 7, 0).unwrap())
+        Some(NaiveTime::from_hms_nano(3, 5, 7, 0).unwrap())
     );
     assert_eq!(
         NaiveTime::from_hms_micro(3, 5, 7, 333),
-        Some(NaiveTime::from_hms_nano_opt(3, 5, 7, 333_000).unwrap())
+        Some(NaiveTime::from_hms_nano(3, 5, 7, 333_000).unwrap())
     );
     assert_eq!(
         NaiveTime::from_hms_micro(3, 5, 7, 777_777),
-        Some(NaiveTime::from_hms_nano_opt(3, 5, 7, 777_777_000).unwrap())
+        Some(NaiveTime::from_hms_nano(3, 5, 7, 777_777_000).unwrap())
     );
     assert_eq!(
         NaiveTime::from_hms_micro(3, 5, 59, 1_999_999),
-        Some(NaiveTime::from_hms_nano_opt(3, 5, 59, 1_999_999_000).unwrap())
+        Some(NaiveTime::from_hms_nano(3, 5, 59, 1_999_999_000).unwrap())
     );
     assert_eq!(NaiveTime::from_hms_micro(3, 5, 59, 2_000_000), None);
     assert_eq!(NaiveTime::from_hms_micro(3, 5, 59, 5_000_000), None); // overflow check
@@ -221,7 +221,7 @@ fn test_time_fmt() {
         "00:00:00.043210"
     );
     assert_eq!(
-        format!("{}", NaiveTime::from_hms_nano_opt(0, 0, 0, 6543210).unwrap()),
+        format!("{}", NaiveTime::from_hms_nano(0, 0, 0, 6543210).unwrap()),
         "00:00:00.006543210"
     );
 

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -23,24 +23,24 @@ fn test_time_from_hms_milli() {
 #[test]
 fn test_time_from_hms_micro() {
     assert_eq!(
-        NaiveTime::from_hms_micro_opt(3, 5, 7, 0),
+        NaiveTime::from_hms_micro(3, 5, 7, 0),
         Some(NaiveTime::from_hms_nano_opt(3, 5, 7, 0).unwrap())
     );
     assert_eq!(
-        NaiveTime::from_hms_micro_opt(3, 5, 7, 333),
+        NaiveTime::from_hms_micro(3, 5, 7, 333),
         Some(NaiveTime::from_hms_nano_opt(3, 5, 7, 333_000).unwrap())
     );
     assert_eq!(
-        NaiveTime::from_hms_micro_opt(3, 5, 7, 777_777),
+        NaiveTime::from_hms_micro(3, 5, 7, 777_777),
         Some(NaiveTime::from_hms_nano_opt(3, 5, 7, 777_777_000).unwrap())
     );
     assert_eq!(
-        NaiveTime::from_hms_micro_opt(3, 5, 59, 1_999_999),
+        NaiveTime::from_hms_micro(3, 5, 59, 1_999_999),
         Some(NaiveTime::from_hms_nano_opt(3, 5, 59, 1_999_999_000).unwrap())
     );
-    assert_eq!(NaiveTime::from_hms_micro_opt(3, 5, 59, 2_000_000), None);
-    assert_eq!(NaiveTime::from_hms_micro_opt(3, 5, 59, 5_000_000), None); // overflow check
-    assert_eq!(NaiveTime::from_hms_micro_opt(3, 5, 59, u32::MAX), None);
+    assert_eq!(NaiveTime::from_hms_micro(3, 5, 59, 2_000_000), None);
+    assert_eq!(NaiveTime::from_hms_micro(3, 5, 59, 5_000_000), None); // overflow check
+    assert_eq!(NaiveTime::from_hms_micro(3, 5, 59, u32::MAX), None);
 }
 
 #[test]
@@ -217,7 +217,7 @@ fn test_time_fmt() {
         "23:59:60.001"
     );
     assert_eq!(
-        format!("{}", NaiveTime::from_hms_micro_opt(0, 0, 0, 43210).unwrap()),
+        format!("{}", NaiveTime::from_hms_micro(0, 0, 0, 43210).unwrap()),
         "00:00:00.043210"
     );
     assert_eq!(

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -353,7 +353,7 @@ fn test_time_parse_from_str() {
 fn test_overflowing_offset() {
     let hmsm = |h, m, s, n| NaiveTime::from_hms_milli(h, m, s, n).unwrap();
 
-    let positive_offset = FixedOffset::east_opt(4 * 60 * 60).unwrap();
+    let positive_offset = FixedOffset::east(4 * 60 * 60).unwrap();
     // regular time
     let t = hmsm(5, 6, 7, 890);
     assert_eq!(t.overflowing_add_offset(positive_offset), (hmsm(9, 6, 7, 890), 0));
@@ -366,7 +366,7 @@ fn test_overflowing_offset() {
     let t = hmsm(1, 2, 3, 456);
     assert_eq!(t.overflowing_sub_offset(positive_offset), (hmsm(21, 2, 3, 456), -1));
     // an odd offset
-    let negative_offset = FixedOffset::west_opt(((2 * 60) + 3) * 60 + 4).unwrap();
+    let negative_offset = FixedOffset::west(((2 * 60) + 3) * 60 + 4).unwrap();
     let t = hmsm(5, 6, 7, 890);
     assert_eq!(t.overflowing_add_offset(negative_offset), (hmsm(3, 3, 3, 890), 0));
     assert_eq!(t.overflowing_sub_offset(negative_offset), (hmsm(7, 9, 11, 890), 0));

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -35,16 +35,6 @@ impl FixedOffset {
     /// Makes a new `FixedOffset` for the Eastern Hemisphere with given timezone difference.
     /// The negative `secs` means the Western Hemisphere.
     ///
-    /// Panics on the out-of-bound `secs`.
-    #[deprecated(since = "0.4.23", note = "use `east_opt()` instead")]
-    #[must_use]
-    pub fn east(secs: i32) -> FixedOffset {
-        FixedOffset::east_opt(secs).expect("FixedOffset::east out of bounds")
-    }
-
-    /// Makes a new `FixedOffset` for the Eastern Hemisphere with given timezone difference.
-    /// The negative `secs` means the Western Hemisphere.
-    ///
     /// Returns `None` on the out-of-bound `secs`.
     ///
     /// # Example
@@ -66,16 +56,6 @@ impl FixedOffset {
         } else {
             None
         }
-    }
-
-    /// Makes a new `FixedOffset` for the Western Hemisphere with given timezone difference.
-    /// The negative `secs` means the Eastern Hemisphere.
-    ///
-    /// Panics on the out-of-bound `secs`.
-    #[deprecated(since = "0.4.23", note = "use `west_opt()` instead")]
-    #[must_use]
-    pub fn west(secs: i32) -> FixedOffset {
-        FixedOffset::west_opt(secs).expect("FixedOffset::west out of bounds")
     }
 
     /// Makes a new `FixedOffset` for the Western Hemisphere with given timezone difference.

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -17,8 +17,8 @@ use crate::{NaiveDateTime, ParseError};
 ///
 /// Using the [`TimeZone`](./trait.TimeZone.html) methods
 /// on a `FixedOffset` struct is the preferred way to construct
-/// `DateTime<FixedOffset>` instances. See the [`east_opt`](#method.east_opt) and
-/// [`west_opt`](#method.west_opt) methods for examples.
+/// `DateTime<FixedOffset>` instances. See the [`east`](#method.east) and
+/// [`west`](#method.west) methods for examples.
 #[derive(PartialEq, Eq, Hash, Copy, Clone)]
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
@@ -43,14 +43,14 @@ impl FixedOffset {
     #[cfg_attr(feature = "std", doc = "```")]
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
-    /// let datetime = FixedOffset::east_opt(5 * hour)
+    /// let datetime = FixedOffset::east(5 * hour)
     ///     .unwrap()
     ///     .with_ymd_and_hms(2016, 11, 08, 0, 0, 0)
     ///     .unwrap();
     /// assert_eq!(&datetime.to_rfc3339(), "2016-11-08T00:00:00+05:00")
     /// ```
     #[must_use]
-    pub const fn east_opt(secs: i32) -> Option<FixedOffset> {
+    pub const fn east(secs: i32) -> Option<FixedOffset> {
         if -86_400 < secs && secs < 86_400 {
             Some(FixedOffset { local_minus_utc: secs })
         } else {
@@ -69,14 +69,14 @@ impl FixedOffset {
     #[cfg_attr(feature = "std", doc = "```")]
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
-    /// let datetime = FixedOffset::west_opt(5 * hour)
+    /// let datetime = FixedOffset::west(5 * hour)
     ///     .unwrap()
     ///     .with_ymd_and_hms(2016, 11, 08, 0, 0, 0)
     ///     .unwrap();
     /// assert_eq!(&datetime.to_rfc3339(), "2016-11-08T00:00:00-05:00")
     /// ```
     #[must_use]
-    pub const fn west_opt(secs: i32) -> Option<FixedOffset> {
+    pub const fn west(secs: i32) -> Option<FixedOffset> {
         if -86_400 < secs && secs < 86_400 {
             Some(FixedOffset { local_minus_utc: -secs })
         } else {
@@ -102,7 +102,7 @@ impl FromStr for FixedOffset {
     type Err = ParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (_, offset) = scan::timezone_offset(s, scan::consume_colon_maybe, false, false, true)?;
-        Self::east_opt(offset).ok_or(OUT_OF_RANGE)
+        Self::east(offset).ok_or(OUT_OF_RANGE)
     }
 }
 
@@ -154,7 +154,7 @@ impl fmt::Display for FixedOffset {
 impl arbitrary::Arbitrary<'_> for FixedOffset {
     fn arbitrary(u: &mut arbitrary::Unstructured) -> arbitrary::Result<FixedOffset> {
         let secs = u.int_in_range(-86_399..=86_399)?;
-        let fixed_offset = FixedOffset::east_opt(secs)
+        let fixed_offset = FixedOffset::east(secs)
             .expect("Could not generate a valid chrono::FixedOffset. It looks like implementation of Arbitrary for FixedOffset is erroneous.");
         Ok(fixed_offset)
     }
@@ -170,22 +170,22 @@ mod tests {
     fn test_date_extreme_offset() {
         // starting from 0.3 we don't have an offset exceeding one day.
         // this makes everything easier!
-        let offset = FixedOffset::east_opt(86399).unwrap();
+        let offset = FixedOffset::east(86399).unwrap();
         assert_eq!(
             format!("{:?}", offset.with_ymd_and_hms(2012, 2, 29, 5, 6, 7).unwrap()),
             "2012-02-29T05:06:07+23:59:59"
         );
-        let offset = FixedOffset::east_opt(-86399).unwrap();
+        let offset = FixedOffset::east(-86399).unwrap();
         assert_eq!(
             format!("{:?}", offset.with_ymd_and_hms(2012, 2, 29, 5, 6, 7).unwrap()),
             "2012-02-29T05:06:07-23:59:59"
         );
-        let offset = FixedOffset::west_opt(86399).unwrap();
+        let offset = FixedOffset::west(86399).unwrap();
         assert_eq!(
             format!("{:?}", offset.with_ymd_and_hms(2012, 3, 4, 5, 6, 7).unwrap()),
             "2012-03-04T05:06:07-23:59:59"
         );
-        let offset = FixedOffset::west_opt(-86399).unwrap();
+        let offset = FixedOffset::west(-86399).unwrap();
         assert_eq!(
             format!("{:?}", offset.with_ymd_and_hms(2012, 3, 4, 5, 6, 7).unwrap()),
             "2012-03-04T05:06:07+23:59:59"

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -35,13 +35,13 @@ mod inner {
     use crate::{FixedOffset, LocalResult, NaiveDateTime};
 
     pub(super) fn offset_from_utc_datetime(_utc_time: &NaiveDateTime) -> LocalResult<FixedOffset> {
-        LocalResult::Single(FixedOffset::east_opt(0).unwrap())
+        LocalResult::Single(FixedOffset::east(0).unwrap())
     }
 
     pub(super) fn offset_from_local_datetime(
         _local_time: &NaiveDateTime,
     ) -> LocalResult<FixedOffset> {
-        LocalResult::Single(FixedOffset::east_opt(0).unwrap())
+        LocalResult::Single(FixedOffset::east(0).unwrap())
     }
 }
 
@@ -55,7 +55,7 @@ mod inner {
 
     pub(super) fn offset_from_utc_datetime(utc: &NaiveDateTime) -> LocalResult<FixedOffset> {
         let offset = js_sys::Date::from(utc.and_utc()).get_timezone_offset();
-        LocalResult::Single(FixedOffset::west_opt((offset as i32) * 60).unwrap())
+        LocalResult::Single(FixedOffset::west((offset as i32) * 60).unwrap())
     }
 
     pub(super) fn offset_from_local_datetime(local: &NaiveDateTime) -> LocalResult<FixedOffset> {
@@ -78,7 +78,7 @@ mod inner {
         );
         let offset = js_date.get_timezone_offset();
         // We always get a result, even if this time does not exist or is ambiguous.
-        LocalResult::Single(FixedOffset::west_opt((offset as i32) * 60).unwrap())
+        LocalResult::Single(FixedOffset::west((offset as i32) * 60).unwrap())
     }
 }
 
@@ -136,7 +136,7 @@ impl Local {
     ///
     /// // Current time in some timezone (let's use +05:00)
     /// // Note that it is usually more efficient to use `Utc::now` for this use case.
-    /// let offset = FixedOffset::east_opt(5 * 60 * 60).unwrap();
+    /// let offset = FixedOffset::east(5 * 60 * 60).unwrap();
     /// let now_with_offset = Local::now().with_timezone(&offset);
     /// ```
     pub fn now() -> DateTime<Local> {

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -97,7 +97,7 @@ mod tz_info;
 /// use chrono::{Local, DateTime, TimeZone};
 ///
 /// let dt1: DateTime<Local> = Local::now();
-/// let dt2: DateTime<Local> = Local.timestamp_opt(0, 0).unwrap();
+/// let dt2: DateTime<Local> = Local.timestamp(0, 0).unwrap();
 /// assert!(dt1 >= dt2);
 /// ```
 #[derive(Copy, Clone, Debug)]

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -155,7 +155,7 @@ impl Cache {
                 .expect("unable to select local time type")
                 .offset();
 
-            return match FixedOffset::east_opt(offset) {
+            return match FixedOffset::east(offset) {
                 Some(offset) => LocalResult::Single(offset),
                 None => LocalResult::None,
             };
@@ -166,6 +166,6 @@ impl Cache {
         self.zone
             .find_local_time_type_from_local(d.timestamp(), d.year())
             .expect("unable to select local time type")
-            .map(|o| FixedOffset::east_opt(o.offset()).unwrap())
+            .map(|o| FixedOffset::east(o.offset()).unwrap())
     }
 }

--- a/src/offset/local/windows.rs
+++ b/src/offset/local/windows.rs
@@ -66,7 +66,7 @@ fn from_utc_time(utc_time: SYSTEMTIME) -> Result<FixedOffset, Error> {
     let utc_secs = system_time_as_unix_seconds(&utc_time)?;
     let local_secs = system_time_as_unix_seconds(&local_time)?;
     let offset = (local_secs - utc_secs) as i32;
-    Ok(FixedOffset::east_opt(offset).unwrap())
+    Ok(FixedOffset::east(offset).unwrap())
 }
 
 fn from_local_time(local_time: SYSTEMTIME) -> Result<FixedOffset, Error> {
@@ -74,7 +74,7 @@ fn from_local_time(local_time: SYSTEMTIME) -> Result<FixedOffset, Error> {
     let utc_secs = system_time_as_unix_seconds(&utc_time)?;
     let local_secs = system_time_as_unix_seconds(&local_time)?;
     let offset = (local_secs - utc_secs) as i32;
-    Ok(FixedOffset::east_opt(offset).unwrap())
+    Ok(FixedOffset::east(offset).unwrap())
 }
 
 fn system_time_from_naive_date_time(dt: &NaiveDateTime) -> SYSTEMTIME {

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -155,9 +155,9 @@ pub trait TimeZone: Sized + Clone {
     /// ```
     /// use chrono::{Utc, TimeZone};
     ///
-    /// assert_eq!(Utc.timestamp_opt(1431648000, 0).unwrap().to_string(), "2015-05-15 00:00:00 UTC");
+    /// assert_eq!(Utc.timestamp(1431648000, 0).unwrap().to_string(), "2015-05-15 00:00:00 UTC");
     /// ```
-    fn timestamp_opt(&self, secs: i64, nsecs: u32) -> LocalResult<DateTime<Self>> {
+    fn timestamp(&self, secs: i64, nsecs: u32) -> LocalResult<DateTime<Self>> {
         match NaiveDateTime::from_timestamp(secs, nsecs) {
             Some(dt) => LocalResult::Single(self.from_utc_datetime(&dt)),
             None => LocalResult::None,
@@ -176,12 +176,12 @@ pub trait TimeZone: Sized + Clone {
     ///
     /// ```
     /// use chrono::{Utc, TimeZone, LocalResult};
-    /// match Utc.timestamp_millis_opt(1431648000) {
+    /// match Utc.timestamp_millis(1431648000) {
     ///     LocalResult::Single(dt) => assert_eq!(dt.timestamp(), 1431648),
     ///     _ => panic!("Incorrect timestamp_millis"),
     /// };
     /// ```
-    fn timestamp_millis_opt(&self, millis: i64) -> LocalResult<DateTime<Self>> {
+    fn timestamp_millis(&self, millis: i64) -> LocalResult<DateTime<Self>> {
         match NaiveDateTime::from_timestamp_millis(millis) {
             Some(dt) => LocalResult::Single(self.from_utc_datetime(&dt)),
             None => LocalResult::None,
@@ -191,7 +191,7 @@ pub trait TimeZone: Sized + Clone {
     /// Makes a new `DateTime` from the number of non-leap nanoseconds
     /// since January 1, 1970 0:00:00 UTC (aka "UNIX timestamp").
     ///
-    /// Unlike [`timestamp_millis_opt`](#method.timestamp_millis_opt), this never fails.
+    /// Unlike [`timestamp_millis`](#method.timestamp_millis), this never fails.
     ///
     /// # Example
     ///
@@ -206,7 +206,7 @@ pub trait TimeZone: Sized + Clone {
             secs -= 1;
             nanos += 1_000_000_000;
         }
-        self.timestamp_opt(secs, nanos as u32).unwrap()
+        self.timestamp(secs, nanos as u32).unwrap()
     }
 
     /// Makes a new `DateTime` from the number of non-leap microseconds
@@ -298,21 +298,21 @@ mod tests {
 
     #[test]
     fn test_negative_millis() {
-        let dt = Utc.timestamp_millis_opt(-1000).unwrap();
+        let dt = Utc.timestamp_millis(-1000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59 UTC");
-        let dt = Utc.timestamp_millis_opt(-7000).unwrap();
+        let dt = Utc.timestamp_millis(-7000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:53 UTC");
-        let dt = Utc.timestamp_millis_opt(-7001).unwrap();
+        let dt = Utc.timestamp_millis(-7001).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:52.999 UTC");
-        let dt = Utc.timestamp_millis_opt(-7003).unwrap();
+        let dt = Utc.timestamp_millis(-7003).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:52.997 UTC");
-        let dt = Utc.timestamp_millis_opt(-999).unwrap();
+        let dt = Utc.timestamp_millis(-999).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59.001 UTC");
-        let dt = Utc.timestamp_millis_opt(-1).unwrap();
+        let dt = Utc.timestamp_millis(-1).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59.999 UTC");
-        let dt = Utc.timestamp_millis_opt(-60000).unwrap();
+        let dt = Utc.timestamp_millis(-60000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:00 UTC");
-        let dt = Utc.timestamp_millis_opt(-3600000).unwrap();
+        let dt = Utc.timestamp_millis(-3600000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:00:00 UTC");
 
         for (millis, expected) in &[
@@ -320,7 +320,7 @@ mod tests {
             (-7001, "1969-12-31 23:59:52.999 UTC"),
             (-7003, "1969-12-31 23:59:52.997 UTC"),
         ] {
-            match Utc.timestamp_millis_opt(*millis) {
+            match Utc.timestamp_millis(*millis) {
                 LocalResult::Single(dt) => {
                     assert_eq!(dt.to_string(), *expected);
                 }

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -20,7 +20,6 @@
 
 use core::fmt;
 
-use crate::format::{parse, ParseResult, Parsed, StrftimeItems};
 use crate::naive::{NaiveDate, NaiveDateTime};
 use crate::DateTime;
 
@@ -146,23 +145,6 @@ pub trait TimeZone: Sized + Clone {
     /// [leap second](crate::NaiveTime#leap-second-handling), but only when `secs % 60 == 59`.
     /// (The true "UNIX timestamp" cannot represent a leap second unambiguously.)
     ///
-    /// # Panics
-    ///
-    /// Panics on the out-of-range number of seconds and/or invalid nanosecond,
-    /// for a non-panicking version see [`timestamp_opt`](#method.timestamp_opt).
-    #[deprecated(since = "0.4.23", note = "use `timestamp_opt()` instead")]
-    fn timestamp(&self, secs: i64, nsecs: u32) -> DateTime<Self> {
-        self.timestamp_opt(secs, nsecs).unwrap()
-    }
-
-    /// Makes a new `DateTime` from the number of non-leap seconds
-    /// since January 1, 1970 0:00:00 UTC (aka "UNIX timestamp")
-    /// and the number of nanoseconds since the last whole non-leap second.
-    ///
-    /// The nanosecond part can exceed 1,000,000,000 in order to represent a
-    /// [leap second](crate::NaiveTime#leap-second-handling), but only when `secs % 60 == 59`.
-    /// (The true "UNIX timestamp" cannot represent a leap second unambiguously.)
-    ///
     /// # Errors
     ///
     /// Returns `LocalResult::None` on out-of-range number of seconds and/or
@@ -180,16 +162,6 @@ pub trait TimeZone: Sized + Clone {
             Some(dt) => LocalResult::Single(self.from_utc_datetime(&dt)),
             None => LocalResult::None,
         }
-    }
-
-    /// Makes a new `DateTime` from the number of non-leap milliseconds
-    /// since January 1, 1970 0:00:00 UTC (aka "UNIX timestamp").
-    ///
-    /// Panics on out-of-range number of milliseconds for a non-panicking
-    /// version see [`timestamp_millis_opt`](#method.timestamp_millis_opt).
-    #[deprecated(since = "0.4.23", note = "use `timestamp_millis_opt()` instead")]
-    fn timestamp_millis(&self, millis: i64) -> DateTime<Self> {
-        self.timestamp_millis_opt(millis).unwrap()
     }
 
     /// Makes a new `DateTime` from the number of non-leap milliseconds
@@ -252,31 +224,6 @@ pub trait TimeZone: Sized + Clone {
             Some(dt) => LocalResult::Single(self.from_utc_datetime(&dt)),
             None => LocalResult::None,
         }
-    }
-
-    /// Parses a string with the specified format string and returns a
-    /// `DateTime` with the current offset.
-    ///
-    /// See the [`crate::format::strftime`] module on the
-    /// supported escape sequences.
-    ///
-    /// If the to-be-parsed string includes an offset, it *must* match the
-    /// offset of the TimeZone, otherwise an error will be returned.
-    ///
-    /// See also [`DateTime::parse_from_str`] which gives a [`DateTime`] with
-    /// parsed [`FixedOffset`].
-    ///
-    /// See also [`NaiveDateTime::parse_from_str`] which gives a [`NaiveDateTime`] without
-    /// an offset, but can be converted to a [`DateTime`] with [`NaiveDateTime::and_utc`] or
-    /// [`NaiveDateTime::and_local_timezone`].
-    #[deprecated(
-        since = "0.4.29",
-        note = "use `DateTime::parse_from_str` or `NaiveDateTime::parse_from_str` with `and_utc()` or `and_local_timezone()` instead"
-    )]
-    fn datetime_from_str(&self, s: &str, fmt: &str) -> ParseResult<DateTime<Self>> {
-        let mut parsed = Parsed::new();
-        parse(&mut parsed, s, StrftimeItems::new(fmt))?;
-        parsed.to_datetime_with_timezone(self)
     }
 
     /// Reconstructs the time zone from the offset.

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -176,7 +176,7 @@ pub trait TimeZone: Sized + Clone {
     /// assert_eq!(Utc.timestamp_opt(1431648000, 0).unwrap().to_string(), "2015-05-15 00:00:00 UTC");
     /// ```
     fn timestamp_opt(&self, secs: i64, nsecs: u32) -> LocalResult<DateTime<Self>> {
-        match NaiveDateTime::from_timestamp_opt(secs, nsecs) {
+        match NaiveDateTime::from_timestamp(secs, nsecs) {
             Some(dt) => LocalResult::Single(self.from_utc_datetime(&dt)),
             None => LocalResult::None,
         }

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -274,7 +274,7 @@ mod tests {
     fn test_fixed_offset_min_max_dates() {
         for offset_hour in -23..=23 {
             dbg!(offset_hour);
-            let offset = FixedOffset::east_opt(offset_hour * 60 * 60).unwrap();
+            let offset = FixedOffset::east(offset_hour * 60 * 60).unwrap();
 
             let local_max = offset.from_utc_datetime(&NaiveDateTime::MAX);
             assert_eq!(local_max.naive_utc(), NaiveDateTime::MAX);

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -36,7 +36,7 @@ use crate::DateTime;
 ///
 /// let dt = Utc.from_utc_datetime(&NaiveDateTime::from_timestamp(61, 0).unwrap());
 ///
-/// assert_eq!(Utc.timestamp_opt(61, 0).unwrap(), dt);
+/// assert_eq!(Utc.timestamp(61, 0).unwrap(), dt);
 /// assert_eq!(Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(), dt);
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -34,7 +34,7 @@ use crate::DateTime;
 /// ```
 /// use chrono::{TimeZone, NaiveDateTime, Utc};
 ///
-/// let dt = Utc.from_utc_datetime(&NaiveDateTime::from_timestamp_opt(61, 0).unwrap());
+/// let dt = Utc.from_utc_datetime(&NaiveDateTime::from_timestamp(61, 0).unwrap());
 ///
 /// assert_eq!(Utc.timestamp_opt(61, 0).unwrap(), dt);
 /// assert_eq!(Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(), dt);
@@ -84,7 +84,7 @@ impl Utc {
         let now =
             SystemTime::now().duration_since(UNIX_EPOCH).expect("system time before Unix epoch");
         let naive =
-            NaiveDateTime::from_timestamp_opt(now.as_secs() as i64, now.subsec_nanos()).unwrap();
+            NaiveDateTime::from_timestamp(now.as_secs() as i64, now.subsec_nanos()).unwrap();
         Utc.from_utc_datetime(&naive)
     }
 

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -71,7 +71,7 @@ impl Utc {
     /// let today_utc = now_utc.date_naive();
     ///
     /// // Current time in some timezone (let's use +05:00)
-    /// let offset = FixedOffset::east_opt(5 * 60 * 60).unwrap();
+    /// let offset = FixedOffset::east(5 * 60 * 60).unwrap();
     /// let now_with_offset = Utc::now().with_timezone(&offset);
     /// ```
     #[cfg(not(all(
@@ -119,7 +119,7 @@ impl TimeZone for Utc {
 
 impl Offset for Utc {
     fn fix(&self) -> FixedOffset {
-        FixedOffset::east_opt(0).unwrap()
+        FixedOffset::east(0).unwrap()
     }
 }
 

--- a/src/round.rs
+++ b/src/round.rs
@@ -180,7 +180,7 @@ where
         if span < 0 {
             return Err(RoundingError::DurationExceedsLimit);
         }
-        let stamp = naive.timestamp_nanos_opt().ok_or(RoundingError::TimestampExceedsLimit)?;
+        let stamp = naive.timestamp_nanos().ok_or(RoundingError::TimestampExceedsLimit)?;
         if span > stamp.abs() {
             return Err(RoundingError::DurationExceedsTimestamp);
         }
@@ -219,7 +219,7 @@ where
         if span < 0 {
             return Err(RoundingError::DurationExceedsLimit);
         }
-        let stamp = naive.timestamp_nanos_opt().ok_or(RoundingError::TimestampExceedsLimit)?;
+        let stamp = naive.timestamp_nanos().ok_or(RoundingError::TimestampExceedsLimit)?;
         if span > stamp.abs() {
             return Err(RoundingError::DurationExceedsTimestamp);
         }
@@ -761,15 +761,15 @@ mod tests {
 
     #[test]
     fn issue1010() {
-        let dt = NaiveDateTime::from_timestamp_opt(-4_227_854_320, 678_774_288).unwrap();
+        let dt = NaiveDateTime::from_timestamp(-4_227_854_320, 678_774_288).unwrap();
         let span = TimeDelta::microseconds(-7_019_067_213_869_040);
         assert_eq!(dt.duration_trunc(span), Err(RoundingError::DurationExceedsLimit));
 
-        let dt = NaiveDateTime::from_timestamp_opt(320_041_586, 920_103_021).unwrap();
+        let dt = NaiveDateTime::from_timestamp(320_041_586, 920_103_021).unwrap();
         let span = TimeDelta::nanoseconds(-8_923_838_508_697_114_584);
         assert_eq!(dt.duration_round(span), Err(RoundingError::DurationExceedsLimit));
 
-        let dt = NaiveDateTime::from_timestamp_opt(-2_621_440, 0).unwrap();
+        let dt = NaiveDateTime::from_timestamp(-2_621_440, 0).unwrap();
         let span = TimeDelta::nanoseconds(-9_223_372_036_854_771_421);
         assert_eq!(dt.duration_round(span), Err(RoundingError::DurationExceedsLimit));
     }

--- a/src/round.rs
+++ b/src/round.rs
@@ -97,7 +97,7 @@ const fn span_for_digits(digits: u16) -> u32 {
 ///
 /// # Limitations
 /// Both rounding and truncating are done via [`TimeDelta::num_nanoseconds`] and
-/// [`DateTime::timestamp_nanos_opt`]. This means that they will fail if either the
+/// [`DateTime::timestamp_nanos`]. This means that they will fail if either the
 /// `TimeDelta` or the `DateTime` are too big to represented as nanoseconds. They
 /// will also fail if the `TimeDelta` is bigger than the timestamp.
 pub trait DurationRound: Sized {

--- a/src/round.rs
+++ b/src/round.rs
@@ -309,7 +309,7 @@ mod tests {
 
     #[test]
     fn test_round_subsecs() {
-        let pst = FixedOffset::east_opt(8 * 60 * 60).unwrap();
+        let pst = FixedOffset::east(8 * 60 * 60).unwrap();
         let dt = pst
             .from_local_datetime(
                 &NaiveDate::from_ymd_opt(2018, 1, 11)
@@ -373,7 +373,7 @@ mod tests {
 
     #[test]
     fn test_trunc_subsecs() {
-        let pst = FixedOffset::east_opt(8 * 60 * 60).unwrap();
+        let pst = FixedOffset::east(8 * 60 * 60).unwrap();
         let dt = pst
             .from_local_datetime(
                 &NaiveDate::from_ymd_opt(2018, 1, 11)
@@ -501,8 +501,7 @@ mod tests {
         );
 
         // timezone east
-        let dt =
-            FixedOffset::east_opt(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
+        let dt = FixedOffset::east(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
         assert_eq!(
             dt.duration_round(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-28 00:00:00 +01:00"
@@ -513,8 +512,7 @@ mod tests {
         );
 
         // timezone west
-        let dt =
-            FixedOffset::west_opt(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
+        let dt = FixedOffset::west(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
         assert_eq!(
             dt.duration_round(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-28 00:00:00 -01:00"
@@ -663,8 +661,7 @@ mod tests {
         );
 
         // timezone east
-        let dt =
-            FixedOffset::east_opt(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
+        let dt = FixedOffset::east(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
         assert_eq!(
             dt.duration_trunc(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-27 00:00:00 +01:00"
@@ -675,8 +672,7 @@ mod tests {
         );
 
         // timezone west
-        let dt =
-            FixedOffset::west_opt(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
+        let dt = FixedOffset::west(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
         assert_eq!(
             dt.duration_trunc(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-27 00:00:00 -01:00"

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -38,11 +38,11 @@ fn now() {
 
     // Ensure offset retrieved when getting local time is correct
     let expected_offset = match tz {
-        "ACST-9:30" => FixedOffset::east_opt(19 * 30 * 60).unwrap(),
-        "Asia/Katmandu" => FixedOffset::east_opt(23 * 15 * 60).unwrap(), // No DST thankfully
-        "EDT" | "EST4" | "-0400" => FixedOffset::east_opt(-4 * 60 * 60).unwrap(),
-        "EST" | "-0500" => FixedOffset::east_opt(-5 * 60 * 60).unwrap(),
-        "UTC0" | "+0000" => FixedOffset::east_opt(0).unwrap(),
+        "ACST-9:30" => FixedOffset::east(19 * 30 * 60).unwrap(),
+        "Asia/Katmandu" => FixedOffset::east(23 * 15 * 60).unwrap(), // No DST thankfully
+        "EDT" | "EST4" | "-0400" => FixedOffset::east(-4 * 60 * 60).unwrap(),
+        "EST" | "-0500" => FixedOffset::east(-5 * 60 * 60).unwrap(),
+        "UTC0" | "+0000" => FixedOffset::east(0).unwrap(),
         tz => panic!("unexpected TZ {}", tz),
     };
     assert_eq!(


### PR DESCRIPTION
Remove everything that is deprecated on the 0.5 branch.

I was wondering if it was better to rename the replacement methods at the same time as removing the deprecated methods, or to leave that for another PR. I.e. renaming things like `FixedOffset::east_opt` to `FixedOffset::east`.