### PR TITLE
Refactor `internals` module part 3

### DIFF
--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -1688,7 +1688,7 @@ impl Datelike for NaiveDate {
 
     #[inline]
     fn iso_week(&self) -> IsoWeek {
-        IsoWeek::from_yof(self.year(), self.of())
+        IsoWeek::from_yof(self.year(), self.ordinal(), self.of().flags())
     }
 
     /// Makes a new `NaiveDate` with the year number changed, while keeping the same month and day.
@@ -2516,7 +2516,7 @@ mod serde {
 #[cfg(test)]
 mod tests {
     use super::{Days, Months, NaiveDate, MAX_YEAR, MIN_YEAR};
-    use crate::naive::internals::YearFlags;
+    use crate::naive::internals::{YearFlags, A, AG, B, BA, C, CB, D, DC, E, ED, F, FE, G, GF};
     use crate::{Datelike, TimeDelta, Weekday};
 
     // as it is hard to verify year flags in `NaiveDate::MIN` and `NaiveDate::MAX`,
@@ -3374,6 +3374,36 @@ mod tests {
             assert_eq!(date.leap_year(), date.with_ordinal(366).is_some());
         }
     }
+
+    #[test]
+    fn test_isoweekdate_with_yearflags() {
+        for (year, year_flags, _) in YEAR_FLAGS {
+            // January 4 should be in the first week
+            let jan4 = NaiveDate::from_ymd_opt(year, 1, 4).unwrap();
+            let iso_week = jan4.iso_week();
+            assert_eq!(jan4.of().flags(), year_flags);
+            assert_eq!(iso_week.week(), 1);
+        }
+    }
+
+    // Used for testing some methods with all combinations of `YearFlags`.
+    // (year, flags, first weekday of year)
+    const YEAR_FLAGS: [(i32, YearFlags, Weekday); 14] = [
+        (2006, A, Weekday::Sun),
+        (2005, B, Weekday::Sat),
+        (2010, C, Weekday::Fri),
+        (2009, D, Weekday::Thu),
+        (2003, E, Weekday::Wed),
+        (2002, F, Weekday::Tue),
+        (2001, G, Weekday::Mon),
+        (2012, AG, Weekday::Sun),
+        (2000, BA, Weekday::Sat),
+        (2016, CB, Weekday::Fri),
+        (2004, DC, Weekday::Thu),
+        (2020, ED, Weekday::Wed),
+        (2008, FE, Weekday::Tue),
+        (2024, GF, Weekday::Mon),
+    ];
 
     #[test]
     #[cfg(feature = "rkyv-validation")]

--- a/src/naive/date.rs
+++ b/src/naive/date.rs
@@ -38,7 +38,6 @@ use crate::{expect, try_opt};
 use crate::{Datelike, TimeDelta, Weekday};
 
 use super::internals::{self, Mdf, Of, YearFlags};
-use super::isoweek;
 
 /// A week represented by a [`NaiveDate`] and a [`Weekday`] which is the first
 /// day of the week.
@@ -1689,7 +1688,7 @@ impl Datelike for NaiveDate {
 
     #[inline]
     fn iso_week(&self) -> IsoWeek {
-        isoweek::iso_week_from_yof(self.year(), self.of())
+        IsoWeek::from_yof(self.year(), self.of())
     }
 
     /// Makes a new `NaiveDate` with the year number changed, while keeping the same month and day.

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -303,11 +303,6 @@ impl Of {
         }
     }
 
-    #[inline]
-    pub(super) const fn flags(&self) -> YearFlags {
-        YearFlags((self.0 & 0b1111) as u8)
-    }
-
     #[cfg_attr(feature = "cargo-clippy", allow(clippy::wrong_self_convention))]
     #[inline]
     pub(super) const fn to_mdf(&self) -> Mdf {

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -322,14 +322,6 @@ impl Of {
         weekday_from_u32_mod7((of >> 4) + (of & 0b111))
     }
 
-    #[inline]
-    pub(super) fn isoweekdate_raw(&self) -> (u32, Weekday) {
-        // week ordinal = ordinal + delta
-        let Of(of) = *self;
-        let weekord = (of >> 4).wrapping_add(self.flags().isoweek_delta());
-        (weekord / 7, weekday_from_u32_mod7(weekord))
-    }
-
     #[cfg_attr(feature = "cargo-clippy", allow(clippy::wrong_self_convention))]
     #[inline]
     pub(super) const fn to_mdf(&self) -> Mdf {
@@ -737,15 +729,6 @@ mod tests {
             check(flags, 2, 29);
             check(flags, 2, 30);
             check(flags, 12, 31);
-        }
-    }
-
-    #[test]
-    fn test_of_isoweekdate_raw() {
-        for &flags in FLAGS.iter() {
-            // January 4 should be in the first week
-            let (week, _) = Of::new(4 /* January 4 */, flags).unwrap().isoweekdate_raw();
-            assert_eq!(week, 1);
         }
     }
 

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -5,7 +5,7 @@
 
 use core::fmt;
 
-use super::internals::{Of, YearFlags};
+use super::internals::YearFlags;
 
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
@@ -38,14 +38,14 @@ impl IsoWeek {
     // because the year range for the week date and the calendar date do not match and
     // it is confusing to have a date that is out of range in one and not in another.
     // currently we sidestep this issue by making `IsoWeek` fully dependent of `Datelike`.
-    pub(super) fn from_yof(year: i32, of: Of) -> Self {
-        let (rawweek, _) = of.isoweekdate_raw();
+    pub(super) fn from_yof(year: i32, ordinal: u32, year_flags: YearFlags) -> Self {
+        let rawweek = (ordinal + year_flags.isoweek_delta()) / 7;
         let (year, week) = if rawweek < 1 {
             // previous year
             let prevlastweek = YearFlags::from_year(year - 1).nisoweeks();
             (year - 1, prevlastweek)
         } else {
-            let lastweek = of.flags().nisoweeks();
+            let lastweek = year_flags.nisoweeks();
             if rawweek > lastweek {
                 // next year
                 (year + 1, 1)

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -31,32 +31,32 @@ pub struct IsoWeek {
     ywf: i32, // (year << 10) | (week << 4) | flag
 }
 
-/// Returns the corresponding `IsoWeek` from the year and the `Of` internal value.
-//
-// internal use only. we don't expose the public constructor for `IsoWeek` for now,
-// because the year range for the week date and the calendar date do not match and
-// it is confusing to have a date that is out of range in one and not in another.
-// currently we sidestep this issue by making `IsoWeek` fully dependent of `Datelike`.
-pub(super) fn iso_week_from_yof(year: i32, of: Of) -> IsoWeek {
-    let (rawweek, _) = of.isoweekdate_raw();
-    let (year, week) = if rawweek < 1 {
-        // previous year
-        let prevlastweek = YearFlags::from_year(year - 1).nisoweeks();
-        (year - 1, prevlastweek)
-    } else {
-        let lastweek = of.flags().nisoweeks();
-        if rawweek > lastweek {
-            // next year
-            (year + 1, 1)
-        } else {
-            (year, rawweek)
-        }
-    };
-    let flags = YearFlags::from_year(year);
-    IsoWeek { ywf: (year << 10) | (week << 4) as i32 | i32::from(flags.0) }
-}
-
 impl IsoWeek {
+    /// Returns the corresponding `IsoWeek` from the year and the `Of` internal value.
+    //
+    // internal use only. we don't expose the public constructor for `IsoWeek` for now,
+    // because the year range for the week date and the calendar date do not match and
+    // it is confusing to have a date that is out of range in one and not in another.
+    // currently we sidestep this issue by making `IsoWeek` fully dependent of `Datelike`.
+    pub(super) fn from_yof(year: i32, of: Of) -> Self {
+        let (rawweek, _) = of.isoweekdate_raw();
+        let (year, week) = if rawweek < 1 {
+            // previous year
+            let prevlastweek = YearFlags::from_year(year - 1).nisoweeks();
+            (year - 1, prevlastweek)
+        } else {
+            let lastweek = of.flags().nisoweeks();
+            if rawweek > lastweek {
+                // next year
+                (year + 1, 1)
+            } else {
+                (year, rawweek)
+            }
+        };
+        let flags = YearFlags::from_year(year);
+        IsoWeek { ywf: (year << 10) | (week << 4) as i32 | i32::from(flags.0) }
+    }
+
     /// Returns the year number for this ISO week.
     ///
     /// # Example


### PR DESCRIPTION
The first commit makes the `iso_week_from_yof` function a method on `IsoWeek`.
The next changes it to consume an `ordinal` and `year_flags` instead of `Of`, and inlines the functionality that was in `Of::isoweekdate_raw`.

The others move over the `weekday` and `year_flags` getters to `NaiveDate`.