### PR TITLE
`Parsed` documentation and error handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,12 @@ use core::fmt;
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
+    /// There is not enough information to create a date/time.
+    ///
+    /// An example is parsing a string with not enough date/time fields, or the result of a
+    /// time that is ambiguous during a time zone transition (due to for example DST).
+    Ambiguous,
+
     /// A date or datetime does not exist.
     ///
     /// Examples are:
@@ -35,6 +41,7 @@ pub enum Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            Error::Ambiguous => write!(f, "not enough information for a unique date and time"),
             Error::DoesNotExist => write!(f, "date or datetime does not exist"),
             Error::Inconsistent => {
                 write!(f, "some of the date or time components are not consistent with each other")

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,11 @@ pub enum Error {
     /// - a leap second on a non-minute boundary.
     DoesNotExist,
 
+    /// Some of the date or time components are not consistent with each other.
+    ///
+    /// An example is parsing 'Sunday 2023-04-21', while that date is a Friday.
+    Inconsistent,
+
     /// One or more of the arguments to a function are invalid.
     ///
     /// An example is creating a `NaiveTime` with 25 as the hour value.
@@ -31,6 +36,9 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Error::DoesNotExist => write!(f, "date or datetime does not exist"),
+            Error::Inconsistent => {
+                write!(f, "some of the date or time components are not consistent with each other")
+            }
             Error::InvalidArgument => write!(f, "invalid parameter"),
             Error::OutOfRange => write!(f, "date outside of the supported range"),
         }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -34,10 +34,8 @@
 use alloc::boxed::Box;
 use core::fmt;
 use core::str::FromStr;
-#[cfg(feature = "std")]
-use std::error::Error;
 
-use crate::{Month, ParseMonthError, ParseWeekdayError, Weekday};
+use crate::{Error, Month, ParseMonthError, ParseWeekdayError, Weekday};
 
 mod formatting;
 mod parsed;
@@ -442,10 +440,20 @@ impl fmt::Display for ParseError {
 }
 
 #[cfg(feature = "std")]
-impl Error for ParseError {
+impl std::error::Error for ParseError {
     #[allow(deprecated)]
     fn description(&self) -> &str {
         "parser error, see to_string() for details"
+    }
+}
+
+impl From<Error> for ParseError {
+    fn from(error: Error) -> Self {
+        match error {
+            Error::Inconsistent => ParseError(ParseErrorKind::Impossible),
+            Error::OutOfRange => ParseError(ParseErrorKind::OutOfRange),
+            _ => panic!("`Parsed::set_*` should only return `Inconsistent` or `OutOfRange`"),
+        }
     }
 }
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -447,6 +447,14 @@ impl std::error::Error for ParseError {
     }
 }
 
+fn parse_error(error: Error, _remainder: &str) -> ParseError {
+    match error {
+        Error::Inconsistent => ParseError(ParseErrorKind::Impossible),
+        Error::OutOfRange => ParseError(ParseErrorKind::OutOfRange),
+        _ => panic!("`Parsed::set_*` should only return `Inconsistent` or `OutOfRange`"),
+    }
+}
+
 impl From<Error> for ParseError {
     fn from(error: Error) -> Self {
         match error {

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -14,7 +14,7 @@ use super::{ParseError, ParseResult};
 use super::{BAD_FORMAT, INVALID, OUT_OF_RANGE, TOO_LONG, TOO_SHORT};
 use crate::{DateTime, FixedOffset, Weekday};
 
-fn set_weekday_with_num_days_from_sunday(p: &mut Parsed, v: i64) -> ParseResult<()> {
+fn set_weekday_with_num_days_from_sunday(p: &mut Parsed, v: i64) -> ParseResult<&mut Parsed> {
     p.set_weekday(match v {
         0 => Weekday::Sun,
         1 => Weekday::Mon,
@@ -27,7 +27,7 @@ fn set_weekday_with_num_days_from_sunday(p: &mut Parsed, v: i64) -> ParseResult<
     })
 }
 
-fn set_weekday_with_number_from_monday(p: &mut Parsed, v: i64) -> ParseResult<()> {
+fn set_weekday_with_number_from_monday(p: &mut Parsed, v: i64) -> ParseResult<&mut Parsed> {
     p.set_weekday(match v {
         1 => Weekday::Mon,
         2 => Weekday::Tue,
@@ -339,7 +339,7 @@ where
 
             Item::Numeric(ref spec, ref _pad) => {
                 use super::Numeric::*;
-                type Setter = fn(&mut Parsed, i64) -> ParseResult<()>;
+                type Setter = fn(&mut Parsed, i64) -> ParseResult<&mut Parsed>;
 
                 let (width, signed, set): (usize, bool, Setter) = match *spec {
                     Year => (4, true, Parsed::set_year),

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -254,7 +254,7 @@ where
     match parse_internal(parsed, s, items) {
         Ok("") => Ok(()),
         Ok(_) => Err(TOO_LONG), // if there are trailing chars it is an error
-        Err((_, e)) => Err(e),
+        Err(e) => Err(e),
     }
 }
 
@@ -281,14 +281,14 @@ where
     I: Iterator<Item = B>,
     B: Borrow<Item<'a>>,
 {
-    parse_internal(parsed, s, items).map_err(|(_s, e)| e)
+    parse_internal(parsed, s, items)
 }
 
 fn parse_internal<'a, 'b, I, B>(
     parsed: &mut Parsed,
     mut s: &'b str,
     items: I,
-) -> Result<&'b str, (&'b str, ParseError)>
+) -> Result<&'b str, ParseError>
 where
     I: Iterator<Item = B>,
     B: Borrow<Item<'a>>,
@@ -300,7 +300,7 @@ where
                     s = s_;
                     v
                 }
-                Err(e) => return Err((s, e)),
+                Err(e) => return Err(e),
             }
         }};
     }
@@ -309,10 +309,10 @@ where
         match *item.borrow() {
             Item::Literal(prefix) => {
                 if s.len() < prefix.len() {
-                    return Err((s, TOO_SHORT));
+                    return Err(TOO_SHORT);
                 }
                 if !s.starts_with(prefix) {
-                    return Err((s, INVALID));
+                    return Err(INVALID);
                 }
                 s = &s[prefix.len()..];
             }
@@ -320,10 +320,10 @@ where
             #[cfg(feature = "alloc")]
             Item::OwnedLiteral(ref prefix) => {
                 if s.len() < prefix.len() {
-                    return Err((s, TOO_SHORT));
+                    return Err(TOO_SHORT);
                 }
                 if !s.starts_with(&prefix[..]) {
-                    return Err((s, INVALID));
+                    return Err(INVALID);
                 }
                 s = &s[prefix.len()..];
             }
@@ -371,7 +371,7 @@ where
                 let v = if signed {
                     if s.starts_with('-') {
                         let v = try_consume!(scan::number(&s[1..], 1, usize::MAX));
-                        0i64.checked_sub(v).ok_or((s, OUT_OF_RANGE))?
+                        0i64.checked_sub(v).ok_or(OUT_OF_RANGE)?
                     } else if s.starts_with('+') {
                         try_consume!(scan::number(&s[1..], 1, usize::MAX))
                     } else {
@@ -381,7 +381,7 @@ where
                 } else {
                     try_consume!(scan::number(s, 1, width))
                 };
-                set(parsed, v).map_err(|e| (s, e))?;
+                set(parsed, v)?;
             }
 
             Item::Fixed(ref spec) => {
@@ -390,66 +390,66 @@ where
                 match spec {
                     &ShortMonthName => {
                         let month0 = try_consume!(scan::short_month0(s));
-                        parsed.set_month(i64::from(month0) + 1).map_err(|e| (s, e))?;
+                        parsed.set_month(i64::from(month0) + 1)?;
                     }
 
                     &LongMonthName => {
                         let month0 = try_consume!(scan::short_or_long_month0(s));
-                        parsed.set_month(i64::from(month0) + 1).map_err(|e| (s, e))?;
+                        parsed.set_month(i64::from(month0) + 1)?;
                     }
 
                     &ShortWeekdayName => {
                         let weekday = try_consume!(scan::short_weekday(s));
-                        parsed.set_weekday(weekday).map_err(|e| (s, e))?;
+                        parsed.set_weekday(weekday)?;
                     }
 
                     &LongWeekdayName => {
                         let weekday = try_consume!(scan::short_or_long_weekday(s));
-                        parsed.set_weekday(weekday).map_err(|e| (s, e))?;
+                        parsed.set_weekday(weekday)?;
                     }
 
                     &LowerAmPm | &UpperAmPm => {
                         if s.len() < 2 {
-                            return Err((s, TOO_SHORT));
+                            return Err(TOO_SHORT);
                         }
                         let ampm = match (s.as_bytes()[0] | 32, s.as_bytes()[1] | 32) {
                             (b'a', b'm') => false,
                             (b'p', b'm') => true,
-                            _ => return Err((s, INVALID)),
+                            _ => return Err(INVALID),
                         };
-                        parsed.set_ampm(ampm).map_err(|e| (s, e))?;
+                        parsed.set_ampm(ampm)?;
                         s = &s[2..];
                     }
 
                     &Nanosecond | &Nanosecond3 | &Nanosecond6 | &Nanosecond9 => {
                         if s.starts_with('.') {
                             let nano = try_consume!(scan::nanosecond(&s[1..]));
-                            parsed.set_nanosecond(nano).map_err(|e| (s, e))?;
+                            parsed.set_nanosecond(nano)?;
                         }
                     }
 
                     &Internal(InternalFixed { val: InternalInternal::Nanosecond3NoDot }) => {
                         if s.len() < 3 {
-                            return Err((s, TOO_SHORT));
+                            return Err(TOO_SHORT);
                         }
                         let nano = try_consume!(scan::nanosecond_fixed(s, 3));
-                        parsed.set_nanosecond(nano).map_err(|e| (s, e))?;
+                        parsed.set_nanosecond(nano)?;
                     }
 
                     &Internal(InternalFixed { val: InternalInternal::Nanosecond6NoDot }) => {
                         if s.len() < 6 {
-                            return Err((s, TOO_SHORT));
+                            return Err(TOO_SHORT);
                         }
                         let nano = try_consume!(scan::nanosecond_fixed(s, 6));
-                        parsed.set_nanosecond(nano).map_err(|e| (s, e))?;
+                        parsed.set_nanosecond(nano)?;
                     }
 
                     &Internal(InternalFixed { val: InternalInternal::Nanosecond9NoDot }) => {
                         if s.len() < 9 {
-                            return Err((s, TOO_SHORT));
+                            return Err(TOO_SHORT);
                         }
                         let nano = try_consume!(scan::nanosecond_fixed(s, 9));
-                        parsed.set_nanosecond(nano).map_err(|e| (s, e))?;
+                        parsed.set_nanosecond(nano)?;
                     }
 
                     &TimezoneName => {
@@ -467,7 +467,7 @@ where
                             false,
                             true,
                         ));
-                        parsed.set_offset(i64::from(offset)).map_err(|e| (s, e))?;
+                        parsed.set_offset(i64::from(offset))?;
                     }
 
                     &TimezoneOffsetColonZ | &TimezoneOffsetZ => {
@@ -478,7 +478,7 @@ where
                             false,
                             true,
                         ));
-                        parsed.set_offset(i64::from(offset)).map_err(|e| (s, e))?;
+                        parsed.set_offset(i64::from(offset))?;
                     }
                     &Internal(InternalFixed {
                         val: InternalInternal::TimezoneOffsetPermissive,
@@ -490,7 +490,7 @@ where
                             true,
                             true,
                         ));
-                        parsed.set_offset(i64::from(offset)).map_err(|e| (s, e))?;
+                        parsed.set_offset(i64::from(offset))?;
                     }
 
                     &RFC2822 => try_consume!(parse_rfc2822(parsed, s)),
@@ -505,7 +505,7 @@ where
             }
 
             Item::Error => {
-                return Err((s, BAD_FORMAT));
+                return Err(BAD_FORMAT);
             }
         }
     }
