### PR TITLE
Remove partial support for handling `-0000` offset

### DIFF
--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -216,7 +216,8 @@ pub(crate) fn parse_rfc3339<'a>(parsed: &mut Parsed, mut s: &'a str) -> ParseRes
     }
 
     let offset = try_consume!(scan::timezone_offset(s, |s| scan::char(s, b':'), true, false, true));
-    if offset <= -86_400 || offset >= 86_400 {
+    const MAX_RFC3339_OFFSET: i32 = 86_400;
+    if !(-MAX_RFC3339_OFFSET..=MAX_RFC3339_OFFSET).contains(&offset) {
         return Err(OUT_OF_RANGE);
     }
     parsed.set_offset(i64::from(offset))?;

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -216,7 +216,11 @@ pub(crate) fn parse_rfc3339<'a>(parsed: &mut Parsed, mut s: &'a str) -> ParseRes
     }
 
     let offset = try_consume!(scan::timezone_offset(s, |s| scan::char(s, b':'), true, false, true));
-    const MAX_RFC3339_OFFSET: i32 = 86_400;
+    // This range check is similar to the one in `FixedOffset::east_opt`, so it would be redundant.
+    // But it is possible to read the offset directly from `Parsed`. We want to only successfully
+    // populate `Parsed` if the input is fully valid RFC 3339.
+    // Max for the hours field is `23`, and for the minutes field `59`.
+    const MAX_RFC3339_OFFSET: i32 = (23 * 60 + 59) * 60;
     if !(-MAX_RFC3339_OFFSET..=MAX_RFC3339_OFFSET).contains(&offset) {
         return Err(OUT_OF_RANGE);
     }


### PR DESCRIPTION
RFC 2822 and others have a special encoding to indicate the offset of a datetime is unknown: `-00:00`.

We currently have code in `format::parse` that ensures we do not provide an offset to the `Parsed` struct if the offset is `-0000`.
`timezone_offset_2822` returns an `Option<i32>` that should be `None` to differentiate this case from `+0000`.

But then `timezone_offset_2822` does return `Some(0)` on the `-0000` input. That makes the `Option` and the code to handle it useless.

I would like to see proper support for encoding this value in a `FixedOffset`, as in https://github.com/chronotope/chrono/pull/1042.

But for now the inconsistency just messes up the error variants we return.
Because I am currently working on converting the parsing code from `ParsedError` to a new `Error` type for 0.5, I just need something consistent to work on.