### PR TITLE
Refactor `internals` module part 2

### DIFF
--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1135,9 +1135,10 @@ impl NaiveDate {
     #[inline]
     #[must_use]
     pub const fn pred_opt(&self) -> Option<NaiveDate> {
-        match self.of().pred() {
-            Some(of) => Some(self.with_of(of)),
-            None => NaiveDate::from_ymd_opt(self.year() - 1, 12, 31),
+        let new_shifted_ordinal = (self.yof & ORDINAL_MASK) - (1 << 4);
+        match new_shifted_ordinal > 0 {
+            true => Some(NaiveDate { yof: self.yof & !ORDINAL_MASK | new_shifted_ordinal }),
+            false => NaiveDate::from_ymd_opt(self.year() - 1, 12, 31),
         }
     }
 

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -346,13 +346,6 @@ impl Of {
         Mdf::from_of(*self)
     }
 
-    /// Returns an `Of` with the next day, or `None` if this is the last day of the year.
-    #[inline]
-    pub(super) const fn succ(&self) -> Option<Of> {
-        let of = Of(self.0 + (1 << 4));
-        of.validate()
-    }
-
     /// Returns an `Of` with the previous day, or `None` if this is the first day of the year.
     #[inline]
     pub(super) const fn pred(&self) -> Option<Of> {
@@ -866,10 +859,6 @@ mod tests {
         assert!(Of::from_mdf(Mdf::new(2, 29, regular_year).unwrap()).is_none());
         assert!(Of::from_mdf(Mdf::new(2, 29, leap_year).unwrap()).is_some());
         assert!(Of::from_mdf(Mdf::new(2, 28, regular_year).unwrap()).is_some());
-
-        assert!(Of::new(365, regular_year).unwrap().succ().is_none());
-        assert!(Of::new(365, leap_year).unwrap().succ().is_some());
-        assert!(Of::new(366, leap_year).unwrap().succ().is_none());
 
         assert!(Of::new(1, regular_year).unwrap().pred().is_none());
         assert!(Of::new(1, leap_year).unwrap().pred().is_none());

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -316,12 +316,6 @@ impl Of {
     }
 
     #[inline]
-    pub(super) const fn with_ordinal(&self, ordinal: u32) -> Option<Of> {
-        let of = Of((ordinal << 4) | (self.0 & 0b1111));
-        of.validate()
-    }
-
-    #[inline]
     pub(super) const fn flags(&self) -> YearFlags {
         YearFlags((self.0 & 0b1111) as u8)
     }
@@ -661,30 +655,6 @@ mod tests {
                     assert_eq!(of.ordinal(), ordinal);
                 }
             }
-        }
-    }
-
-    #[test]
-    fn test_of_with_fields() {
-        fn check(flags: YearFlags, ordinal: u32) {
-            let of = Of::new(ordinal, flags).unwrap();
-
-            for ordinal in 0u32..=1024 {
-                let of = of.with_ordinal(ordinal);
-                assert_eq!(of, Of::new(ordinal, flags));
-                if let Some(of) = of {
-                    assert_eq!(of.ordinal(), ordinal);
-                }
-            }
-        }
-
-        for &flags in NONLEAP_FLAGS.iter() {
-            check(flags, 1);
-            check(flags, 365);
-        }
-        for &flags in LEAP_FLAGS.iter() {
-            check(flags, 1);
-            check(flags, 366);
         }
     }
 

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -267,6 +267,7 @@ pub(super) struct Of(u32);
 
 impl Of {
     #[inline]
+    #[cfg(test)]
     pub(super) const fn new(ordinal: u32, YearFlags(flags): YearFlags) -> Option<Of> {
         let of = Of((ordinal << 4) | flags as u32);
         of.validate()
@@ -308,11 +309,6 @@ impl Of {
             true => Some(self),
             false => None,
         }
-    }
-
-    #[inline]
-    pub(super) const fn ordinal(&self) -> u32 {
-        self.0 >> 4
     }
 
     #[inline]
@@ -644,17 +640,6 @@ mod tests {
             check(false, flags, u32::MAX, 0, u32::MAX, 1024);
             check(false, flags, 0, u32::MAX, 16, u32::MAX);
             check(false, flags, u32::MAX, u32::MAX, u32::MAX, u32::MAX);
-        }
-    }
-
-    #[test]
-    fn test_of_fields() {
-        for &flags in FLAGS.iter() {
-            for ordinal in 1u32..=366 {
-                if let Some(of) = Of::new(ordinal, flags) {
-                    assert_eq!(of.ordinal(), ordinal);
-                }
-            }
         }
     }
 

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -345,15 +345,6 @@ impl Of {
     pub(super) const fn to_mdf(&self) -> Mdf {
         Mdf::from_of(*self)
     }
-
-    /// Returns an `Of` with the previous day, or `None` if this is the first day of the year.
-    #[inline]
-    pub(super) const fn pred(&self) -> Option<Of> {
-        match self.ordinal() {
-            1 => None,
-            _ => Some(Of(self.0 - (1 << 4))),
-        }
-    }
 }
 
 impl fmt::Debug for Of {
@@ -859,9 +850,6 @@ mod tests {
         assert!(Of::from_mdf(Mdf::new(2, 29, regular_year).unwrap()).is_none());
         assert!(Of::from_mdf(Mdf::new(2, 29, leap_year).unwrap()).is_some());
         assert!(Of::from_mdf(Mdf::new(2, 28, regular_year).unwrap()).is_some());
-
-        assert!(Of::new(1, regular_year).unwrap().pred().is_none());
-        assert!(Of::new(1, leap_year).unwrap().pred().is_none());
     }
 
     #[test]


### PR DESCRIPTION
These four commits are somewhat related as they all work on the ordinal part of a `NaiveDate`, or the ordinal + leap year flag (`ol`).