### PR TITLE
0.5: Converting the API to return Results (part 1)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,33 @@
+//! Error type
+use core::fmt;
+
+/// Error type for date and time operations.
+#[non_exhaustive]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Error {
+    /// A date or datetime does not exist.
+    ///
+    /// Examples are:
+    /// - April 31,
+    /// - February 29 in a non-leap year,
+    /// - a time that falls in the gap created by moving the clock forward during a DST transition,
+    /// - a leap second on a non-minute boundary.
+    DoesNotExist,
+
+    /// One or more of the arguments to a function are invalid.
+    ///
+    /// An example is creating a `NaiveTime` with 25 as the hour value.
+    InvalidArgument,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::DoesNotExist => write!(f, "date or datetime does not exist"),
+            Error::InvalidArgument => write!(f, "invalid parameter"),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -526,7 +526,7 @@ impl Parsed {
             None => 0,
         };
 
-        NaiveTime::from_hms_nano(hour, minute, second, nano).ok_or(OUT_OF_RANGE)
+        NaiveTime::from_hms_nano(hour, minute, second, nano).map_err(|_| OUT_OF_RANGE)
     }
 
     /// Returns a parsed naive date and time out of given fields,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,20 +129,20 @@
 //! # fn doctest() -> Option<()> {
 //!
 //! let dt = Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap(); // `2014-07-08T09:10:11Z`
-//! assert_eq!(dt, NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_opt(9, 10, 11)?.and_local_timezone(Utc).unwrap());
+//! assert_eq!(dt, NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_opt(9, 10, 11).unwrap().and_local_timezone(Utc).unwrap());
 //!
 //! // July 8 is 188th day of the year 2014 (`o` for "ordinal")
-//! assert_eq!(dt, NaiveDate::from_yo_opt(2014, 189)?.and_hms_opt(9, 10, 11)?.and_utc());
+//! assert_eq!(dt, NaiveDate::from_yo_opt(2014, 189)?.and_hms_opt(9, 10, 11).unwrap().and_utc());
 //! // July 8 is Tuesday in ISO week 28 of the year 2014.
-//! assert_eq!(dt, NaiveDate::from_isoywd_opt(2014, 28, Weekday::Tue)?.and_hms_opt(9, 10, 11)?.and_utc());
+//! assert_eq!(dt, NaiveDate::from_isoywd_opt(2014, 28, Weekday::Tue)?.and_hms_opt(9, 10, 11).unwrap().and_utc());
 //!
-//! let dt = NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_milli_opt(9, 10, 11, 12)?.and_local_timezone(Utc).unwrap(); // `2014-07-08T09:10:11.012Z`
-//! assert_eq!(dt, NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_micro_opt(9, 10, 11, 12_000)?.and_local_timezone(Utc).unwrap());
-//! assert_eq!(dt, NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_nano_opt(9, 10, 11, 12_000_000)?.and_local_timezone(Utc).unwrap());
+//! let dt = NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_milli_opt(9, 10, 11, 12).unwrap().and_local_timezone(Utc).unwrap(); // `2014-07-08T09:10:11.012Z`
+//! assert_eq!(dt, NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_micro_opt(9, 10, 11, 12_000).unwrap().and_local_timezone(Utc).unwrap());
+//! assert_eq!(dt, NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_nano_opt(9, 10, 11, 12_000_000).unwrap().and_local_timezone(Utc).unwrap());
 //!
 //! // dynamic verification
 //! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 21, 15, 33),
-//!            LocalResult::Single(NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_opt(21, 15, 33)?.and_utc()));
+//!            LocalResult::Single(NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_opt(21, 15, 33).unwrap().and_utc()));
 //! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 80, 15, 33), LocalResult::None);
 //! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 38, 21, 15, 33), LocalResult::None);
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,6 +480,9 @@ pub mod prelude {
 mod datetime;
 pub use datetime::DateTime;
 
+pub(crate) mod error;
+pub use error::Error;
+
 pub mod format;
 /// L10n locales.
 #[cfg(feature = "unstable-locales")]
@@ -591,6 +594,18 @@ macro_rules! try_opt {
     };
 }
 
+/// Workaround because `?` is not (yet) available in const context.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! try_err {
+    ($e:expr) => {
+        match $e {
+            Ok(v) => v,
+            Err(e) => return Err(e),
+        }
+    };
+}
+
 /// Workaround because `.expect()` is not (yet) available in const context.
 #[macro_export]
 #[doc(hidden)]