@@ -567,7 +567,7 @@ fn parse_rfc3339_relaxed<'a>(parsed: &mut Parsed, mut s: &'a str) -> ParseResult
         Item::Space(""),
     ];
 
-    s = parse_internal(parsed, s, DATE_ITEMS.iter()).map_err(|(_s, e)| e)?;
+    s = parse_internal(parsed, s, DATE_ITEMS.iter())?;
 
     s = match s.as_bytes().first() {
         Some(&b't' | &b'T' | &b' ') => &s[1..],
@@ -575,7 +575,7 @@ fn parse_rfc3339_relaxed<'a>(parsed: &mut Parsed, mut s: &'a str) -> ParseResult
         None => return Err(TOO_SHORT),
     };
 
-    s = parse_internal(parsed, s, TIME_ITEMS.iter()).map_err(|(_s, e)| e)?;
+    s = parse_internal(parsed, s, TIME_ITEMS.iter())?;
     s = s.trim_start();
     let (s, offset) = if s.len() >= 3 && "UTC".as_bytes().eq_ignore_ascii_case(&s.as_bytes()[..3]) {
         (&s[3..], 0)

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -1388,37 +1388,18 @@ mod tests {
             Err(OUT_OF_RANGE)
         );
         assert_eq!(
-            parse!(year_div_100: 19, year_mod_100: 83, month: 13, day: 1),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
             parse!(year_div_100: 19, year_mod_100: 83, month: 12, day: 31),
             ymd(1983, 12, 31)
         );
-        assert_eq!(
-            parse!(year_div_100: 19, year_mod_100: 83, month: 12, day: 32),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
-            parse!(year_div_100: 19, year_mod_100: 83, month: 12, day: 0),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
-            parse!(year_div_100: 19, year_mod_100: 100, month: 1, day: 1),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(parse!(year_div_100: 19, year_mod_100: -1, month: 1, day: 1), Err(OUT_OF_RANGE));
         assert_eq!(parse!(year_div_100: 0, year_mod_100: 0, month: 1, day: 1), ymd(0, 1, 1));
-        assert_eq!(parse!(year_div_100: -1, year_mod_100: 42, month: 1, day: 1), Err(IMPOSSIBLE));
         let max_year = NaiveDate::MAX.year();
         assert_eq!(
-            parse!(year_div_100: max_year / 100,
-                          year_mod_100: max_year % 100, month: 1, day: 1),
+            parse!(year_div_100: max_year / 100, year_mod_100: max_year % 100, month: 1, day: 1),
             ymd(max_year, 1, 1)
         );
         assert_eq!(
             parse!(year_div_100: (max_year + 1) / 100,
-                          year_mod_100: (max_year + 1) % 100, month: 1, day: 1),
+                   year_mod_100: (max_year + 1) % 100, month: 1, day: 1),
             Err(OUT_OF_RANGE)
         );
 
@@ -1433,18 +1414,6 @@ mod tests {
         );
         assert_eq!(
             parse!(year: 1984, year_div_100: 18, year_mod_100: 94, month: 1, day: 1),
-            Err(IMPOSSIBLE)
-        );
-        assert_eq!(
-            parse!(year: 1984, year_div_100: 18, year_mod_100: 184, month: 1, day: 1),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
-            parse!(year: -1, year_div_100: 0, year_mod_100: -1, month: 1, day: 1),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
-            parse!(year: -1, year_div_100: -1, year_mod_100: 99, month: 1, day: 1),
             Err(IMPOSSIBLE)
         );
         assert_eq!(parse!(year: -1, year_div_100: 0, month: 1, day: 1), Err(IMPOSSIBLE));
@@ -1521,22 +1490,21 @@ mod tests {
         // more complex cases
         assert_eq!(
             parse!(year: 2014, month: 12, day: 31, ordinal: 365, isoyear: 2015, isoweek: 1,
-                          week_from_sun: 52, week_from_mon: 52, weekday: Wed),
+                   week_from_sun: 52, week_from_mon: 52, weekday: Wed),
             ymd(2014, 12, 31)
         );
         assert_eq!(
             parse!(year: 2014, month: 12, ordinal: 365, isoyear: 2015, isoweek: 1,
-                          week_from_sun: 52, week_from_mon: 52),
+                   week_from_sun: 52, week_from_mon: 52),
             ymd(2014, 12, 31)
         );
         assert_eq!(
             parse!(year: 2014, month: 12, day: 31, ordinal: 365, isoyear: 2014, isoweek: 53,
-                          week_from_sun: 52, week_from_mon: 52, weekday: Wed),
+                   week_from_sun: 52, week_from_mon: 52, weekday: Wed),
             Err(IMPOSSIBLE)
         ); // no ISO week date 2014-W53-3
         assert_eq!(
-            parse!(year: 2012, isoyear: 2015, isoweek: 1,
-                          week_from_sun: 52, week_from_mon: 52),
+            parse!(year: 2012, isoyear: 2015, isoweek: 1, week_from_sun: 52, week_from_mon: 52),
             Err(NOT_ENOUGH)
         ); // ambiguous (2014-12-29, 2014-12-30, 2014-12-31)
         assert_eq!(parse!(year_div_100: 20, isoyear_mod_100: 15, ordinal: 366), Err(NOT_ENOUGH));
