### PR TITLE
Don't mention deprecated methods in docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,7 +260,7 @@
 //! # }
 //! ```
 //!
-//! Parsing can be done with three methods:
+//! Parsing can be done with two methods:
 //!
 //! 1. The standard [`FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) trait
 //!    (and [`parse`](https://doc.rust-lang.org/std/primitive.str.html#method.parse) method
@@ -277,12 +277,6 @@
 //!    and
 //!    [`DateTime::parse_from_rfc3339`](./struct.DateTime.html#method.parse_from_rfc3339)
 //!    are similar but for well-known formats.
-//!
-//! 3. [`Offset::datetime_from_str`](./offset/trait.TimeZone.html#method.datetime_from_str) is
-//!    similar but returns `DateTime` of given offset.
-//!    When the explicit offset is missing from the input, it simply uses given offset.
-//!    It issues an error when the input contains an explicit offset different
-//!    from the current offset.
 //!
 //! More detailed control over the parsing process is available via
 //! [`format`](./format/index.html) module.

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1556,7 +1556,7 @@ impl Datelike for NaiveDate {
     /// assert_eq!(NaiveDate::from_ymd_opt(-308, 3, 14).unwrap().day(), 14);
     /// ```
     ///
-    /// Combined with [`NaiveDate::pred`](#method.pred),
+    /// Combined with [`NaiveDate::pred_opt`](#method.pred_opt),
     /// one can determine the number of days in a particular month.
     /// (Note that this panics when `year` is out of range.)
     ///
@@ -1613,7 +1613,7 @@ impl Datelike for NaiveDate {
     /// assert_eq!(NaiveDate::from_ymd_opt(-308, 3, 14).unwrap().ordinal(), 74);
     /// ```
     ///
-    /// Combined with [`NaiveDate::pred`](#method.pred),
+    /// Combined with [`NaiveDate::pred_opt`](#method.pred_opt),
     /// one can determine the number of days in a particular year.
     /// (Note that this panics when `year` is out of range.)
     ///

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -423,8 +423,7 @@ pub trait TimeZone: Sized + Clone {
     /// Makes a new `DateTime` from the number of non-leap nanoseconds
     /// since January 1, 1970 0:00:00 UTC (aka "UNIX timestamp").
     ///
-    /// Unlike [`timestamp_millis`](#method.timestamp_millis), this never
-    /// panics.
+    /// Unlike [`timestamp_millis_opt`](#method.timestamp_millis_opt), this never fails.
     ///
     /// # Example
     ///

--- a/src/round.rs
+++ b/src/round.rs
@@ -97,7 +97,7 @@ const fn span_for_digits(digits: u16) -> u32 {
 ///
 /// # Limitations
 /// Both rounding and truncating are done via [`Duration::num_nanoseconds`] and
-/// [`DateTime::timestamp_nanos`]. This means that they will fail if either the
+/// [`DateTime::timestamp_nanos_opt`]. This means that they will fail if either the
 /// `Duration` or the `DateTime` are too big to represented as nanoseconds. They
 /// will also fail if the `Duration` is bigger than the timestamp.
 pub trait DurationRound: Sized {

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -22,7 +22,7 @@ fn now() {
 
     // Ensure time set by the test script is correct
     let now = env!("NOW");
-    let actual = Utc.datetime_from_str(&now, "%s").unwrap();
+    let actual = NaiveDateTime::parse_from_str(&now, "%s").unwrap().and_utc();
     let diff = utc - actual;
     assert!(
         diff < chrono::Duration::minutes(5),


### PR DESCRIPTION
First two commits from https://github.com/chronotope/chrono/pull/1394 ported to the 0.4 branch.