@@ -599,6 +614,22 @@ macro_rules! expect {
         match $e {
             Some(v) => v,
             None => panic!($m),
+        }
+    };
+}
+
+/// Workaround because `.ok()` is not (yet) available in const context.
+///
+/// FIXME: This is a temporary macro, intended to be used while we convert our API from returning
+/// `Option` to `Result` piece-by-piece. Remove when that work is done.
+#[macro_export]
+#[allow(unused)]
+#[doc(hidden)]
+macro_rules! ok {
+    ($e:expr) => {
+        match $e {
+            Ok(v) => Some(v),
+            Err(_) => None,
         }
     };
 }

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -24,7 +24,7 @@ use crate::format::{
 };
 use crate::month::Months;
 use crate::naive::{IsoWeek, NaiveDateTime, NaiveTime};
-use crate::{expect, try_opt};
+use crate::{expect, ok, try_opt};
 use crate::{Datelike, TimeDelta, Weekday};
 
 use super::internals::{self, DateImpl, Mdf, Of, YearFlags};
@@ -768,7 +768,7 @@ impl NaiveDate {
     #[inline]
     #[must_use]
     pub const fn and_hms_opt(&self, hour: u32, min: u32, sec: u32) -> Option<NaiveDateTime> {
-        let time = try_opt!(NaiveTime::from_hms(hour, min, sec));
+        let time = try_opt!(ok!(NaiveTime::from_hms(hour, min, sec)));
         Some(self.and_time(time))
     }
 
@@ -803,7 +803,7 @@ impl NaiveDate {
         sec: u32,
         milli: u32,
     ) -> Option<NaiveDateTime> {
-        let time = try_opt!(NaiveTime::from_hms_milli(hour, min, sec, milli));
+        let time = try_opt!(ok!(NaiveTime::from_hms_milli(hour, min, sec, milli)));
         Some(self.and_time(time))
     }
 
@@ -838,7 +838,7 @@ impl NaiveDate {
         sec: u32,
         micro: u32,
     ) -> Option<NaiveDateTime> {
-        let time = try_opt!(NaiveTime::from_hms_micro(hour, min, sec, micro));
+        let time = try_opt!(ok!(NaiveTime::from_hms_micro(hour, min, sec, micro)));
         Some(self.and_time(time))
     }
 
@@ -873,7 +873,7 @@ impl NaiveDate {
         sec: u32,
         nano: u32,
     ) -> Option<NaiveDateTime> {
-        let time = try_opt!(NaiveTime::from_hms_nano(hour, min, sec, nano));
+        let time = try_opt!(ok!(NaiveTime::from_hms_nano(hour, min, sec, nano)));
         Some(self.and_time(time))
     }
 

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -239,7 +239,7 @@ impl NaiveDateTime {
             NaiveDate::from_num_days_from_ce_opt(try_opt!((days as i32).checked_add(719_163)));
         let time = NaiveTime::from_num_seconds_from_midnight(secs as u32, nsecs);
         match (date, time) {
-            (Some(date), Some(time)) => Some(NaiveDateTime { date, time }),
+            (Some(date), Ok(time)) => Some(NaiveDateTime { date, time }),
             (_, _) => None,
         }
     }

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -507,7 +507,7 @@ fn test_and_utc() {
 #[test]
 fn test_checked_add_offset() {
     let ymdhmsm = |y, m, d, h, mn, s, mi| {
-        NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi)
+        Some(NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi).unwrap())
     };
 
     let positive_offset = FixedOffset::east(2 * 60 * 60).unwrap();
@@ -534,7 +534,7 @@ fn test_checked_add_offset() {
 #[test]
 fn test_checked_sub_offset() {
     let ymdhmsm = |y, m, d, h, mn, s, mi| {
-        NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi)
+        Some(NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi).unwrap())
     };
 
     let positive_offset = FixedOffset::east(2 * 60 * 60).unwrap();

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -1,46 +1,46 @@
 use super::NaiveTime;
-use crate::{FixedOffset, TimeDelta, Timelike};
+use crate::{Error, FixedOffset, TimeDelta, Timelike};
 
 #[test]
 fn test_time_from_hms_milli() {
     assert_eq!(
         NaiveTime::from_hms_milli(3, 5, 7, 0),
-        Some(NaiveTime::from_hms_nano(3, 5, 7, 0).unwrap())
+        Ok(NaiveTime::from_hms_nano(3, 5, 7, 0).unwrap())
     );
     assert_eq!(
         NaiveTime::from_hms_milli(3, 5, 7, 777),
-        Some(NaiveTime::from_hms_nano(3, 5, 7, 777_000_000).unwrap())
+        Ok(NaiveTime::from_hms_nano(3, 5, 7, 777_000_000).unwrap())
     );
     assert_eq!(
         NaiveTime::from_hms_milli(3, 5, 59, 1_999),
-        Some(NaiveTime::from_hms_nano(3, 5, 59, 1_999_000_000).unwrap())
+        Ok(NaiveTime::from_hms_nano(3, 5, 59, 1_999_000_000).unwrap())
     );
-    assert_eq!(NaiveTime::from_hms_milli(3, 5, 59, 2_000), None);
-    assert_eq!(NaiveTime::from_hms_milli(3, 5, 59, 5_000), None); // overflow check
-    assert_eq!(NaiveTime::from_hms_milli(3, 5, 59, u32::MAX), None);
+    assert_eq!(NaiveTime::from_hms_milli(3, 5, 59, 2_000), Err(Error::InvalidArgument));
+    assert_eq!(NaiveTime::from_hms_milli(3, 5, 59, 5_000), Err(Error::InvalidArgument)); // overflow check
+    assert_eq!(NaiveTime::from_hms_milli(3, 5, 59, u32::MAX), Err(Error::InvalidArgument));
 }
 
 #[test]
 fn test_time_from_hms_micro() {
     assert_eq!(
         NaiveTime::from_hms_micro(3, 5, 7, 0),
-        Some(NaiveTime::from_hms_nano(3, 5, 7, 0).unwrap())
+        Ok(NaiveTime::from_hms_nano(3, 5, 7, 0).unwrap())
     );
     assert_eq!(
         NaiveTime::from_hms_micro(3, 5, 7, 333),
-        Some(NaiveTime::from_hms_nano(3, 5, 7, 333_000).unwrap())
+        Ok(NaiveTime::from_hms_nano(3, 5, 7, 333_000).unwrap())
     );
     assert_eq!(
         NaiveTime::from_hms_micro(3, 5, 7, 777_777),
-        Some(NaiveTime::from_hms_nano(3, 5, 7, 777_777_000).unwrap())
+        Ok(NaiveTime::from_hms_nano(3, 5, 7, 777_777_000).unwrap())
     );
     assert_eq!(
         NaiveTime::from_hms_micro(3, 5, 59, 1_999_999),
-        Some(NaiveTime::from_hms_nano(3, 5, 59, 1_999_999_000).unwrap())
+        Ok(NaiveTime::from_hms_nano(3, 5, 59, 1_999_999_000).unwrap())
     );
-    assert_eq!(NaiveTime::from_hms_micro(3, 5, 59, 2_000_000), None);
-    assert_eq!(NaiveTime::from_hms_micro(3, 5, 59, 5_000_000), None); // overflow check
-    assert_eq!(NaiveTime::from_hms_micro(3, 5, 59, u32::MAX), None);
+    assert_eq!(NaiveTime::from_hms_micro(3, 5, 59, 2_000_000), Err(Error::InvalidArgument));
+    assert_eq!(NaiveTime::from_hms_micro(3, 5, 59, 5_000_000), Err(Error::InvalidArgument)); // overflow check
+    assert_eq!(NaiveTime::from_hms_micro(3, 5, 59, u32::MAX), Err(Error::InvalidArgument));
 }
 
 #[test]

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -220,7 +220,7 @@ mod tests {
         // issue #123
         let today = Utc::now().date_naive();
 
-        if let Some(dt) = today.and_hms_milli_opt(15, 2, 59, 1000) {
+        if let Ok(dt) = today.and_hms_milli_opt(15, 2, 59, 1000) {
             let timestr = dt.time().to_string();
             // the OS API may or may not support the leap second,
             // but there are only two sensible options.
@@ -231,7 +231,7 @@ mod tests {
             );
         }
 
-        if let Some(dt) = today.and_hms_milli_opt(15, 2, 3, 1234) {
+        if let Ok(dt) = today.and_hms_milli_opt(15, 2, 3, 1234) {
             let timestr = dt.time().to_string();
             assert!(
                 timestr == "15:02:03.234" || timestr == "15:02:04.234",

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -130,7 +130,8 @@ pub trait TimeZone: Sized + Clone {
         min: u32,
         sec: u32,
     ) -> LocalResult<DateTime<Self>> {
-        match NaiveDate::from_ymd_opt(year, month, day).and_then(|d| d.and_hms_opt(hour, min, sec))
+        match NaiveDate::from_ymd_opt(year, month, day)
+            .and_then(|d| d.and_hms_opt(hour, min, sec).ok())
         {
             Some(dt) => self.from_local_datetime(&dt),
             None => LocalResult::None,


### PR DESCRIPTION
This is the first small step to convert the API to return `Result`'s.
I have been looking forward to working on this for a long time. Now that most panic cases are fixed, our const work is done, and the 0.5 branch has had some basic clean-ups it seems like a good time to start.

### `Error` enum

The first commit introduces a basic `Error` enum. We can grow it as needed and bikeshed the variant names.
```rust
// TODO: Error sources that are not yet covered are the platform APIs, the parsing of a `TZfile` and
// parsing of a `TZ` environment variable.
#[non_exhaustive]
#[derive(Copy, Clone, Debug, Eq, PartialEq)]
pub enum Error {
    /// One or more of the arguments to a function are invalid.
    ///
    /// An example is creating a `NaiveTime` with 25 as the hour value.
    InvalidParameter,

    /// The result, or an intermediate value necessary for calculating a result, would be out of
    /// range.
    ///
    /// An example is a date for the year 500.000, which is out of the range supported by chrono's
    /// types.
    OutOfRange,

    /// A date or datetime does not exist.
    ///
    /// Examples are:
    /// - April 31,
    /// - February 29 in a non-leap year,
    /// - a time that falls in the gap created by moving the clock forward during a DST transition,
    /// - a leap second on a non-minute boundary.
    DoesNotExist,

    /// Some of the date or time components are not consistent with each other.
    ///
    /// An example is parsing 'Sunday 2023-04-21', while that date is a Friday.
    Inconsistent,

    /// Character does not match with the expected format.
    ///
    /// Contains the byte index of the character where the input diverges.
    InvalidCharacter(u32),

    /// Value is not allowed by the format (during parsing).
    ///
    /// Examples are a number that is larger or smaller than the defined range, or the name of a
    /// weekday, month or timezone that doesn't match.
    ///
    /// Contains the byte index pointing at the start of the invalid value.
    InvalidValue(u32),

    /// The format string contains a formatting specifier that is not supported.
    ///
    /// Contains the byte index of the formatting specifier within the format string.
    UnsupportedSpecifier(u32),
}
```

https://github.com/chronotope/chrono/issues/1049 has a (slightly outdated) summary our API and the error cases that can arise. I diverged a bit from the latest design in https://github.com/chronotope/chrono/issues/1049#issuecomment-1540452995:
* `Error::InvalidCharacter` and `Error::InvalidValue` are new. They are for our parsing code, so not entirely relevant yet to this PR. I'll add a comment to https://github.com/chronotope/chrono/issues/1049 describing them.
* `UnsupportedSpecifier` is new. My idea was to use `Error::ParsingError` for parsing errors in both the format string and input string. But it is better to keep them separated.

### First methods: `NaiveTime::from_hms*` and `NaiveDate::and_hms*`
These methods are reasonably stand-alone and give a taste of the direction.

I added an `ok` macro to help with converting the API piece-by-piece. We can't use `Option::ok` because it is not available in const functions.

### Next work

- The formatting module is more involved but can probably be done independent of the rest of the API.
- `Duration`/`TimeDelta` can probably be done independent of the rest of the API.
- `FixedOffset` can probably be done independent of the rest of the API.
- Good next candidates are the constructors of `NaiveDate`. Removing the `DateImpl` and `Of` abstractions in https://github.com/chronotope/chrono/pull/1212 will help a lot for this. So I'll wait until that makes it to the 0.4 branch and then to 0.5.
- `NaiveDateTime` becomes easy after `NaiveDate` is done.
- The `Datelike` trait depends on `NaiveDate`.
- `DateTime` depends on changes to `LocalResult` and the `TimeZone` trait first.
- The large chunk of code in `local::tz_info` can probably do with a refactor first. Or we should just convert its error types at the boundary.

The rest will just be a discovery of which changes don't result in massive commits.

@Zomtir Still interested in biting off a piece of the work?