### PR TITLE
support to use dot as timezone offset separator

### DIFF
--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -243,7 +243,11 @@ pub enum Fixed {
     RFC2822,
     /// RFC 3339 & ISO 8601 date and time syntax.
     RFC3339,
-
+    /// Offset from the local time to UTC (`+9.5` or `+09.50` or `-4.0`).
+    ///
+    /// +9.5 = +09:30, +09.50 = +09:30, -4.0 = -04:00.
+    /// The offset is limited from `-24.0` to `+24.0`,
+    TimezoneOffsetDot,
     /// Internal uses only.
     ///
     /// This item exists so that one can add additional internal-only formatting
@@ -282,7 +286,7 @@ pub struct OffsetFormat {
     /// See `OffsetPrecision`.
     pub precision: OffsetPrecision,
     /// Separator between hours, minutes and seconds.
-    pub colons: Colons,
+    pub separator: Separator,
     /// Represent `+00:00` as `Z`.
     pub allow_zulu: bool,
     /// Pad the hour value to two digits.
@@ -312,11 +316,13 @@ pub enum OffsetPrecision {
 
 /// The separator between hours and minutes in an offset.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Colons {
+pub enum Separator {
     /// No separator
     None,
     /// Colon (`:`) as separator
     Colon,
+    /// Dot (`.`) as separator
+    Dot,
     /// No separator when formatting, colon allowed when parsing.
     Maybe,
 }

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -417,6 +417,7 @@ impl<'a> StrftimeItems<'a> {
                             _ => Item::Error,
                         },
                         'f' => fixed(Fixed::Nanosecond),
+                        'z' => fixed(Fixed::TimezoneOffsetDot),
                         _ => Item::Error,
                     },
                     '3' => match next!() {
@@ -651,6 +652,7 @@ mod tests {
         assert_eq!(parse_and_collect("%_e"), [nums(Day)]);
         assert_eq!(parse_and_collect("%z"), [fixed(Fixed::TimezoneOffset)]);
         assert_eq!(parse_and_collect("%:z"), [fixed(Fixed::TimezoneOffsetColon)]);
+        assert_eq!(parse_and_collect("%.z"), [fixed(Fixed::TimezoneOffsetDot)]);
         assert_eq!(parse_and_collect("%Z"), [fixed(Fixed::TimezoneName)]);
         assert_eq!(parse_and_collect("%ZZZZ"), [fixed(Fixed::TimezoneName), Literal("ZZZ")]);
         assert_eq!(parse_and_collect("%Z😽"), [fixed(Fixed::TimezoneName), Literal("😽")]);
@@ -758,6 +760,8 @@ mod tests {
             "2001-07-08T00:34:60.026490+09:30"
         );
         assert_eq!(dt.format("%s").to_string(), "994518299");
+
+        assert_eq!(dt.format("%F %.z %R").to_string(), "2001-07-08 +09.50 00:34");
 
         // special specifiers
         assert_eq!(dt.format("%t").to_string(), "\t");
@@ -920,5 +924,17 @@ mod tests {
         assert_eq!(size_of::<Item>(), 12);
         assert_eq!(size_of::<StrftimeItems>(), 28);
         assert_eq!(size_of::<Locale>(), 2);
+    }
+
+    #[test]
+    fn test_parse_dot_utc() {
+        use crate::DateTime;
+        let dt1 =
+            DateTime::parse_from_str("2021-06-27 +08:30 23:30:12.729", "%Y-%m-%d %:z %H:%M:%S%.f")
+                .unwrap();
+        let dt2 =
+            DateTime::parse_from_str("2021-06-27 +8.5 23:30:12.729", "%Y-%m-%d %.z %H:%M:%S%.f")
+                .unwrap();
+        assert_eq!(dt1, dt2);
     }
 }


### PR DESCRIPTION
# Summary of changes
This PR adds support for using a dot `.` as a separator for timezone offset, like `+9.5` means `+09:30`. Currently, the library only supports using a colon `:` as the separator for offset, but some users prefer using a dot for consistency with other time-related formats.

# Changes
To achieve this, I have made the following changes:
- update parsing logic: add function `scan::timezone_offset_with_dot_separator` to calculate offset
- add specifier `%.z` to formatting and parsing