@@ -1570,20 +1538,6 @@ mod tests {
         assert_eq!(
             parse!(hour_div_12: 0, hour_mod_12: 1, minute: 23, nanosecond: 456_789_012),
             Err(NOT_ENOUGH)
-        );
-
-        // out-of-range conditions
-        assert_eq!(parse!(hour_div_12: 2, hour_mod_12: 0, minute: 0), Err(OUT_OF_RANGE));
-        assert_eq!(parse!(hour_div_12: 1, hour_mod_12: 12, minute: 0), Err(OUT_OF_RANGE));
-        assert_eq!(parse!(hour_div_12: 0, hour_mod_12: 1, minute: 60), Err(OUT_OF_RANGE));
-        assert_eq!(
-            parse!(hour_div_12: 0, hour_mod_12: 1, minute: 23, second: 61),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
-            parse!(hour_div_12: 0, hour_mod_12: 1, minute: 23, second: 34,
-                          nanosecond: 1_000_000_000),
-            Err(OUT_OF_RANGE)
         );
 
         // leap seconds
@@ -1704,51 +1658,44 @@ mod tests {
         // we need to have separate tests for them since it uses another control flow.
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 59, timestamp: 1_341_100_798),
+                   minute: 59, second: 59, timestamp: 1_341_100_798),
             Err(IMPOSSIBLE)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 59, timestamp: 1_341_100_799),
