### PR TITLE
Fixes for `Duration::new`

### DIFF
--- a/src/duration.rs
+++ b/src/duration.rs
@@ -83,7 +83,7 @@ impl Duration {
     pub const fn new(secs: i64, nanos: u32) -> Option<Duration> {
         if secs < MIN.secs
             || secs > MAX.secs
-            || nanos > 1_000_000_000
+            || nanos >= 1_000_000_000
             || (secs == MAX.secs && nanos > MAX.nanos as u32)
             || (secs == MIN.secs && nanos < MIN.nanos as u32)
         {

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -80,7 +80,7 @@ impl Duration {
     /// # Errors
     ///
     /// Returns `None` when the duration is out of bounds, or if `nanos` ≥ 1,000,000,000.
-    pub(crate) const fn new(secs: i64, nanos: u32) -> Option<Duration> {
+    pub const fn new(secs: i64, nanos: u32) -> Option<Duration> {
         if secs < MIN.secs
             || secs > MAX.secs
             || nanos > 1_000_000_000


### PR DESCRIPTION
Thanks to @Skgland in https://github.com/chronotope/chrono/pull/1337#discussion_r1475695141 for noticing.