+                   minute: 59, second: 59, timestamp: 1_341_100_799),
             ymdhms(2012, 6, 30, 23, 59, 59)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 59, timestamp: 1_341_100_800),
+                   minute: 59, second: 59, timestamp: 1_341_100_800),
             Err(IMPOSSIBLE)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 60, timestamp: 1_341_100_799),
+                   minute: 59, second: 60, timestamp: 1_341_100_799),
             ymdhmsn(2012, 6, 30, 23, 59, 59, 1_000_000_000)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 60, timestamp: 1_341_100_800),
+                   minute: 59, second: 60, timestamp: 1_341_100_800),
             ymdhmsn(2012, 6, 30, 23, 59, 59, 1_000_000_000)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 183, hour_div_12: 0, hour_mod_12: 0,
-                          minute: 0, second: 0, timestamp: 1_341_100_800),
+                   minute: 0, second: 0, timestamp: 1_341_100_800),
             ymdhms(2012, 7, 1, 0, 0, 0)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 183, hour_div_12: 0, hour_mod_12: 0,
-                          minute: 0, second: 1, timestamp: 1_341_100_800),
+                   minute: 0, second: 1, timestamp: 1_341_100_800),
             Err(IMPOSSIBLE)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 60, timestamp: 1_341_100_801),
+                   minute: 59, second: 60, timestamp: 1_341_100_801),
             Err(IMPOSSIBLE)
         );
-
-        // error codes
-        assert_eq!(
-            parse!(year: 2015, month: 1, day: 20, weekday: Tue,
-                          hour_div_12: 2, hour_mod_12: 1, minute: 35, second: 20),
-            Err(OUT_OF_RANGE)
-        ); // `hour_div_12` is out of range
     }
 
     #[test]

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -11,13 +11,15 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 
 /// A type to hold parsed fields of date and time that can check all fields are consistent.
 ///
-/// There are two classes of methods:
+/// There are three classes of methods:
 ///
 /// - `set_*` methods to set fields you have available. They do a basic range check, and if the
 ///   same field is set more than once it is checked for consistency.
 ///
 /// - `to_*` methods try to make a concrete date and time value out of set fields.
 ///   They fully check that all fields are consistent and whether the date/datetime exists.
+///
+/// - Methods to inspect the parsed fields.
 ///
 /// `Parsed` is used internally by all parsing functions in chrono. It is a public type so that it
 /// can be used to write custom parsers that reuse the resolving algorithm, or to inspect the
@@ -116,7 +118,7 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 /// assert!(result.is_err());
 /// if result.is_err() {
 ///     // What is the weekday?
-///     assert_eq!(parsed.weekday, Some(Weekday::Thu));
+///     assert_eq!(parsed.weekday(), Some(Weekday::Thu));
 /// }
 /// # Ok::<(), chrono::ParseError>(())
 /// ```
@@ -567,6 +569,175 @@ impl Parsed {
     #[inline]
     pub fn set_offset(&mut self, value: i64) -> ParseResult<()> {
         set_if_consistent(&mut self.offset, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    }
+
+    /// Get the 'year' field if set.
+    ///
+    /// See also [`set_year`](Parsed::set_year).
+    #[inline]
+    pub fn year(&self) -> Option<i32> {
+        self.year
+    }
+
+    /// Get the 'year divided by 100' field if set.
+    ///
+    /// See also [`set_year_div_100`](Parsed::set_year_div_100).
+    #[inline]
+    pub fn year_div_100(&self) -> Option<i32> {
+        self.year_div_100
+    }
+
+    /// Get the 'year modulo 100' field if set.
+    ///
+    /// See also [`set_year_mod_100`](Parsed::set_year_mod_100).
+    #[inline]
+    pub fn year_mod_100(&self) -> Option<i32> {
+        self.year_mod_100
+    }
+
+    /// Get the 'year' field that is part of an [ISO 8601 week date] if set.
+    ///
+    /// See also [`set_isoyear`](Parsed::set_isoyear).
+    ///
+    /// [ISO 8601 week date]: crate::NaiveDate#week-date
+    #[inline]
+    pub fn isoyear(&self) -> Option<i32> {
+        self.isoyear
+    }
+
+    /// Get the 'year divided by 100' field that is part of an [ISO 8601 week date] if set.
+    ///
+    /// See also [`set_isoyear_div_100`](Parsed::set_isoyear_div_100).
+    ///
+    /// [ISO 8601 week date]: crate::NaiveDate#week-date
+    #[inline]
+    pub fn isoyear_div_100(&self) -> Option<i32> {
+        self.isoyear_div_100
+    }
+
+    /// Get the 'year modulo 100' field that is part of an [ISO 8601 week date] if set.
+    ///
+    /// See also [`set_isoyear_mod_100`](Parsed::set_isoyear_mod_100).
+    ///
+    /// [ISO 8601 week date]: crate::NaiveDate#week-date
+    #[inline]
+    pub fn isoyear_mod_100(&self) -> Option<i32> {
+        self.isoyear_mod_100
+    }
+
+    /// Get the 'month' field if set.
+    ///
+    /// See also [`set_month`](Parsed::set_month).
+    #[inline]
+    pub fn month(&self) -> Option<u32> {
+        self.month
+    }
+
+    /// Get the 'week number starting with Sunday' field if set.
+    ///
+    /// See also [`set_week_from_sun`](Parsed::set_week_from_sun).
+    #[inline]
+    pub fn week_from_sun(&self) -> Option<u32> {
+        self.week_from_sun
+    }
+
+    /// Get the 'week number starting with Monday' field if set.
+    ///
+    /// See also [`set_week_from_mon`](Parsed::set_week_from_mon).
+    #[inline]
+    pub fn week_from_mon(&self) -> Option<u32> {
+        self.week_from_mon
+    }
+
+    /// Get the '[ISO 8601 week number]' field if set.
+    ///
+    /// See also [`set_isoweek`](Parsed::set_isoweek).
+    ///
+    /// [ISO 8601 week number]: crate::NaiveDate#week-date
+    #[inline]
+    pub fn isoweek(&self) -> Option<u32> {
+        self.isoweek
+    }
+
+    /// Get the 'day of the week' field if set.
+    ///
+    /// See also [`set_weekday`](Parsed::set_weekday).
+    #[inline]
+    pub fn weekday(&self) -> Option<Weekday> {
+        self.weekday
+    }
+
+    /// Get the 'ordinal' (day of the year) field if set.
+    ///
+    /// See also [`set_ordinal`](Parsed::set_ordinal).
+    #[inline]
+    pub fn ordinal(&self) -> Option<u32> {
+        self.ordinal
+    }
+
+    /// Get the 'day of the month' field if set.
+    ///
+    /// See also [`set_day`](Parsed::set_day).
+    #[inline]
+    pub fn day(&self) -> Option<u32> {
+        self.day
+    }
+
+    /// Get the 'hour divided by 12' field (am/pm) if set.
+    ///
+    /// See also [`set_ampm`](Parsed::set_ampm) and [`set_hour`](Parsed::set_hour).
+    ///
+    /// 0 indicates AM and 1 indicates PM.
+    #[inline]
+    pub fn hour_div_12(&self) -> Option<u32> {
+        self.hour_div_12
+    }
+
+    /// Get the 'hour modulo 12' field if set.
+    ///
+    /// See also [`set_hour12`](Parsed::set_hour12) and [`set_hour`](Parsed::set_hour).
+    pub fn hour_mod_12(&self) -> Option<u32> {
+        self.hour_mod_12
+    }
+
+    /// Get the 'minute' field if set.
+    ///
+    /// See also [`set_minute`](Parsed::set_minute).
+    #[inline]
+    pub fn minute(&self) -> Option<u32> {
+        self.minute
+    }
+
+    /// Get the 'second' field if set.
+    ///
+    /// See also [`set_second`](Parsed::set_second).
+    #[inline]
+    pub fn second(&self) -> Option<u32> {
+        self.second
+    }
+
+    /// Get the 'nanosecond' field if set.
+    ///
+    /// See also [`set_nanosecond`](Parsed::set_nanosecond).
+    #[inline]
+    pub fn nanosecond(&self) -> Option<u32> {
+        self.nanosecond
+    }
+
+    /// Get the 'timestamp' field if set.
+    ///
+    /// See also [`set_timestamp`](Parsed::set_timestamp).
+    #[inline]
+    pub fn timestamp(&self) -> Option<i64> {
+        self.timestamp
+    }
+
+    /// Get the 'offset' field if set.
+    ///
+    /// See also [`set_offset`](Parsed::set_offset).
+    #[inline]
+    pub fn offset(&self) -> Option<i32> {
+        self.offset
     }
 
     /// Returns a parsed naive date out of given fields.

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -63,26 +63,28 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 /// use chrono::Weekday;
 ///
 /// let mut parsed = Parsed::new();
-/// parsed.set_weekday(Weekday::Wed)?;
-/// parsed.set_day(31)?;
-/// parsed.set_month(12)?;
-/// parsed.set_year(2014)?;
-/// parsed.set_hour(4)?;
-/// parsed.set_minute(26)?;
-/// parsed.set_second(40)?;
-/// parsed.set_offset(0)?;
+/// parsed
+///     .set_weekday(Weekday::Wed)?
+///     .set_day(31)?
+///     .set_month(12)?
+///     .set_year(2014)?
+///     .set_hour(4)?
+///     .set_minute(26)?
+///     .set_second(40)?
+///     .set_offset(0)?;
 /// let dt = parsed.to_datetime()?;
 /// assert_eq!(dt.to_rfc2822(), "Wed, 31 Dec 2014 04:26:40 +0000");
 ///
 /// let mut parsed = Parsed::new();
-/// parsed.set_weekday(Weekday::Thu)?; // changed to the wrong day
-/// parsed.set_day(31)?;
-/// parsed.set_month(12)?;
-/// parsed.set_year(2014)?;
-/// parsed.set_hour(4)?;
-/// parsed.set_minute(26)?;
-/// parsed.set_second(40)?;
-/// parsed.set_offset(0)?;
+/// parsed
+///     .set_weekday(Weekday::Thu)? // changed to the wrong day
+///     .set_day(31)?
+///     .set_month(12)?
+///     .set_year(2014)?
+///     .set_hour(4)?
+///     .set_minute(26)?
+///     .set_second(40)?
+///     .set_offset(0)?;
 /// let result = parsed.to_datetime();
 ///
 /// assert!(result.is_err());
@@ -240,8 +242,9 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_year(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.year, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_year(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.year, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Set the 'year divided by 100' field to the given value.
@@ -252,11 +255,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_year_div_100(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_year_div_100(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if !(0..=i32::MAX as i64).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.year_div_100, value as i32)
+        set_if_consistent(&mut self.year_div_100, value as i32)?;
+        Ok(self)
     }
 
     /// Set the 'year modulo 100' field to the given value.
@@ -273,11 +277,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_year_mod_100(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_year_mod_100(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if !(0..100).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.year_mod_100, value as i32)
+        set_if_consistent(&mut self.year_mod_100, value as i32)?;
+        Ok(self)
     }
 
     /// Set the 'year' field that is part of an [ISO 8601 week date] to the given value.
@@ -292,8 +297,9 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_isoyear(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.isoyear, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_isoyear(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.isoyear, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Set the 'year divided by 100' field that is part of an [ISO 8601 week date] to the given
@@ -307,11 +313,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_isoyear_div_100(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_isoyear_div_100(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if !(0..=i32::MAX as i64).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.isoyear_div_100, value as i32)
+        set_if_consistent(&mut self.isoyear_div_100, value as i32)?;
+        Ok(self)
     }
 
     /// Set the 'year modulo 100' that is part of an [ISO 8601 week date] field to the given value.
@@ -330,11 +337,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_isoyear_mod_100(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_isoyear_mod_100(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if !(0..100).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.isoyear_mod_100, value as i32)
+        set_if_consistent(&mut self.isoyear_mod_100, value as i32)?;
+        Ok(self)
     }
 
     /// Set the 'month' field to the given value.
@@ -345,11 +353,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_month(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_month(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if !(1..=12).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.month, value as u32)
+        set_if_consistent(&mut self.month, value as u32)?;
+        Ok(self)
     }
 
     /// Set the 'week number starting with Sunday' field to the given value.
@@ -362,11 +371,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_week_from_sun(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_week_from_sun(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if !(0..=53).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.week_from_sun, value as u32)
+        set_if_consistent(&mut self.week_from_sun, value as u32)?;
+        Ok(self)
     }
 
     /// Set the 'week number starting with Monday' field to the given value.
@@ -379,11 +389,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_week_from_mon(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_week_from_mon(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if !(0..=53).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.week_from_mon, value as u32)
+        set_if_consistent(&mut self.week_from_mon, value as u32)?;
+        Ok(self)
     }
 
     /// Set the '[ISO 8601 week number]' field to the given value.
@@ -396,11 +407,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_isoweek(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_isoweek(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if !(1..=53).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.isoweek, value as u32)
+        set_if_consistent(&mut self.isoweek, value as u32)?;
+        Ok(self)
     }
 
     /// Set the 'day of the week' field to the given value.
@@ -409,8 +421,9 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_weekday(&mut self, value: Weekday) -> ParseResult<()> {
-        set_if_consistent(&mut self.weekday, value)
+    pub fn set_weekday(&mut self, value: Weekday) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.weekday, value)?;
+        Ok(self)
     }
 
     /// Set the 'ordinal' (day of the year) field to the given value.
@@ -421,11 +434,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_ordinal(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_ordinal(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if !(1..=366).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.ordinal, value as u32)
+        set_if_consistent(&mut self.ordinal, value as u32)?;
+        Ok(self)
     }
 
     /// Set the 'day of the month' field to the given value.
@@ -436,11 +450,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_day(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_day(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if !(1..=31).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.day, value as u32)
+        set_if_consistent(&mut self.day, value as u32)?;
+        Ok(self)
     }
 
     /// Set the 'am/pm' field to the given value.
@@ -451,8 +466,9 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_ampm(&mut self, value: bool) -> ParseResult<()> {
-        set_if_consistent(&mut self.hour_div_12, value as u32)
+    pub fn set_ampm(&mut self, value: bool) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.hour_div_12, value as u32)?;
+        Ok(self)
     }
 
     /// Set the 'hour number in 12-hour clocks' field to the given value.
@@ -466,14 +482,15 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_hour12(&mut self, mut value: i64) -> ParseResult<()> {
+    pub fn set_hour12(&mut self, mut value: i64) -> ParseResult<&mut Parsed> {
         if !(1..=12).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
         if value == 12 {
             value = 0
         }
-        set_if_consistent(&mut self.hour_mod_12, value as u32)
+        set_if_consistent(&mut self.hour_mod_12, value as u32)?;
+        Ok(self)
     }
 
     /// Set the 'hour' field to the given value.
@@ -487,12 +504,13 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` one of the fields was already set to a different value.
     #[inline]
-    pub fn set_hour(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_hour(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if !(0..=23).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
         set_if_consistent(&mut self.hour_div_12, value as u32 / 12)?;
-        set_if_consistent(&mut self.hour_mod_12, value as u32 % 12)
+        set_if_consistent(&mut self.hour_mod_12, value as u32 % 12)?;
+        Ok(self)
     }
 
     /// Set the 'minute' field to the given value.
@@ -503,11 +521,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_minute(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_minute(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if !(0..=59).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.minute, value as u32)
+        set_if_consistent(&mut self.minute, value as u32)?;
+        Ok(self)
     }
 
     /// Set the 'second' field to the given value.
@@ -520,11 +539,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_second(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_second(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if !(0..=60).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.second, value as u32)
+        set_if_consistent(&mut self.second, value as u32)?;
+        Ok(self)
     }
 
     /// Set the 'nanosecond' field to the given value.
@@ -537,11 +557,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_nanosecond(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_nanosecond(&mut self, value: i64) -> ParseResult<&mut Parsed> {
         if !(0..=999_999_999).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.nanosecond, value as u32)
+        set_if_consistent(&mut self.nanosecond, value as u32)?;
+        Ok(self)
     }
 
     /// Set the 'timestamp' field to the given value.
@@ -553,8 +574,9 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_timestamp(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.timestamp, value)
+    pub fn set_timestamp(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.timestamp, value)?;
+        Ok(self)
     }
 
     /// Set the 'offset from local time to UTC' field to the given value.
@@ -567,8 +589,9 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_offset(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.offset, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_offset(&mut self, value: i64) -> ParseResult<&mut Parsed> {
+        set_if_consistent(&mut self.offset, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Get the 'year' field if set.
@@ -1231,69 +1254,69 @@ mod tests {
     fn test_parsed_set_fields() {
         // year*, isoyear*
         let mut p = Parsed::new();
-        assert_eq!(p.set_year(1987), Ok(()));
+        assert!(p.set_year(1987).is_ok());
         assert_eq!(p.set_year(1986), Err(IMPOSSIBLE));
         assert_eq!(p.set_year(1988), Err(IMPOSSIBLE));
-        assert_eq!(p.set_year(1987), Ok(()));
-        assert_eq!(p.set_year_div_100(20), Ok(())); // independent to `year`
+        assert!(p.set_year(1987).is_ok());
+        assert!(p.set_year_div_100(20).is_ok()); // independent to `year`
         assert_eq!(p.set_year_div_100(21), Err(IMPOSSIBLE));
         assert_eq!(p.set_year_div_100(19), Err(IMPOSSIBLE));
-        assert_eq!(p.set_year_mod_100(37), Ok(())); // ditto
+        assert!(p.set_year_mod_100(37).is_ok()); // ditto
         assert_eq!(p.set_year_mod_100(38), Err(IMPOSSIBLE));
         assert_eq!(p.set_year_mod_100(36), Err(IMPOSSIBLE));
 
         let mut p = Parsed::new();
-        assert_eq!(p.set_year(0), Ok(()));
-        assert_eq!(p.set_year_div_100(0), Ok(()));
-        assert_eq!(p.set_year_mod_100(0), Ok(()));
+        assert!(p.set_year(0).is_ok());
+        assert!(p.set_year_div_100(0).is_ok());
+        assert!(p.set_year_mod_100(0).is_ok());
 
         let mut p = Parsed::new();
         assert_eq!(p.set_year_div_100(-1), Err(OUT_OF_RANGE));
         assert_eq!(p.set_year_mod_100(-1), Err(OUT_OF_RANGE));
-        assert_eq!(p.set_year(-1), Ok(()));
+        assert!(p.set_year(-1).is_ok());
         assert_eq!(p.set_year(-2), Err(IMPOSSIBLE));
         assert_eq!(p.set_year(0), Err(IMPOSSIBLE));
 
         let mut p = Parsed::new();
         assert_eq!(p.set_year_div_100(0x1_0000_0008), Err(OUT_OF_RANGE));
-        assert_eq!(p.set_year_div_100(8), Ok(()));
+        assert!(p.set_year_div_100(8).is_ok());
         assert_eq!(p.set_year_div_100(0x1_0000_0008), Err(OUT_OF_RANGE));
 
         // month, week*, isoweek, ordinal, day, minute, second, nanosecond, offset
         let mut p = Parsed::new();
-        assert_eq!(p.set_month(7), Ok(()));
+        assert!(p.set_month(7).is_ok());
         assert_eq!(p.set_month(1), Err(IMPOSSIBLE));
         assert_eq!(p.set_month(6), Err(IMPOSSIBLE));
         assert_eq!(p.set_month(8), Err(IMPOSSIBLE));
         assert_eq!(p.set_month(12), Err(IMPOSSIBLE));
 
         let mut p = Parsed::new();
-        assert_eq!(p.set_month(8), Ok(()));
+        assert!(p.set_month(8).is_ok());
         assert_eq!(p.set_month(0x1_0000_0008), Err(OUT_OF_RANGE));
 
         // hour
         let mut p = Parsed::new();
-        assert_eq!(p.set_hour(12), Ok(()));
+        assert!(p.set_hour(12).is_ok());
         assert_eq!(p.set_hour(11), Err(IMPOSSIBLE));
         assert_eq!(p.set_hour(13), Err(IMPOSSIBLE));
-        assert_eq!(p.set_hour(12), Ok(()));
+        assert!(p.set_hour(12).is_ok());
         assert_eq!(p.set_ampm(false), Err(IMPOSSIBLE));
-        assert_eq!(p.set_ampm(true), Ok(()));
-        assert_eq!(p.set_hour12(12), Ok(()));
+        assert!(p.set_ampm(true).is_ok());
+        assert!(p.set_hour12(12).is_ok());
         assert_eq!(p.set_hour12(0), Err(OUT_OF_RANGE)); // requires canonical representation
         assert_eq!(p.set_hour12(1), Err(IMPOSSIBLE));
         assert_eq!(p.set_hour12(11), Err(IMPOSSIBLE));
 
         let mut p = Parsed::new();
-        assert_eq!(p.set_ampm(true), Ok(()));
-        assert_eq!(p.set_hour12(7), Ok(()));
+        assert!(p.set_ampm(true).is_ok());
+        assert!(p.set_hour12(7).is_ok());
         assert_eq!(p.set_hour(7), Err(IMPOSSIBLE));
         assert_eq!(p.set_hour(18), Err(IMPOSSIBLE));
-        assert_eq!(p.set_hour(19), Ok(()));
+        assert!(p.set_hour(19).is_ok());
 
         // timestamp
         let mut p = Parsed::new();
-        assert_eq!(p.set_timestamp(1_234_567_890), Ok(()));
+        assert!(p.set_timestamp(1_234_567_890).is_ok());
         assert_eq!(p.set_timestamp(1_234_567_889), Err(IMPOSSIBLE));
         assert_eq!(p.set_timestamp(1_234_567_891), Err(IMPOSSIBLE));
     }

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -124,89 +124,28 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 /// }
 /// # Ok::<(), chrono::ParseError>(())
 /// ```
-#[non_exhaustive]
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
 pub struct Parsed {
-    /// Year.
-    ///
-    /// This can be negative unlike [`year_div_100`](#structfield.year_div_100)
-    /// and [`year_mod_100`](#structfield.year_mod_100) fields.
-    pub year: Option<i32>,
-
-    /// Year divided by 100. Implies that the year is >= 1 BCE when set.
-    ///
-    /// Due to the common usage, if this field is missing but
-    /// [`year_mod_100`](#structfield.year_mod_100) is present,
-    /// it is inferred to 19 when `year_mod_100 >= 70` and 20 otherwise.
-    pub year_div_100: Option<i32>,
-
-    /// Year modulo 100. Implies that the year is >= 1 BCE when set.
-    pub year_mod_100: Option<i32>,
-
-    /// Year in the [ISO week date](../naive/struct.NaiveDate.html#week-date).
-    ///
-    /// This can be negative unlike [`isoyear_div_100`](#structfield.isoyear_div_100) and
-    /// [`isoyear_mod_100`](#structfield.isoyear_mod_100) fields.
-    pub isoyear: Option<i32>,
-
-    /// Year in the [ISO week date](../naive/struct.NaiveDate.html#week-date), divided by 100.
-    /// Implies that the year is >= 1 BCE when set.
-    ///
-    /// Due to the common usage, if this field is missing but
-    /// [`isoyear_mod_100`](#structfield.isoyear_mod_100) is present,
-    /// it is inferred to 19 when `isoyear_mod_100 >= 70` and 20 otherwise.
-    pub isoyear_div_100: Option<i32>,
-
-    /// Year in the [ISO week date](../naive/struct.NaiveDate.html#week-date), modulo 100.
-    /// Implies that the year is >= 1 BCE when set.
-    pub isoyear_mod_100: Option<i32>,
-
-    /// Month (1--12).
-    pub month: Option<u32>,
-
-    /// Week number, where the week 1 starts at the first Sunday of January
-    /// (0--53, 1--53 or 1--52 depending on the year).
-    pub week_from_sun: Option<u32>,
-
-    /// Week number, where the week 1 starts at the first Monday of January
-    /// (0--53, 1--53 or 1--52 depending on the year).
-    pub week_from_mon: Option<u32>,
-
-    /// [ISO week number](../naive/struct.NaiveDate.html#week-date)
-    /// (1--52 or 1--53 depending on the year).
-    pub isoweek: Option<u32>,
-
-    /// Day of the week.
-    pub weekday: Option<Weekday>,
-
-    /// Day of the year (1--365 or 1--366 depending on the year).
-    pub ordinal: Option<u32>,
-
-    /// Day of the month (1--28, 1--29, 1--30 or 1--31 depending on the month).
-    pub day: Option<u32>,
-
-    /// Hour number divided by 12 (0--1). 0 indicates AM and 1 indicates PM.
-    pub hour_div_12: Option<u32>,
-
-    /// Hour number modulo 12 (0--11).
-    pub hour_mod_12: Option<u32>,
-
-    /// Minute number (0--59).
-    pub minute: Option<u32>,
-
-    /// Second number (0--60, accounting for leap seconds).
-    pub second: Option<u32>,
-
-    /// The number of nanoseconds since the whole second (0--999,999,999).
-    pub nanosecond: Option<u32>,
-
-    /// The number of non-leap seconds since the midnight UTC on January 1, 1970.
-    ///
-    /// This can be off by one if [`second`](#structfield.second) is 60 (a leap second).
-    pub timestamp: Option<i64>,
-
-    /// Offset from the local time to UTC, in seconds.
-    pub offset: Option<i32>,
+    year: Option<i32>,
+    year_div_100: Option<i32>,
+    year_mod_100: Option<i32>,
+    isoyear: Option<i32>,
+    isoyear_div_100: Option<i32>,
+    isoyear_mod_100: Option<i32>,
+    month: Option<u32>,
+    week_from_sun: Option<u32>,
+    week_from_mon: Option<u32>,
+    isoweek: Option<u32>,
+    weekday: Option<Weekday>,
+    ordinal: Option<u32>,
+    day: Option<u32>,
+    hour_div_12: Option<u32>,
+    hour_mod_12: Option<u32>,
+    minute: Option<u32>,
+    second: Option<u32>,
+    nanosecond: Option<u32>,
+    timestamp: Option<i64>,
+    offset: Option<i32>,
 }
 
 /// Checks if `old` is either empty or has the same value as `new` (i.e. "consistent"),


### PR DESCRIPTION
I intend to split this PR in multiple parts, but opened it for discussion on how best to do so.

The main goal is to move all range validation to the `Parsed::set_*` methods.
This is preliminary work to convert this type and the parsing methods to our new `Error` type (cc @Zomtir).

It has four pieces:

### 1. For the 0.4 branch
We have two small bugs in our implementation of `Parsed`:
- If there is a timestamp and an offset field, the offset is added to the timestamp. But the definition of a Unix timestamp is that the value is in UTC, so this is not correct.
- We were returning `OUT_OF_RANGE` if the year value didn't match with values of `year_div_100` or `year_mod_100`. It should return `IMPOSSIBLE` instead.

### 2. Documentation
I have added documentation to all methods describing their error causes. And the `Parsed` type got some documentation describing why it exists (the resolution algorithm), and an example of how to use it. Partly taken from the blog post before chrono 0.2: https://lifthrasiir.github.io/rustlog/worklog-2015-02-19.html

### 3. Goal: move all range validation to the `set_*` methods
The goal of this PR was to move all range validation to the `set_*` methods.

Currently the `set_*` methods do a partial range check, or just a checked cast, and the `to_*` methods do the complete range checks. Doing them all in the `set_*` methods will allow us to give more a precise error when we convert the parsing code to the new error type. (It can then return the position in the format string where an invalid value appeared.)

### 4. Nice to have
It would be nice if the `to_` methods can rely on the range checks performed by `set_*`.
But currently they can't because the fields of `Parsed` are public.

*Making the fields private* seems like a good thing to do for this type in general. It involves:
- Adding functions to get each individual field.
- Changing the macro-heavy tests in `format::parse` to use the `set_*` methods.

As a clean solution to replacing the macro's I changed the return type of the `set_*` methods to be usable as a *builder pattern*.

### How to split
1. I can open a PR to the 0.4 branch with the bug fixes.
2. I can also backport the documentation changes. They will be a bit less nice without the builder pattern and with more error cases.
3. We could bring the range validation in the `set_*` methods to the 0.4 branch. We already document they do range checks, only that they may not have been precise and delay the error until the `to_*` methods.
4. Converting the `set_*` methods to a builder pattern, making the fields of `Parsed` private and simplifying the `to_*` methods require 0.5. None of those are strictly *necessary*, but they do improve our error story and are nice to have.