### PR TITLE
0.5.x: Rename `NaiveDate::*_opt` methods

### DIFF
--- a/bench/benches/chrono.rs
+++ b/bench/benches/chrono.rs
@@ -10,10 +10,10 @@ use chrono::{DateTime, FixedOffset, Local, TimeDelta, Utc, __BenchYearFlags};
 
 fn bench_date_from_ymd(c: &mut Criterion) {
     c.bench_function("bench_date_from_ymd", |b| {
-        let expected = NaiveDate::from_ymd_opt(2024, 2, 12);
+        let expected = NaiveDate::from_ymd(2024, 2, 12);
         b.iter(|| {
             let (y, m, d) = black_box((2024, 2, 12));
-            assert_eq!(NaiveDate::from_ymd_opt(y, m, d), expected)
+            assert_eq!(NaiveDate::from_ymd(y, m, d), expected)
         })
     });
 }
@@ -50,7 +50,7 @@ fn bench_datetime_to_rfc2822(c: &mut Criterion) {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            &NaiveDate::from_ymd_opt(2018, 1, 11)
+            &NaiveDate::from_ymd(2018, 1, 11)
                 .unwrap()
                 .and_hms_nano_opt(10, 5, 13, 84_660_000)
                 .unwrap(),
@@ -63,7 +63,7 @@ fn bench_datetime_to_rfc3339(c: &mut Criterion) {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            &NaiveDate::from_ymd_opt(2018, 1, 11)
+            &NaiveDate::from_ymd(2018, 1, 11)
                 .unwrap()
                 .and_hms_nano_opt(10, 5, 13, 84_660_000)
                 .unwrap(),
@@ -76,7 +76,7 @@ fn bench_datetime_to_rfc3339_opts(c: &mut Criterion) {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            &NaiveDate::from_ymd_opt(2018, 1, 11)
+            &NaiveDate::from_ymd(2018, 1, 11)
                 .unwrap()
                 .and_hms_nano_opt(10, 5, 13, 84_660_000)
                 .unwrap(),
@@ -139,7 +139,7 @@ fn num_days_from_ce_alt<Date: Datelike>(date: &Date) -> i32 {
 fn bench_num_days_from_ce(c: &mut Criterion) {
     let mut group = c.benchmark_group("num_days_from_ce");
     for year in &[1, 500, 2000, 2019] {
-        let d = NaiveDate::from_ymd_opt(*year, 1, 1).unwrap();
+        let d = NaiveDate::from_ymd(*year, 1, 1).unwrap();
         group.bench_with_input(BenchmarkId::new("new", year), &d, |b, y| {
             b.iter(|| num_days_from_ce_alt(y))
         });
@@ -207,7 +207,7 @@ fn bench_format_manual(c: &mut Criterion) {
 }
 
 fn bench_naivedate_add_signed(c: &mut Criterion) {
-    let date = NaiveDate::from_ymd_opt(2023, 7, 29).unwrap();
+    let date = NaiveDate::from_ymd(2023, 7, 29).unwrap();
     let extra = TimeDelta::days(25);
     c.bench_function("bench_naivedate_add_signed", |b| {
         b.iter(|| black_box(date).checked_add_signed(extra).unwrap())

--- a/bench/benches/chrono.rs
+++ b/bench/benches/chrono.rs
@@ -50,10 +50,7 @@ fn bench_datetime_to_rfc2822(c: &mut Criterion) {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            &NaiveDate::from_ymd(2018, 1, 11)
-                .unwrap()
-                .and_hms_nano_opt(10, 5, 13, 84_660_000)
-                .unwrap(),
+            &NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
         )
         .unwrap();
     c.bench_function("bench_datetime_to_rfc2822", |b| b.iter(|| black_box(dt).to_rfc2822()));
@@ -63,10 +60,7 @@ fn bench_datetime_to_rfc3339(c: &mut Criterion) {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            &NaiveDate::from_ymd(2018, 1, 11)
-                .unwrap()
-                .and_hms_nano_opt(10, 5, 13, 84_660_000)
-                .unwrap(),
+            &NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
         )
         .unwrap();
     c.bench_function("bench_datetime_to_rfc3339", |b| b.iter(|| black_box(dt).to_rfc3339()));
@@ -76,10 +70,7 @@ fn bench_datetime_to_rfc3339_opts(c: &mut Criterion) {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            &NaiveDate::from_ymd(2018, 1, 11)
-                .unwrap()
-                .and_hms_nano_opt(10, 5, 13, 84_660_000)
-                .unwrap(),
+            &NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
         )
         .unwrap();
     c.bench_function("bench_datetime_to_rfc3339_opts", |b| {

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -148,10 +148,10 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     /// use chrono::{Utc, NaiveDate};
     ///
-    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_milli_opt(0, 0, 1, 444).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_milli(0, 0, 1, 444).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_millis(), 1_444);
     ///
-    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_milli_opt(1, 46, 40, 555).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_milli(1, 46, 40, 555).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_millis(), 1_000_000_000_555);
     /// ```
     #[inline]
@@ -757,7 +757,7 @@ impl DateTime<FixedOffset> {
     ///
     /// let dt = DateTime::parse_from_str(
     ///     "1983 Apr 13 12:09:14.274 +0000", "%Y %b %d %H:%M:%S%.3f %z");
-    /// assert_eq!(dt, Ok(FixedOffset::east(0).unwrap().from_local_datetime(&NaiveDate::from_ymd(1983, 4, 13).unwrap().and_hms_milli_opt(12, 9, 14, 274).unwrap()).unwrap()));
+    /// assert_eq!(dt, Ok(FixedOffset::east(0).unwrap().from_local_datetime(&NaiveDate::from_ymd(1983, 4, 13).unwrap().and_hms_milli(12, 9, 14, 274).unwrap()).unwrap()));
     /// ```
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<DateTime<FixedOffset>> {
         let mut parsed = Parsed::new();

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -194,22 +194,22 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     /// use chrono::{Utc, NaiveDate};
     ///
-    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_nano_opt(0, 0, 1, 444).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_nano(0, 0, 1, 444).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_nanos(), Some(1_000_000_444));
     ///
-    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano_opt(1, 46, 40, 555).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano(1, 46, 40, 555).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_nanos(), Some(1_000_000_000_000_000_555));
     ///
-    /// let dt = NaiveDate::from_ymd(1677, 9, 21).unwrap().and_hms_nano_opt(0, 12, 43, 145_224_192).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(1677, 9, 21).unwrap().and_hms_nano(0, 12, 43, 145_224_192).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_nanos(), Some(-9_223_372_036_854_775_808));
     ///
-    /// let dt = NaiveDate::from_ymd(2262, 4, 11).unwrap().and_hms_nano_opt(23, 47, 16, 854_775_807).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2262, 4, 11).unwrap().and_hms_nano(23, 47, 16, 854_775_807).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_nanos(), Some(9_223_372_036_854_775_807));
     ///
-    /// let dt = NaiveDate::from_ymd(1677, 9, 21).unwrap().and_hms_nano_opt(0, 12, 43, 145_224_191).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(1677, 9, 21).unwrap().and_hms_nano(0, 12, 43, 145_224_191).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_nanos(), None);
     ///
-    /// let dt = NaiveDate::from_ymd(2262, 4, 11).unwrap().and_hms_nano_opt(23, 47, 16, 854_775_808).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2262, 4, 11).unwrap().and_hms_nano(23, 47, 16, 854_775_808).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_nanos(), None);
     /// ```
     #[inline]

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -167,10 +167,10 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     /// use chrono::{Utc, NaiveDate};
     ///
-    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_micro_opt(0, 0, 1, 444).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_micro(0, 0, 1, 444).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_micros(), 1_000_444);
     ///
-    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_micro_opt(1, 46, 40, 555).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_micro(1, 46, 40, 555).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_micros(), 1_000_000_000_000_555);
     /// ```
     #[inline]
@@ -487,7 +487,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// ```rust
     /// # use chrono::{FixedOffset, SecondsFormat, TimeZone, Utc, NaiveDate};
-    /// let dt = NaiveDate::from_ymd(2018, 1, 26).unwrap().and_hms_micro_opt(18, 30, 9, 453_829).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2018, 1, 26).unwrap().and_hms_micro(18, 30, 9, 453_829).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Millis, false),
     ///            "2018-01-26T18:30:09.453+00:00");
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Millis, true),
@@ -496,7 +496,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///            "2018-01-26T18:30:09Z");
     ///
     /// let pst = FixedOffset::east(8 * 60 * 60).unwrap();
-    /// let dt = pst.from_local_datetime(&NaiveDate::from_ymd(2018, 1, 26).unwrap().and_hms_micro_opt(10, 30, 9, 453_829).unwrap()).unwrap();
+    /// let dt = pst.from_local_datetime(&NaiveDate::from_ymd(2018, 1, 26).unwrap().and_hms_micro(10, 30, 9, 453_829).unwrap()).unwrap();
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Secs, true),
     ///            "2018-01-26T10:30:09+08:00");
     /// ```

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -111,7 +111,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     #[must_use]
     pub fn date_naive(&self) -> NaiveDate {
         let local = self.naive_local();
-        NaiveDate::from_ymd_opt(local.year(), local.month(), local.day()).unwrap()
+        NaiveDate::from_ymd(local.year(), local.month(), local.day()).unwrap()
     }
 
     /// Retrieves the time component.
@@ -148,10 +148,10 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     /// use chrono::{Utc, NaiveDate};
     ///
-    /// let dt = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_milli_opt(0, 0, 1, 444).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_milli_opt(0, 0, 1, 444).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_millis(), 1_444);
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2001, 9, 9).unwrap().and_hms_milli_opt(1, 46, 40, 555).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_milli_opt(1, 46, 40, 555).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_millis(), 1_000_000_000_555);
     /// ```
     #[inline]
@@ -167,10 +167,10 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     /// use chrono::{Utc, NaiveDate};
     ///
-    /// let dt = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_micro_opt(0, 0, 1, 444).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_micro_opt(0, 0, 1, 444).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_micros(), 1_000_444);
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2001, 9, 9).unwrap().and_hms_micro_opt(1, 46, 40, 555).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_micro_opt(1, 46, 40, 555).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_micros(), 1_000_000_000_000_555);
     /// ```
     #[inline]
@@ -194,22 +194,22 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     /// use chrono::{Utc, NaiveDate};
     ///
-    /// let dt = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_nano_opt(0, 0, 1, 444).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_nano_opt(0, 0, 1, 444).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_nanos(), Some(1_000_000_444));
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2001, 9, 9).unwrap().and_hms_nano_opt(1, 46, 40, 555).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano_opt(1, 46, 40, 555).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_nanos(), Some(1_000_000_000_000_000_555));
     ///
-    /// let dt = NaiveDate::from_ymd_opt(1677, 9, 21).unwrap().and_hms_nano_opt(0, 12, 43, 145_224_192).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(1677, 9, 21).unwrap().and_hms_nano_opt(0, 12, 43, 145_224_192).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_nanos(), Some(-9_223_372_036_854_775_808));
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2262, 4, 11).unwrap().and_hms_nano_opt(23, 47, 16, 854_775_807).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2262, 4, 11).unwrap().and_hms_nano_opt(23, 47, 16, 854_775_807).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_nanos(), Some(9_223_372_036_854_775_807));
     ///
-    /// let dt = NaiveDate::from_ymd_opt(1677, 9, 21).unwrap().and_hms_nano_opt(0, 12, 43, 145_224_191).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(1677, 9, 21).unwrap().and_hms_nano_opt(0, 12, 43, 145_224_191).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_nanos(), None);
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2262, 4, 11).unwrap().and_hms_nano_opt(23, 47, 16, 854_775_808).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2262, 4, 11).unwrap().and_hms_nano_opt(23, 47, 16, 854_775_808).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.timestamp_nanos(), None);
     /// ```
     #[inline]
@@ -487,7 +487,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// ```rust
     /// # use chrono::{FixedOffset, SecondsFormat, TimeZone, Utc, NaiveDate};
-    /// let dt = NaiveDate::from_ymd_opt(2018, 1, 26).unwrap().and_hms_micro_opt(18, 30, 9, 453_829).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2018, 1, 26).unwrap().and_hms_micro_opt(18, 30, 9, 453_829).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Millis, false),
     ///            "2018-01-26T18:30:09.453+00:00");
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Millis, true),
@@ -496,7 +496,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///            "2018-01-26T18:30:09Z");
     ///
     /// let pst = FixedOffset::east(8 * 60 * 60).unwrap();
-    /// let dt = pst.from_local_datetime(&NaiveDate::from_ymd_opt(2018, 1, 26).unwrap().and_hms_micro_opt(10, 30, 9, 453_829).unwrap()).unwrap();
+    /// let dt = pst.from_local_datetime(&NaiveDate::from_ymd(2018, 1, 26).unwrap().and_hms_micro_opt(10, 30, 9, 453_829).unwrap()).unwrap();
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Secs, true),
     ///            "2018-01-26T10:30:09+08:00");
     /// ```
@@ -757,7 +757,7 @@ impl DateTime<FixedOffset> {
     ///
     /// let dt = DateTime::parse_from_str(
     ///     "1983 Apr 13 12:09:14.274 +0000", "%Y %b %d %H:%M:%S%.3f %z");
-    /// assert_eq!(dt, Ok(FixedOffset::east(0).unwrap().from_local_datetime(&NaiveDate::from_ymd_opt(1983, 4, 13).unwrap().and_hms_milli_opt(12, 9, 14, 274).unwrap()).unwrap()));
+    /// assert_eq!(dt, Ok(FixedOffset::east(0).unwrap().from_local_datetime(&NaiveDate::from_ymd(1983, 4, 13).unwrap().and_hms_milli_opt(12, 9, 14, 274).unwrap()).unwrap()));
     /// ```
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<DateTime<FixedOffset>> {
         let mut parsed = Parsed::new();

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -396,7 +396,7 @@ pub mod ts_nanoseconds_option {
 ///     time: DateTime<Utc>
 /// }
 ///
-/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap();
+/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap();
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -432,7 +432,7 @@ pub mod ts_microseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap(),
+    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
@@ -527,7 +527,7 @@ pub mod ts_microseconds {
 ///     time: Option<DateTime<Utc>>
 /// }
 ///
-/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap());
+/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap());
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -562,7 +562,7 @@ pub mod ts_microseconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap()),
+    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap()),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -114,7 +114,7 @@ impl<'de> de::Deserialize<'de> for DateTime<Local> {
 ///     time: DateTime<Utc>
 /// }
 ///
-/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap();
+/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap();
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -159,7 +159,7 @@ pub mod ts_nanoseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap(),
+    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
@@ -256,7 +256,7 @@ pub mod ts_nanoseconds {
 ///     time: Option<DateTime<Utc>>
 /// }
 ///
-/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap());
+/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap());
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -300,7 +300,7 @@ pub mod ts_nanoseconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap()),
+    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap()),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -656,7 +656,7 @@ pub mod ts_microseconds_option {
 ///     time: DateTime<Utc>
 /// }
 ///
-/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap();
+/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap();
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -692,7 +692,7 @@ pub mod ts_milliseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap(),
+    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
@@ -781,7 +781,7 @@ pub mod ts_milliseconds {
 ///     time: Option<DateTime<Utc>>
 /// }
 ///
-/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap());
+/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap());
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -816,7 +816,7 @@ pub mod ts_milliseconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap()),
+    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap()),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -114,7 +114,7 @@ impl<'de> de::Deserialize<'de> for DateTime<Local> {
 ///     time: DateTime<Utc>
 /// }
 ///
-/// let time = NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap();
+/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap();
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -159,7 +159,7 @@ pub mod ts_nanoseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap(),
+    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
@@ -256,7 +256,7 @@ pub mod ts_nanoseconds {
 ///     time: Option<DateTime<Utc>>
 /// }
 ///
-/// let time = Some(NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap());
+/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap());
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -300,7 +300,7 @@ pub mod ts_nanoseconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap()),
+    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap().and_local_timezone(Utc).unwrap()),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
@@ -396,7 +396,7 @@ pub mod ts_nanoseconds_option {
 ///     time: DateTime<Utc>
 /// }
 ///
-/// let time = NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap();
+/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap();
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -432,7 +432,7 @@ pub mod ts_microseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap(),
+    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
@@ -527,7 +527,7 @@ pub mod ts_microseconds {
 ///     time: Option<DateTime<Utc>>
 /// }
 ///
-/// let time = Some(NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap());
+/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap());
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -562,7 +562,7 @@ pub mod ts_microseconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap()),
+    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap().and_local_timezone(Utc).unwrap()),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
@@ -656,7 +656,7 @@ pub mod ts_microseconds_option {
 ///     time: DateTime<Utc>
 /// }
 ///
-/// let time = NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap();
+/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap();
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -692,7 +692,7 @@ pub mod ts_milliseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap(),
+    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
@@ -781,7 +781,7 @@ pub mod ts_milliseconds {
 ///     time: Option<DateTime<Utc>>
 /// }
 ///
-/// let time = Some(NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap());
+/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap());
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -816,7 +816,7 @@ pub mod ts_milliseconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap()),
+    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap().and_local_timezone(Utc).unwrap()),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -483,7 +483,7 @@ fn test_datetime_rfc2822() {
             .from_local_datetime(
                 &NaiveDate::from_ymd(2015, 2, 18)
                     .unwrap()
-                    .and_hms_micro_opt(23, 59, 59, 1_234_567)
+                    .and_hms_micro(23, 59, 59, 1_234_567)
                     .unwrap()
             )
             .unwrap())
@@ -493,7 +493,7 @@ fn test_datetime_rfc2822() {
         edt.from_local_datetime(
             &NaiveDate::from_ymd(2015, 2, 18)
                 .unwrap()
-                .and_hms_micro_opt(23, 59, 59, 1_234_567)
+                .and_hms_micro(23, 59, 59, 1_234_567)
                 .unwrap()
         )
         .unwrap()

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -35,7 +35,7 @@ impl TimeZone for DstTester {
         &self,
         local: &NaiveDateTime,
     ) -> crate::LocalResult<Self::Offset> {
-        let local_to_winter_transition_start = NaiveDate::from_ymd_opt(
+        let local_to_winter_transition_start = NaiveDate::from_ymd(
             local.year(),
             DstTester::TO_WINTER_MONTH_DAY.0,
             DstTester::TO_WINTER_MONTH_DAY.1,
@@ -43,7 +43,7 @@ impl TimeZone for DstTester {
         .unwrap()
         .and_time(DstTester::transition_start_local());
 
-        let local_to_winter_transition_end = NaiveDate::from_ymd_opt(
+        let local_to_winter_transition_end = NaiveDate::from_ymd(
             local.year(),
             DstTester::TO_WINTER_MONTH_DAY.0,
             DstTester::TO_WINTER_MONTH_DAY.1,
@@ -51,7 +51,7 @@ impl TimeZone for DstTester {
         .unwrap()
         .and_time(DstTester::transition_start_local() - TimeDelta::hours(1));
 
-        let local_to_summer_transition_start = NaiveDate::from_ymd_opt(
+        let local_to_summer_transition_start = NaiveDate::from_ymd(
             local.year(),
             DstTester::TO_SUMMER_MONTH_DAY.0,
             DstTester::TO_SUMMER_MONTH_DAY.1,
@@ -59,7 +59,7 @@ impl TimeZone for DstTester {
         .unwrap()
         .and_time(DstTester::transition_start_local());
 
-        let local_to_summer_transition_end = NaiveDate::from_ymd_opt(
+        let local_to_summer_transition_end = NaiveDate::from_ymd(
             local.year(),
             DstTester::TO_SUMMER_MONTH_DAY.0,
             DstTester::TO_SUMMER_MONTH_DAY.1,
@@ -87,7 +87,7 @@ impl TimeZone for DstTester {
     }
 
     fn offset_from_utc_datetime(&self, utc: &NaiveDateTime) -> Self::Offset {
-        let utc_to_winter_transition = NaiveDate::from_ymd_opt(
+        let utc_to_winter_transition = NaiveDate::from_ymd(
             utc.year(),
             DstTester::TO_WINTER_MONTH_DAY.0,
             DstTester::TO_WINTER_MONTH_DAY.1,
@@ -96,7 +96,7 @@ impl TimeZone for DstTester {
         .and_time(DstTester::transition_start_local())
             - DstTester::summer_offset();
 
-        let utc_to_summer_transition = NaiveDate::from_ymd_opt(
+        let utc_to_summer_transition = NaiveDate::from_ymd(
             utc.year(),
             DstTester::TO_SUMMER_MONTH_DAY.0,
             DstTester::TO_SUMMER_MONTH_DAY.1,
@@ -417,17 +417,17 @@ fn test_datetime_date_and_time() {
     let tz = FixedOffset::east(5 * 60 * 60).unwrap();
     let d = tz.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap();
     assert_eq!(d.time(), NaiveTime::from_hms(7, 8, 9).unwrap());
-    assert_eq!(d.date_naive(), NaiveDate::from_ymd_opt(2014, 5, 6).unwrap());
+    assert_eq!(d.date_naive(), NaiveDate::from_ymd(2014, 5, 6).unwrap());
 
     let tz = FixedOffset::east(4 * 60 * 60).unwrap();
     let d = tz.with_ymd_and_hms(2016, 5, 4, 3, 2, 1).unwrap();
     assert_eq!(d.time(), NaiveTime::from_hms(3, 2, 1).unwrap());
-    assert_eq!(d.date_naive(), NaiveDate::from_ymd_opt(2016, 5, 4).unwrap());
+    assert_eq!(d.date_naive(), NaiveDate::from_ymd(2016, 5, 4).unwrap());
 
     let tz = FixedOffset::west(13 * 60 * 60).unwrap();
     let d = tz.with_ymd_and_hms(2017, 8, 9, 12, 34, 56).unwrap();
     assert_eq!(d.time(), NaiveTime::from_hms(12, 34, 56).unwrap());
-    assert_eq!(d.date_naive(), NaiveDate::from_ymd_opt(2017, 8, 9).unwrap());
+    assert_eq!(d.date_naive(), NaiveDate::from_ymd(2017, 8, 9).unwrap());
 
     let utc_d = Utc.with_ymd_and_hms(2017, 8, 9, 12, 34, 56).unwrap();
     assert!(utc_d < d);
@@ -459,10 +459,7 @@ fn test_datetime_rfc2822() {
     // timezone +05
     assert_eq!(
         edt.from_local_datetime(
-            &NaiveDate::from_ymd_opt(2015, 2, 18)
-                .unwrap()
-                .and_hms_milli_opt(23, 16, 9, 150)
-                .unwrap()
+            &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap()
         )
         .unwrap()
         .to_rfc2822(),
@@ -472,7 +469,7 @@ fn test_datetime_rfc2822() {
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:60 +0500"),
         Ok(edt
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2015, 2, 18)
+                &NaiveDate::from_ymd(2015, 2, 18)
                     .unwrap()
                     .and_hms_milli_opt(23, 59, 59, 1_000)
                     .unwrap()
@@ -484,7 +481,7 @@ fn test_datetime_rfc2822() {
         DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00"),
         Ok(edt
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2015, 2, 18)
+                &NaiveDate::from_ymd(2015, 2, 18)
                     .unwrap()
                     .and_hms_micro_opt(23, 59, 59, 1_234_567)
                     .unwrap()
@@ -494,7 +491,7 @@ fn test_datetime_rfc2822() {
     // seconds 60
     assert_eq!(
         edt.from_local_datetime(
-            &NaiveDate::from_ymd_opt(2015, 2, 18)
+            &NaiveDate::from_ymd(2015, 2, 18)
                 .unwrap()
                 .and_hms_micro_opt(23, 59, 59, 1_234_567)
                 .unwrap()
@@ -580,10 +577,7 @@ fn test_datetime_rfc3339() {
     // timezone +05
     assert_eq!(
         edt5.from_local_datetime(
-            &NaiveDate::from_ymd_opt(2015, 2, 18)
-                .unwrap()
-                .and_hms_milli_opt(23, 16, 9, 150)
-                .unwrap()
+            &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap()
         )
         .unwrap()
         .to_rfc3339(),
@@ -659,7 +653,7 @@ fn test_rfc3339_opts() {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            &NaiveDate::from_ymd_opt(2018, 1, 11)
+            &NaiveDate::from_ymd(2018, 1, 11)
                 .unwrap()
                 .and_hms_nano_opt(10, 5, 13, 84_660_000)
                 .unwrap(),
@@ -689,7 +683,7 @@ fn test_datetime_from_str() {
         Ok(FixedOffset::east(0)
             .unwrap()
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2015, 2, 18)
+                &NaiveDate::from_ymd(2015, 2, 18)
                     .unwrap()
                     .and_hms_milli_opt(23, 16, 9, 150)
                     .unwrap()
@@ -700,7 +694,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2015, 2, 18)
+                &NaiveDate::from_ymd(2015, 2, 18)
                     .unwrap()
                     .and_hms_milli_opt(23, 16, 9, 150)
                     .unwrap()
@@ -711,7 +705,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15 UTC".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2015, 2, 18)
+                &NaiveDate::from_ymd(2015, 2, 18)
                     .unwrap()
                     .and_hms_milli_opt(23, 16, 9, 150)
                     .unwrap()
@@ -722,7 +716,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15UTC".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2015, 2, 18)
+                &NaiveDate::from_ymd(2015, 2, 18)
                     .unwrap()
                     .and_hms_milli_opt(23, 16, 9, 150)
                     .unwrap()
@@ -733,7 +727,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15Utc".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2015, 2, 18)
+                &NaiveDate::from_ymd(2015, 2, 18)
                     .unwrap()
                     .and_hms_milli_opt(23, 16, 9, 150)
                     .unwrap()
@@ -746,7 +740,7 @@ fn test_datetime_from_str() {
         Ok(FixedOffset::east(0)
             .unwrap()
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2015, 2, 18)
+                &NaiveDate::from_ymd(2015, 2, 18)
                     .unwrap()
                     .and_hms_milli_opt(23, 16, 9, 150)
                     .unwrap()
@@ -758,7 +752,7 @@ fn test_datetime_from_str() {
         Ok(FixedOffset::west(10 * 3600)
             .unwrap()
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2015, 2, 18)
+                &NaiveDate::from_ymd(2015, 2, 18)
                     .unwrap()
                     .and_hms_milli_opt(13, 16, 9, 150)
                     .unwrap()
@@ -771,7 +765,7 @@ fn test_datetime_from_str() {
         "2015-2-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2015, 2, 18)
+                &NaiveDate::from_ymd(2015, 2, 18)
                     .unwrap()
                     .and_hms_milli_opt(23, 16, 9, 150)
                     .unwrap()
@@ -782,7 +776,7 @@ fn test_datetime_from_str() {
         "2015-2-18T13:16:9.15-10:00".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2015, 2, 18)
+                &NaiveDate::from_ymd(2015, 2, 18)
                     .unwrap()
                     .and_hms_milli_opt(23, 16, 9, 150)
                     .unwrap()
@@ -1125,10 +1119,7 @@ fn test_datetime_is_send_and_copy() {
 fn test_subsecond_part() {
     let datetime = Utc
         .from_local_datetime(
-            &NaiveDate::from_ymd_opt(2014, 7, 8)
-                .unwrap()
-                .and_hms_nano_opt(9, 10, 11, 1234567)
-                .unwrap(),
+            &NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_nano_opt(9, 10, 11, 1234567).unwrap(),
         )
         .unwrap();
 
@@ -1154,27 +1145,21 @@ fn test_from_system_time() {
     assert_eq!(
         DateTime::<Utc>::try_from(UNIX_EPOCH + Duration::new(999_999_999, nanos)).unwrap(),
         Utc.from_local_datetime(
-            &NaiveDate::from_ymd_opt(2001, 9, 9)
-                .unwrap()
-                .and_hms_nano_opt(1, 46, 39, nanos)
-                .unwrap()
+            &NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano_opt(1, 46, 39, nanos).unwrap()
         )
         .unwrap()
     );
     assert_eq!(
         DateTime::<Utc>::try_from(UNIX_EPOCH - Duration::new(999_999_999, nanos)).unwrap(),
         Utc.from_local_datetime(
-            &NaiveDate::from_ymd_opt(1938, 4, 24)
-                .unwrap()
-                .and_hms_nano_opt(22, 13, 20, 1_000)
-                .unwrap()
+            &NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano_opt(22, 13, 20, 1_000).unwrap()
         )
         .unwrap()
     );
     assert_eq!(
         DateTime::<Utc>::try_from(UNIX_EPOCH - Duration::new(999_999_999, 0)).unwrap(),
         Utc.from_local_datetime(
-            &NaiveDate::from_ymd_opt(1938, 4, 24).unwrap().and_hms_nano_opt(22, 13, 21, 0).unwrap()
+            &NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano_opt(22, 13, 21, 0).unwrap()
         )
         .unwrap()
     );
@@ -1184,7 +1169,7 @@ fn test_from_system_time() {
     assert_eq!(
         SystemTime::try_from(
             Utc.from_local_datetime(
-                &NaiveDate::from_ymd_opt(2001, 9, 9)
+                &NaiveDate::from_ymd(2001, 9, 9)
                     .unwrap()
                     .and_hms_nano_opt(1, 46, 39, nanos)
                     .unwrap()
@@ -1197,7 +1182,7 @@ fn test_from_system_time() {
     assert_eq!(
         SystemTime::try_from(
             Utc.from_local_datetime(
-                &NaiveDate::from_ymd_opt(1938, 4, 24)
+                &NaiveDate::from_ymd(1938, 4, 24)
                     .unwrap()
                     .and_hms_nano_opt(22, 13, 20, 1_000)
                     .unwrap()
@@ -1229,8 +1214,7 @@ fn test_from_system_time() {
 #[test]
 fn test_datetime_from_timestamp_millis() {
     // 2000-01-12T01:02:03:004Z
-    let naive_dt =
-        NaiveDate::from_ymd_opt(2000, 1, 12).unwrap().and_hms_milli_opt(1, 2, 3, 4).unwrap();
+    let naive_dt = NaiveDate::from_ymd(2000, 1, 12).unwrap().and_hms_milli_opt(1, 2, 3, 4).unwrap();
     let datetime_utc = DateTime::<Utc>::from_naive_utc_and_offset(naive_dt, Utc);
     assert_eq!(
         datetime_utc,
@@ -1245,7 +1229,7 @@ fn test_datetime_before_windows_api_limits() {
     // (https://github.com/chronotope/chrono/issues/651)
     // This used to fail on Windows for timezones with an offset of -5:00 or greater.
     // The API limits years to 1601..=30827.
-    let dt = NaiveDate::from_ymd_opt(1601, 1, 1).unwrap().and_hms_milli_opt(4, 5, 22, 122).unwrap();
+    let dt = NaiveDate::from_ymd(1601, 1, 1).unwrap().and_hms_milli_opt(4, 5, 22, 122).unwrap();
     let local_dt = Local.from_utc_datetime(&dt);
     dbg!(local_dt);
 }
@@ -1272,7 +1256,7 @@ fn test_years_elapsed() {
 
 #[test]
 fn test_datetime_add_assign() {
-    let naivedatetime = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
     let datetime = naivedatetime.and_utc();
     let mut datetime_add = datetime;
 
@@ -1295,7 +1279,7 @@ fn test_datetime_add_assign() {
 #[test]
 #[cfg(feature = "clock")]
 fn test_datetime_add_assign_local() {
-    let naivedatetime = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
 
     let datetime = Local.from_utc_datetime(&naivedatetime);
     let mut datetime_add = Local.from_utc_datetime(&naivedatetime);
@@ -1309,7 +1293,7 @@ fn test_datetime_add_assign_local() {
 
 #[test]
 fn test_datetime_sub_assign() {
-    let naivedatetime = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap().and_hms_opt(12, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).unwrap().and_hms_opt(12, 0, 0).unwrap();
     let datetime = naivedatetime.and_utc();
     let mut datetime_sub = datetime;
 
@@ -1452,7 +1436,7 @@ fn test_local_beyond_max_datetime() {
 #[test]
 #[cfg(feature = "clock")]
 fn test_datetime_sub_assign_local() {
-    let naivedatetime = NaiveDate::from_ymd_opt(2022, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
 
     let datetime = Local.from_utc_datetime(&naivedatetime);
     let mut datetime_sub = Local.from_utc_datetime(&naivedatetime);
@@ -1488,7 +1472,7 @@ fn test_core_duration_max() {
 #[test]
 #[cfg(feature = "clock")]
 fn test_datetime_local_from_preserves_offset() {
-    let naivedatetime = NaiveDate::from_ymd_opt(2023, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2023, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
 
     let datetime = Local.from_utc_datetime(&naivedatetime);
     let offset = datetime.offset().fix();
@@ -1500,7 +1484,7 @@ fn test_datetime_local_from_preserves_offset() {
 
 #[test]
 fn test_datetime_fixed_offset() {
-    let naivedatetime = NaiveDate::from_ymd_opt(2023, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2023, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
 
     let datetime = Utc.from_utc_datetime(&naivedatetime);
     let fixed_utc = FixedOffset::east(0).unwrap();

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -653,10 +653,7 @@ fn test_rfc3339_opts() {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            &NaiveDate::from_ymd(2018, 1, 11)
-                .unwrap()
-                .and_hms_nano_opt(10, 5, 13, 84_660_000)
-                .unwrap(),
+            &NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
         )
         .unwrap();
     assert_eq!(dt.to_rfc3339_opts(Secs, false), "2018-01-11T10:05:13+08:00");
@@ -1092,7 +1089,7 @@ fn test_datetime_is_send_and_copy() {
 fn test_subsecond_part() {
     let datetime = Utc
         .from_local_datetime(
-            &NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_nano_opt(9, 10, 11, 1234567).unwrap(),
+            &NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_nano(9, 10, 11, 1234567).unwrap(),
         )
         .unwrap();
 
@@ -1118,21 +1115,21 @@ fn test_from_system_time() {
     assert_eq!(
         DateTime::<Utc>::try_from(UNIX_EPOCH + Duration::new(999_999_999, nanos)).unwrap(),
         Utc.from_local_datetime(
-            &NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano_opt(1, 46, 39, nanos).unwrap()
+            &NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano(1, 46, 39, nanos).unwrap()
         )
         .unwrap()
     );
     assert_eq!(
         DateTime::<Utc>::try_from(UNIX_EPOCH - Duration::new(999_999_999, nanos)).unwrap(),
         Utc.from_local_datetime(
-            &NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano_opt(22, 13, 20, 1_000).unwrap()
+            &NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 20, 1_000).unwrap()
         )
         .unwrap()
     );
     assert_eq!(
         DateTime::<Utc>::try_from(UNIX_EPOCH - Duration::new(999_999_999, 0)).unwrap(),
         Utc.from_local_datetime(
-            &NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano_opt(22, 13, 21, 0).unwrap()
+            &NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 21, 0).unwrap()
         )
         .unwrap()
     );
@@ -1142,10 +1139,7 @@ fn test_from_system_time() {
     assert_eq!(
         SystemTime::try_from(
             Utc.from_local_datetime(
-                &NaiveDate::from_ymd(2001, 9, 9)
-                    .unwrap()
-                    .and_hms_nano_opt(1, 46, 39, nanos)
-                    .unwrap()
+                &NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano(1, 46, 39, nanos).unwrap()
             )
             .unwrap()
         )
@@ -1155,10 +1149,7 @@ fn test_from_system_time() {
     assert_eq!(
         SystemTime::try_from(
             Utc.from_local_datetime(
-                &NaiveDate::from_ymd(1938, 4, 24)
-                    .unwrap()
-                    .and_hms_nano_opt(22, 13, 20, 1_000)
-                    .unwrap()
+                &NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 20, 1_000).unwrap()
             )
             .unwrap()
         )

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1256,7 +1256,7 @@ fn test_years_elapsed() {
 
 #[test]
 fn test_datetime_add_assign() {
-    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
     let datetime = naivedatetime.and_utc();
     let mut datetime_add = datetime;
 
@@ -1279,7 +1279,7 @@ fn test_datetime_add_assign() {
 #[test]
 #[cfg(feature = "clock")]
 fn test_datetime_add_assign_local() {
-    let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
 
     let datetime = Local.from_utc_datetime(&naivedatetime);
     let mut datetime_add = Local.from_utc_datetime(&naivedatetime);
@@ -1293,7 +1293,7 @@ fn test_datetime_add_assign_local() {
 
 #[test]
 fn test_datetime_sub_assign() {
-    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).unwrap().and_hms_opt(12, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).unwrap().and_hms(12, 0, 0).unwrap();
     let datetime = naivedatetime.and_utc();
     let mut datetime_sub = datetime;
 
@@ -1436,7 +1436,7 @@ fn test_local_beyond_max_datetime() {
 #[test]
 #[cfg(feature = "clock")]
 fn test_datetime_sub_assign_local() {
-    let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
 
     let datetime = Local.from_utc_datetime(&naivedatetime);
     let mut datetime_sub = Local.from_utc_datetime(&naivedatetime);
@@ -1472,7 +1472,7 @@ fn test_core_duration_max() {
 #[test]
 #[cfg(feature = "clock")]
 fn test_datetime_local_from_preserves_offset() {
-    let naivedatetime = NaiveDate::from_ymd(2023, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2023, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
 
     let datetime = Local.from_utc_datetime(&naivedatetime);
     let offset = datetime.offset().fix();
@@ -1484,7 +1484,7 @@ fn test_datetime_local_from_preserves_offset() {
 
 #[test]
 fn test_datetime_fixed_offset() {
-    let naivedatetime = NaiveDate::from_ymd(2023, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2023, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
 
     let datetime = Utc.from_utc_datetime(&naivedatetime);
     let fixed_utc = FixedOffset::east(0).unwrap();

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -459,7 +459,7 @@ fn test_datetime_rfc2822() {
     // timezone +05
     assert_eq!(
         edt.from_local_datetime(
-            &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap()
+            &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
         )
         .unwrap()
         .to_rfc2822(),
@@ -471,7 +471,7 @@ fn test_datetime_rfc2822() {
             .from_local_datetime(
                 &NaiveDate::from_ymd(2015, 2, 18)
                     .unwrap()
-                    .and_hms_milli_opt(23, 59, 59, 1_000)
+                    .and_hms_milli(23, 59, 59, 1_000)
                     .unwrap()
             )
             .unwrap())
@@ -577,7 +577,7 @@ fn test_datetime_rfc3339() {
     // timezone +05
     assert_eq!(
         edt5.from_local_datetime(
-            &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli_opt(23, 16, 9, 150).unwrap()
+            &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
         )
         .unwrap()
         .to_rfc3339(),
@@ -683,10 +683,7 @@ fn test_datetime_from_str() {
         Ok(FixedOffset::east(0)
             .unwrap()
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18)
-                    .unwrap()
-                    .and_hms_milli_opt(23, 16, 9, 150)
-                    .unwrap()
+                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -694,10 +691,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18)
-                    .unwrap()
-                    .and_hms_milli_opt(23, 16, 9, 150)
-                    .unwrap()
+                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -705,10 +699,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15 UTC".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18)
-                    .unwrap()
-                    .and_hms_milli_opt(23, 16, 9, 150)
-                    .unwrap()
+                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -716,10 +707,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15UTC".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18)
-                    .unwrap()
-                    .and_hms_milli_opt(23, 16, 9, 150)
-                    .unwrap()
+                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -727,10 +715,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15Utc".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18)
-                    .unwrap()
-                    .and_hms_milli_opt(23, 16, 9, 150)
-                    .unwrap()
+                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -740,10 +725,7 @@ fn test_datetime_from_str() {
         Ok(FixedOffset::east(0)
             .unwrap()
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18)
-                    .unwrap()
-                    .and_hms_milli_opt(23, 16, 9, 150)
-                    .unwrap()
+                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -752,10 +734,7 @@ fn test_datetime_from_str() {
         Ok(FixedOffset::west(10 * 3600)
             .unwrap()
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18)
-                    .unwrap()
-                    .and_hms_milli_opt(13, 16, 9, 150)
-                    .unwrap()
+                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(13, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -765,10 +744,7 @@ fn test_datetime_from_str() {
         "2015-2-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18)
-                    .unwrap()
-                    .and_hms_milli_opt(23, 16, 9, 150)
-                    .unwrap()
+                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -776,10 +752,7 @@ fn test_datetime_from_str() {
         "2015-2-18T13:16:9.15-10:00".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18)
-                    .unwrap()
-                    .and_hms_milli_opt(23, 16, 9, 150)
-                    .unwrap()
+                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -1214,7 +1187,7 @@ fn test_from_system_time() {
 #[test]
 fn test_datetime_from_timestamp_millis() {
     // 2000-01-12T01:02:03:004Z
-    let naive_dt = NaiveDate::from_ymd(2000, 1, 12).unwrap().and_hms_milli_opt(1, 2, 3, 4).unwrap();
+    let naive_dt = NaiveDate::from_ymd(2000, 1, 12).unwrap().and_hms_milli(1, 2, 3, 4).unwrap();
     let datetime_utc = DateTime::<Utc>::from_naive_utc_and_offset(naive_dt, Utc);
     assert_eq!(
         datetime_utc,
@@ -1229,7 +1202,7 @@ fn test_datetime_before_windows_api_limits() {
     // (https://github.com/chronotope/chrono/issues/651)
     // This used to fail on Windows for timezones with an offset of -5:00 or greater.
     // The API limits years to 1601..=30827.
-    let dt = NaiveDate::from_ymd(1601, 1, 1).unwrap().and_hms_milli_opt(4, 5, 22, 122).unwrap();
+    let dt = NaiveDate::from_ymd(1601, 1, 1).unwrap().and_hms_milli(4, 5, 22, 122).unwrap();
     let local_dt = Local.from_utc_datetime(&dt);
     dbg!(local_dt);
 }

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -614,7 +614,7 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test_date_format() {
-        let d = NaiveDate::from_ymd_opt(2012, 3, 4).unwrap();
+        let d = NaiveDate::from_ymd(2012, 3, 4).unwrap();
         assert_eq!(d.format("%Y,%C,%y,%G,%g").to_string(), "2012,20,12,2012,12");
         assert_eq!(d.format("%m,%b,%h,%B").to_string(), "03,Mar,Mar,March");
         assert_eq!(d.format("%d,%e").to_string(), "04, 4");
@@ -627,31 +627,25 @@ mod tests {
         assert_eq!(d.format("%t%n%%%n%t").to_string(), "\t\n%\n\t");
 
         // non-four-digit years
-        assert_eq!(
-            NaiveDate::from_ymd_opt(12345, 1, 1).unwrap().format("%Y").to_string(),
-            "+12345"
-        );
-        assert_eq!(NaiveDate::from_ymd_opt(1234, 1, 1).unwrap().format("%Y").to_string(), "1234");
-        assert_eq!(NaiveDate::from_ymd_opt(123, 1, 1).unwrap().format("%Y").to_string(), "0123");
-        assert_eq!(NaiveDate::from_ymd_opt(12, 1, 1).unwrap().format("%Y").to_string(), "0012");
-        assert_eq!(NaiveDate::from_ymd_opt(1, 1, 1).unwrap().format("%Y").to_string(), "0001");
-        assert_eq!(NaiveDate::from_ymd_opt(0, 1, 1).unwrap().format("%Y").to_string(), "0000");
-        assert_eq!(NaiveDate::from_ymd_opt(-1, 1, 1).unwrap().format("%Y").to_string(), "-0001");
-        assert_eq!(NaiveDate::from_ymd_opt(-12, 1, 1).unwrap().format("%Y").to_string(), "-0012");
-        assert_eq!(NaiveDate::from_ymd_opt(-123, 1, 1).unwrap().format("%Y").to_string(), "-0123");
-        assert_eq!(NaiveDate::from_ymd_opt(-1234, 1, 1).unwrap().format("%Y").to_string(), "-1234");
-        assert_eq!(
-            NaiveDate::from_ymd_opt(-12345, 1, 1).unwrap().format("%Y").to_string(),
-            "-12345"
-        );
+        assert_eq!(NaiveDate::from_ymd(12345, 1, 1).unwrap().format("%Y").to_string(), "+12345");
+        assert_eq!(NaiveDate::from_ymd(1234, 1, 1).unwrap().format("%Y").to_string(), "1234");
+        assert_eq!(NaiveDate::from_ymd(123, 1, 1).unwrap().format("%Y").to_string(), "0123");
+        assert_eq!(NaiveDate::from_ymd(12, 1, 1).unwrap().format("%Y").to_string(), "0012");
+        assert_eq!(NaiveDate::from_ymd(1, 1, 1).unwrap().format("%Y").to_string(), "0001");
+        assert_eq!(NaiveDate::from_ymd(0, 1, 1).unwrap().format("%Y").to_string(), "0000");
+        assert_eq!(NaiveDate::from_ymd(-1, 1, 1).unwrap().format("%Y").to_string(), "-0001");
+        assert_eq!(NaiveDate::from_ymd(-12, 1, 1).unwrap().format("%Y").to_string(), "-0012");
+        assert_eq!(NaiveDate::from_ymd(-123, 1, 1).unwrap().format("%Y").to_string(), "-0123");
+        assert_eq!(NaiveDate::from_ymd(-1234, 1, 1).unwrap().format("%Y").to_string(), "-1234");
+        assert_eq!(NaiveDate::from_ymd(-12345, 1, 1).unwrap().format("%Y").to_string(), "-12345");
 
         // corner cases
         assert_eq!(
-            NaiveDate::from_ymd_opt(2007, 12, 31).unwrap().format("%G,%g,%U,%W,%V").to_string(),
+            NaiveDate::from_ymd(2007, 12, 31).unwrap().format("%G,%g,%U,%W,%V").to_string(),
             "2008,08,52,53,01"
         );
         assert_eq!(
-            NaiveDate::from_ymd_opt(2010, 1, 3).unwrap().format("%G,%g,%U,%W,%V").to_string(),
+            NaiveDate::from_ymd(2010, 1, 3).unwrap().format("%G,%g,%U,%W,%V").to_string(),
             "2009,09,01,00,53"
         );
     }
@@ -692,17 +686,14 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test_datetime_format() {
-        let dt =
-            NaiveDate::from_ymd_opt(2010, 9, 8).unwrap().and_hms_milli_opt(7, 6, 54, 321).unwrap();
+        let dt = NaiveDate::from_ymd(2010, 9, 8).unwrap().and_hms_milli_opt(7, 6, 54, 321).unwrap();
         assert_eq!(dt.format("%c").to_string(), "Wed Sep  8 07:06:54 2010");
         assert_eq!(dt.format("%s").to_string(), "1283929614");
         assert_eq!(dt.format("%t%n%%%n%t").to_string(), "\t\n%\n\t");
 
         // a horror of leap second: coming near to you.
-        let dt = NaiveDate::from_ymd_opt(2012, 6, 30)
-            .unwrap()
-            .and_hms_milli_opt(23, 59, 59, 1_000)
-            .unwrap();
+        let dt =
+            NaiveDate::from_ymd(2012, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_000).unwrap();
         assert_eq!(dt.format("%c").to_string(), "Sat Jun 30 23:59:60 2012");
         assert_eq!(dt.format("%s").to_string(), "1341100799"); // not 1341100800, it's intentional.
     }

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -686,14 +686,14 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test_datetime_format() {
-        let dt = NaiveDate::from_ymd(2010, 9, 8).unwrap().and_hms_milli_opt(7, 6, 54, 321).unwrap();
+        let dt = NaiveDate::from_ymd(2010, 9, 8).unwrap().and_hms_milli(7, 6, 54, 321).unwrap();
         assert_eq!(dt.format("%c").to_string(), "Wed Sep  8 07:06:54 2010");
         assert_eq!(dt.format("%s").to_string(), "1283929614");
         assert_eq!(dt.format("%t%n%%%n%t").to_string(), "\t\n%\n\t");
 
         // a horror of leap second: coming near to you.
         let dt =
-            NaiveDate::from_ymd(2012, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_000).unwrap();
+            NaiveDate::from_ymd(2012, 6, 30).unwrap().and_hms_milli(23, 59, 59, 1_000).unwrap();
         assert_eq!(dt.format("%c").to_string(), "Sat Jun 30 23:59:60 2012");
         assert_eq!(dt.format("%s").to_string(), "1341100799"); // not 1341100800, it's intentional.
     }

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -217,7 +217,7 @@ pub(crate) fn parse_rfc3339<'a>(parsed: &mut Parsed, mut s: &'a str) -> ParseRes
     }
 
     let offset = try_consume!(scan::timezone_offset(s, |s| scan::char(s, b':'), true, false, true));
-    // This range check is similar to the one in `FixedOffset::east_opt`, so it would be redundant.
+    // This range check is similar to the one in `FixedOffset::east`, so it would be redundant.
     // But it is possible to read the offset directly from `Parsed`. We want to only successfully
     // populate `Parsed` if the input is fully valid RFC 3339.
     // Max for the hours field is `23`, and for the minutes field `59`.

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -396,7 +396,7 @@ impl Parsed {
 
             (Some(year), _, &Parsed { ordinal: Some(ordinal), .. }) => {
                 // year, day of the year
-                let date = NaiveDate::from_yo_opt(year, ordinal).ok_or(OUT_OF_RANGE)?;
+                let date = NaiveDate::from_yo(year, ordinal).ok_or(OUT_OF_RANGE)?;
                 (verify_ymd(date) && verify_isoweekdate(date) && verify_ordinal(date), date)
             }
 
@@ -406,7 +406,7 @@ impl Parsed {
                 &Parsed { week_from_sun: Some(week_from_sun), weekday: Some(weekday), .. },
             ) => {
                 // year, week (starting at 1st Sunday), day of the week
-                let newyear = NaiveDate::from_yo_opt(year, 1).ok_or(OUT_OF_RANGE)?;
+                let newyear = NaiveDate::from_yo(year, 1).ok_or(OUT_OF_RANGE)?;
                 let firstweek = match newyear.weekday() {
                     Weekday::Sun => 0,
                     Weekday::Mon => 6,
@@ -440,7 +440,7 @@ impl Parsed {
                 &Parsed { week_from_mon: Some(week_from_mon), weekday: Some(weekday), .. },
             ) => {
                 // year, week (starting at 1st Monday), day of the week
-                let newyear = NaiveDate::from_yo_opt(year, 1).ok_or(OUT_OF_RANGE)?;
+                let newyear = NaiveDate::from_yo(year, 1).ok_or(OUT_OF_RANGE)?;
                 let firstweek = match newyear.weekday() {
                     Weekday::Sun => 1,
                     Weekday::Mon => 0,

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -470,7 +470,7 @@ impl Parsed {
 
             (_, Some(isoyear), &Parsed { isoweek: Some(isoweek), weekday: Some(weekday), .. }) => {
                 // ISO year, week, day of the week
-                let date = NaiveDate::from_isoywd_opt(isoyear, isoweek, weekday);
+                let date = NaiveDate::from_isoywd(isoyear, isoweek, weekday);
                 let date = date.ok_or(OUT_OF_RANGE)?;
                 (verify_ymd(date) && verify_ordinal(date), date)
             }

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -1022,9 +1022,8 @@ mod tests {
             ($($k:ident: $v:expr),*) => (parse!(offset = 0; $($k: $v),*))
         }
 
-        let ymdhms = |y, m, d, h, n, s| {
-            Ok(NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap())
-        };
+        let ymdhms =
+            |y, m, d, h, n, s| Ok(NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap());
         let ymdhmsn = |y, m, d, h, n, s, nano| {
             Ok(NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano_opt(h, n, s, nano).unwrap())
         };

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -1025,7 +1025,7 @@ mod tests {
         let ymdhms =
             |y, m, d, h, n, s| Ok(NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap());
         let ymdhmsn = |y, m, d, h, n, s, nano| {
-            Ok(NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano_opt(h, n, s, nano).unwrap())
+            Ok(NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano(h, n, s, nano).unwrap())
         };
 
         // omission of fields
@@ -1178,7 +1178,7 @@ mod tests {
             Ok(FixedOffset::east(off)
                 .unwrap()
                 .from_local_datetime(
-                    &NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano_opt(h, n, s, nano).unwrap(),
+                    &NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano(h, n, s, nano).unwrap(),
                 )
                 .unwrap())
         };
@@ -1228,7 +1228,7 @@ mod tests {
                 .from_local_datetime(
                     &NaiveDate::from_ymd(2014, 12, 31)
                         .unwrap()
-                        .and_hms_nano_opt(4, 26, 40, 12_345_678)
+                        .and_hms_nano(4, 26, 40, 12_345_678)
                         .unwrap()
                 )
                 .unwrap())
@@ -1254,7 +1254,7 @@ mod tests {
                 .from_local_datetime(
                     &NaiveDate::from_ymd(2014, 12, 31)
                         .unwrap()
-                        .and_hms_nano_opt(13, 26, 40, 12_345_678)
+                        .and_hms_nano(13, 26, 40, 12_345_678)
                         .unwrap()
                 )
                 .unwrap())

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -390,7 +390,7 @@ impl Parsed {
         let (verified, parsed_date) = match (given_year, given_isoyear, self) {
             (Some(year), _, &Parsed { month: Some(month), day: Some(day), .. }) => {
                 // year, month, day
-                let date = NaiveDate::from_ymd_opt(year, month, day).ok_or(OUT_OF_RANGE)?;
+                let date = NaiveDate::from_ymd(year, month, day).ok_or(OUT_OF_RANGE)?;
                 (verify_isoweekdate(date) && verify_ordinal(date), date)
             }
 
@@ -779,7 +779,7 @@ mod tests {
             )
         }
 
-        let ymd = |y, m, d| Ok(NaiveDate::from_ymd_opt(y, m, d).unwrap());
+        let ymd = |y, m, d| Ok(NaiveDate::from_ymd(y, m, d).unwrap());
 
         // ymd: omission of fields
         assert_eq!(parse!(), Err(NOT_ENOUGH));
@@ -1023,10 +1023,10 @@ mod tests {
         }
 
         let ymdhms = |y, m, d, h, n, s| {
-            Ok(NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap())
+            Ok(NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap())
         };
         let ymdhmsn = |y, m, d, h, n, s, nano| {
-            Ok(NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_nano_opt(h, n, s, nano).unwrap())
+            Ok(NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano_opt(h, n, s, nano).unwrap())
         };
 
         // omission of fields
@@ -1081,12 +1081,12 @@ mod tests {
 
         // more timestamps
         let max_days_from_year_1970 =
-            NaiveDate::MAX.signed_duration_since(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap());
-        let year_0_from_year_1970 = NaiveDate::from_ymd_opt(0, 1, 1)
+            NaiveDate::MAX.signed_duration_since(NaiveDate::from_ymd(1970, 1, 1).unwrap());
+        let year_0_from_year_1970 = NaiveDate::from_ymd(0, 1, 1)
             .unwrap()
-            .signed_duration_since(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap());
+            .signed_duration_since(NaiveDate::from_ymd(1970, 1, 1).unwrap());
         let min_days_from_year_1970 =
-            NaiveDate::MIN.signed_duration_since(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap());
+            NaiveDate::MIN.signed_duration_since(NaiveDate::from_ymd(1970, 1, 1).unwrap());
         assert_eq!(
             parse!(timestamp: min_days_from_year_1970.num_seconds()),
             ymdhms(NaiveDate::MIN.year(), 1, 1, 0, 0, 0)
@@ -1179,10 +1179,7 @@ mod tests {
             Ok(FixedOffset::east(off)
                 .unwrap()
                 .from_local_datetime(
-                    &NaiveDate::from_ymd_opt(y, m, d)
-                        .unwrap()
-                        .and_hms_nano_opt(h, n, s, nano)
-                        .unwrap(),
+                    &NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano_opt(h, n, s, nano).unwrap(),
                 )
                 .unwrap())
         };
@@ -1230,7 +1227,7 @@ mod tests {
                           minute: 26, second: 40, nanosecond: 12_345_678, offset: 0),
             Ok(Utc
                 .from_local_datetime(
-                    &NaiveDate::from_ymd_opt(2014, 12, 31)
+                    &NaiveDate::from_ymd(2014, 12, 31)
                         .unwrap()
                         .and_hms_nano_opt(4, 26, 40, 12_345_678)
                         .unwrap()
@@ -1256,7 +1253,7 @@ mod tests {
             Ok(FixedOffset::east(32400)
                 .unwrap()
                 .from_local_datetime(
-                    &NaiveDate::from_ymd_opt(2014, 12, 31)
+                    &NaiveDate::from_ymd(2014, 12, 31)
                         .unwrap()
                         .and_hms_nano_opt(13, 26, 40, 12_345_678)
                         .unwrap()
@@ -1293,9 +1290,9 @@ mod tests {
         parsed.year = Some(2002);
         parsed.week_from_mon = Some(22);
         parsed.weekday = Some(Weekday::Mon);
-        assert_eq!(NaiveDate::from_ymd_opt(2002, 6, 3).unwrap(), parsed.to_naive_date().unwrap());
+        assert_eq!(NaiveDate::from_ymd(2002, 6, 3).unwrap(), parsed.to_naive_date().unwrap());
 
         parsed.year = Some(2001);
-        assert_eq!(NaiveDate::from_ymd_opt(2001, 5, 28).unwrap(), parsed.to_naive_date().unwrap());
+        assert_eq!(NaiveDate::from_ymd(2001, 5, 28).unwrap(), parsed.to_naive_date().unwrap());
     }
 }

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -314,7 +314,7 @@ impl<'a> StrftimeItems<'a> {
     /// use chrono::NaiveDate;
     ///
     /// let fmt_items = StrftimeItems::new("%e %b %Y %k.%M").parse()?;
-    /// let datetime = NaiveDate::from_ymd_opt(2023, 7, 11).unwrap().and_hms_opt(9, 0, 0).unwrap();
+    /// let datetime = NaiveDate::from_ymd(2023, 7, 11).unwrap().and_hms_opt(9, 0, 0).unwrap();
     ///
     /// // Formatting
     /// assert_eq!(
@@ -364,7 +364,7 @@ impl<'a> StrftimeItems<'a> {
     /// }
     ///
     /// let fmt_items = format_items("%e %b %Y", "%k.%M")?;
-    /// let datetime = NaiveDate::from_ymd_opt(2023, 7, 11).unwrap().and_hms_opt(9, 0, 0).unwrap();
+    /// let datetime = NaiveDate::from_ymd(2023, 7, 11).unwrap().and_hms_opt(9, 0, 0).unwrap();
     ///
     /// assert_eq!(
     ///     datetime.format_with_items(fmt_items.as_slice().iter()).to_string(),
@@ -853,7 +853,7 @@ mod tests {
         let dt = FixedOffset::east(34200)
             .unwrap()
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2001, 7, 8)
+                &NaiveDate::from_ymd(2001, 7, 8)
                     .unwrap()
                     .and_hms_nano_opt(0, 34, 59, 1_026_490_708)
                     .unwrap(),
@@ -993,7 +993,7 @@ mod tests {
             "dim 08 jui 2001 00:34:60 +09:30"
         );
 
-        let nd = NaiveDate::from_ymd_opt(2001, 7, 8).unwrap();
+        let nd = NaiveDate::from_ymd(2001, 7, 8).unwrap();
 
         // date specifiers
         assert_eq!(nd.format_localized("%b", Locale::de_DE).to_string(), "Jul");
@@ -1021,7 +1021,7 @@ mod tests {
         let dt = FixedOffset::east(34200)
             .unwrap()
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2001, 7, 8)
+                &NaiveDate::from_ymd(2001, 7, 8)
                     .unwrap()
                     .and_hms_nano_opt(0, 34, 59, 1_026_490_708)
                     .unwrap(),

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -855,7 +855,7 @@ mod tests {
             .from_local_datetime(
                 &NaiveDate::from_ymd(2001, 7, 8)
                     .unwrap()
-                    .and_hms_nano_opt(0, 34, 59, 1_026_490_708)
+                    .and_hms_nano(0, 34, 59, 1_026_490_708)
                     .unwrap(),
             )
             .unwrap();
@@ -1023,7 +1023,7 @@ mod tests {
             .from_local_datetime(
                 &NaiveDate::from_ymd(2001, 7, 8)
                     .unwrap()
-                    .and_hms_nano_opt(0, 34, 59, 1_026_490_708)
+                    .and_hms_nano(0, 34, 59, 1_026_490_708)
                     .unwrap(),
             )
             .unwrap();

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -314,7 +314,7 @@ impl<'a> StrftimeItems<'a> {
     /// use chrono::NaiveDate;
     ///
     /// let fmt_items = StrftimeItems::new("%e %b %Y %k.%M").parse()?;
-    /// let datetime = NaiveDate::from_ymd(2023, 7, 11).unwrap().and_hms_opt(9, 0, 0).unwrap();
+    /// let datetime = NaiveDate::from_ymd(2023, 7, 11).unwrap().and_hms(9, 0, 0).unwrap();
     ///
     /// // Formatting
     /// assert_eq!(
@@ -364,7 +364,7 @@ impl<'a> StrftimeItems<'a> {
     /// }
     ///
     /// let fmt_items = format_items("%e %b %Y", "%k.%M")?;
-    /// let datetime = NaiveDate::from_ymd(2023, 7, 11).unwrap().and_hms_opt(9, 0, 0).unwrap();
+    /// let datetime = NaiveDate::from_ymd(2023, 7, 11).unwrap().and_hms(9, 0, 0).unwrap();
     ///
     /// assert_eq!(
     ///     datetime.format_with_items(fmt_items.as_slice().iter()).to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,12 +129,12 @@
 //! # fn doctest() -> Option<()> {
 //!
 //! let dt = Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap(); // `2014-07-08T09:10:11Z`
-//! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_opt(9, 10, 11).unwrap().and_local_timezone(Utc).unwrap());
+//! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms(9, 10, 11).unwrap().and_local_timezone(Utc).unwrap());
 //!
 //! // July 8 is 188th day of the year 2014 (`o` for "ordinal")
-//! assert_eq!(dt, NaiveDate::from_yo(2014, 189)?.and_hms_opt(9, 10, 11).unwrap().and_utc());
+//! assert_eq!(dt, NaiveDate::from_yo(2014, 189)?.and_hms(9, 10, 11).unwrap().and_utc());
 //! // July 8 is Tuesday in ISO week 28 of the year 2014.
-//! assert_eq!(dt, NaiveDate::from_isoywd(2014, 28, Weekday::Tue)?.and_hms_opt(9, 10, 11).unwrap().and_utc());
+//! assert_eq!(dt, NaiveDate::from_isoywd(2014, 28, Weekday::Tue)?.and_hms(9, 10, 11).unwrap().and_utc());
 //!
 //! let dt = NaiveDate::from_ymd(2014, 7, 8)?.and_hms_milli_opt(9, 10, 11, 12).unwrap().and_local_timezone(Utc).unwrap(); // `2014-07-08T09:10:11.012Z`
 //! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_micro_opt(9, 10, 11, 12_000).unwrap().and_local_timezone(Utc).unwrap());
@@ -142,7 +142,7 @@
 //!
 //! // dynamic verification
 //! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 21, 15, 33),
-//!            LocalResult::Single(NaiveDate::from_ymd(2014, 7, 8)?.and_hms_opt(21, 15, 33).unwrap().and_utc()));
+//!            LocalResult::Single(NaiveDate::from_ymd(2014, 7, 8)?.and_hms(21, 15, 33).unwrap().and_utc()));
 //! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 80, 15, 33), LocalResult::None);
 //! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 38, 21, 15, 33), LocalResult::None);
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@
 //! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_opt(9, 10, 11).unwrap().and_local_timezone(Utc).unwrap());
 //!
 //! // July 8 is 188th day of the year 2014 (`o` for "ordinal")
-//! assert_eq!(dt, NaiveDate::from_yo_opt(2014, 189)?.and_hms_opt(9, 10, 11).unwrap().and_utc());
+//! assert_eq!(dt, NaiveDate::from_yo(2014, 189)?.and_hms_opt(9, 10, 11).unwrap().and_utc());
 //! // July 8 is Tuesday in ISO week 28 of the year 2014.
 //! assert_eq!(dt, NaiveDate::from_isoywd_opt(2014, 28, Weekday::Tue)?.and_hms_opt(9, 10, 11).unwrap().and_utc());
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@
 //! // July 8 is Tuesday in ISO week 28 of the year 2014.
 //! assert_eq!(dt, NaiveDate::from_isoywd(2014, 28, Weekday::Tue)?.and_hms(9, 10, 11).unwrap().and_utc());
 //!
-//! let dt = NaiveDate::from_ymd(2014, 7, 8)?.and_hms_milli_opt(9, 10, 11, 12).unwrap().and_local_timezone(Utc).unwrap(); // `2014-07-08T09:10:11.012Z`
+//! let dt = NaiveDate::from_ymd(2014, 7, 8)?.and_hms_milli(9, 10, 11, 12).unwrap().and_local_timezone(Utc).unwrap(); // `2014-07-08T09:10:11.012Z`
 //! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_micro_opt(9, 10, 11, 12_000).unwrap().and_local_timezone(Utc).unwrap());
 //! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_nano_opt(9, 10, 11, 12_000_000).unwrap().and_local_timezone(Utc).unwrap());
 //!
@@ -149,8 +149,8 @@
 //! # #[cfg(feature = "clock")] {
 //! // other time zone objects can be used to construct a local datetime.
 //! // obviously, `local_dt` is normally different from `dt`, but `fixed_dt` should be identical.
-//! let local_dt = Local.from_local_datetime(&NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_milli_opt(9, 10, 11, 12).unwrap()).unwrap();
-//! let fixed_dt = FixedOffset::east(9 * 3600).unwrap().from_local_datetime(&NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_milli_opt(18, 10, 11, 12).unwrap()).unwrap();
+//! let local_dt = Local.from_local_datetime(&NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_milli(9, 10, 11, 12).unwrap()).unwrap();
+//! let fixed_dt = FixedOffset::east(9 * 3600).unwrap().from_local_datetime(&NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_milli(18, 10, 11, 12).unwrap()).unwrap();
 //! assert_eq!(dt, fixed_dt);
 //! # let _ = local_dt;
 //! # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,28 +129,28 @@
 //! # fn doctest() -> Option<()> {
 //!
 //! let dt = Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap(); // `2014-07-08T09:10:11Z`
-//! assert_eq!(dt, NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_opt(9, 10, 11).unwrap().and_local_timezone(Utc).unwrap());
+//! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_opt(9, 10, 11).unwrap().and_local_timezone(Utc).unwrap());
 //!
 //! // July 8 is 188th day of the year 2014 (`o` for "ordinal")
 //! assert_eq!(dt, NaiveDate::from_yo_opt(2014, 189)?.and_hms_opt(9, 10, 11).unwrap().and_utc());
 //! // July 8 is Tuesday in ISO week 28 of the year 2014.
 //! assert_eq!(dt, NaiveDate::from_isoywd_opt(2014, 28, Weekday::Tue)?.and_hms_opt(9, 10, 11).unwrap().and_utc());
 //!
-//! let dt = NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_milli_opt(9, 10, 11, 12).unwrap().and_local_timezone(Utc).unwrap(); // `2014-07-08T09:10:11.012Z`
-//! assert_eq!(dt, NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_micro_opt(9, 10, 11, 12_000).unwrap().and_local_timezone(Utc).unwrap());
-//! assert_eq!(dt, NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_nano_opt(9, 10, 11, 12_000_000).unwrap().and_local_timezone(Utc).unwrap());
+//! let dt = NaiveDate::from_ymd(2014, 7, 8)?.and_hms_milli_opt(9, 10, 11, 12).unwrap().and_local_timezone(Utc).unwrap(); // `2014-07-08T09:10:11.012Z`
+//! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_micro_opt(9, 10, 11, 12_000).unwrap().and_local_timezone(Utc).unwrap());
+//! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_nano_opt(9, 10, 11, 12_000_000).unwrap().and_local_timezone(Utc).unwrap());
 //!
 //! // dynamic verification
 //! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 21, 15, 33),
-//!            LocalResult::Single(NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_opt(21, 15, 33).unwrap().and_utc()));
+//!            LocalResult::Single(NaiveDate::from_ymd(2014, 7, 8)?.and_hms_opt(21, 15, 33).unwrap().and_utc()));
 //! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 80, 15, 33), LocalResult::None);
 //! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 38, 21, 15, 33), LocalResult::None);
 //!
 //! # #[cfg(feature = "clock")] {
 //! // other time zone objects can be used to construct a local datetime.
 //! // obviously, `local_dt` is normally different from `dt`, but `fixed_dt` should be identical.
-//! let local_dt = Local.from_local_datetime(&NaiveDate::from_ymd_opt(2014, 7, 8).unwrap().and_hms_milli_opt(9, 10, 11, 12).unwrap()).unwrap();
-//! let fixed_dt = FixedOffset::east(9 * 3600).unwrap().from_local_datetime(&NaiveDate::from_ymd_opt(2014, 7, 8).unwrap().and_hms_milli_opt(18, 10, 11, 12).unwrap()).unwrap();
+//! let local_dt = Local.from_local_datetime(&NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_milli_opt(9, 10, 11, 12).unwrap()).unwrap();
+//! let fixed_dt = FixedOffset::east(9 * 3600).unwrap().from_local_datetime(&NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_milli_opt(18, 10, 11, 12).unwrap()).unwrap();
 //! assert_eq!(dt, fixed_dt);
 //! # let _ = local_dt;
 //! # }
@@ -170,7 +170,7 @@
 //! use chrono::TimeDelta;
 //!
 //! // assume this returned `2014-11-28T21:45:59.324310806+09:00`:
-//! let dt = FixedOffset::east(9*3600).unwrap().from_local_datetime(&NaiveDate::from_ymd_opt(2014, 11, 28).unwrap().and_hms_nano_opt(21, 45, 59, 324310806).unwrap()).unwrap();
+//! let dt = FixedOffset::east(9*3600).unwrap().from_local_datetime(&NaiveDate::from_ymd(2014, 11, 28).unwrap().and_hms_nano_opt(21, 45, 59, 324310806).unwrap()).unwrap();
 //!
 //! // property accessors
 //! assert_eq!((dt.year(), dt.month(), dt.day()), (2014, 11, 28));
@@ -184,7 +184,7 @@
 //! // time zone accessor and manipulation
 //! assert_eq!(dt.offset().fix().local_minus_utc(), 9 * 3600);
 //! assert_eq!(dt.timezone(), FixedOffset::east(9 * 3600).unwrap());
-//! assert_eq!(dt.with_timezone(&Utc), NaiveDate::from_ymd_opt(2014, 11, 28).unwrap().and_hms_nano_opt(12, 45, 59, 324310806).unwrap().and_local_timezone(Utc).unwrap());
+//! assert_eq!(dt.with_timezone(&Utc), NaiveDate::from_ymd(2014, 11, 28).unwrap().and_hms_nano_opt(12, 45, 59, 324310806).unwrap().and_local_timezone(Utc).unwrap());
 //!
 //! // a sample of property manipulations (validates dynamically)
 //! assert_eq!(dt.with_day(29).unwrap().weekday(), Weekday::Sat); // 2014-11-29 is Saturday
@@ -243,7 +243,7 @@
 //! assert_eq!(format!("{:?}", dt), "2014-11-28T12:00:09Z");
 //!
 //! // Note that milli/nanoseconds are only printed if they are non-zero
-//! let dt_nano = NaiveDate::from_ymd_opt(2014, 11, 28).unwrap().and_hms_nano_opt(12, 0, 9, 1).unwrap().and_local_timezone(Utc).unwrap();
+//! let dt_nano = NaiveDate::from_ymd(2014, 11, 28).unwrap().and_hms_nano_opt(12, 0, 9, 1).unwrap().and_local_timezone(Utc).unwrap();
 //! assert_eq!(format!("{:?}", dt_nano), "2014-11-28T12:00:09.000000001Z");
 //! # }
 //! # #[cfg(not(all(feature = "unstable-locales", feature = "alloc")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,7 @@
 //!
 //! let dt = NaiveDate::from_ymd(2014, 7, 8)?.and_hms_milli(9, 10, 11, 12).unwrap().and_local_timezone(Utc).unwrap(); // `2014-07-08T09:10:11.012Z`
 //! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_micro(9, 10, 11, 12_000).unwrap().and_local_timezone(Utc).unwrap());
-//! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_nano_opt(9, 10, 11, 12_000_000).unwrap().and_local_timezone(Utc).unwrap());
+//! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_nano(9, 10, 11, 12_000_000).unwrap().and_local_timezone(Utc).unwrap());
 //!
 //! // dynamic verification
 //! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 21, 15, 33),
@@ -170,7 +170,7 @@
 //! use chrono::TimeDelta;
 //!
 //! // assume this returned `2014-11-28T21:45:59.324310806+09:00`:
-//! let dt = FixedOffset::east(9*3600).unwrap().from_local_datetime(&NaiveDate::from_ymd(2014, 11, 28).unwrap().and_hms_nano_opt(21, 45, 59, 324310806).unwrap()).unwrap();
+//! let dt = FixedOffset::east(9*3600).unwrap().from_local_datetime(&NaiveDate::from_ymd(2014, 11, 28).unwrap().and_hms_nano(21, 45, 59, 324310806).unwrap()).unwrap();
 //!
 //! // property accessors
 //! assert_eq!((dt.year(), dt.month(), dt.day()), (2014, 11, 28));
@@ -184,7 +184,7 @@
 //! // time zone accessor and manipulation
 //! assert_eq!(dt.offset().fix().local_minus_utc(), 9 * 3600);
 //! assert_eq!(dt.timezone(), FixedOffset::east(9 * 3600).unwrap());
-//! assert_eq!(dt.with_timezone(&Utc), NaiveDate::from_ymd(2014, 11, 28).unwrap().and_hms_nano_opt(12, 45, 59, 324310806).unwrap().and_local_timezone(Utc).unwrap());
+//! assert_eq!(dt.with_timezone(&Utc), NaiveDate::from_ymd(2014, 11, 28).unwrap().and_hms_nano(12, 45, 59, 324310806).unwrap().and_local_timezone(Utc).unwrap());
 //!
 //! // a sample of property manipulations (validates dynamically)
 //! assert_eq!(dt.with_day(29).unwrap().weekday(), Weekday::Sat); // 2014-11-29 is Saturday
@@ -243,7 +243,7 @@
 //! assert_eq!(format!("{:?}", dt), "2014-11-28T12:00:09Z");
 //!
 //! // Note that milli/nanoseconds are only printed if they are non-zero
-//! let dt_nano = NaiveDate::from_ymd(2014, 11, 28).unwrap().and_hms_nano_opt(12, 0, 9, 1).unwrap().and_local_timezone(Utc).unwrap();
+//! let dt_nano = NaiveDate::from_ymd(2014, 11, 28).unwrap().and_hms_nano(12, 0, 9, 1).unwrap().and_local_timezone(Utc).unwrap();
 //! assert_eq!(format!("{:?}", dt_nano), "2014-11-28T12:00:09.000000001Z");
 //! # }
 //! # #[cfg(not(all(feature = "unstable-locales", feature = "alloc")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@
 //! assert_eq!(dt, NaiveDate::from_isoywd(2014, 28, Weekday::Tue)?.and_hms(9, 10, 11).unwrap().and_utc());
 //!
 //! let dt = NaiveDate::from_ymd(2014, 7, 8)?.and_hms_milli(9, 10, 11, 12).unwrap().and_local_timezone(Utc).unwrap(); // `2014-07-08T09:10:11.012Z`
-//! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_micro_opt(9, 10, 11, 12_000).unwrap().and_local_timezone(Utc).unwrap());
+//! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_micro(9, 10, 11, 12_000).unwrap().and_local_timezone(Utc).unwrap());
 //! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_nano_opt(9, 10, 11, 12_000_000).unwrap().and_local_timezone(Utc).unwrap());
 //!
 //! // dynamic verification

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@
 //! // July 8 is 188th day of the year 2014 (`o` for "ordinal")
 //! assert_eq!(dt, NaiveDate::from_yo(2014, 189)?.and_hms_opt(9, 10, 11).unwrap().and_utc());
 //! // July 8 is Tuesday in ISO week 28 of the year 2014.
-//! assert_eq!(dt, NaiveDate::from_isoywd_opt(2014, 28, Weekday::Tue)?.and_hms_opt(9, 10, 11).unwrap().and_utc());
+//! assert_eq!(dt, NaiveDate::from_isoywd(2014, 28, Weekday::Tue)?.and_hms_opt(9, 10, 11).unwrap().and_utc());
 //!
 //! let dt = NaiveDate::from_ymd(2014, 7, 8)?.and_hms_milli_opt(9, 10, 11, 12).unwrap().and_local_timezone(Utc).unwrap(); // `2014-07-08T09:10:11.012Z`
 //! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_micro_opt(9, 10, 11, 12_000).unwrap().and_local_timezone(Utc).unwrap());

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -768,15 +768,15 @@ impl NaiveDate {
     /// use chrono::{Error, NaiveDate};
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3).unwrap();
-    /// assert!(d.and_hms_nano_opt(12, 34, 56,   789_012_345).is_ok());
-    /// assert!(d.and_hms_nano_opt(12, 34, 59, 1_789_012_345).is_ok()); // leap second
-    /// assert_eq!(d.and_hms_nano_opt(12, 34, 59, 2_789_012_345), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_nano_opt(12, 34, 60,   789_012_345), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_nano_opt(12, 60, 56,   789_012_345), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_nano_opt(24, 34, 56,   789_012_345), Err(Error::InvalidArgument));
+    /// assert!(d.and_hms_nano(12, 34, 56,   789_012_345).is_ok());
+    /// assert!(d.and_hms_nano(12, 34, 59, 1_789_012_345).is_ok()); // leap second
+    /// assert_eq!(d.and_hms_nano(12, 34, 59, 2_789_012_345), Err(Error::InvalidArgument));
+    /// assert_eq!(d.and_hms_nano(12, 34, 60,   789_012_345), Err(Error::InvalidArgument));
+    /// assert_eq!(d.and_hms_nano(12, 60, 56,   789_012_345), Err(Error::InvalidArgument));
+    /// assert_eq!(d.and_hms_nano(24, 34, 56,   789_012_345), Err(Error::InvalidArgument));
     /// ```
     #[inline]
-    pub const fn and_hms_nano_opt(
+    pub const fn and_hms_nano(
         &self,
         hour: u32,
         min: u32,

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -109,7 +109,7 @@ impl arbitrary::Arbitrary<'_> for NaiveDate {
         let year = u.int_in_range(MIN_YEAR..=MAX_YEAR)?;
         let max_days = YearFlags::from_year(year).ndays();
         let ord = u.int_in_range(1..=max_days)?;
-        NaiveDate::from_yo_opt(year, ord).ok_or(arbitrary::Error::IncorrectFormat)
+        NaiveDate::from_yo(year, ord).ok_or(arbitrary::Error::IncorrectFormat)
     }
 }
 
@@ -198,18 +198,18 @@ impl NaiveDate {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let from_yo_opt = NaiveDate::from_yo_opt;
+    /// let from_yo = NaiveDate::from_yo;
     ///
-    /// assert!(from_yo_opt(2015, 100).is_some());
-    /// assert!(from_yo_opt(2015, 0).is_none());
-    /// assert!(from_yo_opt(2015, 365).is_some());
-    /// assert!(from_yo_opt(2015, 366).is_none());
-    /// assert!(from_yo_opt(-4, 366).is_some()); // 5 BCE is a leap year
-    /// assert!(from_yo_opt(400000, 1).is_none());
-    /// assert!(from_yo_opt(-400000, 1).is_none());
+    /// assert!(from_yo(2015, 100).is_some());
+    /// assert!(from_yo(2015, 0).is_none());
+    /// assert!(from_yo(2015, 365).is_some());
+    /// assert!(from_yo(2015, 366).is_none());
+    /// assert!(from_yo(-4, 366).is_some()); // 5 BCE is a leap year
+    /// assert!(from_yo(400000, 1).is_none());
+    /// assert!(from_yo(-400000, 1).is_none());
     /// ```
     #[must_use]
-    pub const fn from_yo_opt(year: i32, ordinal: u32) -> Option<NaiveDate> {
+    pub const fn from_yo(year: i32, ordinal: u32) -> Option<NaiveDate> {
         let flags = YearFlags::from_year(year);
         NaiveDate::from_ordinal_and_flags(year, ordinal, flags)
     }
@@ -828,7 +828,7 @@ impl NaiveDate {
         let new_ol = (self.yof() & OL_MASK) + (1 << 4);
         match new_ol <= MAX_OL {
             true => Some(NaiveDate::from_yof(self.yof() & !OL_MASK | new_ol)),
-            false => NaiveDate::from_yo_opt(self.year() + 1, 1),
+            false => NaiveDate::from_yo(self.year() + 1, 1),
         }
     }
 

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -843,13 +843,13 @@ impl NaiveDate {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 6, 3).unwrap().pred_opt(),
+    /// assert_eq!(NaiveDate::from_ymd(2015, 6, 3).unwrap().pred(),
     ///            Some(NaiveDate::from_ymd(2015, 6, 2).unwrap()));
-    /// assert_eq!(NaiveDate::MIN.pred_opt(), None);
+    /// assert_eq!(NaiveDate::MIN.pred(), None);
     /// ```
     #[inline]
     #[must_use]
-    pub const fn pred_opt(&self) -> Option<NaiveDate> {
+    pub const fn pred(&self) -> Option<NaiveDate> {
         let new_shifted_ordinal = (self.yof() & ORDINAL_MASK) - (1 << 4);
         match new_shifted_ordinal > 0 {
             true => Some(NaiveDate::from_yof(self.yof() & !ORDINAL_MASK | new_shifted_ordinal)),
@@ -1313,7 +1313,7 @@ impl Datelike for NaiveDate {
     /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).unwrap().day(), 14);
     /// ```
     ///
-    /// Combined with [`NaiveDate::pred_opt`](#method.pred_opt),
+    /// Combined with [`NaiveDate::pred`](#method.pred),
     /// one can determine the number of days in a particular month.
     /// (Note that this panics when `year` is out of range.)
     ///
@@ -1326,7 +1326,7 @@ impl Datelike for NaiveDate {
     ///     let d = NaiveDate::from_ymd(y, m, 1).unwrap();
     ///
     ///     // ...is preceded by the last day of the original month
-    ///     d.pred_opt().unwrap().day()
+    ///     d.pred().unwrap().day()
     /// }
     ///
     /// assert_eq!(ndays_in_month(2015, 8), 31);
@@ -1370,7 +1370,7 @@ impl Datelike for NaiveDate {
     /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).unwrap().ordinal(), 74);
     /// ```
     ///
-    /// Combined with [`NaiveDate::pred_opt`](#method.pred_opt),
+    /// Combined with [`NaiveDate::pred`](#method.pred),
     /// one can determine the number of days in a particular year.
     /// (Note that this panics when `year` is out of range.)
     ///
@@ -1382,7 +1382,7 @@ impl Datelike for NaiveDate {
     ///     let d = NaiveDate::from_ymd(year + 1, 1, 1).unwrap();
     ///
     ///     // ...is preceded by the last day of the original year
-    ///     d.pred_opt().unwrap().ordinal()
+    ///     d.pred().unwrap().ordinal()
     /// }
     ///
     /// assert_eq!(ndays_in_year(2015), 365);
@@ -1885,7 +1885,7 @@ impl DoubleEndedIterator for NaiveDateDaysIterator {
     fn next_back(&mut self) -> Option<Self::Item> {
         // We return the current value, and have no way to return `NaiveDate::MIN`.
         let current = self.value;
-        self.value = current.pred_opt()?;
+        self.value = current.pred()?;
         Some(current)
     }
 }

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -653,7 +653,7 @@ impl NaiveDate {
     /// Makes a new `NaiveDateTime` from the current date, hour, minute and second.
     ///
     /// No [leap second](./struct.NaiveTime.html#leap-second-handling) is allowed here;
-    /// use `NaiveDate::and_hms_*_opt` methods with a subsecond parameter instead.
+    /// use `NaiveDate::and_hms_*` methods with a subsecond parameter instead.
     ///
     /// # Errors
     ///
@@ -665,13 +665,13 @@ impl NaiveDate {
     /// use chrono::{Error, NaiveDate};
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3).unwrap();
-    /// assert!(d.and_hms_opt(12, 34, 56).is_ok());
-    /// assert_eq!(d.and_hms_opt(12, 34, 60), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_opt(12, 60, 56), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_opt(24, 34, 56), Err(Error::InvalidArgument));
+    /// assert!(d.and_hms(12, 34, 56).is_ok());
+    /// assert_eq!(d.and_hms(12, 34, 60), Err(Error::InvalidArgument));
+    /// assert_eq!(d.and_hms(12, 60, 56), Err(Error::InvalidArgument));
+    /// assert_eq!(d.and_hms(24, 34, 56), Err(Error::InvalidArgument));
     /// ```
     #[inline]
-    pub const fn and_hms_opt(&self, hour: u32, min: u32, sec: u32) -> Result<NaiveDateTime, Error> {
+    pub const fn and_hms(&self, hour: u32, min: u32, sec: u32) -> Result<NaiveDateTime, Error> {
         let time = try_err!(NaiveTime::from_hms(hour, min, sec));
         Ok(self.and_time(time))
     }

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -731,15 +731,15 @@ impl NaiveDate {
     /// use chrono::{Error, NaiveDate};
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3).unwrap();
-    /// assert!(d.and_hms_micro_opt(12, 34, 56,   789_012).is_ok());
-    /// assert!(d.and_hms_micro_opt(12, 34, 59, 1_789_012).is_ok()); // leap second
-    /// assert_eq!(d.and_hms_micro_opt(12, 34, 59, 2_789_012), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_micro_opt(12, 34, 60,   789_012), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_micro_opt(12, 60, 56,   789_012), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_micro_opt(24, 34, 56,   789_012), Err(Error::InvalidArgument));
+    /// assert!(d.and_hms_micro(12, 34, 56,   789_012).is_ok());
+    /// assert!(d.and_hms_micro(12, 34, 59, 1_789_012).is_ok()); // leap second
+    /// assert_eq!(d.and_hms_micro(12, 34, 59, 2_789_012), Err(Error::InvalidArgument));
+    /// assert_eq!(d.and_hms_micro(12, 34, 60,   789_012), Err(Error::InvalidArgument));
+    /// assert_eq!(d.and_hms_micro(12, 60, 56,   789_012), Err(Error::InvalidArgument));
+    /// assert_eq!(d.and_hms_micro(24, 34, 56,   789_012), Err(Error::InvalidArgument));
     /// ```
     #[inline]
-    pub const fn and_hms_micro_opt(
+    pub const fn and_hms_micro(
         &self,
         hour: u32,
         min: u32,

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -818,13 +818,13 @@ impl NaiveDate {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 6, 3).unwrap().succ_opt(),
+    /// assert_eq!(NaiveDate::from_ymd(2015, 6, 3).unwrap().succ(),
     ///            Some(NaiveDate::from_ymd(2015, 6, 4).unwrap()));
-    /// assert_eq!(NaiveDate::MAX.succ_opt(), None);
+    /// assert_eq!(NaiveDate::MAX.succ(), None);
     /// ```
     #[inline]
     #[must_use]
-    pub const fn succ_opt(&self) -> Option<NaiveDate> {
+    pub const fn succ(&self) -> Option<NaiveDate> {
         let new_ol = (self.yof() & OL_MASK) + (1 << 4);
         match new_ol <= MAX_OL {
             true => Some(NaiveDate::from_yof(self.yof() & !OL_MASK | new_ol)),
@@ -1869,7 +1869,7 @@ impl Iterator for NaiveDateDaysIterator {
         // We return the current value, and have no way to return `NaiveDate::MAX`.
         let current = self.value;
         // This can't panic because current is < NaiveDate::MAX:
-        self.value = current.succ_opt()?;
+        self.value = current.succ()?;
         Some(current)
     }
 

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -694,15 +694,15 @@ impl NaiveDate {
     /// use chrono::{Error, NaiveDate};
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3).unwrap();
-    /// assert!(d.and_hms_milli_opt(12, 34, 56,   789).is_ok());
-    /// assert!(d.and_hms_milli_opt(12, 34, 59, 1_789).is_ok()); // leap second
-    /// assert_eq!(d.and_hms_milli_opt(12, 34, 59, 2_789), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_milli_opt(12, 34, 60,   789), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_milli_opt(12, 60, 56,   789), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_milli_opt(24, 34, 56,   789), Err(Error::InvalidArgument));
+    /// assert!(d.and_hms_milli(12, 34, 56,   789).is_ok());
+    /// assert!(d.and_hms_milli(12, 34, 59, 1_789).is_ok()); // leap second
+    /// assert_eq!(d.and_hms_milli(12, 34, 59, 2_789), Err(Error::InvalidArgument));
+    /// assert_eq!(d.and_hms_milli(12, 34, 60,   789), Err(Error::InvalidArgument));
+    /// assert_eq!(d.and_hms_milli(12, 60, 56,   789), Err(Error::InvalidArgument));
+    /// assert_eq!(d.and_hms_milli(24, 34, 56,   789), Err(Error::InvalidArgument));
     /// ```
     #[inline]
-    pub const fn and_hms_milli_opt(
+    pub const fn and_hms_milli(
         &self,
         hour: u32,
         min: u32,

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -231,15 +231,15 @@ impl NaiveDate {
     /// use chrono::{NaiveDate, Weekday};
     ///
     /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
-    /// let from_isoywd_opt = NaiveDate::from_isoywd_opt;
+    /// let from_isoywd = NaiveDate::from_isoywd;
     ///
-    /// assert_eq!(from_isoywd_opt(2015, 0, Weekday::Sun), None);
-    /// assert_eq!(from_isoywd_opt(2015, 10, Weekday::Sun), Some(from_ymd(2015, 3, 8)));
-    /// assert_eq!(from_isoywd_opt(2015, 30, Weekday::Mon), Some(from_ymd(2015, 7, 20)));
-    /// assert_eq!(from_isoywd_opt(2015, 60, Weekday::Mon), None);
+    /// assert_eq!(from_isoywd(2015, 0, Weekday::Sun), None);
+    /// assert_eq!(from_isoywd(2015, 10, Weekday::Sun), Some(from_ymd(2015, 3, 8)));
+    /// assert_eq!(from_isoywd(2015, 30, Weekday::Mon), Some(from_ymd(2015, 7, 20)));
+    /// assert_eq!(from_isoywd(2015, 60, Weekday::Mon), None);
     ///
-    /// assert_eq!(from_isoywd_opt(400000, 10, Weekday::Fri), None);
-    /// assert_eq!(from_isoywd_opt(-400000, 10, Weekday::Sat), None);
+    /// assert_eq!(from_isoywd(400000, 10, Weekday::Fri), None);
+    /// assert_eq!(from_isoywd(-400000, 10, Weekday::Sat), None);
     /// ```
     ///
     /// The year number of ISO week date may differ from that of the calendar date.
@@ -247,24 +247,24 @@ impl NaiveDate {
     /// ```
     /// # use chrono::{NaiveDate, Weekday};
     /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
-    /// # let from_isoywd_opt = NaiveDate::from_isoywd_opt;
+    /// # let from_isoywd = NaiveDate::from_isoywd;
     /// //           Mo Tu We Th Fr Sa Su
     /// // 2014-W52  22 23 24 25 26 27 28    has 4+ days of new year,
     /// // 2015-W01  29 30 31  1  2  3  4 <- so this is the first week
-    /// assert_eq!(from_isoywd_opt(2014, 52, Weekday::Sun), Some(from_ymd(2014, 12, 28)));
-    /// assert_eq!(from_isoywd_opt(2014, 53, Weekday::Mon), None);
-    /// assert_eq!(from_isoywd_opt(2015, 1, Weekday::Mon), Some(from_ymd(2014, 12, 29)));
+    /// assert_eq!(from_isoywd(2014, 52, Weekday::Sun), Some(from_ymd(2014, 12, 28)));
+    /// assert_eq!(from_isoywd(2014, 53, Weekday::Mon), None);
+    /// assert_eq!(from_isoywd(2015, 1, Weekday::Mon), Some(from_ymd(2014, 12, 29)));
     ///
     /// // 2015-W52  21 22 23 24 25 26 27    has 4+ days of old year,
     /// // 2015-W53  28 29 30 31  1  2  3 <- so this is the last week
     /// // 2016-W01   4  5  6  7  8  9 10
-    /// assert_eq!(from_isoywd_opt(2015, 52, Weekday::Sun), Some(from_ymd(2015, 12, 27)));
-    /// assert_eq!(from_isoywd_opt(2015, 53, Weekday::Sun), Some(from_ymd(2016, 1, 3)));
-    /// assert_eq!(from_isoywd_opt(2015, 54, Weekday::Mon), None);
-    /// assert_eq!(from_isoywd_opt(2016, 1, Weekday::Mon), Some(from_ymd(2016, 1, 4)));
+    /// assert_eq!(from_isoywd(2015, 52, Weekday::Sun), Some(from_ymd(2015, 12, 27)));
+    /// assert_eq!(from_isoywd(2015, 53, Weekday::Sun), Some(from_ymd(2016, 1, 3)));
+    /// assert_eq!(from_isoywd(2015, 54, Weekday::Mon), None);
+    /// assert_eq!(from_isoywd(2016, 1, Weekday::Mon), Some(from_ymd(2016, 1, 4)));
     /// ```
     #[must_use]
-    pub const fn from_isoywd_opt(year: i32, week: u32, weekday: Weekday) -> Option<NaiveDate> {
+    pub const fn from_isoywd(year: i32, week: u32, weekday: Weekday) -> Option<NaiveDate> {
         let flags = YearFlags::from_year(year);
         let nweeks = flags.nisoweeks();
         if 1 <= week && week <= nweeks {

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -163,17 +163,17 @@ impl NaiveDate {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let from_ymd_opt = NaiveDate::from_ymd_opt;
+    /// let from_ymd = NaiveDate::from_ymd;
     ///
-    /// assert!(from_ymd_opt(2015, 3, 14).is_some());
-    /// assert!(from_ymd_opt(2015, 0, 14).is_none());
-    /// assert!(from_ymd_opt(2015, 2, 29).is_none());
-    /// assert!(from_ymd_opt(-4, 2, 29).is_some()); // 5 BCE is a leap year
-    /// assert!(from_ymd_opt(400000, 1, 1).is_none());
-    /// assert!(from_ymd_opt(-400000, 1, 1).is_none());
+    /// assert!(from_ymd(2015, 3, 14).is_some());
+    /// assert!(from_ymd(2015, 0, 14).is_none());
+    /// assert!(from_ymd(2015, 2, 29).is_none());
+    /// assert!(from_ymd(-4, 2, 29).is_some()); // 5 BCE is a leap year
+    /// assert!(from_ymd(400000, 1, 1).is_none());
+    /// assert!(from_ymd(-400000, 1, 1).is_none());
     /// ```
     #[must_use]
-    pub const fn from_ymd_opt(year: i32, month: u32, day: u32) -> Option<NaiveDate> {
+    pub const fn from_ymd(year: i32, month: u32, day: u32) -> Option<NaiveDate> {
         let flags = YearFlags::from_year(year);
 
         if let Some(mdf) = Mdf::new(month, day, flags) {
@@ -230,7 +230,7 @@ impl NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Weekday};
     ///
-    /// let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     /// let from_isoywd_opt = NaiveDate::from_isoywd_opt;
     ///
     /// assert_eq!(from_isoywd_opt(2015, 0, Weekday::Sun), None);
@@ -246,7 +246,7 @@ impl NaiveDate {
     ///
     /// ```
     /// # use chrono::{NaiveDate, Weekday};
-    /// # let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     /// # let from_isoywd_opt = NaiveDate::from_isoywd_opt;
     /// //           Mo Tu We Th Fr Sa Su
     /// // 2014-W52  22 23 24 25 26 27 28    has 4+ days of new year,
@@ -309,7 +309,7 @@ impl NaiveDate {
     /// use chrono::NaiveDate;
     ///
     /// let from_ndays_opt = NaiveDate::from_num_days_from_ce_opt;
-    /// let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     ///
     /// assert_eq!(from_ndays_opt(730_000),      Some(from_ymd(1999, 9, 3)));
     /// assert_eq!(from_ndays_opt(1),            Some(from_ymd(1, 1, 1)));
@@ -346,7 +346,7 @@ impl NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Weekday};
     /// assert_eq!(NaiveDate::from_weekday_of_month_opt(2017, 3, Weekday::Fri, 2),
-    ///            NaiveDate::from_ymd_opt(2017, 3, 10))
+    ///            NaiveDate::from_ymd(2017, 3, 10))
     /// ```
     #[must_use]
     pub const fn from_weekday_of_month_opt(
@@ -358,10 +358,10 @@ impl NaiveDate {
         if n == 0 {
             return None;
         }
-        let first = try_opt!(NaiveDate::from_ymd_opt(year, month, 1)).weekday();
+        let first = try_opt!(NaiveDate::from_ymd(year, month, 1)).weekday();
         let first_to_dow = (7 + weekday.number_from_monday() - first.number_from_monday()) % 7;
         let day = (n - 1) as u32 * 7 + first_to_dow + 1;
-        NaiveDate::from_ymd_opt(year, month, day)
+        NaiveDate::from_ymd(year, month, day)
     }
 
     /// Parses a string with the specified format string and returns a new `NaiveDate`.
@@ -376,9 +376,9 @@ impl NaiveDate {
     /// let parse_from_str = NaiveDate::parse_from_str;
     ///
     /// assert_eq!(parse_from_str("2015-09-05", "%Y-%m-%d"),
-    ///            Ok(NaiveDate::from_ymd_opt(2015, 9, 5).unwrap()));
+    ///            Ok(NaiveDate::from_ymd(2015, 9, 5).unwrap()));
     /// assert_eq!(parse_from_str("5sep2015", "%d%b%Y"),
-    ///            Ok(NaiveDate::from_ymd_opt(2015, 9, 5).unwrap()));
+    ///            Ok(NaiveDate::from_ymd(2015, 9, 5).unwrap()));
     /// ```
     ///
     /// Time and offset is ignored for the purpose of parsing.
@@ -387,7 +387,7 @@ impl NaiveDate {
     /// # use chrono::NaiveDate;
     /// # let parse_from_str = NaiveDate::parse_from_str;
     /// assert_eq!(parse_from_str("2014-5-17T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
-    ///            Ok(NaiveDate::from_ymd_opt(2014, 5, 17).unwrap()));
+    ///            Ok(NaiveDate::from_ymd(2014, 5, 17).unwrap()));
     /// ```
     ///
     /// Out-of-bound dates or insufficient fields are errors.
@@ -425,7 +425,7 @@ impl NaiveDate {
     /// # use chrono::{NaiveDate};
     /// let (date, remainder) = NaiveDate::parse_and_remainder(
     ///     "2015-02-18 trailing text", "%Y-%m-%d").unwrap();
-    /// assert_eq!(date, NaiveDate::from_ymd_opt(2015, 2, 18).unwrap());
+    /// assert_eq!(date, NaiveDate::from_ymd(2015, 2, 18).unwrap());
     /// assert_eq!(remainder, " trailing text");
     /// ```
     pub fn parse_and_remainder<'a>(s: &'a str, fmt: &str) -> ParseResult<(NaiveDate, &'a str)> {
@@ -447,12 +447,12 @@ impl NaiveDate {
     /// ```
     /// # use chrono::{NaiveDate, Months};
     /// assert_eq!(
-    ///     NaiveDate::from_ymd_opt(2022, 2, 20).unwrap().checked_add_months(Months::new(6)),
-    ///     Some(NaiveDate::from_ymd_opt(2022, 8, 20).unwrap())
+    ///     NaiveDate::from_ymd(2022, 2, 20).unwrap().checked_add_months(Months::new(6)),
+    ///     Some(NaiveDate::from_ymd(2022, 8, 20).unwrap())
     /// );
     /// assert_eq!(
-    ///     NaiveDate::from_ymd_opt(2022, 7, 31).unwrap().checked_add_months(Months::new(2)),
-    ///     Some(NaiveDate::from_ymd_opt(2022, 9, 30).unwrap())
+    ///     NaiveDate::from_ymd(2022, 7, 31).unwrap().checked_add_months(Months::new(2)),
+    ///     Some(NaiveDate::from_ymd(2022, 9, 30).unwrap())
     /// );
     /// ```
     #[must_use]
@@ -480,12 +480,12 @@ impl NaiveDate {
     /// ```
     /// # use chrono::{NaiveDate, Months};
     /// assert_eq!(
-    ///     NaiveDate::from_ymd_opt(2022, 2, 20).unwrap().checked_sub_months(Months::new(6)),
-    ///     Some(NaiveDate::from_ymd_opt(2021, 8, 20).unwrap())
+    ///     NaiveDate::from_ymd(2022, 2, 20).unwrap().checked_sub_months(Months::new(6)),
+    ///     Some(NaiveDate::from_ymd(2021, 8, 20).unwrap())
     /// );
     ///
     /// assert_eq!(
-    ///     NaiveDate::from_ymd_opt(2014, 1, 1).unwrap()
+    ///     NaiveDate::from_ymd(2014, 1, 1).unwrap()
     ///         .checked_sub_months(Months::new(core::i32::MAX as u32 + 1)),
     ///     None
     /// );
@@ -560,15 +560,15 @@ impl NaiveDate {
     /// ```
     /// # use chrono::{NaiveDate, Days};
     /// assert_eq!(
-    ///     NaiveDate::from_ymd_opt(2022, 2, 20).unwrap().checked_add_days(Days::new(9)),
-    ///     Some(NaiveDate::from_ymd_opt(2022, 3, 1).unwrap())
+    ///     NaiveDate::from_ymd(2022, 2, 20).unwrap().checked_add_days(Days::new(9)),
+    ///     Some(NaiveDate::from_ymd(2022, 3, 1).unwrap())
     /// );
     /// assert_eq!(
-    ///     NaiveDate::from_ymd_opt(2022, 7, 31).unwrap().checked_add_days(Days::new(2)),
-    ///     Some(NaiveDate::from_ymd_opt(2022, 8, 2).unwrap())
+    ///     NaiveDate::from_ymd(2022, 7, 31).unwrap().checked_add_days(Days::new(2)),
+    ///     Some(NaiveDate::from_ymd(2022, 8, 2).unwrap())
     /// );
     /// assert_eq!(
-    ///     NaiveDate::from_ymd_opt(2022, 7, 31).unwrap().checked_add_days(Days::new(1000000000000)),
+    ///     NaiveDate::from_ymd(2022, 7, 31).unwrap().checked_add_days(Days::new(1000000000000)),
     ///     None
     /// );
     /// ```
@@ -591,11 +591,11 @@ impl NaiveDate {
     /// ```
     /// # use chrono::{NaiveDate, Days};
     /// assert_eq!(
-    ///     NaiveDate::from_ymd_opt(2022, 2, 20).unwrap().checked_sub_days(Days::new(6)),
-    ///     Some(NaiveDate::from_ymd_opt(2022, 2, 14).unwrap())
+    ///     NaiveDate::from_ymd(2022, 2, 20).unwrap().checked_sub_days(Days::new(6)),
+    ///     Some(NaiveDate::from_ymd(2022, 2, 14).unwrap())
     /// );
     /// assert_eq!(
-    ///     NaiveDate::from_ymd_opt(2022, 2, 20).unwrap().checked_sub_days(Days::new(1000000000000)),
+    ///     NaiveDate::from_ymd(2022, 2, 20).unwrap().checked_sub_days(Days::new(1000000000000)),
     ///     None
     /// );
     /// ```
@@ -637,7 +637,7 @@ impl NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, NaiveTime, NaiveDateTime};
     ///
-    /// let d = NaiveDate::from_ymd_opt(2015, 6, 3).unwrap();
+    /// let d = NaiveDate::from_ymd(2015, 6, 3).unwrap();
     /// let t = NaiveTime::from_hms_milli(12, 34, 56, 789).unwrap();
     ///
     /// let dt: NaiveDateTime = d.and_time(t);
@@ -664,7 +664,7 @@ impl NaiveDate {
     /// ```
     /// use chrono::{Error, NaiveDate};
     ///
-    /// let d = NaiveDate::from_ymd_opt(2015, 6, 3).unwrap();
+    /// let d = NaiveDate::from_ymd(2015, 6, 3).unwrap();
     /// assert!(d.and_hms_opt(12, 34, 56).is_ok());
     /// assert_eq!(d.and_hms_opt(12, 34, 60), Err(Error::InvalidArgument));
     /// assert_eq!(d.and_hms_opt(12, 60, 56), Err(Error::InvalidArgument));
@@ -693,7 +693,7 @@ impl NaiveDate {
     /// ```
     /// use chrono::{Error, NaiveDate};
     ///
-    /// let d = NaiveDate::from_ymd_opt(2015, 6, 3).unwrap();
+    /// let d = NaiveDate::from_ymd(2015, 6, 3).unwrap();
     /// assert!(d.and_hms_milli_opt(12, 34, 56,   789).is_ok());
     /// assert!(d.and_hms_milli_opt(12, 34, 59, 1_789).is_ok()); // leap second
     /// assert_eq!(d.and_hms_milli_opt(12, 34, 59, 2_789), Err(Error::InvalidArgument));
@@ -730,7 +730,7 @@ impl NaiveDate {
     /// ```
     /// use chrono::{Error, NaiveDate};
     ///
-    /// let d = NaiveDate::from_ymd_opt(2015, 6, 3).unwrap();
+    /// let d = NaiveDate::from_ymd(2015, 6, 3).unwrap();
     /// assert!(d.and_hms_micro_opt(12, 34, 56,   789_012).is_ok());
     /// assert!(d.and_hms_micro_opt(12, 34, 59, 1_789_012).is_ok()); // leap second
     /// assert_eq!(d.and_hms_micro_opt(12, 34, 59, 2_789_012), Err(Error::InvalidArgument));
@@ -767,7 +767,7 @@ impl NaiveDate {
     /// ```
     /// use chrono::{Error, NaiveDate};
     ///
-    /// let d = NaiveDate::from_ymd_opt(2015, 6, 3).unwrap();
+    /// let d = NaiveDate::from_ymd(2015, 6, 3).unwrap();
     /// assert!(d.and_hms_nano_opt(12, 34, 56,   789_012_345).is_ok());
     /// assert!(d.and_hms_nano_opt(12, 34, 59, 1_789_012_345).is_ok()); // leap second
     /// assert_eq!(d.and_hms_nano_opt(12, 34, 59, 2_789_012_345), Err(Error::InvalidArgument));
@@ -818,8 +818,8 @@ impl NaiveDate {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 6, 3).unwrap().succ_opt(),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 6, 4).unwrap()));
+    /// assert_eq!(NaiveDate::from_ymd(2015, 6, 3).unwrap().succ_opt(),
+    ///            Some(NaiveDate::from_ymd(2015, 6, 4).unwrap()));
     /// assert_eq!(NaiveDate::MAX.succ_opt(), None);
     /// ```
     #[inline]
@@ -843,8 +843,8 @@ impl NaiveDate {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 6, 3).unwrap().pred_opt(),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 6, 2).unwrap()));
+    /// assert_eq!(NaiveDate::from_ymd(2015, 6, 3).unwrap().pred_opt(),
+    ///            Some(NaiveDate::from_ymd(2015, 6, 2).unwrap()));
     /// assert_eq!(NaiveDate::MIN.pred_opt(), None);
     /// ```
     #[inline]
@@ -853,7 +853,7 @@ impl NaiveDate {
         let new_shifted_ordinal = (self.yof() & ORDINAL_MASK) - (1 << 4);
         match new_shifted_ordinal > 0 {
             true => Some(NaiveDate::from_yof(self.yof() & !ORDINAL_MASK | new_shifted_ordinal)),
-            false => NaiveDate::from_ymd_opt(self.year() - 1, 12, 31),
+            false => NaiveDate::from_ymd(self.year() - 1, 12, 31),
         }
     }
 
@@ -868,11 +868,11 @@ impl NaiveDate {
     /// ```
     /// use chrono::{TimeDelta, NaiveDate};
     ///
-    /// let d = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap();
+    /// let d = NaiveDate::from_ymd(2015, 9, 5).unwrap();
     /// assert_eq!(d.checked_add_signed(TimeDelta::days(40)),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 10, 15).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 10, 15).unwrap()));
     /// assert_eq!(d.checked_add_signed(TimeDelta::days(-40)),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 7, 27).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 7, 27).unwrap()));
     /// assert_eq!(d.checked_add_signed(TimeDelta::days(1_000_000_000)), None);
     /// assert_eq!(d.checked_add_signed(TimeDelta::days(-1_000_000_000)), None);
     /// assert_eq!(NaiveDate::MAX.checked_add_signed(TimeDelta::days(1)), None);
@@ -897,11 +897,11 @@ impl NaiveDate {
     /// ```
     /// use chrono::{TimeDelta, NaiveDate};
     ///
-    /// let d = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap();
+    /// let d = NaiveDate::from_ymd(2015, 9, 5).unwrap();
     /// assert_eq!(d.checked_sub_signed(TimeDelta::days(40)),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 7, 27).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 7, 27).unwrap()));
     /// assert_eq!(d.checked_sub_signed(TimeDelta::days(-40)),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 10, 15).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 10, 15).unwrap()));
     /// assert_eq!(d.checked_sub_signed(TimeDelta::days(1_000_000_000)), None);
     /// assert_eq!(d.checked_sub_signed(TimeDelta::days(-1_000_000_000)), None);
     /// assert_eq!(NaiveDate::MIN.checked_sub_signed(TimeDelta::days(1)), None);
@@ -926,7 +926,7 @@ impl NaiveDate {
     /// ```
     /// use chrono::{TimeDelta, NaiveDate};
     ///
-    /// let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     /// let since = NaiveDate::signed_duration_since;
     ///
     /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2014, 1, 1)), TimeDelta::zero());
@@ -981,7 +981,7 @@ impl NaiveDate {
     /// use chrono::format::strftime::StrftimeItems;
     ///
     /// let fmt = StrftimeItems::new("%Y-%m-%d");
-    /// let d = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap();
+    /// let d = NaiveDate::from_ymd(2015, 9, 5).unwrap();
     /// assert_eq!(d.format_with_items(fmt.clone()).to_string(), "2015-09-05");
     /// assert_eq!(d.format("%Y-%m-%d").to_string(),             "2015-09-05");
     /// ```
@@ -992,7 +992,7 @@ impl NaiveDate {
     /// # use chrono::NaiveDate;
     /// # use chrono::format::strftime::StrftimeItems;
     /// # let fmt = StrftimeItems::new("%Y-%m-%d").clone();
-    /// # let d = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap();
+    /// # let d = NaiveDate::from_ymd(2015, 9, 5).unwrap();
     /// assert_eq!(format!("{}", d.format_with_items(fmt)), "2015-09-05");
     /// ```
     #[cfg(feature = "alloc")]
@@ -1025,7 +1025,7 @@ impl NaiveDate {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let d = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap();
+    /// let d = NaiveDate::from_ymd(2015, 9, 5).unwrap();
     /// assert_eq!(d.format("%Y-%m-%d").to_string(), "2015-09-05");
     /// assert_eq!(d.format("%A, %-d %B, %C%y").to_string(), "Saturday, 5 September, 2015");
     /// ```
@@ -1034,7 +1034,7 @@ impl NaiveDate {
     ///
     /// ```
     /// # use chrono::NaiveDate;
-    /// # let d = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap();
+    /// # let d = NaiveDate::from_ymd(2015, 9, 5).unwrap();
     /// assert_eq!(format!("{}", d.format("%Y-%m-%d")), "2015-09-05");
     /// assert_eq!(format!("{}", d.format("%A, %-d %B, %C%y")), "Saturday, 5 September, 2015");
     /// ```
@@ -1084,20 +1084,20 @@ impl NaiveDate {
     /// # use chrono::NaiveDate;
     ///
     /// let expected = [
-    ///     NaiveDate::from_ymd_opt(2016, 2, 27).unwrap(),
-    ///     NaiveDate::from_ymd_opt(2016, 2, 28).unwrap(),
-    ///     NaiveDate::from_ymd_opt(2016, 2, 29).unwrap(),
-    ///     NaiveDate::from_ymd_opt(2016, 3, 1).unwrap(),
+    ///     NaiveDate::from_ymd(2016, 2, 27).unwrap(),
+    ///     NaiveDate::from_ymd(2016, 2, 28).unwrap(),
+    ///     NaiveDate::from_ymd(2016, 2, 29).unwrap(),
+    ///     NaiveDate::from_ymd(2016, 3, 1).unwrap(),
     /// ];
     ///
     /// let mut count = 0;
-    /// for (idx, d) in NaiveDate::from_ymd_opt(2016, 2, 27).unwrap().iter_days().take(4).enumerate() {
+    /// for (idx, d) in NaiveDate::from_ymd(2016, 2, 27).unwrap().iter_days().take(4).enumerate() {
     ///    assert_eq!(d, expected[idx]);
     ///    count += 1;
     /// }
     /// assert_eq!(count, 4);
     ///
-    /// for d in NaiveDate::from_ymd_opt(2016, 3, 1).unwrap().iter_days().rev().take(4) {
+    /// for d in NaiveDate::from_ymd(2016, 3, 1).unwrap().iter_days().rev().take(4) {
     ///     count -= 1;
     ///     assert_eq!(d, expected[count]);
     /// }
@@ -1115,20 +1115,20 @@ impl NaiveDate {
     /// # use chrono::NaiveDate;
     ///
     /// let expected = [
-    ///     NaiveDate::from_ymd_opt(2016, 2, 27).unwrap(),
-    ///     NaiveDate::from_ymd_opt(2016, 3, 5).unwrap(),
-    ///     NaiveDate::from_ymd_opt(2016, 3, 12).unwrap(),
-    ///     NaiveDate::from_ymd_opt(2016, 3, 19).unwrap(),
+    ///     NaiveDate::from_ymd(2016, 2, 27).unwrap(),
+    ///     NaiveDate::from_ymd(2016, 3, 5).unwrap(),
+    ///     NaiveDate::from_ymd(2016, 3, 12).unwrap(),
+    ///     NaiveDate::from_ymd(2016, 3, 19).unwrap(),
     /// ];
     ///
     /// let mut count = 0;
-    /// for (idx, d) in NaiveDate::from_ymd_opt(2016, 2, 27).unwrap().iter_weeks().take(4).enumerate() {
+    /// for (idx, d) in NaiveDate::from_ymd(2016, 2, 27).unwrap().iter_weeks().take(4).enumerate() {
     ///    assert_eq!(d, expected[idx]);
     ///    count += 1;
     /// }
     /// assert_eq!(count, 4);
     ///
-    /// for d in NaiveDate::from_ymd_opt(2016, 3, 19).unwrap().iter_weeks().rev().take(4) {
+    /// for d in NaiveDate::from_ymd(2016, 3, 19).unwrap().iter_weeks().rev().take(4) {
     ///     count -= 1;
     ///     assert_eq!(d, expected[count]);
     /// }
@@ -1149,12 +1149,12 @@ impl NaiveDate {
     ///
     /// ```
     /// # use chrono::NaiveDate;
-    /// assert_eq!(NaiveDate::from_ymd_opt(2000, 1, 1).unwrap().leap_year(), true);
-    /// assert_eq!(NaiveDate::from_ymd_opt(2001, 1, 1).unwrap().leap_year(), false);
-    /// assert_eq!(NaiveDate::from_ymd_opt(2002, 1, 1).unwrap().leap_year(), false);
-    /// assert_eq!(NaiveDate::from_ymd_opt(2003, 1, 1).unwrap().leap_year(), false);
-    /// assert_eq!(NaiveDate::from_ymd_opt(2004, 1, 1).unwrap().leap_year(), true);
-    /// assert_eq!(NaiveDate::from_ymd_opt(2100, 1, 1).unwrap().leap_year(), false);
+    /// assert_eq!(NaiveDate::from_ymd(2000, 1, 1).unwrap().leap_year(), true);
+    /// assert_eq!(NaiveDate::from_ymd(2001, 1, 1).unwrap().leap_year(), false);
+    /// assert_eq!(NaiveDate::from_ymd(2002, 1, 1).unwrap().leap_year(), false);
+    /// assert_eq!(NaiveDate::from_ymd(2003, 1, 1).unwrap().leap_year(), false);
+    /// assert_eq!(NaiveDate::from_ymd(2004, 1, 1).unwrap().leap_year(), true);
+    /// assert_eq!(NaiveDate::from_ymd(2100, 1, 1).unwrap().leap_year(), false);
     /// ```
     pub const fn leap_year(&self) -> bool {
         self.yof() & (0b1000) == 0
@@ -1258,8 +1258,8 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().year(), 2015);
-    /// assert_eq!(NaiveDate::from_ymd_opt(-308, 3, 14).unwrap().year(), -308); // 309 BCE
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().year(), 2015);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).unwrap().year(), -308); // 309 BCE
     /// ```
     #[inline]
     fn year(&self) -> i32 {
@@ -1275,8 +1275,8 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().month(), 9);
-    /// assert_eq!(NaiveDate::from_ymd_opt(-308, 3, 14).unwrap().month(), 3);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().month(), 9);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).unwrap().month(), 3);
     /// ```
     #[inline]
     fn month(&self) -> u32 {
@@ -1292,8 +1292,8 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().month0(), 8);
-    /// assert_eq!(NaiveDate::from_ymd_opt(-308, 3, 14).unwrap().month0(), 2);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().month0(), 8);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).unwrap().month0(), 2);
     /// ```
     #[inline]
     fn month0(&self) -> u32 {
@@ -1309,8 +1309,8 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().day(), 8);
-    /// assert_eq!(NaiveDate::from_ymd_opt(-308, 3, 14).unwrap().day(), 14);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().day(), 8);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).unwrap().day(), 14);
     /// ```
     ///
     /// Combined with [`NaiveDate::pred_opt`](#method.pred_opt),
@@ -1323,7 +1323,7 @@ impl Datelike for NaiveDate {
     /// fn ndays_in_month(year: i32, month: u32) -> u32 {
     ///     // the first day of the next month...
     ///     let (y, m) = if month == 12 { (year + 1, 1) } else { (year, month + 1) };
-    ///     let d = NaiveDate::from_ymd_opt(y, m, 1).unwrap();
+    ///     let d = NaiveDate::from_ymd(y, m, 1).unwrap();
     ///
     ///     // ...is preceded by the last day of the original month
     ///     d.pred_opt().unwrap().day()
@@ -1349,8 +1349,8 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().day0(), 7);
-    /// assert_eq!(NaiveDate::from_ymd_opt(-308, 3, 14).unwrap().day0(), 13);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().day0(), 7);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).unwrap().day0(), 13);
     /// ```
     #[inline]
     fn day0(&self) -> u32 {
@@ -1366,8 +1366,8 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().ordinal(), 251);
-    /// assert_eq!(NaiveDate::from_ymd_opt(-308, 3, 14).unwrap().ordinal(), 74);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().ordinal(), 251);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).unwrap().ordinal(), 74);
     /// ```
     ///
     /// Combined with [`NaiveDate::pred_opt`](#method.pred_opt),
@@ -1379,7 +1379,7 @@ impl Datelike for NaiveDate {
     ///
     /// fn ndays_in_year(year: i32) -> u32 {
     ///     // the first day of the next year...
-    ///     let d = NaiveDate::from_ymd_opt(year + 1, 1, 1).unwrap();
+    ///     let d = NaiveDate::from_ymd(year + 1, 1, 1).unwrap();
     ///
     ///     // ...is preceded by the last day of the original year
     ///     d.pred_opt().unwrap().ordinal()
@@ -1405,8 +1405,8 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().ordinal0(), 250);
-    /// assert_eq!(NaiveDate::from_ymd_opt(-308, 3, 14).unwrap().ordinal0(), 73);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().ordinal0(), 250);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).unwrap().ordinal0(), 73);
     /// ```
     #[inline]
     fn ordinal0(&self) -> u32 {
@@ -1420,8 +1420,8 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().weekday(), Weekday::Tue);
-    /// assert_eq!(NaiveDate::from_ymd_opt(-308, 3, 14).unwrap().weekday(), Weekday::Fri);
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().weekday(), Weekday::Tue);
+    /// assert_eq!(NaiveDate::from_ymd(-308, 3, 14).unwrap().weekday(), Weekday::Fri);
     /// ```
     #[inline]
     fn weekday(&self) -> Weekday {
@@ -1445,18 +1445,18 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().with_year(2016),
-    ///            Some(NaiveDate::from_ymd_opt(2016, 9, 8).unwrap()));
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().with_year(-308),
-    ///            Some(NaiveDate::from_ymd_opt(-308, 9, 8).unwrap()));
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().with_year(2016),
+    ///            Some(NaiveDate::from_ymd(2016, 9, 8).unwrap()));
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().with_year(-308),
+    ///            Some(NaiveDate::from_ymd(-308, 9, 8).unwrap()));
     /// ```
     ///
     /// A leap day (February 29) is a good example that this method can return `None`.
     ///
     /// ```
     /// # use chrono::{NaiveDate, Datelike};
-    /// assert!(NaiveDate::from_ymd_opt(2016, 2, 29).unwrap().with_year(2015).is_none());
-    /// assert!(NaiveDate::from_ymd_opt(2016, 2, 29).unwrap().with_year(2020).is_some());
+    /// assert!(NaiveDate::from_ymd(2016, 2, 29).unwrap().with_year(2015).is_none());
+    /// assert!(NaiveDate::from_ymd(2016, 2, 29).unwrap().with_year(2020).is_some());
     /// ```
     #[inline]
     fn with_year(&self, year: i32) -> Option<NaiveDate> {
@@ -1481,10 +1481,10 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().with_month(10),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 10, 8).unwrap()));
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().with_month(13), None); // no month 13
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 30).unwrap().with_month(2), None); // no February 30
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().with_month(10),
+    ///            Some(NaiveDate::from_ymd(2015, 10, 8).unwrap()));
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().with_month(13), None); // no month 13
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 30).unwrap().with_month(2), None); // no February 30
     /// ```
     #[inline]
     fn with_month(&self, month: u32) -> Option<NaiveDate> {
@@ -1503,10 +1503,10 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().with_month0(9),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 10, 8).unwrap()));
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().with_month0(12), None); // no month 13
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 30).unwrap().with_month0(1), None); // no February 30
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().with_month0(9),
+    ///            Some(NaiveDate::from_ymd(2015, 10, 8).unwrap()));
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().with_month0(12), None); // no month 13
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 30).unwrap().with_month0(1), None); // no February 30
     /// ```
     #[inline]
     fn with_month0(&self, month0: u32) -> Option<NaiveDate> {
@@ -1525,9 +1525,9 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().with_day(30),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 9, 30).unwrap()));
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().with_day(31),
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().with_day(30),
+    ///            Some(NaiveDate::from_ymd(2015, 9, 30).unwrap()));
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().with_day(31),
     ///            None); // no September 31
     /// ```
     #[inline]
@@ -1546,9 +1546,9 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().with_day0(29),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 9, 30).unwrap()));
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().with_day0(30),
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().with_day0(29),
+    ///            Some(NaiveDate::from_ymd(2015, 9, 30).unwrap()));
+    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().with_day0(30),
     ///            None); // no September 31
     /// ```
     #[inline]
@@ -1569,15 +1569,15 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 1, 1).unwrap().with_ordinal(60),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 3, 1).unwrap()));
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 1, 1).unwrap().with_ordinal(366),
+    /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1).unwrap().with_ordinal(60),
+    ///            Some(NaiveDate::from_ymd(2015, 3, 1).unwrap()));
+    /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1).unwrap().with_ordinal(366),
     ///            None); // 2015 had only 365 days
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2016, 1, 1).unwrap().with_ordinal(60),
-    ///            Some(NaiveDate::from_ymd_opt(2016, 2, 29).unwrap()));
-    /// assert_eq!(NaiveDate::from_ymd_opt(2016, 1, 1).unwrap().with_ordinal(366),
-    ///            Some(NaiveDate::from_ymd_opt(2016, 12, 31).unwrap()));
+    /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1).unwrap().with_ordinal(60),
+    ///            Some(NaiveDate::from_ymd(2016, 2, 29).unwrap()));
+    /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1).unwrap().with_ordinal(366),
+    ///            Some(NaiveDate::from_ymd(2016, 12, 31).unwrap()));
     /// ```
     #[inline]
     fn with_ordinal(&self, ordinal: u32) -> Option<NaiveDate> {
@@ -1603,15 +1603,15 @@ impl Datelike for NaiveDate {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 1, 1).unwrap().with_ordinal0(59),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 3, 1).unwrap()));
-    /// assert_eq!(NaiveDate::from_ymd_opt(2015, 1, 1).unwrap().with_ordinal0(365),
+    /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1).unwrap().with_ordinal0(59),
+    ///            Some(NaiveDate::from_ymd(2015, 3, 1).unwrap()));
+    /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1).unwrap().with_ordinal0(365),
     ///            None); // 2015 had only 365 days
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(2016, 1, 1).unwrap().with_ordinal0(59),
-    ///            Some(NaiveDate::from_ymd_opt(2016, 2, 29).unwrap()));
-    /// assert_eq!(NaiveDate::from_ymd_opt(2016, 1, 1).unwrap().with_ordinal0(365),
-    ///            Some(NaiveDate::from_ymd_opt(2016, 12, 31).unwrap()));
+    /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1).unwrap().with_ordinal0(59),
+    ///            Some(NaiveDate::from_ymd(2016, 2, 29).unwrap()));
+    /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1).unwrap().with_ordinal0(365),
+    ///            Some(NaiveDate::from_ymd(2016, 12, 31).unwrap()));
     /// ```
     #[inline]
     fn with_ordinal0(&self, ordinal0: u32) -> Option<NaiveDate> {
@@ -1635,7 +1635,7 @@ impl Datelike for NaiveDate {
 /// ```
 /// use chrono::{TimeDelta, NaiveDate};
 ///
-/// let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+/// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::zero(),             from_ymd(2014, 1, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::seconds(86399),     from_ymd(2014, 1, 1));
@@ -1688,7 +1688,7 @@ impl AddAssign<TimeDelta> for NaiveDate {
 /// ```
 /// use chrono::{NaiveDate, Months};
 ///
-/// let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+/// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// assert_eq!(from_ymd(2014, 1, 1) + Months::new(1), from_ymd(2014, 2, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) + Months::new(11), from_ymd(2014, 12, 1));
@@ -1720,7 +1720,7 @@ impl Add<Months> for NaiveDate {
 /// ```
 /// use chrono::{NaiveDate, Months};
 ///
-/// let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+/// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// assert_eq!(from_ymd(2014, 1, 1) - Months::new(11), from_ymd(2013, 2, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) - Months::new(12), from_ymd(2013, 1, 1));
@@ -1778,7 +1778,7 @@ impl Sub<Days> for NaiveDate {
 /// ```
 /// use chrono::{TimeDelta, NaiveDate};
 ///
-/// let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+/// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::zero(),             from_ymd(2014, 1, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::seconds(86399),     from_ymd(2014, 1, 1));
@@ -1831,7 +1831,7 @@ impl SubAssign<TimeDelta> for NaiveDate {
 /// ```
 /// use chrono::{TimeDelta, NaiveDate};
 ///
-/// let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+/// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2014, 1, 1), TimeDelta::zero());
 /// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 12, 31), TimeDelta::days(1));
@@ -1935,17 +1935,17 @@ impl FusedIterator for NaiveDateWeeksIterator {}
 /// ```
 /// use chrono::NaiveDate;
 ///
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd_opt(2015,  9,  5).unwrap()), "2015-09-05");
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd_opt(   0,  1,  1).unwrap()), "0000-01-01");
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd_opt(9999, 12, 31).unwrap()), "9999-12-31");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(2015,  9,  5).unwrap()), "2015-09-05");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(   0,  1,  1).unwrap()), "0000-01-01");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(9999, 12, 31).unwrap()), "9999-12-31");
 /// ```
 ///
 /// ISO 8601 requires an explicit sign for years before 1 BCE or after 9999 CE.
 ///
 /// ```
 /// # use chrono::NaiveDate;
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd_opt(   -1,  1,  1).unwrap()),  "-0001-01-01");
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd_opt(10000, 12, 31).unwrap()), "+10000-12-31");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(   -1,  1,  1).unwrap()),  "-0001-01-01");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(10000, 12, 31).unwrap()), "+10000-12-31");
 /// ```
 impl fmt::Debug for NaiveDate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -1978,17 +1978,17 @@ impl fmt::Debug for NaiveDate {
 /// ```
 /// use chrono::NaiveDate;
 ///
-/// assert_eq!(format!("{}", NaiveDate::from_ymd_opt(2015,  9,  5).unwrap()), "2015-09-05");
-/// assert_eq!(format!("{}", NaiveDate::from_ymd_opt(   0,  1,  1).unwrap()), "0000-01-01");
-/// assert_eq!(format!("{}", NaiveDate::from_ymd_opt(9999, 12, 31).unwrap()), "9999-12-31");
+/// assert_eq!(format!("{}", NaiveDate::from_ymd(2015,  9,  5).unwrap()), "2015-09-05");
+/// assert_eq!(format!("{}", NaiveDate::from_ymd(   0,  1,  1).unwrap()), "0000-01-01");
+/// assert_eq!(format!("{}", NaiveDate::from_ymd(9999, 12, 31).unwrap()), "9999-12-31");
 /// ```
 ///
 /// ISO 8601 requires an explicit sign for years before 1 BCE or after 9999 CE.
 ///
 /// ```
 /// # use chrono::NaiveDate;
-/// assert_eq!(format!("{}", NaiveDate::from_ymd_opt(   -1,  1,  1).unwrap()),  "-0001-01-01");
-/// assert_eq!(format!("{}", NaiveDate::from_ymd_opt(10000, 12, 31).unwrap()), "+10000-12-31");
+/// assert_eq!(format!("{}", NaiveDate::from_ymd(   -1,  1,  1).unwrap()),  "-0001-01-01");
+/// assert_eq!(format!("{}", NaiveDate::from_ymd(10000, 12, 31).unwrap()), "+10000-12-31");
 /// ```
 impl fmt::Display for NaiveDate {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -2004,10 +2004,10 @@ impl fmt::Display for NaiveDate {
 /// ```
 /// use chrono::NaiveDate;
 ///
-/// let d = NaiveDate::from_ymd_opt(2015, 9, 18).unwrap();
+/// let d = NaiveDate::from_ymd(2015, 9, 18).unwrap();
 /// assert_eq!("2015-09-18".parse::<NaiveDate>(), Ok(d));
 ///
-/// let d = NaiveDate::from_ymd_opt(12345, 6, 7).unwrap();
+/// let d = NaiveDate::from_ymd(12345, 6, 7).unwrap();
 /// assert_eq!("+12345-6-7".parse::<NaiveDate>(), Ok(d));
 ///
 /// assert!("foo".parse::<NaiveDate>().is_err());
@@ -2038,11 +2038,11 @@ impl str::FromStr for NaiveDate {
 /// use chrono::NaiveDate;
 ///
 /// let default_date = NaiveDate::default();
-/// assert_eq!(default_date, NaiveDate::from_ymd_opt(1970, 1, 1).unwrap());
+/// assert_eq!(default_date, NaiveDate::from_ymd(1970, 1, 1).unwrap());
 /// ```
 impl Default for NaiveDate {
     fn default() -> Self {
-        NaiveDate::from_ymd_opt(1970, 1, 1).unwrap()
+        NaiveDate::from_ymd(1970, 1, 1).unwrap()
     }
 }
 
@@ -2123,15 +2123,15 @@ where
     E: ::std::fmt::Debug,
 {
     assert_eq!(
-        to_string(&NaiveDate::from_ymd_opt(2014, 7, 24).unwrap()).ok(),
+        to_string(&NaiveDate::from_ymd(2014, 7, 24).unwrap()).ok(),
         Some(r#""2014-07-24""#.into())
     );
     assert_eq!(
-        to_string(&NaiveDate::from_ymd_opt(0, 1, 1).unwrap()).ok(),
+        to_string(&NaiveDate::from_ymd(0, 1, 1).unwrap()).ok(),
         Some(r#""0000-01-01""#.into())
     );
     assert_eq!(
-        to_string(&NaiveDate::from_ymd_opt(-1, 12, 31).unwrap()).ok(),
+        to_string(&NaiveDate::from_ymd(-1, 12, 31).unwrap()).ok(),
         Some(r#""-0001-12-31""#.into())
     );
     assert_eq!(to_string(&NaiveDate::MIN).ok(), Some(r#""-262143-01-01""#.into()));
@@ -2146,18 +2146,12 @@ where
 {
     use std::{i32, i64};
 
-    assert_eq!(
-        from_str(r#""2016-07-08""#).ok(),
-        Some(NaiveDate::from_ymd_opt(2016, 7, 8).unwrap())
-    );
-    assert_eq!(from_str(r#""2016-7-8""#).ok(), Some(NaiveDate::from_ymd_opt(2016, 7, 8).unwrap()));
-    assert_eq!(from_str(r#""+002016-07-08""#).ok(), NaiveDate::from_ymd_opt(2016, 7, 8));
-    assert_eq!(from_str(r#""0000-01-01""#).ok(), Some(NaiveDate::from_ymd_opt(0, 1, 1).unwrap()));
-    assert_eq!(from_str(r#""0-1-1""#).ok(), Some(NaiveDate::from_ymd_opt(0, 1, 1).unwrap()));
-    assert_eq!(
-        from_str(r#""-0001-12-31""#).ok(),
-        Some(NaiveDate::from_ymd_opt(-1, 12, 31).unwrap())
-    );
+    assert_eq!(from_str(r#""2016-07-08""#).ok(), Some(NaiveDate::from_ymd(2016, 7, 8).unwrap()));
+    assert_eq!(from_str(r#""2016-7-8""#).ok(), Some(NaiveDate::from_ymd(2016, 7, 8).unwrap()));
+    assert_eq!(from_str(r#""+002016-07-08""#).ok(), NaiveDate::from_ymd(2016, 7, 8));
+    assert_eq!(from_str(r#""0000-01-01""#).ok(), Some(NaiveDate::from_ymd(0, 1, 1).unwrap()));
+    assert_eq!(from_str(r#""0-1-1""#).ok(), Some(NaiveDate::from_ymd(0, 1, 1).unwrap()));
+    assert_eq!(from_str(r#""-0001-12-31""#).ok(), Some(NaiveDate::from_ymd(-1, 12, 31).unwrap()));
     assert_eq!(from_str(r#""-262143-01-01""#).ok(), Some(NaiveDate::MIN));
     assert_eq!(from_str(r#""+262142-12-31""#).ok(), Some(NaiveDate::MAX));
 
@@ -2254,7 +2248,7 @@ mod serde {
             // it is not self-describing.
             use bincode::{deserialize, serialize};
 
-            let d = NaiveDate::from_ymd_opt(2014, 7, 24).unwrap();
+            let d = NaiveDate::from_ymd(2014, 7, 24).unwrap();
             let encoded = serialize(&d).unwrap();
             let decoded: NaiveDate = deserialize(&encoded).unwrap();
             assert_eq!(d, decoded);

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -345,11 +345,11 @@ impl NaiveDate {
     ///
     /// ```
     /// use chrono::{NaiveDate, Weekday};
-    /// assert_eq!(NaiveDate::from_weekday_of_month_opt(2017, 3, Weekday::Fri, 2),
+    /// assert_eq!(NaiveDate::from_weekday_of_month(2017, 3, Weekday::Fri, 2),
     ///            NaiveDate::from_ymd(2017, 3, 10))
     /// ```
     #[must_use]
-    pub const fn from_weekday_of_month_opt(
+    pub const fn from_weekday_of_month(
         year: i32,
         month: u32,
         weekday: Weekday,

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -308,18 +308,18 @@ impl NaiveDate {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let from_ndays_opt = NaiveDate::from_num_days_from_ce_opt;
+    /// let from_ndays = NaiveDate::from_num_days_from_ce;
     /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     ///
-    /// assert_eq!(from_ndays_opt(730_000),      Some(from_ymd(1999, 9, 3)));
-    /// assert_eq!(from_ndays_opt(1),            Some(from_ymd(1, 1, 1)));
-    /// assert_eq!(from_ndays_opt(0),            Some(from_ymd(0, 12, 31)));
-    /// assert_eq!(from_ndays_opt(-1),           Some(from_ymd(0, 12, 30)));
-    /// assert_eq!(from_ndays_opt(100_000_000),  None);
-    /// assert_eq!(from_ndays_opt(-100_000_000), None);
+    /// assert_eq!(from_ndays(730_000),      Some(from_ymd(1999, 9, 3)));
+    /// assert_eq!(from_ndays(1),            Some(from_ymd(1, 1, 1)));
+    /// assert_eq!(from_ndays(0),            Some(from_ymd(0, 12, 31)));
+    /// assert_eq!(from_ndays(-1),           Some(from_ymd(0, 12, 30)));
+    /// assert_eq!(from_ndays(100_000_000),  None);
+    /// assert_eq!(from_ndays(-100_000_000), None);
     /// ```
     #[must_use]
-    pub const fn from_num_days_from_ce_opt(days: i32) -> Option<NaiveDate> {
+    pub const fn from_num_days_from_ce(days: i32) -> Option<NaiveDate> {
         let days = try_opt!(days.checked_add(365)); // make December 31, 1 BCE equal to day 0
         let year_div_400 = days.div_euclid(146_097);
         let cycle = days.rem_euclid(146_097);

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -198,7 +198,7 @@ fn test_date_from_yo() {
 
 #[test]
 fn test_date_from_isoywd() {
-    let from_isoywd = NaiveDate::from_isoywd_opt;
+    let from_isoywd = NaiveDate::from_isoywd;
     let ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 
     assert_eq!(from_isoywd(2004, 0, Weekday::Sun), None);
@@ -240,7 +240,7 @@ fn test_date_from_isoywd_and_iso_week() {
             ]
             .iter()
             {
-                let d = NaiveDate::from_isoywd_opt(year, week, weekday);
+                let d = NaiveDate::from_isoywd(year, week, weekday);
                 if let Some(d) = d {
                     assert_eq!(d.weekday(), weekday);
                     let w = d.iso_week();
@@ -257,7 +257,7 @@ fn test_date_from_isoywd_and_iso_week() {
                 let d = NaiveDate::from_ymd(year, month, day);
                 if let Some(d) = d {
                     let w = d.iso_week();
-                    let d_ = NaiveDate::from_isoywd_opt(w.year(), w.week(), d.weekday());
+                    let d_ = NaiveDate::from_isoywd(w.year(), w.week(), d.weekday());
                     assert_eq!(d, d_.unwrap());
                 }
             }

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -300,8 +300,8 @@ fn test_date_from_num_days_from_ce() {
 }
 
 #[test]
-fn test_date_from_weekday_of_month_opt() {
-    let ymwd = NaiveDate::from_weekday_of_month_opt;
+fn test_date_from_weekday_of_month() {
+    let ymwd = NaiveDate::from_weekday_of_month;
     assert_eq!(ymwd(2018, 8, Weekday::Tue, 0), None);
     assert_eq!(ymwd(2018, 8, Weekday::Wed, 1), Some(NaiveDate::from_ymd(2018, 8, 1).unwrap()));
     assert_eq!(ymwd(2018, 8, Weekday::Thu, 1), Some(NaiveDate::from_ymd(2018, 8, 2).unwrap()));

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -141,7 +141,7 @@ fn test_readme_doomsday() {
         let d117 = NaiveDate::from_ymd(y, 11, 7).unwrap();
 
         // "March 0"
-        let d30 = NaiveDate::from_ymd(y, 3, 1).unwrap().pred_opt().unwrap();
+        let d30 = NaiveDate::from_ymd(y, 3, 1).unwrap().pred().unwrap();
 
         let weekday = d30.weekday();
         let other_dates = [d4, d6, d8, d10, d12, d59, d95, d711, d117];
@@ -434,11 +434,11 @@ fn test_date_succ() {
 #[test]
 fn test_date_pred() {
     let ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
-    assert_eq!(ymd(2016, 3, 1).pred_opt(), Some(ymd(2016, 2, 29)));
-    assert_eq!(ymd(2015, 1, 1).pred_opt(), Some(ymd(2014, 12, 31)));
-    assert_eq!(ymd(2014, 6, 1).pred_opt(), Some(ymd(2014, 5, 31)));
-    assert_eq!(ymd(2014, 5, 7).pred_opt(), Some(ymd(2014, 5, 6)));
-    assert_eq!(ymd(NaiveDate::MIN.year(), 1, 1).pred_opt(), None);
+    assert_eq!(ymd(2016, 3, 1).pred(), Some(ymd(2016, 2, 29)));
+    assert_eq!(ymd(2015, 1, 1).pred(), Some(ymd(2014, 12, 31)));
+    assert_eq!(ymd(2014, 6, 1).pred(), Some(ymd(2014, 5, 31)));
+    assert_eq!(ymd(2014, 5, 7).pred(), Some(ymd(2014, 5, 6)));
+    assert_eq!(ymd(NaiveDate::MIN.year(), 1, 1).pred(), None);
 }
 
 #[test]

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -167,33 +167,33 @@ fn test_date_from_ymd() {
 
 #[test]
 fn test_date_from_yo() {
-    let yo_opt = NaiveDate::from_yo_opt;
+    let from_yo = NaiveDate::from_yo_opt;
     let ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
 
-    assert_eq!(yo_opt(2012, 0), None);
-    assert_eq!(yo_opt(2012, 1), Some(ymd(2012, 1, 1)));
-    assert_eq!(yo_opt(2012, 2), Some(ymd(2012, 1, 2)));
-    assert_eq!(yo_opt(2012, 32), Some(ymd(2012, 2, 1)));
-    assert_eq!(yo_opt(2012, 60), Some(ymd(2012, 2, 29)));
-    assert_eq!(yo_opt(2012, 61), Some(ymd(2012, 3, 1)));
-    assert_eq!(yo_opt(2012, 100), Some(ymd(2012, 4, 9)));
-    assert_eq!(yo_opt(2012, 200), Some(ymd(2012, 7, 18)));
-    assert_eq!(yo_opt(2012, 300), Some(ymd(2012, 10, 26)));
-    assert_eq!(yo_opt(2012, 366), Some(ymd(2012, 12, 31)));
-    assert_eq!(yo_opt(2012, 367), None);
-    assert_eq!(yo_opt(2012, 1 << 28 | 60), None);
+    assert_eq!(from_yo(2012, 0), None);
+    assert_eq!(from_yo(2012, 1), Some(ymd(2012, 1, 1)));
+    assert_eq!(from_yo(2012, 2), Some(ymd(2012, 1, 2)));
+    assert_eq!(from_yo(2012, 32), Some(ymd(2012, 2, 1)));
+    assert_eq!(from_yo(2012, 60), Some(ymd(2012, 2, 29)));
+    assert_eq!(from_yo(2012, 61), Some(ymd(2012, 3, 1)));
+    assert_eq!(from_yo(2012, 100), Some(ymd(2012, 4, 9)));
+    assert_eq!(from_yo(2012, 200), Some(ymd(2012, 7, 18)));
+    assert_eq!(from_yo(2012, 300), Some(ymd(2012, 10, 26)));
+    assert_eq!(from_yo(2012, 366), Some(ymd(2012, 12, 31)));
+    assert_eq!(from_yo(2012, 367), None);
+    assert_eq!(from_yo(2012, 1 << 28 | 60), None);
 
-    assert_eq!(yo_opt(2014, 0), None);
-    assert_eq!(yo_opt(2014, 1), Some(ymd(2014, 1, 1)));
-    assert_eq!(yo_opt(2014, 2), Some(ymd(2014, 1, 2)));
-    assert_eq!(yo_opt(2014, 32), Some(ymd(2014, 2, 1)));
-    assert_eq!(yo_opt(2014, 59), Some(ymd(2014, 2, 28)));
-    assert_eq!(yo_opt(2014, 60), Some(ymd(2014, 3, 1)));
-    assert_eq!(yo_opt(2014, 100), Some(ymd(2014, 4, 10)));
-    assert_eq!(yo_opt(2014, 200), Some(ymd(2014, 7, 19)));
-    assert_eq!(yo_opt(2014, 300), Some(ymd(2014, 10, 27)));
-    assert_eq!(yo_opt(2014, 365), Some(ymd(2014, 12, 31)));
-    assert_eq!(yo_opt(2014, 366), None);
+    assert_eq!(from_yo(2014, 0), None);
+    assert_eq!(from_yo(2014, 1), Some(ymd(2014, 1, 1)));
+    assert_eq!(from_yo(2014, 2), Some(ymd(2014, 1, 2)));
+    assert_eq!(from_yo(2014, 32), Some(ymd(2014, 2, 1)));
+    assert_eq!(from_yo(2014, 59), Some(ymd(2014, 2, 28)));
+    assert_eq!(from_yo(2014, 60), Some(ymd(2014, 3, 1)));
+    assert_eq!(from_yo(2014, 100), Some(ymd(2014, 4, 10)));
+    assert_eq!(from_yo(2014, 200), Some(ymd(2014, 7, 19)));
+    assert_eq!(from_yo(2014, 300), Some(ymd(2014, 10, 27)));
+    assert_eq!(from_yo(2014, 365), Some(ymd(2014, 12, 31)));
+    assert_eq!(from_yo(2014, 366), None);
 }
 
 #[test]

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -267,7 +267,7 @@ fn test_date_from_isoywd_and_iso_week() {
 
 #[test]
 fn test_date_from_num_days_from_ce() {
-    let from_ndays_from_ce = NaiveDate::from_num_days_from_ce_opt;
+    let from_ndays_from_ce = NaiveDate::from_num_days_from_ce;
     assert_eq!(from_ndays_from_ce(1), Some(NaiveDate::from_ymd(1, 1, 1).unwrap()));
     assert_eq!(from_ndays_from_ce(2), Some(NaiveDate::from_ymd(1, 1, 2).unwrap()));
     assert_eq!(from_ndays_from_ce(31), Some(NaiveDate::from_ymd(1, 1, 31).unwrap()));

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -6,8 +6,8 @@ use crate::{Datelike, TimeDelta, Weekday};
 // we use a separate run-time test.
 #[test]
 fn test_date_bounds() {
-    let calculated_min = NaiveDate::from_ymd_opt(MIN_YEAR, 1, 1).unwrap();
-    let calculated_max = NaiveDate::from_ymd_opt(MAX_YEAR, 12, 31).unwrap();
+    let calculated_min = NaiveDate::from_ymd(MIN_YEAR, 1, 1).unwrap();
+    let calculated_max = NaiveDate::from_ymd(MAX_YEAR, 12, 31).unwrap();
     assert!(
         NaiveDate::MIN == calculated_min,
         "`NaiveDate::MIN` should have year flag {:?}",
@@ -43,13 +43,13 @@ fn test_date_bounds() {
 fn diff_months() {
     // identity
     assert_eq!(
-        NaiveDate::from_ymd_opt(2022, 8, 3).unwrap().checked_add_months(Months::new(0)),
-        Some(NaiveDate::from_ymd_opt(2022, 8, 3).unwrap())
+        NaiveDate::from_ymd(2022, 8, 3).unwrap().checked_add_months(Months::new(0)),
+        Some(NaiveDate::from_ymd(2022, 8, 3).unwrap())
     );
 
     // add with months exceeding `i32::MAX`
     assert_eq!(
-        NaiveDate::from_ymd_opt(2022, 8, 3)
+        NaiveDate::from_ymd(2022, 8, 3)
             .unwrap()
             .checked_add_months(Months::new(i32::MAX as u32 + 1)),
         None
@@ -57,7 +57,7 @@ fn diff_months() {
 
     // sub with months exceeding `i32::MIN`
     assert_eq!(
-        NaiveDate::from_ymd_opt(2022, 8, 3)
+        NaiveDate::from_ymd(2022, 8, 3)
             .unwrap()
             .checked_sub_months(Months::new(i32::MIN.unsigned_abs() + 1)),
         None
@@ -71,56 +71,56 @@ fn diff_months() {
 
     // sub crossing year 0 boundary
     assert_eq!(
-        NaiveDate::from_ymd_opt(2022, 8, 3).unwrap().checked_sub_months(Months::new(2050 * 12)),
-        Some(NaiveDate::from_ymd_opt(-28, 8, 3).unwrap())
+        NaiveDate::from_ymd(2022, 8, 3).unwrap().checked_sub_months(Months::new(2050 * 12)),
+        Some(NaiveDate::from_ymd(-28, 8, 3).unwrap())
     );
 
     // add crossing year boundary
     assert_eq!(
-        NaiveDate::from_ymd_opt(2022, 8, 3).unwrap().checked_add_months(Months::new(6)),
-        Some(NaiveDate::from_ymd_opt(2023, 2, 3).unwrap())
+        NaiveDate::from_ymd(2022, 8, 3).unwrap().checked_add_months(Months::new(6)),
+        Some(NaiveDate::from_ymd(2023, 2, 3).unwrap())
     );
 
     // sub crossing year boundary
     assert_eq!(
-        NaiveDate::from_ymd_opt(2022, 8, 3).unwrap().checked_sub_months(Months::new(10)),
-        Some(NaiveDate::from_ymd_opt(2021, 10, 3).unwrap())
+        NaiveDate::from_ymd(2022, 8, 3).unwrap().checked_sub_months(Months::new(10)),
+        Some(NaiveDate::from_ymd(2021, 10, 3).unwrap())
     );
 
     // add clamping day, non-leap year
     assert_eq!(
-        NaiveDate::from_ymd_opt(2022, 1, 29).unwrap().checked_add_months(Months::new(1)),
-        Some(NaiveDate::from_ymd_opt(2022, 2, 28).unwrap())
+        NaiveDate::from_ymd(2022, 1, 29).unwrap().checked_add_months(Months::new(1)),
+        Some(NaiveDate::from_ymd(2022, 2, 28).unwrap())
     );
 
     // add to leap day
     assert_eq!(
-        NaiveDate::from_ymd_opt(2022, 10, 29).unwrap().checked_add_months(Months::new(16)),
-        Some(NaiveDate::from_ymd_opt(2024, 2, 29).unwrap())
+        NaiveDate::from_ymd(2022, 10, 29).unwrap().checked_add_months(Months::new(16)),
+        Some(NaiveDate::from_ymd(2024, 2, 29).unwrap())
     );
 
     // add into december
     assert_eq!(
-        NaiveDate::from_ymd_opt(2022, 10, 31).unwrap().checked_add_months(Months::new(2)),
-        Some(NaiveDate::from_ymd_opt(2022, 12, 31).unwrap())
+        NaiveDate::from_ymd(2022, 10, 31).unwrap().checked_add_months(Months::new(2)),
+        Some(NaiveDate::from_ymd(2022, 12, 31).unwrap())
     );
 
     // sub into december
     assert_eq!(
-        NaiveDate::from_ymd_opt(2022, 10, 31).unwrap().checked_sub_months(Months::new(10)),
-        Some(NaiveDate::from_ymd_opt(2021, 12, 31).unwrap())
+        NaiveDate::from_ymd(2022, 10, 31).unwrap().checked_sub_months(Months::new(10)),
+        Some(NaiveDate::from_ymd(2021, 12, 31).unwrap())
     );
 
     // add into january
     assert_eq!(
-        NaiveDate::from_ymd_opt(2022, 8, 3).unwrap().checked_add_months(Months::new(5)),
-        Some(NaiveDate::from_ymd_opt(2023, 1, 3).unwrap())
+        NaiveDate::from_ymd(2022, 8, 3).unwrap().checked_add_months(Months::new(5)),
+        Some(NaiveDate::from_ymd(2023, 1, 3).unwrap())
     );
 
     // sub into january
     assert_eq!(
-        NaiveDate::from_ymd_opt(2022, 8, 3).unwrap().checked_sub_months(Months::new(7)),
-        Some(NaiveDate::from_ymd_opt(2022, 1, 3).unwrap())
+        NaiveDate::from_ymd(2022, 8, 3).unwrap().checked_sub_months(Months::new(7)),
+        Some(NaiveDate::from_ymd(2022, 1, 3).unwrap())
     );
 }
 
@@ -128,20 +128,20 @@ fn diff_months() {
 fn test_readme_doomsday() {
     for y in NaiveDate::MIN.year()..=NaiveDate::MAX.year() {
         // even months
-        let d4 = NaiveDate::from_ymd_opt(y, 4, 4).unwrap();
-        let d6 = NaiveDate::from_ymd_opt(y, 6, 6).unwrap();
-        let d8 = NaiveDate::from_ymd_opt(y, 8, 8).unwrap();
-        let d10 = NaiveDate::from_ymd_opt(y, 10, 10).unwrap();
-        let d12 = NaiveDate::from_ymd_opt(y, 12, 12).unwrap();
+        let d4 = NaiveDate::from_ymd(y, 4, 4).unwrap();
+        let d6 = NaiveDate::from_ymd(y, 6, 6).unwrap();
+        let d8 = NaiveDate::from_ymd(y, 8, 8).unwrap();
+        let d10 = NaiveDate::from_ymd(y, 10, 10).unwrap();
+        let d12 = NaiveDate::from_ymd(y, 12, 12).unwrap();
 
         // nine to five, seven-eleven
-        let d59 = NaiveDate::from_ymd_opt(y, 5, 9).unwrap();
-        let d95 = NaiveDate::from_ymd_opt(y, 9, 5).unwrap();
-        let d711 = NaiveDate::from_ymd_opt(y, 7, 11).unwrap();
-        let d117 = NaiveDate::from_ymd_opt(y, 11, 7).unwrap();
+        let d59 = NaiveDate::from_ymd(y, 5, 9).unwrap();
+        let d95 = NaiveDate::from_ymd(y, 9, 5).unwrap();
+        let d711 = NaiveDate::from_ymd(y, 7, 11).unwrap();
+        let d117 = NaiveDate::from_ymd(y, 11, 7).unwrap();
 
         // "March 0"
-        let d30 = NaiveDate::from_ymd_opt(y, 3, 1).unwrap().pred_opt().unwrap();
+        let d30 = NaiveDate::from_ymd(y, 3, 1).unwrap().pred_opt().unwrap();
 
         let weekday = d30.weekday();
         let other_dates = [d4, d6, d8, d10, d12, d59, d95, d711, d117];
@@ -151,7 +151,7 @@ fn test_readme_doomsday() {
 
 #[test]
 fn test_date_from_ymd() {
-    let from_ymd = NaiveDate::from_ymd_opt;
+    let from_ymd = NaiveDate::from_ymd;
 
     assert!(from_ymd(2012, 0, 1).is_none());
     assert!(from_ymd(2012, 1, 1).is_some());
@@ -168,7 +168,7 @@ fn test_date_from_ymd() {
 #[test]
 fn test_date_from_yo() {
     let from_yo = NaiveDate::from_yo_opt;
-    let ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    let ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 
     assert_eq!(from_yo(2012, 0), None);
     assert_eq!(from_yo(2012, 1), Some(ymd(2012, 1, 1)));
@@ -199,7 +199,7 @@ fn test_date_from_yo() {
 #[test]
 fn test_date_from_isoywd() {
     let from_isoywd = NaiveDate::from_isoywd_opt;
-    let ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    let ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 
     assert_eq!(from_isoywd(2004, 0, Weekday::Sun), None);
     assert_eq!(from_isoywd(2004, 1, Weekday::Mon), Some(ymd(2003, 12, 29)));
@@ -254,7 +254,7 @@ fn test_date_from_isoywd_and_iso_week() {
     for year in 2000..2401 {
         for month in 1..13 {
             for day in 1..32 {
-                let d = NaiveDate::from_ymd_opt(year, month, day);
+                let d = NaiveDate::from_ymd(year, month, day);
                 if let Some(d) = d {
                     let w = d.iso_week();
                     let d_ = NaiveDate::from_isoywd_opt(w.year(), w.week(), d.weekday());
@@ -268,26 +268,23 @@ fn test_date_from_isoywd_and_iso_week() {
 #[test]
 fn test_date_from_num_days_from_ce() {
     let from_ndays_from_ce = NaiveDate::from_num_days_from_ce_opt;
-    assert_eq!(from_ndays_from_ce(1), Some(NaiveDate::from_ymd_opt(1, 1, 1).unwrap()));
-    assert_eq!(from_ndays_from_ce(2), Some(NaiveDate::from_ymd_opt(1, 1, 2).unwrap()));
-    assert_eq!(from_ndays_from_ce(31), Some(NaiveDate::from_ymd_opt(1, 1, 31).unwrap()));
-    assert_eq!(from_ndays_from_ce(32), Some(NaiveDate::from_ymd_opt(1, 2, 1).unwrap()));
-    assert_eq!(from_ndays_from_ce(59), Some(NaiveDate::from_ymd_opt(1, 2, 28).unwrap()));
-    assert_eq!(from_ndays_from_ce(60), Some(NaiveDate::from_ymd_opt(1, 3, 1).unwrap()));
-    assert_eq!(from_ndays_from_ce(365), Some(NaiveDate::from_ymd_opt(1, 12, 31).unwrap()));
-    assert_eq!(from_ndays_from_ce(365 + 1), Some(NaiveDate::from_ymd_opt(2, 1, 1).unwrap()));
-    assert_eq!(from_ndays_from_ce(365 * 2 + 1), Some(NaiveDate::from_ymd_opt(3, 1, 1).unwrap()));
-    assert_eq!(from_ndays_from_ce(365 * 3 + 1), Some(NaiveDate::from_ymd_opt(4, 1, 1).unwrap()));
-    assert_eq!(from_ndays_from_ce(365 * 4 + 2), Some(NaiveDate::from_ymd_opt(5, 1, 1).unwrap()));
-    assert_eq!(from_ndays_from_ce(146097 + 1), Some(NaiveDate::from_ymd_opt(401, 1, 1).unwrap()));
-    assert_eq!(
-        from_ndays_from_ce(146097 * 5 + 1),
-        Some(NaiveDate::from_ymd_opt(2001, 1, 1).unwrap())
-    );
-    assert_eq!(from_ndays_from_ce(719163), Some(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap()));
-    assert_eq!(from_ndays_from_ce(0), Some(NaiveDate::from_ymd_opt(0, 12, 31).unwrap())); // 1 BCE
-    assert_eq!(from_ndays_from_ce(-365), Some(NaiveDate::from_ymd_opt(0, 1, 1).unwrap()));
-    assert_eq!(from_ndays_from_ce(-366), Some(NaiveDate::from_ymd_opt(-1, 12, 31).unwrap())); // 2 BCE
+    assert_eq!(from_ndays_from_ce(1), Some(NaiveDate::from_ymd(1, 1, 1).unwrap()));
+    assert_eq!(from_ndays_from_ce(2), Some(NaiveDate::from_ymd(1, 1, 2).unwrap()));
+    assert_eq!(from_ndays_from_ce(31), Some(NaiveDate::from_ymd(1, 1, 31).unwrap()));
+    assert_eq!(from_ndays_from_ce(32), Some(NaiveDate::from_ymd(1, 2, 1).unwrap()));
+    assert_eq!(from_ndays_from_ce(59), Some(NaiveDate::from_ymd(1, 2, 28).unwrap()));
+    assert_eq!(from_ndays_from_ce(60), Some(NaiveDate::from_ymd(1, 3, 1).unwrap()));
+    assert_eq!(from_ndays_from_ce(365), Some(NaiveDate::from_ymd(1, 12, 31).unwrap()));
+    assert_eq!(from_ndays_from_ce(365 + 1), Some(NaiveDate::from_ymd(2, 1, 1).unwrap()));
+    assert_eq!(from_ndays_from_ce(365 * 2 + 1), Some(NaiveDate::from_ymd(3, 1, 1).unwrap()));
+    assert_eq!(from_ndays_from_ce(365 * 3 + 1), Some(NaiveDate::from_ymd(4, 1, 1).unwrap()));
+    assert_eq!(from_ndays_from_ce(365 * 4 + 2), Some(NaiveDate::from_ymd(5, 1, 1).unwrap()));
+    assert_eq!(from_ndays_from_ce(146097 + 1), Some(NaiveDate::from_ymd(401, 1, 1).unwrap()));
+    assert_eq!(from_ndays_from_ce(146097 * 5 + 1), Some(NaiveDate::from_ymd(2001, 1, 1).unwrap()));
+    assert_eq!(from_ndays_from_ce(719163), Some(NaiveDate::from_ymd(1970, 1, 1).unwrap()));
+    assert_eq!(from_ndays_from_ce(0), Some(NaiveDate::from_ymd(0, 12, 31).unwrap())); // 1 BCE
+    assert_eq!(from_ndays_from_ce(-365), Some(NaiveDate::from_ymd(0, 1, 1).unwrap()));
+    assert_eq!(from_ndays_from_ce(-366), Some(NaiveDate::from_ymd(-1, 12, 31).unwrap())); // 2 BCE
 
     for days in (-9999..10001).map(|x| x * 100) {
         assert_eq!(from_ndays_from_ce(days).map(|d| d.num_days_from_ce()), Some(days));
@@ -306,24 +303,24 @@ fn test_date_from_num_days_from_ce() {
 fn test_date_from_weekday_of_month_opt() {
     let ymwd = NaiveDate::from_weekday_of_month_opt;
     assert_eq!(ymwd(2018, 8, Weekday::Tue, 0), None);
-    assert_eq!(ymwd(2018, 8, Weekday::Wed, 1), Some(NaiveDate::from_ymd_opt(2018, 8, 1).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Thu, 1), Some(NaiveDate::from_ymd_opt(2018, 8, 2).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Sun, 1), Some(NaiveDate::from_ymd_opt(2018, 8, 5).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Mon, 1), Some(NaiveDate::from_ymd_opt(2018, 8, 6).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Tue, 1), Some(NaiveDate::from_ymd_opt(2018, 8, 7).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Wed, 2), Some(NaiveDate::from_ymd_opt(2018, 8, 8).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Sun, 2), Some(NaiveDate::from_ymd_opt(2018, 8, 12).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Thu, 3), Some(NaiveDate::from_ymd_opt(2018, 8, 16).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Thu, 4), Some(NaiveDate::from_ymd_opt(2018, 8, 23).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Thu, 5), Some(NaiveDate::from_ymd_opt(2018, 8, 30).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Fri, 5), Some(NaiveDate::from_ymd_opt(2018, 8, 31).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Wed, 1), Some(NaiveDate::from_ymd(2018, 8, 1).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Thu, 1), Some(NaiveDate::from_ymd(2018, 8, 2).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Sun, 1), Some(NaiveDate::from_ymd(2018, 8, 5).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Mon, 1), Some(NaiveDate::from_ymd(2018, 8, 6).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Tue, 1), Some(NaiveDate::from_ymd(2018, 8, 7).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Wed, 2), Some(NaiveDate::from_ymd(2018, 8, 8).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Sun, 2), Some(NaiveDate::from_ymd(2018, 8, 12).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Thu, 3), Some(NaiveDate::from_ymd(2018, 8, 16).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Thu, 4), Some(NaiveDate::from_ymd(2018, 8, 23).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Thu, 5), Some(NaiveDate::from_ymd(2018, 8, 30).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Fri, 5), Some(NaiveDate::from_ymd(2018, 8, 31).unwrap()));
     assert_eq!(ymwd(2018, 8, Weekday::Sat, 5), None);
 }
 
 #[test]
 fn test_date_fields() {
     fn check(year: i32, month: u32, day: u32, ordinal: u32) {
-        let d1 = NaiveDate::from_ymd_opt(year, month, day).unwrap();
+        let d1 = NaiveDate::from_ymd(year, month, day).unwrap();
         assert_eq!(d1.year(), year);
         assert_eq!(d1.month(), month);
         assert_eq!(d1.day(), day);
@@ -361,72 +358,72 @@ fn test_date_fields() {
 
 #[test]
 fn test_date_weekday() {
-    assert_eq!(NaiveDate::from_ymd_opt(1582, 10, 15).unwrap().weekday(), Weekday::Fri);
+    assert_eq!(NaiveDate::from_ymd(1582, 10, 15).unwrap().weekday(), Weekday::Fri);
     // May 20, 1875 = ISO 8601 reference date
-    assert_eq!(NaiveDate::from_ymd_opt(1875, 5, 20).unwrap().weekday(), Weekday::Thu);
-    assert_eq!(NaiveDate::from_ymd_opt(2000, 1, 1).unwrap().weekday(), Weekday::Sat);
+    assert_eq!(NaiveDate::from_ymd(1875, 5, 20).unwrap().weekday(), Weekday::Thu);
+    assert_eq!(NaiveDate::from_ymd(2000, 1, 1).unwrap().weekday(), Weekday::Sat);
 }
 
 #[test]
 fn test_date_with_fields() {
-    let d = NaiveDate::from_ymd_opt(2000, 2, 29).unwrap();
-    assert_eq!(d.with_year(-400), Some(NaiveDate::from_ymd_opt(-400, 2, 29).unwrap()));
+    let d = NaiveDate::from_ymd(2000, 2, 29).unwrap();
+    assert_eq!(d.with_year(-400), Some(NaiveDate::from_ymd(-400, 2, 29).unwrap()));
     assert_eq!(d.with_year(-100), None);
-    assert_eq!(d.with_year(1600), Some(NaiveDate::from_ymd_opt(1600, 2, 29).unwrap()));
+    assert_eq!(d.with_year(1600), Some(NaiveDate::from_ymd(1600, 2, 29).unwrap()));
     assert_eq!(d.with_year(1900), None);
-    assert_eq!(d.with_year(2000), Some(NaiveDate::from_ymd_opt(2000, 2, 29).unwrap()));
+    assert_eq!(d.with_year(2000), Some(NaiveDate::from_ymd(2000, 2, 29).unwrap()));
     assert_eq!(d.with_year(2001), None);
-    assert_eq!(d.with_year(2004), Some(NaiveDate::from_ymd_opt(2004, 2, 29).unwrap()));
+    assert_eq!(d.with_year(2004), Some(NaiveDate::from_ymd(2004, 2, 29).unwrap()));
     assert_eq!(d.with_year(i32::MAX), None);
 
-    let d = NaiveDate::from_ymd_opt(2000, 4, 30).unwrap();
+    let d = NaiveDate::from_ymd(2000, 4, 30).unwrap();
     assert_eq!(d.with_month(0), None);
-    assert_eq!(d.with_month(1), Some(NaiveDate::from_ymd_opt(2000, 1, 30).unwrap()));
+    assert_eq!(d.with_month(1), Some(NaiveDate::from_ymd(2000, 1, 30).unwrap()));
     assert_eq!(d.with_month(2), None);
-    assert_eq!(d.with_month(3), Some(NaiveDate::from_ymd_opt(2000, 3, 30).unwrap()));
-    assert_eq!(d.with_month(4), Some(NaiveDate::from_ymd_opt(2000, 4, 30).unwrap()));
-    assert_eq!(d.with_month(12), Some(NaiveDate::from_ymd_opt(2000, 12, 30).unwrap()));
+    assert_eq!(d.with_month(3), Some(NaiveDate::from_ymd(2000, 3, 30).unwrap()));
+    assert_eq!(d.with_month(4), Some(NaiveDate::from_ymd(2000, 4, 30).unwrap()));
+    assert_eq!(d.with_month(12), Some(NaiveDate::from_ymd(2000, 12, 30).unwrap()));
     assert_eq!(d.with_month(13), None);
     assert_eq!(d.with_month(u32::MAX), None);
 
-    let d = NaiveDate::from_ymd_opt(2000, 2, 8).unwrap();
+    let d = NaiveDate::from_ymd(2000, 2, 8).unwrap();
     assert_eq!(d.with_day(0), None);
-    assert_eq!(d.with_day(1), Some(NaiveDate::from_ymd_opt(2000, 2, 1).unwrap()));
-    assert_eq!(d.with_day(29), Some(NaiveDate::from_ymd_opt(2000, 2, 29).unwrap()));
+    assert_eq!(d.with_day(1), Some(NaiveDate::from_ymd(2000, 2, 1).unwrap()));
+    assert_eq!(d.with_day(29), Some(NaiveDate::from_ymd(2000, 2, 29).unwrap()));
     assert_eq!(d.with_day(30), None);
     assert_eq!(d.with_day(u32::MAX), None);
 }
 
 #[test]
 fn test_date_with_ordinal() {
-    let d = NaiveDate::from_ymd_opt(2000, 5, 5).unwrap();
+    let d = NaiveDate::from_ymd(2000, 5, 5).unwrap();
     assert_eq!(d.with_ordinal(0), None);
-    assert_eq!(d.with_ordinal(1), Some(NaiveDate::from_ymd_opt(2000, 1, 1).unwrap()));
-    assert_eq!(d.with_ordinal(60), Some(NaiveDate::from_ymd_opt(2000, 2, 29).unwrap()));
-    assert_eq!(d.with_ordinal(61), Some(NaiveDate::from_ymd_opt(2000, 3, 1).unwrap()));
-    assert_eq!(d.with_ordinal(366), Some(NaiveDate::from_ymd_opt(2000, 12, 31).unwrap()));
+    assert_eq!(d.with_ordinal(1), Some(NaiveDate::from_ymd(2000, 1, 1).unwrap()));
+    assert_eq!(d.with_ordinal(60), Some(NaiveDate::from_ymd(2000, 2, 29).unwrap()));
+    assert_eq!(d.with_ordinal(61), Some(NaiveDate::from_ymd(2000, 3, 1).unwrap()));
+    assert_eq!(d.with_ordinal(366), Some(NaiveDate::from_ymd(2000, 12, 31).unwrap()));
     assert_eq!(d.with_ordinal(367), None);
     assert_eq!(d.with_ordinal(1 << 28 | 60), None);
-    let d = NaiveDate::from_ymd_opt(1999, 5, 5).unwrap();
+    let d = NaiveDate::from_ymd(1999, 5, 5).unwrap();
     assert_eq!(d.with_ordinal(366), None);
     assert_eq!(d.with_ordinal(u32::MAX), None);
 }
 
 #[test]
 fn test_date_num_days_from_ce() {
-    assert_eq!(NaiveDate::from_ymd_opt(1, 1, 1).unwrap().num_days_from_ce(), 1);
+    assert_eq!(NaiveDate::from_ymd(1, 1, 1).unwrap().num_days_from_ce(), 1);
 
     for year in -9999..10001 {
         assert_eq!(
-            NaiveDate::from_ymd_opt(year, 1, 1).unwrap().num_days_from_ce(),
-            NaiveDate::from_ymd_opt(year - 1, 12, 31).unwrap().num_days_from_ce() + 1
+            NaiveDate::from_ymd(year, 1, 1).unwrap().num_days_from_ce(),
+            NaiveDate::from_ymd(year - 1, 12, 31).unwrap().num_days_from_ce() + 1
         );
     }
 }
 
 #[test]
 fn test_date_succ() {
-    let ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    let ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     assert_eq!(ymd(2014, 5, 6).succ_opt(), Some(ymd(2014, 5, 7)));
     assert_eq!(ymd(2014, 5, 31).succ_opt(), Some(ymd(2014, 6, 1)));
     assert_eq!(ymd(2014, 12, 31).succ_opt(), Some(ymd(2015, 1, 1)));
@@ -436,7 +433,7 @@ fn test_date_succ() {
 
 #[test]
 fn test_date_pred() {
-    let ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    let ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     assert_eq!(ymd(2016, 3, 1).pred_opt(), Some(ymd(2016, 2, 29)));
     assert_eq!(ymd(2015, 1, 1).pred_opt(), Some(ymd(2014, 12, 31)));
     assert_eq!(ymd(2014, 6, 1).pred_opt(), Some(ymd(2014, 5, 31)));
@@ -447,8 +444,8 @@ fn test_date_pred() {
 #[test]
 fn test_date_add() {
     fn check((y1, m1, d1): (i32, u32, u32), rhs: TimeDelta, ymd: Option<(i32, u32, u32)>) {
-        let lhs = NaiveDate::from_ymd_opt(y1, m1, d1).unwrap();
-        let sum = ymd.map(|(y, m, d)| NaiveDate::from_ymd_opt(y, m, d).unwrap());
+        let lhs = NaiveDate::from_ymd(y1, m1, d1).unwrap();
+        let sum = ymd.map(|(y, m, d)| NaiveDate::from_ymd(y, m, d).unwrap());
         assert_eq!(lhs.checked_add_signed(rhs), sum);
         assert_eq!(lhs.checked_sub_signed(-rhs), sum);
     }
@@ -477,8 +474,8 @@ fn test_date_add() {
 #[test]
 fn test_date_sub() {
     fn check((y1, m1, d1): (i32, u32, u32), (y2, m2, d2): (i32, u32, u32), diff: TimeDelta) {
-        let lhs = NaiveDate::from_ymd_opt(y1, m1, d1).unwrap();
-        let rhs = NaiveDate::from_ymd_opt(y2, m2, d2).unwrap();
+        let lhs = NaiveDate::from_ymd(y1, m1, d1).unwrap();
+        let rhs = NaiveDate::from_ymd(y2, m2, d2).unwrap();
         assert_eq!(lhs.signed_duration_since(rhs), diff);
         assert_eq!(rhs.signed_duration_since(lhs), -diff);
     }
@@ -497,8 +494,8 @@ fn test_date_sub() {
 #[test]
 fn test_date_add_days() {
     fn check((y1, m1, d1): (i32, u32, u32), rhs: Days, ymd: Option<(i32, u32, u32)>) {
-        let lhs = NaiveDate::from_ymd_opt(y1, m1, d1).unwrap();
-        let sum = ymd.map(|(y, m, d)| NaiveDate::from_ymd_opt(y, m, d).unwrap());
+        let lhs = NaiveDate::from_ymd(y1, m1, d1).unwrap();
+        let sum = ymd.map(|(y, m, d)| NaiveDate::from_ymd(y, m, d).unwrap());
         assert_eq!(lhs.checked_add_days(rhs), sum);
     }
 
@@ -519,8 +516,8 @@ fn test_date_add_days() {
 #[test]
 fn test_date_sub_days() {
     fn check((y1, m1, d1): (i32, u32, u32), (y2, m2, d2): (i32, u32, u32), diff: Days) {
-        let lhs = NaiveDate::from_ymd_opt(y1, m1, d1).unwrap();
-        let rhs = NaiveDate::from_ymd_opt(y2, m2, d2).unwrap();
+        let lhs = NaiveDate::from_ymd(y1, m1, d1).unwrap();
+        let rhs = NaiveDate::from_ymd(y2, m2, d2).unwrap();
         assert_eq!(lhs - diff, rhs);
     }
 
@@ -537,7 +534,7 @@ fn test_date_sub_days() {
 
 #[test]
 fn test_date_addassignment() {
-    let ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    let ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     let mut date = ymd(2016, 10, 1);
     date += TimeDelta::days(10);
     assert_eq!(date, ymd(2016, 10, 11));
@@ -547,7 +544,7 @@ fn test_date_addassignment() {
 
 #[test]
 fn test_date_subassignment() {
-    let ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    let ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     let mut date = ymd(2016, 10, 11);
     date -= TimeDelta::days(10);
     assert_eq!(date, ymd(2016, 10, 1));
@@ -557,19 +554,19 @@ fn test_date_subassignment() {
 
 #[test]
 fn test_date_fmt() {
-    assert_eq!(format!("{:?}", NaiveDate::from_ymd_opt(2012, 3, 4).unwrap()), "2012-03-04");
-    assert_eq!(format!("{:?}", NaiveDate::from_ymd_opt(0, 3, 4).unwrap()), "0000-03-04");
-    assert_eq!(format!("{:?}", NaiveDate::from_ymd_opt(-307, 3, 4).unwrap()), "-0307-03-04");
-    assert_eq!(format!("{:?}", NaiveDate::from_ymd_opt(12345, 3, 4).unwrap()), "+12345-03-04");
+    assert_eq!(format!("{:?}", NaiveDate::from_ymd(2012, 3, 4).unwrap()), "2012-03-04");
+    assert_eq!(format!("{:?}", NaiveDate::from_ymd(0, 3, 4).unwrap()), "0000-03-04");
+    assert_eq!(format!("{:?}", NaiveDate::from_ymd(-307, 3, 4).unwrap()), "-0307-03-04");
+    assert_eq!(format!("{:?}", NaiveDate::from_ymd(12345, 3, 4).unwrap()), "+12345-03-04");
 
-    assert_eq!(NaiveDate::from_ymd_opt(2012, 3, 4).unwrap().to_string(), "2012-03-04");
-    assert_eq!(NaiveDate::from_ymd_opt(0, 3, 4).unwrap().to_string(), "0000-03-04");
-    assert_eq!(NaiveDate::from_ymd_opt(-307, 3, 4).unwrap().to_string(), "-0307-03-04");
-    assert_eq!(NaiveDate::from_ymd_opt(12345, 3, 4).unwrap().to_string(), "+12345-03-04");
+    assert_eq!(NaiveDate::from_ymd(2012, 3, 4).unwrap().to_string(), "2012-03-04");
+    assert_eq!(NaiveDate::from_ymd(0, 3, 4).unwrap().to_string(), "0000-03-04");
+    assert_eq!(NaiveDate::from_ymd(-307, 3, 4).unwrap().to_string(), "-0307-03-04");
+    assert_eq!(NaiveDate::from_ymd(12345, 3, 4).unwrap().to_string(), "+12345-03-04");
 
     // the format specifier should have no effect on `NaiveTime`
-    assert_eq!(format!("{:+30?}", NaiveDate::from_ymd_opt(1234, 5, 6).unwrap()), "1234-05-06");
-    assert_eq!(format!("{:30?}", NaiveDate::from_ymd_opt(12345, 6, 7).unwrap()), "+12345-06-07");
+    assert_eq!(format!("{:+30?}", NaiveDate::from_ymd(1234, 5, 6).unwrap()), "1234-05-06");
+    assert_eq!(format!("{:30?}", NaiveDate::from_ymd(12345, 6, 7).unwrap()), "+12345-06-07");
 }
 
 #[test]
@@ -652,7 +649,7 @@ fn test_date_from_str() {
 
 #[test]
 fn test_date_parse_from_str() {
-    let ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    let ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     assert_eq!(
         NaiveDate::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
         Ok(ymd(2014, 5, 7))
@@ -668,31 +665,25 @@ fn test_date_parse_from_str() {
 
     assert_eq!(
         NaiveDate::parse_from_str("2020-01-0", "%Y-%W-%w").ok(),
-        NaiveDate::from_ymd_opt(2020, 1, 12),
+        NaiveDate::from_ymd(2020, 1, 12),
     );
 
     assert_eq!(
         NaiveDate::parse_from_str("2019-01-0", "%Y-%W-%w").ok(),
-        NaiveDate::from_ymd_opt(2019, 1, 13),
+        NaiveDate::from_ymd(2019, 1, 13),
     );
 }
 
 #[test]
 fn test_day_iterator_limit() {
-    assert_eq!(NaiveDate::from_ymd_opt(MAX_YEAR, 12, 29).unwrap().iter_days().take(4).count(), 2);
-    assert_eq!(
-        NaiveDate::from_ymd_opt(MIN_YEAR, 1, 3).unwrap().iter_days().rev().take(4).count(),
-        2
-    );
+    assert_eq!(NaiveDate::from_ymd(MAX_YEAR, 12, 29).unwrap().iter_days().take(4).count(), 2);
+    assert_eq!(NaiveDate::from_ymd(MIN_YEAR, 1, 3).unwrap().iter_days().rev().take(4).count(), 2);
 }
 
 #[test]
 fn test_week_iterator_limit() {
-    assert_eq!(NaiveDate::from_ymd_opt(MAX_YEAR, 12, 12).unwrap().iter_weeks().take(4).count(), 2);
-    assert_eq!(
-        NaiveDate::from_ymd_opt(MIN_YEAR, 1, 15).unwrap().iter_weeks().rev().take(4).count(),
-        2
-    );
+    assert_eq!(NaiveDate::from_ymd(MAX_YEAR, 12, 12).unwrap().iter_weeks().take(4).count(), 2);
+    assert_eq!(NaiveDate::from_ymd(MIN_YEAR, 1, 15).unwrap().iter_weeks().rev().take(4).count(), 2);
 }
 
 #[test]
@@ -701,11 +692,11 @@ fn test_weeks_from() {
     // these internally use `weeks_from` via the parsing infrastructure
     assert_eq!(
         NaiveDate::parse_from_str("2020-01-0", "%Y-%W-%w").ok(),
-        NaiveDate::from_ymd_opt(2020, 1, 12),
+        NaiveDate::from_ymd(2020, 1, 12),
     );
     assert_eq!(
         NaiveDate::parse_from_str("2019-01-0", "%Y-%W-%w").ok(),
-        NaiveDate::from_ymd_opt(2019, 1, 13),
+        NaiveDate::from_ymd(2019, 1, 13),
     );
 
     // direct tests
@@ -729,18 +720,16 @@ fn test_weeks_from() {
             Weekday::Sun,
         ] {
             assert_eq!(
-                NaiveDate::from_ymd_opt(*y, 1, 1).map(|d| d.weeks_from(*day)),
+                NaiveDate::from_ymd(*y, 1, 1).map(|d| d.weeks_from(*day)),
                 Some(if day == starts_on { 1 } else { 0 })
             );
 
             // last day must always be in week 52 or 53
-            assert!(
-                [52, 53].contains(&NaiveDate::from_ymd_opt(*y, 12, 31).unwrap().weeks_from(*day)),
-            );
+            assert!([52, 53].contains(&NaiveDate::from_ymd(*y, 12, 31).unwrap().weeks_from(*day)),);
         }
     }
 
-    let base = NaiveDate::from_ymd_opt(2019, 1, 1).unwrap();
+    let base = NaiveDate::from_ymd(2019, 1, 1).unwrap();
 
     // 400 years covers all year types
     for day in &[
@@ -761,7 +750,7 @@ fn test_weeks_from() {
 
 #[test]
 fn test_with_0_overflow() {
-    let dt = NaiveDate::from_ymd_opt(2023, 4, 18).unwrap();
+    let dt = NaiveDate::from_ymd(2023, 4, 18).unwrap();
     assert!(dt.with_month0(4294967295).is_none());
     assert!(dt.with_day0(4294967295).is_none());
     assert!(dt.with_ordinal0(4294967295).is_none());
@@ -770,7 +759,7 @@ fn test_with_0_overflow() {
 #[test]
 fn test_leap_year() {
     for year in 0..=MAX_YEAR {
-        let date = NaiveDate::from_ymd_opt(year, 1, 1).unwrap();
+        let date = NaiveDate::from_ymd(year, 1, 1).unwrap();
         let is_leap = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
         assert_eq!(date.leap_year(), is_leap);
         assert_eq!(date.leap_year(), date.with_ordinal(366).is_some());
@@ -806,7 +795,7 @@ fn test_weekday_with_yearflags() {
 fn test_isoweekdate_with_yearflags() {
     for (year, year_flags, _) in YEAR_FLAGS {
         // January 4 should be in the first week
-        let jan4 = NaiveDate::from_ymd_opt(year, 1, 4).unwrap();
+        let jan4 = NaiveDate::from_ymd(year, 1, 4).unwrap();
         let iso_week = jan4.iso_week();
         assert_eq!(jan4.year_flags(), year_flags);
         assert_eq!(iso_week.week(), 1);

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -424,11 +424,11 @@ fn test_date_num_days_from_ce() {
 #[test]
 fn test_date_succ() {
     let ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
-    assert_eq!(ymd(2014, 5, 6).succ_opt(), Some(ymd(2014, 5, 7)));
-    assert_eq!(ymd(2014, 5, 31).succ_opt(), Some(ymd(2014, 6, 1)));
-    assert_eq!(ymd(2014, 12, 31).succ_opt(), Some(ymd(2015, 1, 1)));
-    assert_eq!(ymd(2016, 2, 28).succ_opt(), Some(ymd(2016, 2, 29)));
-    assert_eq!(ymd(NaiveDate::MAX.year(), 12, 31).succ_opt(), None);
+    assert_eq!(ymd(2014, 5, 6).succ(), Some(ymd(2014, 5, 7)));
+    assert_eq!(ymd(2014, 5, 31).succ(), Some(ymd(2014, 6, 1)));
+    assert_eq!(ymd(2014, 12, 31).succ(), Some(ymd(2015, 1, 1)));
+    assert_eq!(ymd(2016, 2, 28).succ(), Some(ymd(2016, 2, 29)));
+    assert_eq!(ymd(NaiveDate::MAX.year(), 12, 31).succ(), None);
 }
 
 #[test]

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -167,7 +167,7 @@ fn test_date_from_ymd() {
 
 #[test]
 fn test_date_from_yo() {
-    let from_yo = NaiveDate::from_yo_opt;
+    let from_yo = NaiveDate::from_yo;
     let ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 
     assert_eq!(from_yo(2012, 0), None);
@@ -326,7 +326,7 @@ fn test_date_fields() {
         assert_eq!(d1.day(), day);
         assert_eq!(d1.ordinal(), ordinal);
 
-        let d2 = NaiveDate::from_yo_opt(year, ordinal).unwrap();
+        let d2 = NaiveDate::from_yo(year, ordinal).unwrap();
         assert_eq!(d2.year(), year);
         assert_eq!(d2.month(), month);
         assert_eq!(d2.day(), day);
@@ -769,21 +769,21 @@ fn test_leap_year() {
 #[test]
 fn test_date_yearflags() {
     for (year, year_flags, _) in YEAR_FLAGS {
-        assert_eq!(NaiveDate::from_yo_opt(year, 1).unwrap().year_flags(), year_flags);
+        assert_eq!(NaiveDate::from_yo(year, 1).unwrap().year_flags(), year_flags);
     }
 }
 
 #[test]
 fn test_weekday_with_yearflags() {
     for (year, year_flags, first_weekday) in YEAR_FLAGS {
-        let first_day_of_year = NaiveDate::from_yo_opt(year, 1).unwrap();
+        let first_day_of_year = NaiveDate::from_yo(year, 1).unwrap();
         dbg!(year);
         assert_eq!(first_day_of_year.year_flags(), year_flags);
         assert_eq!(first_day_of_year.weekday(), first_weekday);
 
         let mut prev = first_day_of_year.weekday();
         for ordinal in 2u32..=year_flags.ndays() {
-            let date = NaiveDate::from_yo_opt(year, ordinal).unwrap();
+            let date = NaiveDate::from_yo(year, ordinal).unwrap();
             let expected = prev.succ();
             assert_eq!(date.weekday(), expected);
             prev = expected;
@@ -806,7 +806,7 @@ fn test_isoweekdate_with_yearflags() {
 fn test_date_to_mdf_to_date() {
     for (year, year_flags, _) in YEAR_FLAGS {
         for ordinal in 1..=year_flags.ndays() {
-            let date = NaiveDate::from_yo_opt(year, ordinal).unwrap();
+            let date = NaiveDate::from_yo(year, ordinal).unwrap();
             assert_eq!(date, NaiveDate::from_mdf(date.year(), date.mdf()).unwrap());
         }
     }

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -151,18 +151,18 @@ fn test_readme_doomsday() {
 
 #[test]
 fn test_date_from_ymd() {
-    let ymd_opt = NaiveDate::from_ymd_opt;
+    let from_ymd = NaiveDate::from_ymd_opt;
 
-    assert!(ymd_opt(2012, 0, 1).is_none());
-    assert!(ymd_opt(2012, 1, 1).is_some());
-    assert!(ymd_opt(2012, 2, 29).is_some());
-    assert!(ymd_opt(2014, 2, 29).is_none());
-    assert!(ymd_opt(2014, 3, 0).is_none());
-    assert!(ymd_opt(2014, 3, 1).is_some());
-    assert!(ymd_opt(2014, 3, 31).is_some());
-    assert!(ymd_opt(2014, 3, 32).is_none());
-    assert!(ymd_opt(2014, 12, 31).is_some());
-    assert!(ymd_opt(2014, 13, 1).is_none());
+    assert!(from_ymd(2012, 0, 1).is_none());
+    assert!(from_ymd(2012, 1, 1).is_some());
+    assert!(from_ymd(2012, 2, 29).is_some());
+    assert!(from_ymd(2014, 2, 29).is_none());
+    assert!(from_ymd(2014, 3, 0).is_none());
+    assert!(from_ymd(2014, 3, 1).is_some());
+    assert!(from_ymd(2014, 3, 31).is_some());
+    assert!(from_ymd(2014, 3, 32).is_none());
+    assert!(from_ymd(2014, 12, 31).is_some());
+    assert!(from_ymd(2014, 13, 1).is_none());
 }
 
 #[test]

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -198,31 +198,31 @@ fn test_date_from_yo() {
 
 #[test]
 fn test_date_from_isoywd() {
-    let isoywd_opt = NaiveDate::from_isoywd_opt;
+    let from_isoywd = NaiveDate::from_isoywd_opt;
     let ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
 
-    assert_eq!(isoywd_opt(2004, 0, Weekday::Sun), None);
-    assert_eq!(isoywd_opt(2004, 1, Weekday::Mon), Some(ymd(2003, 12, 29)));
-    assert_eq!(isoywd_opt(2004, 1, Weekday::Sun), Some(ymd(2004, 1, 4)));
-    assert_eq!(isoywd_opt(2004, 2, Weekday::Mon), Some(ymd(2004, 1, 5)));
-    assert_eq!(isoywd_opt(2004, 2, Weekday::Sun), Some(ymd(2004, 1, 11)));
-    assert_eq!(isoywd_opt(2004, 52, Weekday::Mon), Some(ymd(2004, 12, 20)));
-    assert_eq!(isoywd_opt(2004, 52, Weekday::Sun), Some(ymd(2004, 12, 26)));
-    assert_eq!(isoywd_opt(2004, 53, Weekday::Mon), Some(ymd(2004, 12, 27)));
-    assert_eq!(isoywd_opt(2004, 53, Weekday::Sun), Some(ymd(2005, 1, 2)));
-    assert_eq!(isoywd_opt(2004, 54, Weekday::Mon), None);
+    assert_eq!(from_isoywd(2004, 0, Weekday::Sun), None);
+    assert_eq!(from_isoywd(2004, 1, Weekday::Mon), Some(ymd(2003, 12, 29)));
+    assert_eq!(from_isoywd(2004, 1, Weekday::Sun), Some(ymd(2004, 1, 4)));
+    assert_eq!(from_isoywd(2004, 2, Weekday::Mon), Some(ymd(2004, 1, 5)));
+    assert_eq!(from_isoywd(2004, 2, Weekday::Sun), Some(ymd(2004, 1, 11)));
+    assert_eq!(from_isoywd(2004, 52, Weekday::Mon), Some(ymd(2004, 12, 20)));
+    assert_eq!(from_isoywd(2004, 52, Weekday::Sun), Some(ymd(2004, 12, 26)));
+    assert_eq!(from_isoywd(2004, 53, Weekday::Mon), Some(ymd(2004, 12, 27)));
+    assert_eq!(from_isoywd(2004, 53, Weekday::Sun), Some(ymd(2005, 1, 2)));
+    assert_eq!(from_isoywd(2004, 54, Weekday::Mon), None);
 
-    assert_eq!(isoywd_opt(2011, 0, Weekday::Sun), None);
-    assert_eq!(isoywd_opt(2011, 1, Weekday::Mon), Some(ymd(2011, 1, 3)));
-    assert_eq!(isoywd_opt(2011, 1, Weekday::Sun), Some(ymd(2011, 1, 9)));
-    assert_eq!(isoywd_opt(2011, 2, Weekday::Mon), Some(ymd(2011, 1, 10)));
-    assert_eq!(isoywd_opt(2011, 2, Weekday::Sun), Some(ymd(2011, 1, 16)));
+    assert_eq!(from_isoywd(2011, 0, Weekday::Sun), None);
+    assert_eq!(from_isoywd(2011, 1, Weekday::Mon), Some(ymd(2011, 1, 3)));
+    assert_eq!(from_isoywd(2011, 1, Weekday::Sun), Some(ymd(2011, 1, 9)));
+    assert_eq!(from_isoywd(2011, 2, Weekday::Mon), Some(ymd(2011, 1, 10)));
+    assert_eq!(from_isoywd(2011, 2, Weekday::Sun), Some(ymd(2011, 1, 16)));
 
-    assert_eq!(isoywd_opt(2018, 51, Weekday::Mon), Some(ymd(2018, 12, 17)));
-    assert_eq!(isoywd_opt(2018, 51, Weekday::Sun), Some(ymd(2018, 12, 23)));
-    assert_eq!(isoywd_opt(2018, 52, Weekday::Mon), Some(ymd(2018, 12, 24)));
-    assert_eq!(isoywd_opt(2018, 52, Weekday::Sun), Some(ymd(2018, 12, 30)));
-    assert_eq!(isoywd_opt(2018, 53, Weekday::Mon), None);
+    assert_eq!(from_isoywd(2018, 51, Weekday::Mon), Some(ymd(2018, 12, 17)));
+    assert_eq!(from_isoywd(2018, 51, Weekday::Sun), Some(ymd(2018, 12, 23)));
+    assert_eq!(from_isoywd(2018, 52, Weekday::Mon), Some(ymd(2018, 12, 24)));
+    assert_eq!(from_isoywd(2018, 52, Weekday::Sun), Some(ymd(2018, 12, 30)));
+    assert_eq!(from_isoywd(2018, 53, Weekday::Mon), None);
 }
 
 #[test]

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -473,10 +473,10 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime};
     ///
-    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_nano_opt(0, 0, 1, 444).unwrap();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_nano(0, 0, 1, 444).unwrap();
     /// assert_eq!(dt.timestamp_nanos(), Some(1_000_000_444));
     ///
-    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano_opt(1, 46, 40, 555).unwrap();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano(1, 46, 40, 555).unwrap();
     ///
     /// const A_BILLION: i64 = 1_000_000_000;
     /// let nanos = dt.timestamp_nanos().unwrap();
@@ -521,10 +521,10 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_nano_opt(9, 10, 11, 123_456_789).unwrap();
+    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_nano(9, 10, 11, 123_456_789).unwrap();
     /// assert_eq!(dt.timestamp_subsec_millis(), 123);
     ///
-    /// let dt = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_nano_opt(8, 59, 59, 1_234_567_890).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_nano(8, 59, 59, 1_234_567_890).unwrap();
     /// assert_eq!(dt.timestamp_subsec_millis(), 1_234);
     /// ```
     #[inline]
@@ -543,10 +543,10 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_nano_opt(9, 10, 11, 123_456_789).unwrap();
+    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_nano(9, 10, 11, 123_456_789).unwrap();
     /// assert_eq!(dt.timestamp_subsec_micros(), 123_456);
     ///
-    /// let dt = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_nano_opt(8, 59, 59, 1_234_567_890).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_nano(8, 59, 59, 1_234_567_890).unwrap();
     /// assert_eq!(dt.timestamp_subsec_micros(), 1_234_567);
     /// ```
     #[inline]
@@ -565,10 +565,10 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_nano_opt(9, 10, 11, 123_456_789).unwrap();
+    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_nano(9, 10, 11, 123_456_789).unwrap();
     /// assert_eq!(dt.timestamp_subsec_nanos(), 123_456_789);
     ///
-    /// let dt = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_nano_opt(8, 59, 59, 1_234_567_890).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_nano(8, 59, 59, 1_234_567_890).unwrap();
     /// assert_eq!(dt.timestamp_subsec_nanos(), 1_234_567_890);
     /// ```
     #[inline]
@@ -1556,9 +1556,9 @@ impl Timelike for NaiveDateTime {
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 59, 789).unwrap();
     /// assert_eq!(dt.with_nanosecond(333_333_333),
-    ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_nano_opt(12, 34, 59, 333_333_333).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_nano(12, 34, 59, 333_333_333).unwrap()));
     /// assert_eq!(dt.with_nanosecond(1_333_333_333), // leap second
-    ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_nano_opt(12, 34, 59, 1_333_333_333).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_nano(12, 34, 59, 1_333_333_333).unwrap()));
     /// assert_eq!(dt.with_nanosecond(2_000_000_000), None);
     /// ```
     #[inline]
@@ -2144,10 +2144,8 @@ where
         Some(r#""0000-01-01T00:00:60""#.into())
     );
     assert_eq!(
-        to_string(
-            &NaiveDate::from_ymd(-1, 12, 31).unwrap().and_hms_nano_opt(23, 59, 59, 7).unwrap()
-        )
-        .ok(),
+        to_string(&NaiveDate::from_ymd(-1, 12, 31).unwrap().and_hms_nano(23, 59, 59, 7).unwrap())
+            .ok(),
         Some(r#""-0001-12-31T23:59:59.000000007""#.into())
     );
     assert_eq!(
@@ -2155,7 +2153,7 @@ where
         Some(r#""-262143-01-01T00:00:00""#.into())
     );
     assert_eq!(
-        to_string(&NaiveDate::MAX.and_hms_nano_opt(23, 59, 59, 1_999_999_999).unwrap()).ok(),
+        to_string(&NaiveDate::MAX.and_hms_nano(23, 59, 59, 1_999_999_999).unwrap()).ok(),
         Some(r#""+262142-12-31T23:59:60.999999999""#.into())
     );
 }
@@ -2188,7 +2186,7 @@ where
     );
     assert_eq!(
         from_str(r#""-0001-12-31T23:59:59.000000007""#).ok(),
-        Some(NaiveDate::from_ymd(-1, 12, 31).unwrap().and_hms_nano_opt(23, 59, 59, 7).unwrap())
+        Some(NaiveDate::from_ymd(-1, 12, 31).unwrap().and_hms_nano(23, 59, 59, 7).unwrap())
     );
     assert_eq!(
         from_str(r#""-262143-01-01T00:00:00""#).ok(),
@@ -2196,11 +2194,11 @@ where
     );
     assert_eq!(
         from_str(r#""+262142-12-31T23:59:60.999999999""#).ok(),
-        Some(NaiveDate::MAX.and_hms_nano_opt(23, 59, 59, 1_999_999_999).unwrap())
+        Some(NaiveDate::MAX.and_hms_nano(23, 59, 59, 1_999_999_999).unwrap())
     );
     assert_eq!(
         from_str(r#""+262142-12-31T23:59:60.9999999999997""#).ok(), // excess digits are ignored
-        Some(NaiveDate::MAX.and_hms_nano_opt(23, 59, 59, 1_999_999_999).unwrap())
+        Some(NaiveDate::MAX.and_hms_nano(23, 59, 59, 1_999_999_999).unwrap())
     );
 
     // bad formats

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -696,7 +696,7 @@ impl NaiveDateTime {
     pub const fn checked_add_offset(self, rhs: FixedOffset) -> Option<NaiveDateTime> {
         let (time, days) = self.time.overflowing_add_offset(rhs);
         let date = match days {
-            -1 => try_opt!(self.date.pred_opt()),
+            -1 => try_opt!(self.date.pred()),
             1 => try_opt!(self.date.succ()),
             _ => self.date,
         };
@@ -711,7 +711,7 @@ impl NaiveDateTime {
     pub const fn checked_sub_offset(self, rhs: FixedOffset) -> Option<NaiveDateTime> {
         let (time, days) = self.time.overflowing_sub_offset(rhs);
         let date = match days {
-            -1 => try_opt!(self.date.pred_opt()),
+            -1 => try_opt!(self.date.pred()),
             1 => try_opt!(self.date.succ()),
             _ => self.date,
         };
@@ -727,7 +727,7 @@ impl NaiveDateTime {
     pub(crate) fn overflowing_add_offset(self, rhs: FixedOffset) -> NaiveDateTime {
         let (time, days) = self.time.overflowing_add_offset(rhs);
         let date = match days {
-            -1 => self.date.pred_opt().unwrap_or(NaiveDate::BEFORE_MIN),
+            -1 => self.date.pred().unwrap_or(NaiveDate::BEFORE_MIN),
             1 => self.date.succ().unwrap_or(NaiveDate::AFTER_MAX),
             _ => self.date,
         };
@@ -744,7 +744,7 @@ impl NaiveDateTime {
     pub(crate) fn overflowing_sub_offset(self, rhs: FixedOffset) -> NaiveDateTime {
         let (time, days) = self.time.overflowing_sub_offset(rhs);
         let date = match days {
-            -1 => self.date.pred_opt().unwrap_or(NaiveDate::BEFORE_MIN),
+            -1 => self.date.pred().unwrap_or(NaiveDate::BEFORE_MIN),
             1 => self.date.succ().unwrap_or(NaiveDate::AFTER_MAX),
             _ => self.date,
         };

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -49,7 +49,7 @@ const MAX_SECS_BITS: usize = 44;
 /// ```
 /// use chrono::{NaiveDate, NaiveDateTime};
 ///
-/// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_opt(9, 10, 11).unwrap();
+/// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms(9, 10, 11).unwrap();
 /// # let _ = dt;
 /// ```
 ///
@@ -58,7 +58,7 @@ const MAX_SECS_BITS: usize = 44;
 ///
 /// ```
 /// # use chrono::{NaiveDate, NaiveDateTime};
-/// # let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_opt(9, 10, 11).unwrap();
+/// # let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms(9, 10, 11).unwrap();
 /// use chrono::{Datelike, Timelike, Weekday};
 ///
 /// assert_eq!(dt.weekday(), Weekday::Fri);
@@ -255,7 +255,7 @@ impl NaiveDateTime {
     /// let parse_from_str = NaiveDateTime::parse_from_str;
     ///
     /// assert_eq!(parse_from_str("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S"),
-    ///            Ok(NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap()));
+    ///            Ok(NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms(23, 56, 4).unwrap()));
     /// assert_eq!(parse_from_str("5sep2015pm012345.6789", "%d%b%Y%p%I%M%S%.f"),
     ///            Ok(NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_micro_opt(13, 23, 45, 678_900).unwrap()));
     /// ```
@@ -266,7 +266,7 @@ impl NaiveDateTime {
     /// # use chrono::{NaiveDateTime, NaiveDate};
     /// # let parse_from_str = NaiveDateTime::parse_from_str;
     /// assert_eq!(parse_from_str("2014-5-17T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
-    ///            Ok(NaiveDate::from_ymd(2014, 5, 17).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    ///            Ok(NaiveDate::from_ymd(2014, 5, 17).unwrap().and_hms(12, 34, 56).unwrap()));
     /// ```
     ///
     /// [Leap seconds](./struct.NaiveTime.html#leap-second-handling) are correctly handled by
@@ -287,7 +287,7 @@ impl NaiveDateTime {
     /// # use chrono::{NaiveDateTime, NaiveDate};
     /// # let parse_from_str = NaiveDateTime::parse_from_str;
     /// assert_eq!(parse_from_str("94/9/4 7:15", "%y/%m/%d %H:%M"),
-    ///            Ok(NaiveDate::from_ymd(1994, 9, 4).unwrap().and_hms_opt(7, 15, 0).unwrap()));
+    ///            Ok(NaiveDate::from_ymd(1994, 9, 4).unwrap().and_hms(7, 15, 0).unwrap()));
     ///
     /// assert!(parse_from_str("04m33s", "%Mm%Ss").is_err());
     /// assert!(parse_from_str("94/9/4 12", "%y/%m/%d %H").is_err());
@@ -335,7 +335,7 @@ impl NaiveDateTime {
     ///     "2015-02-18 23:16:09 trailing text", "%Y-%m-%d %H:%M:%S").unwrap();
     /// assert_eq!(
     ///     datetime,
-    ///     NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_opt(23, 16, 9).unwrap()
+    ///     NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms(23, 16, 9).unwrap()
     /// );
     /// assert_eq!(remainder, " trailing text");
     /// ```
@@ -352,7 +352,7 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_opt(9, 10, 11).unwrap();
+    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms(9, 10, 11).unwrap();
     /// assert_eq!(dt.date(), NaiveDate::from_ymd(2016, 7, 8).unwrap());
     /// ```
     #[inline]
@@ -367,7 +367,7 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveTime};
     ///
-    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_opt(9, 10, 11).unwrap();
+    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms(9, 10, 11).unwrap();
     /// assert_eq!(dt.time(), NaiveTime::from_hms(9, 10, 11).unwrap());
     /// ```
     #[inline]
@@ -388,13 +388,13 @@ impl NaiveDateTime {
     /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_milli_opt(0, 0, 1, 980).unwrap();
     /// assert_eq!(dt.timestamp(), 1);
     ///
-    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_opt(1, 46, 40).unwrap();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms(1, 46, 40).unwrap();
     /// assert_eq!(dt.timestamp(), 1_000_000_000);
     ///
-    /// let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().and_hms_opt(23, 59, 59).unwrap();
+    /// let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().and_hms(23, 59, 59).unwrap();
     /// assert_eq!(dt.timestamp(), -1);
     ///
-    /// let dt = NaiveDate::from_ymd(-1, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    /// let dt = NaiveDate::from_ymd(-1, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
     /// assert_eq!(dt.timestamp(), -62198755200);
     /// ```
     #[inline]
@@ -596,7 +596,7 @@ impl NaiveDateTime {
     /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     ///
     /// let d = from_ymd(2016, 7, 8);
-    /// let hms = |h, m, s| d.and_hms_opt(h, m, s).unwrap();
+    /// let hms = |h, m, s| d.and_hms(h, m, s).unwrap();
     /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::zero()),
     ///            Some(hms(3, 5, 7)));
     /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::seconds(1)),
@@ -606,7 +606,7 @@ impl NaiveDateTime {
     /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::seconds(3600 + 60)),
     ///            Some(hms(4, 6, 7)));
     /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::seconds(86_400)),
-    ///            Some(from_ymd(2016, 7, 9).and_hms_opt(3, 5, 7).unwrap()));
+    ///            Some(from_ymd(2016, 7, 9).and_hms(3, 5, 7).unwrap()));
     ///
     /// let hmsm = |h, m, s, milli| d.and_hms_milli_opt(h, m, s, milli).unwrap();
     /// assert_eq!(hmsm(3, 5, 7, 980).checked_add_signed(TimeDelta::milliseconds(450)),
@@ -617,7 +617,7 @@ impl NaiveDateTime {
     ///
     /// ```
     /// # use chrono::{TimeDelta, NaiveDate};
-    /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_opt(h, m, s).unwrap();
+    /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms(h, m, s).unwrap();
     /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::days(1_000_000_000)), None);
     /// ```
     ///
@@ -671,13 +671,13 @@ impl NaiveDateTime {
     /// use chrono::{Months, NaiveDate};
     ///
     /// assert_eq!(
-    ///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(1, 0, 0).unwrap()
+    ///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms(1, 0, 0).unwrap()
     ///         .checked_add_months(Months::new(1)),
-    ///     Some(NaiveDate::from_ymd(2014, 2, 1).unwrap().and_hms_opt(1, 0, 0).unwrap())
+    ///     Some(NaiveDate::from_ymd(2014, 2, 1).unwrap().and_hms(1, 0, 0).unwrap())
     /// );
     ///
     /// assert_eq!(
-    ///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(1, 0, 0).unwrap()
+    ///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms(1, 0, 0).unwrap()
     ///         .checked_add_months(Months::new(core::i32::MAX as u32 + 1)),
     ///     None
     /// );
@@ -770,7 +770,7 @@ impl NaiveDateTime {
     /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     ///
     /// let d = from_ymd(2016, 7, 8);
-    /// let hms = |h, m, s| d.and_hms_opt(h, m, s).unwrap();
+    /// let hms = |h, m, s| d.and_hms(h, m, s).unwrap();
     /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::zero()),
     ///            Some(hms(3, 5, 7)));
     /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::seconds(1)),
@@ -780,7 +780,7 @@ impl NaiveDateTime {
     /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::seconds(3600 + 60)),
     ///            Some(hms(2, 4, 7)));
     /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::seconds(86_400)),
-    ///            Some(from_ymd(2016, 7, 7).and_hms_opt(3, 5, 7).unwrap()));
+    ///            Some(from_ymd(2016, 7, 7).and_hms(3, 5, 7).unwrap()));
     ///
     /// let hmsm = |h, m, s, milli| d.and_hms_milli_opt(h, m, s, milli).unwrap();
     /// assert_eq!(hmsm(3, 5, 7, 450).checked_sub_signed(TimeDelta::milliseconds(670)),
@@ -791,7 +791,7 @@ impl NaiveDateTime {
     ///
     /// ```
     /// # use chrono::{TimeDelta, NaiveDate};
-    /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_opt(h, m, s).unwrap();
+    /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms(h, m, s).unwrap();
     /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::days(1_000_000_000)), None);
     /// ```
     ///
@@ -841,13 +841,13 @@ impl NaiveDateTime {
     /// use chrono::{Months, NaiveDate};
     ///
     /// assert_eq!(
-    ///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(1, 0, 0).unwrap()
+    ///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms(1, 0, 0).unwrap()
     ///         .checked_sub_months(Months::new(1)),
-    ///     Some(NaiveDate::from_ymd(2013, 12, 1).unwrap().and_hms_opt(1, 0, 0).unwrap())
+    ///     Some(NaiveDate::from_ymd(2013, 12, 1).unwrap().and_hms(1, 0, 0).unwrap())
     /// );
     ///
     /// assert_eq!(
-    ///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(1, 0, 0).unwrap()
+    ///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms(1, 0, 0).unwrap()
     ///         .checked_sub_months(Months::new(core::i32::MAX as u32 + 1)),
     ///     None
     /// );
@@ -890,12 +890,12 @@ impl NaiveDateTime {
     /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     ///
     /// let d = from_ymd(2016, 7, 8);
-    /// assert_eq!(d.and_hms_opt(3, 5, 7).unwrap().signed_duration_since(d.and_hms_opt(2, 4, 6).unwrap()),
+    /// assert_eq!(d.and_hms(3, 5, 7).unwrap().signed_duration_since(d.and_hms(2, 4, 6).unwrap()),
     ///            TimeDelta::seconds(3600 + 60 + 1));
     ///
     /// // July 8 is 190th day in the year 2016
     /// let d0 = from_ymd(2016, 1, 1);
-    /// assert_eq!(d.and_hms_milli_opt(0, 7, 6, 500).unwrap().signed_duration_since(d0.and_hms_opt(0, 0, 0).unwrap()),
+    /// assert_eq!(d.and_hms_milli_opt(0, 7, 6, 500).unwrap().signed_duration_since(d0.and_hms(0, 0, 0).unwrap()),
     ///            TimeDelta::seconds(189 * 86_400 + 7 * 60 + 6) + TimeDelta::milliseconds(500));
     /// ```
     ///
@@ -906,9 +906,9 @@ impl NaiveDateTime {
     /// # use chrono::{TimeDelta, NaiveDate};
     /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     /// let leap = from_ymd(2015, 6, 30).and_hms_milli_opt(23, 59, 59, 1_500).unwrap();
-    /// assert_eq!(leap.signed_duration_since(from_ymd(2015, 6, 30).and_hms_opt(23, 0, 0).unwrap()),
+    /// assert_eq!(leap.signed_duration_since(from_ymd(2015, 6, 30).and_hms(23, 0, 0).unwrap()),
     ///            TimeDelta::seconds(3600) + TimeDelta::milliseconds(500));
-    /// assert_eq!(from_ymd(2015, 7, 1).and_hms_opt(1, 0, 0).unwrap().signed_duration_since(leap),
+    /// assert_eq!(from_ymd(2015, 7, 1).and_hms(1, 0, 0).unwrap().signed_duration_since(leap),
     ///            TimeDelta::seconds(3600) - TimeDelta::milliseconds(500));
     /// ```
     #[must_use]
@@ -934,7 +934,7 @@ impl NaiveDateTime {
     /// use chrono::format::strftime::StrftimeItems;
     ///
     /// let fmt = StrftimeItems::new("%Y-%m-%d %H:%M:%S");
-    /// let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms(23, 56, 4).unwrap();
     /// assert_eq!(dt.format_with_items(fmt.clone()).to_string(), "2015-09-05 23:56:04");
     /// assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(),    "2015-09-05 23:56:04");
     /// ```
@@ -945,7 +945,7 @@ impl NaiveDateTime {
     /// # use chrono::NaiveDate;
     /// # use chrono::format::strftime::StrftimeItems;
     /// # let fmt = StrftimeItems::new("%Y-%m-%d %H:%M:%S").clone();
-    /// # let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
+    /// # let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms(23, 56, 4).unwrap();
     /// assert_eq!(format!("{}", dt.format_with_items(fmt)), "2015-09-05 23:56:04");
     /// ```
     #[cfg(feature = "alloc")]
@@ -978,7 +978,7 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms(23, 56, 4).unwrap();
     /// assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2015-09-05 23:56:04");
     /// assert_eq!(dt.format("around %l %p on %b %-d").to_string(), "around 11 PM on Sep 5");
     /// ```
@@ -987,7 +987,7 @@ impl NaiveDateTime {
     ///
     /// ```
     /// # use chrono::NaiveDate;
-    /// # let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
+    /// # let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms(23, 56, 4).unwrap();
     /// assert_eq!(format!("{}", dt.format("%Y-%m-%d %H:%M:%S")), "2015-09-05 23:56:04");
     /// assert_eq!(format!("{}", dt.format("around %l %p on %b %-d")), "around 11 PM on Sep 5");
     /// ```
@@ -1015,7 +1015,7 @@ impl NaiveDateTime {
     /// use chrono::{NaiveDate, FixedOffset};
     /// let hour = 3600;
     /// let tz = FixedOffset::east(5 * hour).unwrap();
-    /// let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap().and_local_timezone(tz).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms(23, 56, 4).unwrap().and_local_timezone(tz).unwrap();
     /// assert_eq!(dt.timezone(), tz);
     /// ```
     #[must_use]
@@ -1029,7 +1029,7 @@ impl NaiveDateTime {
     ///
     /// ```
     /// use chrono::{NaiveDate, Utc};
-    /// let dt = NaiveDate::from_ymd(2023, 1, 30).unwrap().and_hms_opt(19, 32, 33).unwrap().and_utc();
+    /// let dt = NaiveDate::from_ymd(2023, 1, 30).unwrap().and_hms(19, 32, 33).unwrap().and_utc();
     /// assert_eq!(dt.timezone(), Utc);
     /// ```
     #[must_use]
@@ -1057,10 +1057,10 @@ impl From<NaiveDate> for NaiveDateTime {
     /// use chrono::{NaiveDate, NaiveDateTime};
     ///
     /// let nd = NaiveDate::from_ymd(2016, 5, 28).unwrap();
-    /// let ndt = NaiveDate::from_ymd(2016, 5, 28).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    /// let ndt = NaiveDate::from_ymd(2016, 5, 28).unwrap().and_hms(0, 0, 0).unwrap();
     /// assert_eq!(ndt, NaiveDateTime::from(nd));
     fn from(date: NaiveDate) -> Self {
-        date.and_hms_opt(0, 0, 0).unwrap()
+        date.and_hms(0, 0, 0).unwrap()
     }
 }
 
@@ -1074,7 +1074,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.year(), 2015);
     /// ```
     #[inline]
@@ -1093,7 +1093,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.month(), 9);
     /// ```
     #[inline]
@@ -1112,7 +1112,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.month0(), 8);
     /// ```
     #[inline]
@@ -1131,7 +1131,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.day(), 25);
     /// ```
     #[inline]
@@ -1150,7 +1150,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.day0(), 24);
     /// ```
     #[inline]
@@ -1169,7 +1169,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.ordinal(), 268);
     /// ```
     #[inline]
@@ -1188,7 +1188,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.ordinal0(), 267);
     /// ```
     #[inline]
@@ -1205,7 +1205,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike, Weekday};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.weekday(), Weekday::Fri);
     /// ```
     #[inline]
@@ -1233,9 +1233,9 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
-    /// assert_eq!(dt.with_year(2016), Some(NaiveDate::from_ymd(2016, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap()));
-    /// assert_eq!(dt.with_year(-308), Some(NaiveDate::from_ymd(-308, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
+    /// assert_eq!(dt.with_year(2016), Some(NaiveDate::from_ymd(2016, 9, 25).unwrap().and_hms(12, 34, 56).unwrap()));
+    /// assert_eq!(dt.with_year(-308), Some(NaiveDate::from_ymd(-308, 9, 25).unwrap().and_hms(12, 34, 56).unwrap()));
     /// ```
     #[inline]
     fn with_year(&self, year: i32) -> Option<NaiveDateTime> {
@@ -1255,8 +1255,8 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms_opt(12, 34, 56).unwrap();
-    /// assert_eq!(dt.with_month(10), Some(NaiveDate::from_ymd(2015, 10, 30).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms(12, 34, 56).unwrap();
+    /// assert_eq!(dt.with_month(10), Some(NaiveDate::from_ymd(2015, 10, 30).unwrap().and_hms(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_month(13), None); // no month 13
     /// assert_eq!(dt.with_month(2), None); // no February 30
     /// ```
@@ -1279,8 +1279,8 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms_opt(12, 34, 56).unwrap();
-    /// assert_eq!(dt.with_month0(9), Some(NaiveDate::from_ymd(2015, 10, 30).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms(12, 34, 56).unwrap();
+    /// assert_eq!(dt.with_month0(9), Some(NaiveDate::from_ymd(2015, 10, 30).unwrap().and_hms(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_month0(12), None); // no month 13
     /// assert_eq!(dt.with_month0(1), None); // no February 30
     /// ```
@@ -1302,8 +1302,8 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
-    /// assert_eq!(dt.with_day(30), Some(NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms(12, 34, 56).unwrap();
+    /// assert_eq!(dt.with_day(30), Some(NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_day(31), None); // no September 31
     /// ```
     #[inline]
@@ -1324,8 +1324,8 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
-    /// assert_eq!(dt.with_day0(29), Some(NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms(12, 34, 56).unwrap();
+    /// assert_eq!(dt.with_day0(29), Some(NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_day0(30), None); // no September 31
     /// ```
     #[inline]
@@ -1347,16 +1347,16 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.with_ordinal(60),
-    ///            Some(NaiveDate::from_ymd(2015, 3, 1).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 3, 1).unwrap().and_hms(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_ordinal(366), None); // 2015 had only 365 days
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 9, 8).unwrap().and_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.with_ordinal(60),
-    ///            Some(NaiveDate::from_ymd(2016, 2, 29).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2016, 2, 29).unwrap().and_hms(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_ordinal(366),
-    ///            Some(NaiveDate::from_ymd(2016, 12, 31).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2016, 12, 31).unwrap().and_hms(12, 34, 56).unwrap()));
     /// ```
     #[inline]
     fn with_ordinal(&self, ordinal: u32) -> Option<NaiveDateTime> {
@@ -1377,16 +1377,16 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.with_ordinal0(59),
-    ///            Some(NaiveDate::from_ymd(2015, 3, 1).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 3, 1).unwrap().and_hms(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_ordinal0(365), None); // 2015 had only 365 days
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 9, 8).unwrap().and_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.with_ordinal0(59),
-    ///            Some(NaiveDate::from_ymd(2016, 2, 29).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2016, 2, 29).unwrap().and_hms(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_ordinal0(365),
-    ///            Some(NaiveDate::from_ymd(2016, 12, 31).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2016, 12, 31).unwrap().and_hms(12, 34, 56).unwrap()));
     /// ```
     #[inline]
     fn with_ordinal0(&self, ordinal0: u32) -> Option<NaiveDateTime> {
@@ -1586,15 +1586,15 @@ impl Timelike for NaiveDateTime {
 /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// let d = from_ymd(2016, 7, 8);
-/// let hms = |h, m, s| d.and_hms_opt(h, m, s).unwrap();
+/// let hms = |h, m, s| d.and_hms(h, m, s).unwrap();
 /// assert_eq!(hms(3, 5, 7) + TimeDelta::zero(),             hms(3, 5, 7));
 /// assert_eq!(hms(3, 5, 7) + TimeDelta::seconds(1),         hms(3, 5, 8));
 /// assert_eq!(hms(3, 5, 7) + TimeDelta::seconds(-1),        hms(3, 5, 6));
 /// assert_eq!(hms(3, 5, 7) + TimeDelta::seconds(3600 + 60), hms(4, 6, 7));
 /// assert_eq!(hms(3, 5, 7) + TimeDelta::seconds(86_400),
-///            from_ymd(2016, 7, 9).and_hms_opt(3, 5, 7).unwrap());
+///            from_ymd(2016, 7, 9).and_hms(3, 5, 7).unwrap());
 /// assert_eq!(hms(3, 5, 7) + TimeDelta::days(365),
-///            from_ymd(2017, 7, 8).and_hms_opt(3, 5, 7).unwrap());
+///            from_ymd(2017, 7, 8).and_hms(3, 5, 7).unwrap());
 ///
 /// let hmsm = |h, m, s, milli| d.and_hms_milli_opt(h, m, s, milli).unwrap();
 /// assert_eq!(hmsm(3, 5, 7, 980) + TimeDelta::milliseconds(450), hmsm(3, 5, 8, 430));
@@ -1714,28 +1714,28 @@ impl Add<FixedOffset> for NaiveDateTime {
 /// use chrono::{Months, NaiveDate};
 ///
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(1, 0, 0).unwrap() + Months::new(1),
-///     NaiveDate::from_ymd(2014, 2, 1).unwrap().and_hms_opt(1, 0, 0).unwrap()
+///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms(1, 0, 0).unwrap() + Months::new(1),
+///     NaiveDate::from_ymd(2014, 2, 1).unwrap().and_hms(1, 0, 0).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(0, 2, 0).unwrap() + Months::new(11),
-///     NaiveDate::from_ymd(2014, 12, 1).unwrap().and_hms_opt(0, 2, 0).unwrap()
+///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms(0, 2, 0).unwrap() + Months::new(11),
+///     NaiveDate::from_ymd(2014, 12, 1).unwrap().and_hms(0, 2, 0).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(0, 0, 3).unwrap() + Months::new(12),
-///     NaiveDate::from_ymd(2015, 1, 1).unwrap().and_hms_opt(0, 0, 3).unwrap()
+///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms(0, 0, 3).unwrap() + Months::new(12),
+///     NaiveDate::from_ymd(2015, 1, 1).unwrap().and_hms(0, 0, 3).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(0, 0, 4).unwrap() + Months::new(13),
-///     NaiveDate::from_ymd(2015, 2, 1).unwrap().and_hms_opt(0, 0, 4).unwrap()
+///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms(0, 0, 4).unwrap() + Months::new(13),
+///     NaiveDate::from_ymd(2015, 2, 1).unwrap().and_hms(0, 0, 4).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 1, 31).unwrap().and_hms_opt(0, 5, 0).unwrap() + Months::new(1),
-///     NaiveDate::from_ymd(2014, 2, 28).unwrap().and_hms_opt(0, 5, 0).unwrap()
+///     NaiveDate::from_ymd(2014, 1, 31).unwrap().and_hms(0, 5, 0).unwrap() + Months::new(1),
+///     NaiveDate::from_ymd(2014, 2, 28).unwrap().and_hms(0, 5, 0).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd(2020, 1, 31).unwrap().and_hms_opt(6, 0, 0).unwrap() + Months::new(1),
-///     NaiveDate::from_ymd(2020, 2, 29).unwrap().and_hms_opt(6, 0, 0).unwrap()
+///     NaiveDate::from_ymd(2020, 1, 31).unwrap().and_hms(6, 0, 0).unwrap() + Months::new(1),
+///     NaiveDate::from_ymd(2020, 2, 29).unwrap().and_hms(6, 0, 0).unwrap()
 /// );
 /// ```
 impl Add<Months> for NaiveDateTime {
@@ -1767,15 +1767,15 @@ impl Add<Months> for NaiveDateTime {
 /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// let d = from_ymd(2016, 7, 8);
-/// let hms = |h, m, s| d.and_hms_opt(h, m, s).unwrap();
+/// let hms = |h, m, s| d.and_hms(h, m, s).unwrap();
 /// assert_eq!(hms(3, 5, 7) - TimeDelta::zero(),             hms(3, 5, 7));
 /// assert_eq!(hms(3, 5, 7) - TimeDelta::seconds(1),         hms(3, 5, 6));
 /// assert_eq!(hms(3, 5, 7) - TimeDelta::seconds(-1),        hms(3, 5, 8));
 /// assert_eq!(hms(3, 5, 7) - TimeDelta::seconds(3600 + 60), hms(2, 4, 7));
 /// assert_eq!(hms(3, 5, 7) - TimeDelta::seconds(86_400),
-///            from_ymd(2016, 7, 7).and_hms_opt(3, 5, 7).unwrap());
+///            from_ymd(2016, 7, 7).and_hms(3, 5, 7).unwrap());
 /// assert_eq!(hms(3, 5, 7) - TimeDelta::days(365),
-///            from_ymd(2015, 7, 9).and_hms_opt(3, 5, 7).unwrap());
+///            from_ymd(2015, 7, 9).and_hms(3, 5, 7).unwrap());
 ///
 /// let hmsm = |h, m, s, milli| d.and_hms_milli_opt(h, m, s, milli).unwrap();
 /// assert_eq!(hmsm(3, 5, 7, 450) - TimeDelta::milliseconds(670), hmsm(3, 5, 6, 780));
@@ -1895,16 +1895,16 @@ impl Sub<FixedOffset> for NaiveDateTime {
 /// use chrono::{Months, NaiveDate};
 ///
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 01, 01).unwrap().and_hms_opt(01, 00, 00).unwrap() - Months::new(11),
-///     NaiveDate::from_ymd(2013, 02, 01).unwrap().and_hms_opt(01, 00, 00).unwrap()
+///     NaiveDate::from_ymd(2014, 01, 01).unwrap().and_hms(01, 00, 00).unwrap() - Months::new(11),
+///     NaiveDate::from_ymd(2013, 02, 01).unwrap().and_hms(01, 00, 00).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 01, 01).unwrap().and_hms_opt(00, 02, 00).unwrap() - Months::new(12),
-///     NaiveDate::from_ymd(2013, 01, 01).unwrap().and_hms_opt(00, 02, 00).unwrap()
+///     NaiveDate::from_ymd(2014, 01, 01).unwrap().and_hms(00, 02, 00).unwrap() - Months::new(12),
+///     NaiveDate::from_ymd(2013, 01, 01).unwrap().and_hms(00, 02, 00).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 01, 01).unwrap().and_hms_opt(00, 00, 03).unwrap() - Months::new(13),
-///     NaiveDate::from_ymd(2012, 12, 01).unwrap().and_hms_opt(00, 00, 03).unwrap()
+///     NaiveDate::from_ymd(2014, 01, 01).unwrap().and_hms(00, 00, 03).unwrap() - Months::new(13),
+///     NaiveDate::from_ymd(2012, 12, 01).unwrap().and_hms(00, 00, 03).unwrap()
 /// );
 /// ```
 impl Sub<Months> for NaiveDateTime {
@@ -1934,11 +1934,11 @@ impl Sub<Months> for NaiveDateTime {
 /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// let d = from_ymd(2016, 7, 8);
-/// assert_eq!(d.and_hms_opt(3, 5, 7).unwrap() - d.and_hms_opt(2, 4, 6).unwrap(), TimeDelta::seconds(3600 + 60 + 1));
+/// assert_eq!(d.and_hms(3, 5, 7).unwrap() - d.and_hms(2, 4, 6).unwrap(), TimeDelta::seconds(3600 + 60 + 1));
 ///
 /// // July 8 is 190th day in the year 2016
 /// let d0 = from_ymd(2016, 1, 1);
-/// assert_eq!(d.and_hms_milli_opt(0, 7, 6, 500).unwrap() - d0.and_hms_opt(0, 0, 0).unwrap(),
+/// assert_eq!(d.and_hms_milli_opt(0, 7, 6, 500).unwrap() - d0.and_hms(0, 0, 0).unwrap(),
 ///            TimeDelta::seconds(189 * 86_400 + 7 * 60 + 6) + TimeDelta::milliseconds(500));
 /// ```
 ///
@@ -1949,9 +1949,9 @@ impl Sub<Months> for NaiveDateTime {
 /// # use chrono::{TimeDelta, NaiveDate};
 /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 /// let leap = from_ymd(2015, 6, 30).and_hms_milli_opt(23, 59, 59, 1_500).unwrap();
-/// assert_eq!(leap - from_ymd(2015, 6, 30).and_hms_opt(23, 0, 0).unwrap(),
+/// assert_eq!(leap - from_ymd(2015, 6, 30).and_hms(23, 0, 0).unwrap(),
 ///            TimeDelta::seconds(3600) + TimeDelta::milliseconds(500));
-/// assert_eq!(from_ymd(2015, 7, 1).and_hms_opt(1, 0, 0).unwrap() - leap,
+/// assert_eq!(from_ymd(2015, 7, 1).and_hms(1, 0, 0).unwrap() - leap,
 ///            TimeDelta::seconds(3600) - TimeDelta::milliseconds(500));
 /// ```
 impl Sub<NaiveDateTime> for NaiveDateTime {
@@ -2007,7 +2007,7 @@ impl Sub<Days> for NaiveDateTime {
 /// ```
 /// use chrono::NaiveDate;
 ///
-/// let dt = NaiveDate::from_ymd(2016, 11, 15).unwrap().and_hms_opt(7, 39, 24).unwrap();
+/// let dt = NaiveDate::from_ymd(2016, 11, 15).unwrap().and_hms(7, 39, 24).unwrap();
 /// assert_eq!(format!("{:?}", dt), "2016-11-15T07:39:24");
 /// ```
 ///
@@ -2040,7 +2040,7 @@ impl fmt::Debug for NaiveDateTime {
 /// ```
 /// use chrono::NaiveDate;
 ///
-/// let dt = NaiveDate::from_ymd(2016, 11, 15).unwrap().and_hms_opt(7, 39, 24).unwrap();
+/// let dt = NaiveDate::from_ymd(2016, 11, 15).unwrap().and_hms(7, 39, 24).unwrap();
 /// assert_eq!(format!("{}", dt), "2016-11-15 07:39:24");
 /// ```
 ///
@@ -2067,7 +2067,7 @@ impl fmt::Display for NaiveDateTime {
 /// ```
 /// use chrono::{NaiveDateTime, NaiveDate};
 ///
-/// let dt = NaiveDate::from_ymd(2015, 9, 18).unwrap().and_hms_opt(23, 56, 4).unwrap();
+/// let dt = NaiveDate::from_ymd(2015, 9, 18).unwrap().and_hms(23, 56, 4).unwrap();
 /// assert_eq!("2015-09-18T23:56:04".parse::<NaiveDateTime>(), Ok(dt));
 ///
 /// let dt = NaiveDate::from_ymd(12345, 6, 7).unwrap().and_hms_milli_opt(7, 59, 59, 1_500).unwrap(); // leap second
@@ -2137,7 +2137,7 @@ where
         Some(r#""2016-07-08T09:10:48.090""#.into())
     );
     assert_eq!(
-        to_string(&NaiveDate::from_ymd(2014, 7, 24).unwrap().and_hms_opt(12, 34, 6).unwrap()).ok(),
+        to_string(&NaiveDate::from_ymd(2014, 7, 24).unwrap().and_hms(12, 34, 6).unwrap()).ok(),
         Some(r#""2014-07-24T12:34:06""#.into())
     );
     assert_eq!(
@@ -2155,7 +2155,7 @@ where
         Some(r#""-0001-12-31T23:59:59.000000007""#.into())
     );
     assert_eq!(
-        to_string(&NaiveDate::MIN.and_hms_opt(0, 0, 0).unwrap()).ok(),
+        to_string(&NaiveDate::MIN.and_hms(0, 0, 0).unwrap()).ok(),
         Some(r#""-262143-01-01T00:00:00""#.into())
     );
     assert_eq!(
@@ -2180,7 +2180,7 @@ where
     );
     assert_eq!(
         from_str(r#""2014-07-24T12:34:06""#).ok(),
-        Some(NaiveDate::from_ymd(2014, 7, 24).unwrap().and_hms_opt(12, 34, 6).unwrap())
+        Some(NaiveDate::from_ymd(2014, 7, 24).unwrap().and_hms(12, 34, 6).unwrap())
     );
     assert_eq!(
         from_str(r#""0000-01-01T00:00:60""#).ok(),
@@ -2196,7 +2196,7 @@ where
     );
     assert_eq!(
         from_str(r#""-262143-01-01T00:00:00""#).ok(),
-        Some(NaiveDate::MIN.and_hms_opt(0, 0, 0).unwrap())
+        Some(NaiveDate::MIN.and_hms(0, 0, 0).unwrap())
     );
     assert_eq!(
         from_str(r#""+262142-12-31T23:59:60.999999999""#).ok(),

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -277,7 +277,7 @@ impl NaiveDateTime {
     /// # use chrono::{NaiveDateTime, NaiveDate};
     /// # let parse_from_str = NaiveDateTime::parse_from_str;
     /// assert_eq!(parse_from_str("2015-07-01 08:59:60.123", "%Y-%m-%d %H:%M:%S%.f"),
-    ///            Ok(NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_milli_opt(8, 59, 59, 1_123).unwrap()));
+    ///            Ok(NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_milli(8, 59, 59, 1_123).unwrap()));
     /// ```
     ///
     /// Missing seconds are assumed to be zero,
@@ -385,7 +385,7 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_milli_opt(0, 0, 1, 980).unwrap();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_milli(0, 0, 1, 980).unwrap();
     /// assert_eq!(dt.timestamp(), 1);
     ///
     /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms(1, 46, 40).unwrap();
@@ -416,13 +416,13 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_milli_opt(0, 0, 1, 444).unwrap();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_milli(0, 0, 1, 444).unwrap();
     /// assert_eq!(dt.timestamp_millis(), 1_444);
     ///
-    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_milli_opt(1, 46, 40, 555).unwrap();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_milli(1, 46, 40, 555).unwrap();
     /// assert_eq!(dt.timestamp_millis(), 1_000_000_000_555);
     ///
-    /// let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().and_hms_milli_opt(23, 59, 59, 100).unwrap();
+    /// let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().and_hms_milli(23, 59, 59, 100).unwrap();
     /// assert_eq!(dt.timestamp_millis(), -900);
     /// ```
     #[inline]
@@ -608,7 +608,7 @@ impl NaiveDateTime {
     /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::seconds(86_400)),
     ///            Some(from_ymd(2016, 7, 9).and_hms(3, 5, 7).unwrap()));
     ///
-    /// let hmsm = |h, m, s, milli| d.and_hms_milli_opt(h, m, s, milli).unwrap();
+    /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli).unwrap();
     /// assert_eq!(hmsm(3, 5, 7, 980).checked_add_signed(TimeDelta::milliseconds(450)),
     ///            Some(hmsm(3, 5, 8, 430)));
     /// ```
@@ -627,7 +627,7 @@ impl NaiveDateTime {
     /// ```
     /// # use chrono::{TimeDelta, NaiveDate};
     /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
-    /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli_opt(h, m, s, milli).unwrap();
+    /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli).unwrap();
     /// let leap = hmsm(3, 5, 59, 1_300);
     /// assert_eq!(leap.checked_add_signed(TimeDelta::zero()),
     ///            Some(hmsm(3, 5, 59, 1_300)));
@@ -642,7 +642,7 @@ impl NaiveDateTime {
     /// assert_eq!(leap.checked_add_signed(TimeDelta::seconds(-10)),
     ///            Some(hmsm(3, 5, 50, 300)));
     /// assert_eq!(leap.checked_add_signed(TimeDelta::days(1)),
-    ///            Some(from_ymd(2016, 7, 9).and_hms_milli_opt(3, 5, 59, 300).unwrap()));
+    ///            Some(from_ymd(2016, 7, 9).and_hms_milli(3, 5, 59, 300).unwrap()));
     /// ```
     #[must_use]
     pub const fn checked_add_signed(self, rhs: TimeDelta) -> Option<NaiveDateTime> {
@@ -782,7 +782,7 @@ impl NaiveDateTime {
     /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::seconds(86_400)),
     ///            Some(from_ymd(2016, 7, 7).and_hms(3, 5, 7).unwrap()));
     ///
-    /// let hmsm = |h, m, s, milli| d.and_hms_milli_opt(h, m, s, milli).unwrap();
+    /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli).unwrap();
     /// assert_eq!(hmsm(3, 5, 7, 450).checked_sub_signed(TimeDelta::milliseconds(670)),
     ///            Some(hmsm(3, 5, 6, 780)));
     /// ```
@@ -801,7 +801,7 @@ impl NaiveDateTime {
     /// ```
     /// # use chrono::{TimeDelta, NaiveDate};
     /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
-    /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli_opt(h, m, s, milli).unwrap();
+    /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli).unwrap();
     /// let leap = hmsm(3, 5, 59, 1_300);
     /// assert_eq!(leap.checked_sub_signed(TimeDelta::zero()),
     ///            Some(hmsm(3, 5, 59, 1_300)));
@@ -812,7 +812,7 @@ impl NaiveDateTime {
     /// assert_eq!(leap.checked_sub_signed(TimeDelta::seconds(60)),
     ///            Some(hmsm(3, 5, 0, 300)));
     /// assert_eq!(leap.checked_sub_signed(TimeDelta::days(1)),
-    ///            Some(from_ymd(2016, 7, 7).and_hms_milli_opt(3, 6, 0, 300).unwrap()));
+    ///            Some(from_ymd(2016, 7, 7).and_hms_milli(3, 6, 0, 300).unwrap()));
     /// ```
     #[must_use]
     pub const fn checked_sub_signed(self, rhs: TimeDelta) -> Option<NaiveDateTime> {
@@ -895,7 +895,7 @@ impl NaiveDateTime {
     ///
     /// // July 8 is 190th day in the year 2016
     /// let d0 = from_ymd(2016, 1, 1);
-    /// assert_eq!(d.and_hms_milli_opt(0, 7, 6, 500).unwrap().signed_duration_since(d0.and_hms(0, 0, 0).unwrap()),
+    /// assert_eq!(d.and_hms_milli(0, 7, 6, 500).unwrap().signed_duration_since(d0.and_hms(0, 0, 0).unwrap()),
     ///            TimeDelta::seconds(189 * 86_400 + 7 * 60 + 6) + TimeDelta::milliseconds(500));
     /// ```
     ///
@@ -905,7 +905,7 @@ impl NaiveDateTime {
     /// ```
     /// # use chrono::{TimeDelta, NaiveDate};
     /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
-    /// let leap = from_ymd(2015, 6, 30).and_hms_milli_opt(23, 59, 59, 1_500).unwrap();
+    /// let leap = from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500).unwrap();
     /// assert_eq!(leap.signed_duration_since(from_ymd(2015, 6, 30).and_hms(23, 0, 0).unwrap()),
     ///            TimeDelta::seconds(3600) + TimeDelta::milliseconds(500));
     /// assert_eq!(from_ymd(2015, 7, 1).and_hms(1, 0, 0).unwrap().signed_duration_since(leap),
@@ -1404,7 +1404,7 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.hour(), 12);
     /// ```
     #[inline]
@@ -1421,7 +1421,7 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.minute(), 34);
     /// ```
     #[inline]
@@ -1438,7 +1438,7 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.second(), 56);
     /// ```
     #[inline]
@@ -1457,7 +1457,7 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.nanosecond(), 789_000_000);
     /// ```
     #[inline]
@@ -1478,9 +1478,9 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.with_hour(7),
-    ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(7, 34, 56, 789).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(7, 34, 56, 789).unwrap()));
     /// assert_eq!(dt.with_hour(24), None);
     /// ```
     #[inline]
@@ -1501,9 +1501,9 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.with_minute(45),
-    ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 45, 56, 789).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 45, 56, 789).unwrap()));
     /// assert_eq!(dt.with_minute(60), None);
     /// ```
     #[inline]
@@ -1527,9 +1527,9 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.with_second(17),
-    ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 17, 789).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 17, 789).unwrap()));
     /// assert_eq!(dt.with_second(60), None);
     /// ```
     #[inline]
@@ -1554,7 +1554,7 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 59, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 59, 789).unwrap();
     /// assert_eq!(dt.with_nanosecond(333_333_333),
     ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_nano_opt(12, 34, 59, 333_333_333).unwrap()));
     /// assert_eq!(dt.with_nanosecond(1_333_333_333), // leap second
@@ -1596,7 +1596,7 @@ impl Timelike for NaiveDateTime {
 /// assert_eq!(hms(3, 5, 7) + TimeDelta::days(365),
 ///            from_ymd(2017, 7, 8).and_hms(3, 5, 7).unwrap());
 ///
-/// let hmsm = |h, m, s, milli| d.and_hms_milli_opt(h, m, s, milli).unwrap();
+/// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli).unwrap();
 /// assert_eq!(hmsm(3, 5, 7, 980) + TimeDelta::milliseconds(450), hmsm(3, 5, 8, 430));
 /// ```
 ///
@@ -1606,7 +1606,7 @@ impl Timelike for NaiveDateTime {
 /// ```
 /// # use chrono::{TimeDelta, NaiveDate};
 /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
-/// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli_opt(h, m, s, milli).unwrap();
+/// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli).unwrap();
 /// let leap = hmsm(3, 5, 59, 1_300);
 /// assert_eq!(leap + TimeDelta::zero(),             hmsm(3, 5, 59, 1_300));
 /// assert_eq!(leap + TimeDelta::milliseconds(-500), hmsm(3, 5, 59, 800));
@@ -1615,7 +1615,7 @@ impl Timelike for NaiveDateTime {
 /// assert_eq!(leap + TimeDelta::seconds(10),        hmsm(3, 6, 9, 300));
 /// assert_eq!(leap + TimeDelta::seconds(-10),       hmsm(3, 5, 50, 300));
 /// assert_eq!(leap + TimeDelta::days(1),
-///            from_ymd(2016, 7, 9).and_hms_milli_opt(3, 5, 59, 300).unwrap());
+///            from_ymd(2016, 7, 9).and_hms_milli(3, 5, 59, 300).unwrap());
 /// ```
 ///
 /// [leap second handling]: crate::NaiveTime#leap-second-handling
@@ -1777,7 +1777,7 @@ impl Add<Months> for NaiveDateTime {
 /// assert_eq!(hms(3, 5, 7) - TimeDelta::days(365),
 ///            from_ymd(2015, 7, 9).and_hms(3, 5, 7).unwrap());
 ///
-/// let hmsm = |h, m, s, milli| d.and_hms_milli_opt(h, m, s, milli).unwrap();
+/// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli).unwrap();
 /// assert_eq!(hmsm(3, 5, 7, 450) - TimeDelta::milliseconds(670), hmsm(3, 5, 6, 780));
 /// ```
 ///
@@ -1787,14 +1787,14 @@ impl Add<Months> for NaiveDateTime {
 /// ```
 /// # use chrono::{TimeDelta, NaiveDate};
 /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
-/// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli_opt(h, m, s, milli).unwrap();
+/// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli).unwrap();
 /// let leap = hmsm(3, 5, 59, 1_300);
 /// assert_eq!(leap - TimeDelta::zero(),            hmsm(3, 5, 59, 1_300));
 /// assert_eq!(leap - TimeDelta::milliseconds(200), hmsm(3, 5, 59, 1_100));
 /// assert_eq!(leap - TimeDelta::milliseconds(500), hmsm(3, 5, 59, 800));
 /// assert_eq!(leap - TimeDelta::seconds(60),       hmsm(3, 5, 0, 300));
 /// assert_eq!(leap - TimeDelta::days(1),
-///            from_ymd(2016, 7, 7).and_hms_milli_opt(3, 6, 0, 300).unwrap());
+///            from_ymd(2016, 7, 7).and_hms_milli(3, 6, 0, 300).unwrap());
 /// ```
 ///
 /// [leap second handling]: crate::NaiveTime#leap-second-handling
@@ -1938,7 +1938,7 @@ impl Sub<Months> for NaiveDateTime {
 ///
 /// // July 8 is 190th day in the year 2016
 /// let d0 = from_ymd(2016, 1, 1);
-/// assert_eq!(d.and_hms_milli_opt(0, 7, 6, 500).unwrap() - d0.and_hms(0, 0, 0).unwrap(),
+/// assert_eq!(d.and_hms_milli(0, 7, 6, 500).unwrap() - d0.and_hms(0, 0, 0).unwrap(),
 ///            TimeDelta::seconds(189 * 86_400 + 7 * 60 + 6) + TimeDelta::milliseconds(500));
 /// ```
 ///
@@ -1948,7 +1948,7 @@ impl Sub<Months> for NaiveDateTime {
 /// ```
 /// # use chrono::{TimeDelta, NaiveDate};
 /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
-/// let leap = from_ymd(2015, 6, 30).and_hms_milli_opt(23, 59, 59, 1_500).unwrap();
+/// let leap = from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500).unwrap();
 /// assert_eq!(leap - from_ymd(2015, 6, 30).and_hms(23, 0, 0).unwrap(),
 ///            TimeDelta::seconds(3600) + TimeDelta::milliseconds(500));
 /// assert_eq!(from_ymd(2015, 7, 1).and_hms(1, 0, 0).unwrap() - leap,
@@ -2015,7 +2015,7 @@ impl Sub<Days> for NaiveDateTime {
 ///
 /// ```
 /// # use chrono::NaiveDate;
-/// let dt = NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_500).unwrap();
+/// let dt = NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli(23, 59, 59, 1_500).unwrap();
 /// assert_eq!(format!("{:?}", dt), "2015-06-30T23:59:60.500");
 /// ```
 impl fmt::Debug for NaiveDateTime {
@@ -2048,7 +2048,7 @@ impl fmt::Debug for NaiveDateTime {
 ///
 /// ```
 /// # use chrono::NaiveDate;
-/// let dt = NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_500).unwrap();
+/// let dt = NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli(23, 59, 59, 1_500).unwrap();
 /// assert_eq!(format!("{}", dt), "2015-06-30 23:59:60.500");
 /// ```
 impl fmt::Display for NaiveDateTime {
@@ -2070,7 +2070,7 @@ impl fmt::Display for NaiveDateTime {
 /// let dt = NaiveDate::from_ymd(2015, 9, 18).unwrap().and_hms(23, 56, 4).unwrap();
 /// assert_eq!("2015-09-18T23:56:04".parse::<NaiveDateTime>(), Ok(dt));
 ///
-/// let dt = NaiveDate::from_ymd(12345, 6, 7).unwrap().and_hms_milli_opt(7, 59, 59, 1_500).unwrap(); // leap second
+/// let dt = NaiveDate::from_ymd(12345, 6, 7).unwrap().and_hms_milli(7, 59, 59, 1_500).unwrap(); // leap second
 /// assert_eq!("+12345-6-7T7:59:60.5".parse::<NaiveDateTime>(), Ok(dt));
 ///
 /// assert!("foo".parse::<NaiveDateTime>().is_err());
@@ -2130,10 +2130,8 @@ where
     E: ::std::fmt::Debug,
 {
     assert_eq!(
-        to_string(
-            &NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli_opt(9, 10, 48, 90).unwrap()
-        )
-        .ok(),
+        to_string(&NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli(9, 10, 48, 90).unwrap())
+            .ok(),
         Some(r#""2016-07-08T09:10:48.090""#.into())
     );
     assert_eq!(
@@ -2141,10 +2139,8 @@ where
         Some(r#""2014-07-24T12:34:06""#.into())
     );
     assert_eq!(
-        to_string(
-            &NaiveDate::from_ymd(0, 1, 1).unwrap().and_hms_milli_opt(0, 0, 59, 1_000).unwrap()
-        )
-        .ok(),
+        to_string(&NaiveDate::from_ymd(0, 1, 1).unwrap().and_hms_milli(0, 0, 59, 1_000).unwrap())
+            .ok(),
         Some(r#""0000-01-01T00:00:60""#.into())
     );
     assert_eq!(
@@ -2172,11 +2168,11 @@ where
 {
     assert_eq!(
         from_str(r#""2016-07-08T09:10:48.090""#).ok(),
-        Some(NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli_opt(9, 10, 48, 90).unwrap())
+        Some(NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli(9, 10, 48, 90).unwrap())
     );
     assert_eq!(
         from_str(r#""2016-7-8T9:10:48.09""#).ok(),
-        Some(NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli_opt(9, 10, 48, 90).unwrap())
+        Some(NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli(9, 10, 48, 90).unwrap())
     );
     assert_eq!(
         from_str(r#""2014-07-24T12:34:06""#).ok(),
@@ -2184,11 +2180,11 @@ where
     );
     assert_eq!(
         from_str(r#""0000-01-01T00:00:60""#).ok(),
-        Some(NaiveDate::from_ymd(0, 1, 1).unwrap().and_hms_milli_opt(0, 0, 59, 1_000).unwrap())
+        Some(NaiveDate::from_ymd(0, 1, 1).unwrap().and_hms_milli(0, 0, 59, 1_000).unwrap())
     );
     assert_eq!(
         from_str(r#""0-1-1T0:0:60""#).ok(),
-        Some(NaiveDate::from_ymd(0, 1, 1).unwrap().and_hms_milli_opt(0, 0, 59, 1_000).unwrap())
+        Some(NaiveDate::from_ymd(0, 1, 1).unwrap().and_hms_milli(0, 0, 59, 1_000).unwrap())
     );
     assert_eq!(
         from_str(r#""-0001-12-31T23:59:59.000000007""#).ok(),

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -49,7 +49,7 @@ const MAX_SECS_BITS: usize = 44;
 /// ```
 /// use chrono::{NaiveDate, NaiveDateTime};
 ///
-/// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_opt(9, 10, 11).unwrap();
+/// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_opt(9, 10, 11).unwrap();
 /// # let _ = dt;
 /// ```
 ///
@@ -58,7 +58,7 @@ const MAX_SECS_BITS: usize = 44;
 ///
 /// ```
 /// # use chrono::{NaiveDate, NaiveDateTime};
-/// # let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_opt(9, 10, 11).unwrap();
+/// # let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_opt(9, 10, 11).unwrap();
 /// use chrono::{Datelike, Timelike, Weekday};
 ///
 /// assert_eq!(dt.weekday(), Weekday::Fri);
@@ -88,7 +88,7 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveTime, NaiveDateTime};
     ///
-    /// let d = NaiveDate::from_ymd_opt(2015, 6, 3).unwrap();
+    /// let d = NaiveDate::from_ymd(2015, 6, 3).unwrap();
     /// let t = NaiveTime::from_hms_milli(12, 34, 56, 789).unwrap();
     ///
     /// let dt = NaiveDateTime::new(d, t);
@@ -256,9 +256,9 @@ impl NaiveDateTime {
     /// let parse_from_str = NaiveDateTime::parse_from_str;
     ///
     /// assert_eq!(parse_from_str("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S"),
-    ///            Ok(NaiveDate::from_ymd_opt(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap()));
+    ///            Ok(NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap()));
     /// assert_eq!(parse_from_str("5sep2015pm012345.6789", "%d%b%Y%p%I%M%S%.f"),
-    ///            Ok(NaiveDate::from_ymd_opt(2015, 9, 5).unwrap().and_hms_micro_opt(13, 23, 45, 678_900).unwrap()));
+    ///            Ok(NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_micro_opt(13, 23, 45, 678_900).unwrap()));
     /// ```
     ///
     /// Offset is ignored for the purpose of parsing.
@@ -267,7 +267,7 @@ impl NaiveDateTime {
     /// # use chrono::{NaiveDateTime, NaiveDate};
     /// # let parse_from_str = NaiveDateTime::parse_from_str;
     /// assert_eq!(parse_from_str("2014-5-17T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
-    ///            Ok(NaiveDate::from_ymd_opt(2014, 5, 17).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    ///            Ok(NaiveDate::from_ymd(2014, 5, 17).unwrap().and_hms_opt(12, 34, 56).unwrap()));
     /// ```
     ///
     /// [Leap seconds](./struct.NaiveTime.html#leap-second-handling) are correctly handled by
@@ -278,7 +278,7 @@ impl NaiveDateTime {
     /// # use chrono::{NaiveDateTime, NaiveDate};
     /// # let parse_from_str = NaiveDateTime::parse_from_str;
     /// assert_eq!(parse_from_str("2015-07-01 08:59:60.123", "%Y-%m-%d %H:%M:%S%.f"),
-    ///            Ok(NaiveDate::from_ymd_opt(2015, 7, 1).unwrap().and_hms_milli_opt(8, 59, 59, 1_123).unwrap()));
+    ///            Ok(NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_milli_opt(8, 59, 59, 1_123).unwrap()));
     /// ```
     ///
     /// Missing seconds are assumed to be zero,
@@ -288,7 +288,7 @@ impl NaiveDateTime {
     /// # use chrono::{NaiveDateTime, NaiveDate};
     /// # let parse_from_str = NaiveDateTime::parse_from_str;
     /// assert_eq!(parse_from_str("94/9/4 7:15", "%y/%m/%d %H:%M"),
-    ///            Ok(NaiveDate::from_ymd_opt(1994, 9, 4).unwrap().and_hms_opt(7, 15, 0).unwrap()));
+    ///            Ok(NaiveDate::from_ymd(1994, 9, 4).unwrap().and_hms_opt(7, 15, 0).unwrap()));
     ///
     /// assert!(parse_from_str("04m33s", "%Mm%Ss").is_err());
     /// assert!(parse_from_str("94/9/4 12", "%y/%m/%d %H").is_err());
@@ -336,7 +336,7 @@ impl NaiveDateTime {
     ///     "2015-02-18 23:16:09 trailing text", "%Y-%m-%d %H:%M:%S").unwrap();
     /// assert_eq!(
     ///     datetime,
-    ///     NaiveDate::from_ymd_opt(2015, 2, 18).unwrap().and_hms_opt(23, 16, 9).unwrap()
+    ///     NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_opt(23, 16, 9).unwrap()
     /// );
     /// assert_eq!(remainder, " trailing text");
     /// ```
@@ -353,8 +353,8 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_opt(9, 10, 11).unwrap();
-    /// assert_eq!(dt.date(), NaiveDate::from_ymd_opt(2016, 7, 8).unwrap());
+    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_opt(9, 10, 11).unwrap();
+    /// assert_eq!(dt.date(), NaiveDate::from_ymd(2016, 7, 8).unwrap());
     /// ```
     #[inline]
     pub const fn date(&self) -> NaiveDate {
@@ -368,7 +368,7 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveTime};
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_opt(9, 10, 11).unwrap();
+    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_opt(9, 10, 11).unwrap();
     /// assert_eq!(dt.time(), NaiveTime::from_hms(9, 10, 11).unwrap());
     /// ```
     #[inline]
@@ -386,16 +386,16 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_milli_opt(0, 0, 1, 980).unwrap();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_milli_opt(0, 0, 1, 980).unwrap();
     /// assert_eq!(dt.timestamp(), 1);
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2001, 9, 9).unwrap().and_hms_opt(1, 46, 40).unwrap();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_opt(1, 46, 40).unwrap();
     /// assert_eq!(dt.timestamp(), 1_000_000_000);
     ///
-    /// let dt = NaiveDate::from_ymd_opt(1969, 12, 31).unwrap().and_hms_opt(23, 59, 59).unwrap();
+    /// let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().and_hms_opt(23, 59, 59).unwrap();
     /// assert_eq!(dt.timestamp(), -1);
     ///
-    /// let dt = NaiveDate::from_ymd_opt(-1, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    /// let dt = NaiveDate::from_ymd(-1, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
     /// assert_eq!(dt.timestamp(), -62198755200);
     /// ```
     #[inline]
@@ -417,13 +417,13 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_milli_opt(0, 0, 1, 444).unwrap();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_milli_opt(0, 0, 1, 444).unwrap();
     /// assert_eq!(dt.timestamp_millis(), 1_444);
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2001, 9, 9).unwrap().and_hms_milli_opt(1, 46, 40, 555).unwrap();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_milli_opt(1, 46, 40, 555).unwrap();
     /// assert_eq!(dt.timestamp_millis(), 1_000_000_000_555);
     ///
-    /// let dt = NaiveDate::from_ymd_opt(1969, 12, 31).unwrap().and_hms_milli_opt(23, 59, 59, 100).unwrap();
+    /// let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().and_hms_milli_opt(23, 59, 59, 100).unwrap();
     /// assert_eq!(dt.timestamp_millis(), -900);
     /// ```
     #[inline]
@@ -443,10 +443,10 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_micro_opt(0, 0, 1, 444).unwrap();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_micro_opt(0, 0, 1, 444).unwrap();
     /// assert_eq!(dt.timestamp_micros(), 1_000_444);
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2001, 9, 9).unwrap().and_hms_micro_opt(1, 46, 40, 555).unwrap();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_micro_opt(1, 46, 40, 555).unwrap();
     /// assert_eq!(dt.timestamp_micros(), 1_000_000_000_000_555);
     /// ```
     #[inline]
@@ -474,10 +474,10 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime};
     ///
-    /// let dt = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_nano_opt(0, 0, 1, 444).unwrap();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_nano_opt(0, 0, 1, 444).unwrap();
     /// assert_eq!(dt.timestamp_nanos(), Some(1_000_000_444));
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2001, 9, 9).unwrap().and_hms_nano_opt(1, 46, 40, 555).unwrap();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano_opt(1, 46, 40, 555).unwrap();
     ///
     /// const A_BILLION: i64 = 1_000_000_000;
     /// let nanos = dt.timestamp_nanos().unwrap();
@@ -522,10 +522,10 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_nano_opt(9, 10, 11, 123_456_789).unwrap();
+    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_nano_opt(9, 10, 11, 123_456_789).unwrap();
     /// assert_eq!(dt.timestamp_subsec_millis(), 123);
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2015, 7, 1).unwrap().and_hms_nano_opt(8, 59, 59, 1_234_567_890).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_nano_opt(8, 59, 59, 1_234_567_890).unwrap();
     /// assert_eq!(dt.timestamp_subsec_millis(), 1_234);
     /// ```
     #[inline]
@@ -544,10 +544,10 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_nano_opt(9, 10, 11, 123_456_789).unwrap();
+    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_nano_opt(9, 10, 11, 123_456_789).unwrap();
     /// assert_eq!(dt.timestamp_subsec_micros(), 123_456);
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2015, 7, 1).unwrap().and_hms_nano_opt(8, 59, 59, 1_234_567_890).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_nano_opt(8, 59, 59, 1_234_567_890).unwrap();
     /// assert_eq!(dt.timestamp_subsec_micros(), 1_234_567);
     /// ```
     #[inline]
@@ -566,10 +566,10 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_nano_opt(9, 10, 11, 123_456_789).unwrap();
+    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_nano_opt(9, 10, 11, 123_456_789).unwrap();
     /// assert_eq!(dt.timestamp_subsec_nanos(), 123_456_789);
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2015, 7, 1).unwrap().and_hms_nano_opt(8, 59, 59, 1_234_567_890).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_nano_opt(8, 59, 59, 1_234_567_890).unwrap();
     /// assert_eq!(dt.timestamp_subsec_nanos(), 1_234_567_890);
     /// ```
     #[inline]
@@ -594,7 +594,7 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{TimeDelta, NaiveDate};
     ///
-    /// let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     ///
     /// let d = from_ymd(2016, 7, 8);
     /// let hms = |h, m, s| d.and_hms_opt(h, m, s).unwrap();
@@ -618,7 +618,7 @@ impl NaiveDateTime {
     ///
     /// ```
     /// # use chrono::{TimeDelta, NaiveDate};
-    /// # let hms = |h, m, s| NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_opt(h, m, s).unwrap();
+    /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_opt(h, m, s).unwrap();
     /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::days(1_000_000_000)), None);
     /// ```
     ///
@@ -627,7 +627,7 @@ impl NaiveDateTime {
     ///
     /// ```
     /// # use chrono::{TimeDelta, NaiveDate};
-    /// # let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli_opt(h, m, s, milli).unwrap();
     /// let leap = hmsm(3, 5, 59, 1_300);
     /// assert_eq!(leap.checked_add_signed(TimeDelta::zero()),
@@ -672,13 +672,13 @@ impl NaiveDateTime {
     /// use chrono::{Months, NaiveDate};
     ///
     /// assert_eq!(
-    ///     NaiveDate::from_ymd_opt(2014, 1, 1).unwrap().and_hms_opt(1, 0, 0).unwrap()
+    ///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(1, 0, 0).unwrap()
     ///         .checked_add_months(Months::new(1)),
-    ///     Some(NaiveDate::from_ymd_opt(2014, 2, 1).unwrap().and_hms_opt(1, 0, 0).unwrap())
+    ///     Some(NaiveDate::from_ymd(2014, 2, 1).unwrap().and_hms_opt(1, 0, 0).unwrap())
     /// );
     ///
     /// assert_eq!(
-    ///     NaiveDate::from_ymd_opt(2014, 1, 1).unwrap().and_hms_opt(1, 0, 0).unwrap()
+    ///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(1, 0, 0).unwrap()
     ///         .checked_add_months(Months::new(core::i32::MAX as u32 + 1)),
     ///     None
     /// );
@@ -768,7 +768,7 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{TimeDelta, NaiveDate};
     ///
-    /// let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     ///
     /// let d = from_ymd(2016, 7, 8);
     /// let hms = |h, m, s| d.and_hms_opt(h, m, s).unwrap();
@@ -792,7 +792,7 @@ impl NaiveDateTime {
     ///
     /// ```
     /// # use chrono::{TimeDelta, NaiveDate};
-    /// # let hms = |h, m, s| NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_opt(h, m, s).unwrap();
+    /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_opt(h, m, s).unwrap();
     /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::days(1_000_000_000)), None);
     /// ```
     ///
@@ -801,7 +801,7 @@ impl NaiveDateTime {
     ///
     /// ```
     /// # use chrono::{TimeDelta, NaiveDate};
-    /// # let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli_opt(h, m, s, milli).unwrap();
     /// let leap = hmsm(3, 5, 59, 1_300);
     /// assert_eq!(leap.checked_sub_signed(TimeDelta::zero()),
@@ -842,13 +842,13 @@ impl NaiveDateTime {
     /// use chrono::{Months, NaiveDate};
     ///
     /// assert_eq!(
-    ///     NaiveDate::from_ymd_opt(2014, 1, 1).unwrap().and_hms_opt(1, 0, 0).unwrap()
+    ///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(1, 0, 0).unwrap()
     ///         .checked_sub_months(Months::new(1)),
-    ///     Some(NaiveDate::from_ymd_opt(2013, 12, 1).unwrap().and_hms_opt(1, 0, 0).unwrap())
+    ///     Some(NaiveDate::from_ymd(2013, 12, 1).unwrap().and_hms_opt(1, 0, 0).unwrap())
     /// );
     ///
     /// assert_eq!(
-    ///     NaiveDate::from_ymd_opt(2014, 1, 1).unwrap().and_hms_opt(1, 0, 0).unwrap()
+    ///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(1, 0, 0).unwrap()
     ///         .checked_sub_months(Months::new(core::i32::MAX as u32 + 1)),
     ///     None
     /// );
@@ -888,7 +888,7 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{TimeDelta, NaiveDate};
     ///
-    /// let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     ///
     /// let d = from_ymd(2016, 7, 8);
     /// assert_eq!(d.and_hms_opt(3, 5, 7).unwrap().signed_duration_since(d.and_hms_opt(2, 4, 6).unwrap()),
@@ -905,7 +905,7 @@ impl NaiveDateTime {
     ///
     /// ```
     /// # use chrono::{TimeDelta, NaiveDate};
-    /// # let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+    /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     /// let leap = from_ymd(2015, 6, 30).and_hms_milli_opt(23, 59, 59, 1_500).unwrap();
     /// assert_eq!(leap.signed_duration_since(from_ymd(2015, 6, 30).and_hms_opt(23, 0, 0).unwrap()),
     ///            TimeDelta::seconds(3600) + TimeDelta::milliseconds(500));
@@ -935,7 +935,7 @@ impl NaiveDateTime {
     /// use chrono::format::strftime::StrftimeItems;
     ///
     /// let fmt = StrftimeItems::new("%Y-%m-%d %H:%M:%S");
-    /// let dt = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
     /// assert_eq!(dt.format_with_items(fmt.clone()).to_string(), "2015-09-05 23:56:04");
     /// assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(),    "2015-09-05 23:56:04");
     /// ```
@@ -946,7 +946,7 @@ impl NaiveDateTime {
     /// # use chrono::NaiveDate;
     /// # use chrono::format::strftime::StrftimeItems;
     /// # let fmt = StrftimeItems::new("%Y-%m-%d %H:%M:%S").clone();
-    /// # let dt = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
+    /// # let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
     /// assert_eq!(format!("{}", dt.format_with_items(fmt)), "2015-09-05 23:56:04");
     /// ```
     #[cfg(feature = "alloc")]
@@ -979,7 +979,7 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
     /// assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2015-09-05 23:56:04");
     /// assert_eq!(dt.format("around %l %p on %b %-d").to_string(), "around 11 PM on Sep 5");
     /// ```
@@ -988,7 +988,7 @@ impl NaiveDateTime {
     ///
     /// ```
     /// # use chrono::NaiveDate;
-    /// # let dt = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
+    /// # let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap();
     /// assert_eq!(format!("{}", dt.format("%Y-%m-%d %H:%M:%S")), "2015-09-05 23:56:04");
     /// assert_eq!(format!("{}", dt.format("around %l %p on %b %-d")), "around 11 PM on Sep 5");
     /// ```
@@ -1016,7 +1016,7 @@ impl NaiveDateTime {
     /// use chrono::{NaiveDate, FixedOffset};
     /// let hour = 3600;
     /// let tz = FixedOffset::east(5 * hour).unwrap();
-    /// let dt = NaiveDate::from_ymd_opt(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap().and_local_timezone(tz).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_opt(23, 56, 4).unwrap().and_local_timezone(tz).unwrap();
     /// assert_eq!(dt.timezone(), tz);
     /// ```
     #[must_use]
@@ -1030,7 +1030,7 @@ impl NaiveDateTime {
     ///
     /// ```
     /// use chrono::{NaiveDate, Utc};
-    /// let dt = NaiveDate::from_ymd_opt(2023, 1, 30).unwrap().and_hms_opt(19, 32, 33).unwrap().and_utc();
+    /// let dt = NaiveDate::from_ymd(2023, 1, 30).unwrap().and_hms_opt(19, 32, 33).unwrap().and_utc();
     /// assert_eq!(dt.timezone(), Utc);
     /// ```
     #[must_use]
@@ -1046,7 +1046,7 @@ impl NaiveDateTime {
 
     /// The Unix Epoch, 1970-01-01 00:00:00.
     pub const UNIX_EPOCH: Self =
-        expect!(NaiveDate::from_ymd_opt(1970, 1, 1), "").and_time(NaiveTime::MIN);
+        expect!(NaiveDate::from_ymd(1970, 1, 1), "").and_time(NaiveTime::MIN);
 }
 
 impl From<NaiveDate> for NaiveDateTime {
@@ -1057,8 +1057,8 @@ impl From<NaiveDate> for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime};
     ///
-    /// let nd = NaiveDate::from_ymd_opt(2016, 5, 28).unwrap();
-    /// let ndt = NaiveDate::from_ymd_opt(2016, 5, 28).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    /// let nd = NaiveDate::from_ymd(2016, 5, 28).unwrap();
+    /// let ndt = NaiveDate::from_ymd(2016, 5, 28).unwrap().and_hms_opt(0, 0, 0).unwrap();
     /// assert_eq!(ndt, NaiveDateTime::from(nd));
     fn from(date: NaiveDate) -> Self {
         date.and_hms_opt(0, 0, 0).unwrap()
@@ -1075,7 +1075,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
     /// assert_eq!(dt.year(), 2015);
     /// ```
     #[inline]
@@ -1094,7 +1094,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
     /// assert_eq!(dt.month(), 9);
     /// ```
     #[inline]
@@ -1113,7 +1113,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
     /// assert_eq!(dt.month0(), 8);
     /// ```
     #[inline]
@@ -1132,7 +1132,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
     /// assert_eq!(dt.day(), 25);
     /// ```
     #[inline]
@@ -1151,7 +1151,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
     /// assert_eq!(dt.day0(), 24);
     /// ```
     #[inline]
@@ -1170,7 +1170,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
     /// assert_eq!(dt.ordinal(), 268);
     /// ```
     #[inline]
@@ -1189,7 +1189,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
     /// assert_eq!(dt.ordinal0(), 267);
     /// ```
     #[inline]
@@ -1206,7 +1206,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike, Weekday};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
     /// assert_eq!(dt.weekday(), Weekday::Fri);
     /// ```
     #[inline]
@@ -1234,9 +1234,9 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
-    /// assert_eq!(dt.with_year(2016), Some(NaiveDate::from_ymd_opt(2016, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap()));
-    /// assert_eq!(dt.with_year(-308), Some(NaiveDate::from_ymd_opt(-308, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// assert_eq!(dt.with_year(2016), Some(NaiveDate::from_ymd(2016, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    /// assert_eq!(dt.with_year(-308), Some(NaiveDate::from_ymd(-308, 9, 25).unwrap().and_hms_opt(12, 34, 56).unwrap()));
     /// ```
     #[inline]
     fn with_year(&self, year: i32) -> Option<NaiveDateTime> {
@@ -1256,8 +1256,8 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 30).unwrap().and_hms_opt(12, 34, 56).unwrap();
-    /// assert_eq!(dt.with_month(10), Some(NaiveDate::from_ymd_opt(2015, 10, 30).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// assert_eq!(dt.with_month(10), Some(NaiveDate::from_ymd(2015, 10, 30).unwrap().and_hms_opt(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_month(13), None); // no month 13
     /// assert_eq!(dt.with_month(2), None); // no February 30
     /// ```
@@ -1280,8 +1280,8 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 30).unwrap().and_hms_opt(12, 34, 56).unwrap();
-    /// assert_eq!(dt.with_month0(9), Some(NaiveDate::from_ymd_opt(2015, 10, 30).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// assert_eq!(dt.with_month0(9), Some(NaiveDate::from_ymd(2015, 10, 30).unwrap().and_hms_opt(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_month0(12), None); // no month 13
     /// assert_eq!(dt.with_month0(1), None); // no February 30
     /// ```
@@ -1303,8 +1303,8 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
-    /// assert_eq!(dt.with_day(30), Some(NaiveDate::from_ymd_opt(2015, 9, 30).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// assert_eq!(dt.with_day(30), Some(NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms_opt(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_day(31), None); // no September 31
     /// ```
     #[inline]
@@ -1325,8 +1325,8 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
-    /// assert_eq!(dt.with_day0(29), Some(NaiveDate::from_ymd_opt(2015, 9, 30).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// assert_eq!(dt.with_day0(29), Some(NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms_opt(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_day0(30), None); // no September 31
     /// ```
     #[inline]
@@ -1348,16 +1348,16 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
     /// assert_eq!(dt.with_ordinal(60),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 3, 1).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 3, 1).unwrap().and_hms_opt(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_ordinal(366), None); // 2015 had only 365 days
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2016, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
     /// assert_eq!(dt.with_ordinal(60),
-    ///            Some(NaiveDate::from_ymd_opt(2016, 2, 29).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2016, 2, 29).unwrap().and_hms_opt(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_ordinal(366),
-    ///            Some(NaiveDate::from_ymd_opt(2016, 12, 31).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2016, 12, 31).unwrap().and_hms_opt(12, 34, 56).unwrap()));
     /// ```
     #[inline]
     fn with_ordinal(&self, ordinal: u32) -> Option<NaiveDateTime> {
@@ -1378,16 +1378,16 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Datelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
     /// assert_eq!(dt.with_ordinal0(59),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 3, 1).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 3, 1).unwrap().and_hms_opt(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_ordinal0(365), None); // 2015 had only 365 days
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2016, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 9, 8).unwrap().and_hms_opt(12, 34, 56).unwrap();
     /// assert_eq!(dt.with_ordinal0(59),
-    ///            Some(NaiveDate::from_ymd_opt(2016, 2, 29).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2016, 2, 29).unwrap().and_hms_opt(12, 34, 56).unwrap()));
     /// assert_eq!(dt.with_ordinal0(365),
-    ///            Some(NaiveDate::from_ymd_opt(2016, 12, 31).unwrap().and_hms_opt(12, 34, 56).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2016, 12, 31).unwrap().and_hms_opt(12, 34, 56).unwrap()));
     /// ```
     #[inline]
     fn with_ordinal0(&self, ordinal0: u32) -> Option<NaiveDateTime> {
@@ -1405,7 +1405,7 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.hour(), 12);
     /// ```
     #[inline]
@@ -1422,7 +1422,7 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.minute(), 34);
     /// ```
     #[inline]
@@ -1439,7 +1439,7 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.second(), 56);
     /// ```
     #[inline]
@@ -1458,7 +1458,7 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.nanosecond(), 789_000_000);
     /// ```
     #[inline]
@@ -1479,9 +1479,9 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.with_hour(7),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_milli_opt(7, 34, 56, 789).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(7, 34, 56, 789).unwrap()));
     /// assert_eq!(dt.with_hour(24), None);
     /// ```
     #[inline]
@@ -1502,9 +1502,9 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.with_minute(45),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_milli_opt(12, 45, 56, 789).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 45, 56, 789).unwrap()));
     /// assert_eq!(dt.with_minute(60), None);
     /// ```
     #[inline]
@@ -1528,9 +1528,9 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.with_second(17),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 17, 789).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 17, 789).unwrap()));
     /// assert_eq!(dt.with_second(60), None);
     /// ```
     #[inline]
@@ -1555,11 +1555,11 @@ impl Timelike for NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 59, 789).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli_opt(12, 34, 59, 789).unwrap();
     /// assert_eq!(dt.with_nanosecond(333_333_333),
-    ///            Some(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_nano_opt(12, 34, 59, 333_333_333).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_nano_opt(12, 34, 59, 333_333_333).unwrap()));
     /// assert_eq!(dt.with_nanosecond(1_333_333_333), // leap second
-    ///            Some(NaiveDate::from_ymd_opt(2015, 9, 8).unwrap().and_hms_nano_opt(12, 34, 59, 1_333_333_333).unwrap()));
+    ///            Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_nano_opt(12, 34, 59, 1_333_333_333).unwrap()));
     /// assert_eq!(dt.with_nanosecond(2_000_000_000), None);
     /// ```
     #[inline]
@@ -1584,7 +1584,7 @@ impl Timelike for NaiveDateTime {
 /// ```
 /// use chrono::{TimeDelta, NaiveDate};
 ///
-/// let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+/// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// let d = from_ymd(2016, 7, 8);
 /// let hms = |h, m, s| d.and_hms_opt(h, m, s).unwrap();
@@ -1606,7 +1606,7 @@ impl Timelike for NaiveDateTime {
 ///
 /// ```
 /// # use chrono::{TimeDelta, NaiveDate};
-/// # let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+/// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli_opt(h, m, s, milli).unwrap();
 /// let leap = hmsm(3, 5, 59, 1_300);
 /// assert_eq!(leap + TimeDelta::zero(),             hmsm(3, 5, 59, 1_300));
@@ -1715,28 +1715,28 @@ impl Add<FixedOffset> for NaiveDateTime {
 /// use chrono::{Months, NaiveDate};
 ///
 /// assert_eq!(
-///     NaiveDate::from_ymd_opt(2014, 1, 1).unwrap().and_hms_opt(1, 0, 0).unwrap() + Months::new(1),
-///     NaiveDate::from_ymd_opt(2014, 2, 1).unwrap().and_hms_opt(1, 0, 0).unwrap()
+///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(1, 0, 0).unwrap() + Months::new(1),
+///     NaiveDate::from_ymd(2014, 2, 1).unwrap().and_hms_opt(1, 0, 0).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd_opt(2014, 1, 1).unwrap().and_hms_opt(0, 2, 0).unwrap() + Months::new(11),
-///     NaiveDate::from_ymd_opt(2014, 12, 1).unwrap().and_hms_opt(0, 2, 0).unwrap()
+///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(0, 2, 0).unwrap() + Months::new(11),
+///     NaiveDate::from_ymd(2014, 12, 1).unwrap().and_hms_opt(0, 2, 0).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd_opt(2014, 1, 1).unwrap().and_hms_opt(0, 0, 3).unwrap() + Months::new(12),
-///     NaiveDate::from_ymd_opt(2015, 1, 1).unwrap().and_hms_opt(0, 0, 3).unwrap()
+///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(0, 0, 3).unwrap() + Months::new(12),
+///     NaiveDate::from_ymd(2015, 1, 1).unwrap().and_hms_opt(0, 0, 3).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd_opt(2014, 1, 1).unwrap().and_hms_opt(0, 0, 4).unwrap() + Months::new(13),
-///     NaiveDate::from_ymd_opt(2015, 2, 1).unwrap().and_hms_opt(0, 0, 4).unwrap()
+///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms_opt(0, 0, 4).unwrap() + Months::new(13),
+///     NaiveDate::from_ymd(2015, 2, 1).unwrap().and_hms_opt(0, 0, 4).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd_opt(2014, 1, 31).unwrap().and_hms_opt(0, 5, 0).unwrap() + Months::new(1),
-///     NaiveDate::from_ymd_opt(2014, 2, 28).unwrap().and_hms_opt(0, 5, 0).unwrap()
+///     NaiveDate::from_ymd(2014, 1, 31).unwrap().and_hms_opt(0, 5, 0).unwrap() + Months::new(1),
+///     NaiveDate::from_ymd(2014, 2, 28).unwrap().and_hms_opt(0, 5, 0).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd_opt(2020, 1, 31).unwrap().and_hms_opt(6, 0, 0).unwrap() + Months::new(1),
-///     NaiveDate::from_ymd_opt(2020, 2, 29).unwrap().and_hms_opt(6, 0, 0).unwrap()
+///     NaiveDate::from_ymd(2020, 1, 31).unwrap().and_hms_opt(6, 0, 0).unwrap() + Months::new(1),
+///     NaiveDate::from_ymd(2020, 2, 29).unwrap().and_hms_opt(6, 0, 0).unwrap()
 /// );
 /// ```
 impl Add<Months> for NaiveDateTime {
@@ -1765,7 +1765,7 @@ impl Add<Months> for NaiveDateTime {
 /// ```
 /// use chrono::{TimeDelta, NaiveDate};
 ///
-/// let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+/// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// let d = from_ymd(2016, 7, 8);
 /// let hms = |h, m, s| d.and_hms_opt(h, m, s).unwrap();
@@ -1787,7 +1787,7 @@ impl Add<Months> for NaiveDateTime {
 ///
 /// ```
 /// # use chrono::{TimeDelta, NaiveDate};
-/// # let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+/// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli_opt(h, m, s, milli).unwrap();
 /// let leap = hmsm(3, 5, 59, 1_300);
 /// assert_eq!(leap - TimeDelta::zero(),            hmsm(3, 5, 59, 1_300));
@@ -1896,16 +1896,16 @@ impl Sub<FixedOffset> for NaiveDateTime {
 /// use chrono::{Months, NaiveDate};
 ///
 /// assert_eq!(
-///     NaiveDate::from_ymd_opt(2014, 01, 01).unwrap().and_hms_opt(01, 00, 00).unwrap() - Months::new(11),
-///     NaiveDate::from_ymd_opt(2013, 02, 01).unwrap().and_hms_opt(01, 00, 00).unwrap()
+///     NaiveDate::from_ymd(2014, 01, 01).unwrap().and_hms_opt(01, 00, 00).unwrap() - Months::new(11),
+///     NaiveDate::from_ymd(2013, 02, 01).unwrap().and_hms_opt(01, 00, 00).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd_opt(2014, 01, 01).unwrap().and_hms_opt(00, 02, 00).unwrap() - Months::new(12),
-///     NaiveDate::from_ymd_opt(2013, 01, 01).unwrap().and_hms_opt(00, 02, 00).unwrap()
+///     NaiveDate::from_ymd(2014, 01, 01).unwrap().and_hms_opt(00, 02, 00).unwrap() - Months::new(12),
+///     NaiveDate::from_ymd(2013, 01, 01).unwrap().and_hms_opt(00, 02, 00).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd_opt(2014, 01, 01).unwrap().and_hms_opt(00, 00, 03).unwrap() - Months::new(13),
-///     NaiveDate::from_ymd_opt(2012, 12, 01).unwrap().and_hms_opt(00, 00, 03).unwrap()
+///     NaiveDate::from_ymd(2014, 01, 01).unwrap().and_hms_opt(00, 00, 03).unwrap() - Months::new(13),
+///     NaiveDate::from_ymd(2012, 12, 01).unwrap().and_hms_opt(00, 00, 03).unwrap()
 /// );
 /// ```
 impl Sub<Months> for NaiveDateTime {
@@ -1932,7 +1932,7 @@ impl Sub<Months> for NaiveDateTime {
 /// ```
 /// use chrono::{TimeDelta, NaiveDate};
 ///
-/// let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+/// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// let d = from_ymd(2016, 7, 8);
 /// assert_eq!(d.and_hms_opt(3, 5, 7).unwrap() - d.and_hms_opt(2, 4, 6).unwrap(), TimeDelta::seconds(3600 + 60 + 1));
@@ -1948,7 +1948,7 @@ impl Sub<Months> for NaiveDateTime {
 ///
 /// ```
 /// # use chrono::{TimeDelta, NaiveDate};
-/// # let from_ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
+/// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 /// let leap = from_ymd(2015, 6, 30).and_hms_milli_opt(23, 59, 59, 1_500).unwrap();
 /// assert_eq!(leap - from_ymd(2015, 6, 30).and_hms_opt(23, 0, 0).unwrap(),
 ///            TimeDelta::seconds(3600) + TimeDelta::milliseconds(500));
@@ -2008,7 +2008,7 @@ impl Sub<Days> for NaiveDateTime {
 /// ```
 /// use chrono::NaiveDate;
 ///
-/// let dt = NaiveDate::from_ymd_opt(2016, 11, 15).unwrap().and_hms_opt(7, 39, 24).unwrap();
+/// let dt = NaiveDate::from_ymd(2016, 11, 15).unwrap().and_hms_opt(7, 39, 24).unwrap();
 /// assert_eq!(format!("{:?}", dt), "2016-11-15T07:39:24");
 /// ```
 ///
@@ -2016,7 +2016,7 @@ impl Sub<Days> for NaiveDateTime {
 ///
 /// ```
 /// # use chrono::NaiveDate;
-/// let dt = NaiveDate::from_ymd_opt(2015, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_500).unwrap();
+/// let dt = NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_500).unwrap();
 /// assert_eq!(format!("{:?}", dt), "2015-06-30T23:59:60.500");
 /// ```
 impl fmt::Debug for NaiveDateTime {
@@ -2041,7 +2041,7 @@ impl fmt::Debug for NaiveDateTime {
 /// ```
 /// use chrono::NaiveDate;
 ///
-/// let dt = NaiveDate::from_ymd_opt(2016, 11, 15).unwrap().and_hms_opt(7, 39, 24).unwrap();
+/// let dt = NaiveDate::from_ymd(2016, 11, 15).unwrap().and_hms_opt(7, 39, 24).unwrap();
 /// assert_eq!(format!("{}", dt), "2016-11-15 07:39:24");
 /// ```
 ///
@@ -2049,7 +2049,7 @@ impl fmt::Debug for NaiveDateTime {
 ///
 /// ```
 /// # use chrono::NaiveDate;
-/// let dt = NaiveDate::from_ymd_opt(2015, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_500).unwrap();
+/// let dt = NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_500).unwrap();
 /// assert_eq!(format!("{}", dt), "2015-06-30 23:59:60.500");
 /// ```
 impl fmt::Display for NaiveDateTime {
@@ -2068,10 +2068,10 @@ impl fmt::Display for NaiveDateTime {
 /// ```
 /// use chrono::{NaiveDateTime, NaiveDate};
 ///
-/// let dt = NaiveDate::from_ymd_opt(2015, 9, 18).unwrap().and_hms_opt(23, 56, 4).unwrap();
+/// let dt = NaiveDate::from_ymd(2015, 9, 18).unwrap().and_hms_opt(23, 56, 4).unwrap();
 /// assert_eq!("2015-09-18T23:56:04".parse::<NaiveDateTime>(), Ok(dt));
 ///
-/// let dt = NaiveDate::from_ymd_opt(12345, 6, 7).unwrap().and_hms_milli_opt(7, 59, 59, 1_500).unwrap(); // leap second
+/// let dt = NaiveDate::from_ymd(12345, 6, 7).unwrap().and_hms_milli_opt(7, 59, 59, 1_500).unwrap(); // leap second
 /// assert_eq!("+12345-6-7T7:59:60.5".parse::<NaiveDateTime>(), Ok(dt));
 ///
 /// assert!("foo".parse::<NaiveDateTime>().is_err());
@@ -2132,26 +2132,25 @@ where
 {
     assert_eq!(
         to_string(
-            &NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_milli_opt(9, 10, 48, 90).unwrap()
+            &NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli_opt(9, 10, 48, 90).unwrap()
         )
         .ok(),
         Some(r#""2016-07-08T09:10:48.090""#.into())
     );
     assert_eq!(
-        to_string(&NaiveDate::from_ymd_opt(2014, 7, 24).unwrap().and_hms_opt(12, 34, 6).unwrap())
-            .ok(),
+        to_string(&NaiveDate::from_ymd(2014, 7, 24).unwrap().and_hms_opt(12, 34, 6).unwrap()).ok(),
         Some(r#""2014-07-24T12:34:06""#.into())
     );
     assert_eq!(
         to_string(
-            &NaiveDate::from_ymd_opt(0, 1, 1).unwrap().and_hms_milli_opt(0, 0, 59, 1_000).unwrap()
+            &NaiveDate::from_ymd(0, 1, 1).unwrap().and_hms_milli_opt(0, 0, 59, 1_000).unwrap()
         )
         .ok(),
         Some(r#""0000-01-01T00:00:60""#.into())
     );
     assert_eq!(
         to_string(
-            &NaiveDate::from_ymd_opt(-1, 12, 31).unwrap().and_hms_nano_opt(23, 59, 59, 7).unwrap()
+            &NaiveDate::from_ymd(-1, 12, 31).unwrap().and_hms_nano_opt(23, 59, 59, 7).unwrap()
         )
         .ok(),
         Some(r#""-0001-12-31T23:59:59.000000007""#.into())
@@ -2174,31 +2173,27 @@ where
 {
     assert_eq!(
         from_str(r#""2016-07-08T09:10:48.090""#).ok(),
-        Some(
-            NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_milli_opt(9, 10, 48, 90).unwrap()
-        )
+        Some(NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli_opt(9, 10, 48, 90).unwrap())
     );
     assert_eq!(
         from_str(r#""2016-7-8T9:10:48.09""#).ok(),
-        Some(
-            NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_milli_opt(9, 10, 48, 90).unwrap()
-        )
+        Some(NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli_opt(9, 10, 48, 90).unwrap())
     );
     assert_eq!(
         from_str(r#""2014-07-24T12:34:06""#).ok(),
-        Some(NaiveDate::from_ymd_opt(2014, 7, 24).unwrap().and_hms_opt(12, 34, 6).unwrap())
+        Some(NaiveDate::from_ymd(2014, 7, 24).unwrap().and_hms_opt(12, 34, 6).unwrap())
     );
     assert_eq!(
         from_str(r#""0000-01-01T00:00:60""#).ok(),
-        Some(NaiveDate::from_ymd_opt(0, 1, 1).unwrap().and_hms_milli_opt(0, 0, 59, 1_000).unwrap())
+        Some(NaiveDate::from_ymd(0, 1, 1).unwrap().and_hms_milli_opt(0, 0, 59, 1_000).unwrap())
     );
     assert_eq!(
         from_str(r#""0-1-1T0:0:60""#).ok(),
-        Some(NaiveDate::from_ymd_opt(0, 1, 1).unwrap().and_hms_milli_opt(0, 0, 59, 1_000).unwrap())
+        Some(NaiveDate::from_ymd(0, 1, 1).unwrap().and_hms_milli_opt(0, 0, 59, 1_000).unwrap())
     );
     assert_eq!(
         from_str(r#""-0001-12-31T23:59:59.000000007""#).ok(),
-        Some(NaiveDate::from_ymd_opt(-1, 12, 31).unwrap().and_hms_nano_opt(23, 59, 59, 7).unwrap())
+        Some(NaiveDate::from_ymd(-1, 12, 31).unwrap().and_hms_nano_opt(23, 59, 59, 7).unwrap())
     );
     assert_eq!(
         from_str(r#""-262143-01-01T00:00:00""#).ok(),

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -257,7 +257,7 @@ impl NaiveDateTime {
     /// assert_eq!(parse_from_str("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S"),
     ///            Ok(NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms(23, 56, 4).unwrap()));
     /// assert_eq!(parse_from_str("5sep2015pm012345.6789", "%d%b%Y%p%I%M%S%.f"),
-    ///            Ok(NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_micro_opt(13, 23, 45, 678_900).unwrap()));
+    ///            Ok(NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_micro(13, 23, 45, 678_900).unwrap()));
     /// ```
     ///
     /// Offset is ignored for the purpose of parsing.
@@ -442,10 +442,10 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_micro_opt(0, 0, 1, 444).unwrap();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_micro(0, 0, 1, 444).unwrap();
     /// assert_eq!(dt.timestamp_micros(), 1_000_444);
     ///
-    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_micro_opt(1, 46, 40, 555).unwrap();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_micro(1, 46, 40, 555).unwrap();
     /// assert_eq!(dt.timestamp_micros(), 1_000_000_000_000_555);
     /// ```
     #[inline]

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -697,7 +697,7 @@ impl NaiveDateTime {
         let (time, days) = self.time.overflowing_add_offset(rhs);
         let date = match days {
             -1 => try_opt!(self.date.pred_opt()),
-            1 => try_opt!(self.date.succ_opt()),
+            1 => try_opt!(self.date.succ()),
             _ => self.date,
         };
         Some(NaiveDateTime { date, time })
@@ -712,7 +712,7 @@ impl NaiveDateTime {
         let (time, days) = self.time.overflowing_sub_offset(rhs);
         let date = match days {
             -1 => try_opt!(self.date.pred_opt()),
-            1 => try_opt!(self.date.succ_opt()),
+            1 => try_opt!(self.date.succ()),
             _ => self.date,
         };
         Some(NaiveDateTime { date, time })
@@ -728,7 +728,7 @@ impl NaiveDateTime {
         let (time, days) = self.time.overflowing_add_offset(rhs);
         let date = match days {
             -1 => self.date.pred_opt().unwrap_or(NaiveDate::BEFORE_MIN),
-            1 => self.date.succ_opt().unwrap_or(NaiveDate::AFTER_MAX),
+            1 => self.date.succ().unwrap_or(NaiveDate::AFTER_MAX),
             _ => self.date,
         };
         NaiveDateTime { date, time }
@@ -745,7 +745,7 @@ impl NaiveDateTime {
         let (time, days) = self.time.overflowing_sub_offset(rhs);
         let date = match days {
             -1 => self.date.pred_opt().unwrap_or(NaiveDate::BEFORE_MIN),
-            1 => self.date.succ_opt().unwrap_or(NaiveDate::AFTER_MAX),
+            1 => self.date.succ().unwrap_or(NaiveDate::AFTER_MAX),
             _ => self.date,
         };
         NaiveDateTime { date, time }

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -235,8 +235,7 @@ impl NaiveDateTime {
         if days < i32::MIN as i64 || days > i32::MAX as i64 {
             return None;
         }
-        let date =
-            NaiveDate::from_num_days_from_ce_opt(try_opt!((days as i32).checked_add(719_163)));
+        let date = NaiveDate::from_num_days_from_ce(try_opt!((days as i32).checked_add(719_163)));
         let time = NaiveTime::from_num_seconds_from_midnight(secs as u32, nsecs);
         match (date, time) {
             (Some(date), Ok(time)) => Some(NaiveDateTime { date, time }),

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -852,7 +852,7 @@ pub mod ts_milliseconds_option {
 ///     time: NaiveDateTime
 /// }
 ///
-/// let time = NaiveDate::from_ymd(2015, 5, 15).unwrap().and_hms_opt(10, 0, 0).unwrap();
+/// let time = NaiveDate::from_ymd(2015, 5, 15).unwrap().and_hms(10, 0, 0).unwrap();
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -887,7 +887,7 @@ pub mod ts_seconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd(2015, 5, 15).unwrap().and_hms_opt(10, 0, 0).unwrap(),
+    ///     time: NaiveDate::from_ymd(2015, 5, 15).unwrap().and_hms(10, 0, 0).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
@@ -969,7 +969,7 @@ pub mod ts_seconds {
 ///     time: Option<NaiveDateTime>
 /// }
 ///
-/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_opt(02, 04, 59).unwrap());
+/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms(02, 04, 59).unwrap());
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -1004,7 +1004,7 @@ pub mod ts_seconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_opt(02, 04, 59).unwrap()),
+    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms(02, 04, 59).unwrap()),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699}"#);

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -67,7 +67,7 @@ impl<'de> de::Deserialize<'de> for NaiveDateTime {
 ///     time: NaiveDateTime
 /// }
 ///
-/// let time = NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap();
+/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap();
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -110,7 +110,7 @@ pub mod ts_nanoseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap(),
+    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
@@ -204,7 +204,7 @@ pub mod ts_nanoseconds {
 ///     time: Option<NaiveDateTime>
 /// }
 ///
-/// let time = Some(NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap());
+/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap());
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -247,7 +247,7 @@ pub mod ts_nanoseconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap()),
+    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap()),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
@@ -344,7 +344,7 @@ pub mod ts_nanoseconds_option {
 ///     time: NaiveDateTime
 /// }
 ///
-/// let time = NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap();
+/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap();
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -379,7 +379,7 @@ pub mod ts_microseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap(),
+    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
@@ -468,7 +468,7 @@ pub mod ts_microseconds {
 ///     time: Option<NaiveDateTime>
 /// }
 ///
-/// let time = Some(NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap());
+/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap());
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -503,7 +503,7 @@ pub mod ts_microseconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap()),
+    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap()),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
@@ -598,7 +598,7 @@ pub mod ts_microseconds_option {
 ///     time: NaiveDateTime
 /// }
 ///
-/// let time = NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap();
+/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap();
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -633,7 +633,7 @@ pub mod ts_milliseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap(),
+    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
@@ -722,7 +722,7 @@ pub mod ts_milliseconds {
 ///     time: Option<NaiveDateTime>
 /// }
 ///
-/// let time = Some(NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap());
+/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap());
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -757,7 +757,7 @@ pub mod ts_milliseconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap()),
+    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap()),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
@@ -852,7 +852,7 @@ pub mod ts_milliseconds_option {
 ///     time: NaiveDateTime
 /// }
 ///
-/// let time = NaiveDate::from_ymd_opt(2015, 5, 15).unwrap().and_hms_opt(10, 0, 0).unwrap();
+/// let time = NaiveDate::from_ymd(2015, 5, 15).unwrap().and_hms_opt(10, 0, 0).unwrap();
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -887,7 +887,7 @@ pub mod ts_seconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd_opt(2015, 5, 15).unwrap().and_hms_opt(10, 0, 0).unwrap(),
+    ///     time: NaiveDate::from_ymd(2015, 5, 15).unwrap().and_hms_opt(10, 0, 0).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
@@ -969,7 +969,7 @@ pub mod ts_seconds {
 ///     time: Option<NaiveDateTime>
 /// }
 ///
-/// let time = Some(NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_opt(02, 04, 59).unwrap());
+/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_opt(02, 04, 59).unwrap());
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -1004,7 +1004,7 @@ pub mod ts_seconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_opt(02, 04, 59).unwrap()),
+    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_opt(02, 04, 59).unwrap()),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699}"#);
@@ -1153,8 +1153,7 @@ mod tests {
     // it is not self-describing.
     #[test]
     fn test_serde_bincode() {
-        let dt =
-            NaiveDate::from_ymd_opt(2016, 7, 8).unwrap().and_hms_milli_opt(9, 10, 48, 90).unwrap();
+        let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli_opt(9, 10, 48, 90).unwrap();
         let encoded = serialize(&dt).unwrap();
         let decoded: NaiveDateTime = deserialize(&encoded).unwrap();
         assert_eq!(dt, decoded);

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -344,7 +344,7 @@ pub mod ts_nanoseconds_option {
 ///     time: NaiveDateTime
 /// }
 ///
-/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap();
+/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro(02, 04, 59, 918355).unwrap();
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -379,7 +379,7 @@ pub mod ts_microseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap(),
+    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro(02, 04, 59, 918355).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
@@ -468,7 +468,7 @@ pub mod ts_microseconds {
 ///     time: Option<NaiveDateTime>
 /// }
 ///
-/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap());
+/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro(02, 04, 59, 918355).unwrap());
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -503,7 +503,7 @@ pub mod ts_microseconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro_opt(02, 04, 59, 918355).unwrap()),
+    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro(02, 04, 59, 918355).unwrap()),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -67,7 +67,7 @@ impl<'de> de::Deserialize<'de> for NaiveDateTime {
 ///     time: NaiveDateTime
 /// }
 ///
-/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap();
+/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano(02, 04, 59, 918355733).unwrap();
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -110,7 +110,7 @@ pub mod ts_nanoseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap(),
+    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano(02, 04, 59, 918355733).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
@@ -204,7 +204,7 @@ pub mod ts_nanoseconds {
 ///     time: Option<NaiveDateTime>
 /// }
 ///
-/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap());
+/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano(02, 04, 59, 918355733).unwrap());
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -247,7 +247,7 @@ pub mod ts_nanoseconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano_opt(02, 04, 59, 918355733).unwrap()),
+    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano(02, 04, 59, 918355733).unwrap()),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -598,7 +598,7 @@ pub mod ts_microseconds_option {
 ///     time: NaiveDateTime
 /// }
 ///
-/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap();
+/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli(02, 04, 59, 918).unwrap();
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -633,7 +633,7 @@ pub mod ts_milliseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap(),
+    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli(02, 04, 59, 918).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
@@ -722,7 +722,7 @@ pub mod ts_milliseconds {
 ///     time: Option<NaiveDateTime>
 /// }
 ///
-/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap());
+/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli(02, 04, 59, 918).unwrap());
 /// let my_s = S {
 ///     time: time.clone(),
 /// };
@@ -757,7 +757,7 @@ pub mod ts_milliseconds_option {
     /// }
     ///
     /// let my_s = S {
-    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli_opt(02, 04, 59, 918).unwrap()),
+    ///     time: Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli(02, 04, 59, 918).unwrap()),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
@@ -1153,7 +1153,7 @@ mod tests {
     // it is not self-describing.
     #[test]
     fn test_serde_bincode() {
-        let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli_opt(9, 10, 48, 90).unwrap();
+        let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli(9, 10, 48, 90).unwrap();
         let encoded = serialize(&dt).unwrap();
         let decoded: NaiveDateTime = deserialize(&encoded).unwrap();
         assert_eq!(dt, decoded);

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -29,7 +29,7 @@ fn test_datetime_from_timestamp_millis() {
     }
 
     // Test that the result of `from_timestamp_millis` compares equal to
-    // that of `from_timestamp_opt`.
+    // that of `from_timestamp`.
     let secs_test = [0, 1, 2, 1000, 1234, 12345678, -1, -2, -1000, -12345678];
     for secs in secs_test.iter().cloned() {
         assert_eq!(
@@ -67,7 +67,7 @@ fn test_datetime_from_timestamp_micros() {
     }
 
     // Test that the result of `from_timestamp_micros` compares equal to
-    // that of `from_timestamp_opt`.
+    // that of `from_timestamp`.
     let secs_test = [0, 1, 2, 1000, 1234, 12345678, -1, -2, -1000, -12345678];
     for secs in secs_test.iter().copied() {
         assert_eq!(
@@ -118,7 +118,7 @@ fn test_datetime_from_timestamp_nanos() {
     );
 
     // Test that the result of `from_timestamp_nanos` compares equal to
-    // that of `from_timestamp_opt`.
+    // that of `from_timestamp`.
     let secs_test = [0, 1, 2, 1000, 1234, 12345678, -1, -2, -1000, -12345678];
     for secs in secs_test.iter().copied() {
         assert_eq!(

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -502,7 +502,7 @@ fn test_and_utc() {
 #[test]
 fn test_checked_add_offset() {
     let ymdhmsm = |y, m, d, h, mn, s, mi| {
-        Some(NaiveDate::from_ymd(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi).unwrap())
+        Some(NaiveDate::from_ymd(y, m, d).unwrap().and_hms_milli(h, mn, s, mi).unwrap())
     };
 
     let positive_offset = FixedOffset::east(2 * 60 * 60).unwrap();
@@ -529,7 +529,7 @@ fn test_checked_add_offset() {
 #[test]
 fn test_checked_sub_offset() {
     let ymdhmsm = |y, m, d, h, mn, s, mi| {
-        Some(NaiveDate::from_ymd(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi).unwrap())
+        Some(NaiveDate::from_ymd(y, m, d).unwrap().and_hms_milli(h, mn, s, mi).unwrap())
     };
 
     let positive_offset = FixedOffset::east(2 * 60 * 60).unwrap();
@@ -559,7 +559,7 @@ fn test_checked_sub_offset() {
 #[test]
 fn test_overflowing_add_offset() {
     let ymdhmsm = |y, m, d, h, mn, s, mi| {
-        NaiveDate::from_ymd(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi).unwrap()
+        NaiveDate::from_ymd(y, m, d).unwrap().and_hms_milli(h, mn, s, mi).unwrap()
     };
     let positive_offset = FixedOffset::east(2 * 60 * 60).unwrap();
     // regular date

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -131,8 +131,7 @@ fn test_datetime_from_timestamp_nanos() {
 #[test]
 fn test_datetime_from_timestamp() {
     let from_timestamp = |secs| NaiveDateTime::from_timestamp(secs, 0);
-    let ymdhms =
-        |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
+    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
     assert_eq!(from_timestamp(-1), Some(ymdhms(1969, 12, 31, 23, 59, 59)));
     assert_eq!(from_timestamp(0), Some(ymdhms(1970, 1, 1, 0, 0, 0)));
     assert_eq!(from_timestamp(1), Some(ymdhms(1970, 1, 1, 0, 0, 1)));
@@ -149,9 +148,9 @@ fn test_datetime_add() {
         rhs: TimeDelta,
         result: Option<(i32, u32, u32, u32, u32, u32)>,
     ) {
-        let lhs = NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
+        let lhs = NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
         let sum = result.map(|(y, m, d, h, n, s)| {
-            NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap()
+            NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap()
         });
         assert_eq!(lhs.checked_add_signed(rhs), sum);
         assert_eq!(lhs.checked_sub_signed(-rhs), sum);
@@ -187,8 +186,7 @@ fn test_datetime_add() {
 
 #[test]
 fn test_datetime_sub() {
-    let ymdhms =
-        |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
+    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
     let since = NaiveDateTime::signed_duration_since;
     assert_eq!(since(ymdhms(2014, 5, 6, 7, 8, 9), ymdhms(2014, 5, 6, 7, 8, 9)), TimeDelta::zero());
     assert_eq!(
@@ -211,8 +209,7 @@ fn test_datetime_sub() {
 
 #[test]
 fn test_datetime_addassignment() {
-    let ymdhms =
-        |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
+    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
     let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
     date += TimeDelta::minutes(10_000_000);
     assert_eq!(date, ymdhms(2035, 10, 6, 20, 50, 10));
@@ -222,8 +219,7 @@ fn test_datetime_addassignment() {
 
 #[test]
 fn test_datetime_subassignment() {
-    let ymdhms =
-        |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
+    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
     let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
     date -= TimeDelta::minutes(10_000_000);
     assert_eq!(date, ymdhms(1997, 9, 26, 23, 30, 10));
@@ -235,12 +231,12 @@ fn test_datetime_subassignment() {
 fn test_core_duration_ops() {
     use core::time::Duration;
 
-    let mut dt = NaiveDate::from_ymd(2023, 8, 29).unwrap().and_hms_opt(11, 34, 12).unwrap();
+    let mut dt = NaiveDate::from_ymd(2023, 8, 29).unwrap().and_hms(11, 34, 12).unwrap();
     let same = dt + Duration::ZERO;
     assert_eq!(dt, same);
 
     dt += Duration::new(3600, 0);
-    assert_eq!(dt, NaiveDate::from_ymd(2023, 8, 29).unwrap().and_hms_opt(12, 34, 12).unwrap());
+    assert_eq!(dt, NaiveDate::from_ymd(2023, 8, 29).unwrap().and_hms(12, 34, 12).unwrap());
 }
 
 #[test]
@@ -248,14 +244,14 @@ fn test_core_duration_ops() {
 fn test_core_duration_max() {
     use core::time::Duration;
 
-    let mut utc_dt = NaiveDate::from_ymd(2023, 8, 29).unwrap().and_hms_opt(11, 34, 12).unwrap();
+    let mut utc_dt = NaiveDate::from_ymd(2023, 8, 29).unwrap().and_hms(11, 34, 12).unwrap();
     utc_dt += Duration::MAX;
 }
 
 #[test]
 fn test_datetime_timestamp() {
     let to_timestamp = |y, m, d, h, n, s| {
-        NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap().timestamp()
+        NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap().timestamp()
     };
     assert_eq!(to_timestamp(1969, 12, 31, 23, 59, 59), -1);
     assert_eq!(to_timestamp(1970, 1, 1, 0, 0, 0), 0);
@@ -347,8 +343,7 @@ fn test_datetime_from_str() {
 
 #[test]
 fn test_datetime_parse_from_str() {
-    let ymdhms =
-        |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
+    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
     let ymdhmsn = |y, m, d, h, n, s, nano| {
         NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano_opt(h, n, s, nano).unwrap()
     };
@@ -400,7 +395,7 @@ fn test_datetime_parse_from_str() {
 #[test]
 fn test_datetime_parse_from_str_with_spaces() {
     let parse_from_str = NaiveDateTime::parse_from_str;
-    let dt = NaiveDate::from_ymd(2013, 8, 9).unwrap().and_hms_opt(23, 54, 35).unwrap();
+    let dt = NaiveDate::from_ymd(2013, 8, 9).unwrap().and_hms(23, 54, 35).unwrap();
     // with varying spaces - should succeed
     assert_eq!(parse_from_str(" Aug 09 2013 23:54:35", " %b %d %Y %H:%M:%S"), Ok(dt));
     assert_eq!(parse_from_str("Aug 09 2013 23:54:35 ", "%b %d %Y %H:%M:%S "), Ok(dt));
@@ -445,7 +440,7 @@ fn test_datetime_parse_from_str_with_spaces() {
 #[test]
 fn test_datetime_add_sub_invariant() {
     // issue #37
-    let base = NaiveDate::from_ymd(2000, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    let base = NaiveDate::from_ymd(2000, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
     let t = -946684799990000;
     let time = base + TimeDelta::microseconds(t);
     assert_eq!(t, time.signed_duration_since(base).num_microseconds().unwrap());
@@ -485,7 +480,7 @@ fn test_nanosecond_range() {
 
 #[test]
 fn test_and_local_timezone() {
-    let ndt = NaiveDate::from_ymd(2022, 6, 15).unwrap().and_hms_opt(18, 59, 36).unwrap();
+    let ndt = NaiveDate::from_ymd(2022, 6, 15).unwrap().and_hms(18, 59, 36).unwrap();
     let dt_utc = ndt.and_local_timezone(Utc).unwrap();
     assert_eq!(dt_utc.naive_local(), ndt);
     assert_eq!(dt_utc.timezone(), Utc);
@@ -498,7 +493,7 @@ fn test_and_local_timezone() {
 
 #[test]
 fn test_and_utc() {
-    let ndt = NaiveDate::from_ymd(2023, 1, 30).unwrap().and_hms_opt(19, 32, 33).unwrap();
+    let ndt = NaiveDate::from_ymd(2023, 1, 30).unwrap().and_hms(19, 32, 33).unwrap();
     let dt_utc = ndt.and_utc();
     assert_eq!(dt_utc.naive_local(), ndt);
     assert_eq!(dt_utc.timezone(), Utc);

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -132,7 +132,7 @@ fn test_datetime_from_timestamp_nanos() {
 fn test_datetime_from_timestamp() {
     let from_timestamp = |secs| NaiveDateTime::from_timestamp(secs, 0);
     let ymdhms =
-        |y, m, d, h, n, s| NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
+        |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
     assert_eq!(from_timestamp(-1), Some(ymdhms(1969, 12, 31, 23, 59, 59)));
     assert_eq!(from_timestamp(0), Some(ymdhms(1970, 1, 1, 0, 0, 0)));
     assert_eq!(from_timestamp(1), Some(ymdhms(1970, 1, 1, 0, 0, 1)));
@@ -149,9 +149,9 @@ fn test_datetime_add() {
         rhs: TimeDelta,
         result: Option<(i32, u32, u32, u32, u32, u32)>,
     ) {
-        let lhs = NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
+        let lhs = NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
         let sum = result.map(|(y, m, d, h, n, s)| {
-            NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap()
+            NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap()
         });
         assert_eq!(lhs.checked_add_signed(rhs), sum);
         assert_eq!(lhs.checked_sub_signed(-rhs), sum);
@@ -168,7 +168,7 @@ fn test_datetime_add() {
     // assumes that we have correct values for MAX/MIN_DAYS_FROM_YEAR_0 from `naive::date`.
     // (they are private constants, but the equivalence is tested in that module.)
     let max_days_from_year_0 =
-        NaiveDate::MAX.signed_duration_since(NaiveDate::from_ymd_opt(0, 1, 1).unwrap());
+        NaiveDate::MAX.signed_duration_since(NaiveDate::from_ymd(0, 1, 1).unwrap());
     check((0, 1, 1, 0, 0, 0), max_days_from_year_0, Some((NaiveDate::MAX.year(), 12, 31, 0, 0, 0)));
     check(
         (0, 1, 1, 0, 0, 0),
@@ -179,7 +179,7 @@ fn test_datetime_add() {
     check((0, 1, 1, 0, 0, 0), TimeDelta::max_value(), None);
 
     let min_days_from_year_0 =
-        NaiveDate::MIN.signed_duration_since(NaiveDate::from_ymd_opt(0, 1, 1).unwrap());
+        NaiveDate::MIN.signed_duration_since(NaiveDate::from_ymd(0, 1, 1).unwrap());
     check((0, 1, 1, 0, 0, 0), min_days_from_year_0, Some((NaiveDate::MIN.year(), 1, 1, 0, 0, 0)));
     check((0, 1, 1, 0, 0, 0), min_days_from_year_0 - TimeDelta::seconds(1), None);
     check((0, 1, 1, 0, 0, 0), TimeDelta::min_value(), None);
@@ -188,7 +188,7 @@ fn test_datetime_add() {
 #[test]
 fn test_datetime_sub() {
     let ymdhms =
-        |y, m, d, h, n, s| NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
+        |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
     let since = NaiveDateTime::signed_duration_since;
     assert_eq!(since(ymdhms(2014, 5, 6, 7, 8, 9), ymdhms(2014, 5, 6, 7, 8, 9)), TimeDelta::zero());
     assert_eq!(
@@ -212,7 +212,7 @@ fn test_datetime_sub() {
 #[test]
 fn test_datetime_addassignment() {
     let ymdhms =
-        |y, m, d, h, n, s| NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
+        |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
     let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
     date += TimeDelta::minutes(10_000_000);
     assert_eq!(date, ymdhms(2035, 10, 6, 20, 50, 10));
@@ -223,7 +223,7 @@ fn test_datetime_addassignment() {
 #[test]
 fn test_datetime_subassignment() {
     let ymdhms =
-        |y, m, d, h, n, s| NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
+        |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
     let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
     date -= TimeDelta::minutes(10_000_000);
     assert_eq!(date, ymdhms(1997, 9, 26, 23, 30, 10));
@@ -235,12 +235,12 @@ fn test_datetime_subassignment() {
 fn test_core_duration_ops() {
     use core::time::Duration;
 
-    let mut dt = NaiveDate::from_ymd_opt(2023, 8, 29).unwrap().and_hms_opt(11, 34, 12).unwrap();
+    let mut dt = NaiveDate::from_ymd(2023, 8, 29).unwrap().and_hms_opt(11, 34, 12).unwrap();
     let same = dt + Duration::ZERO;
     assert_eq!(dt, same);
 
     dt += Duration::new(3600, 0);
-    assert_eq!(dt, NaiveDate::from_ymd_opt(2023, 8, 29).unwrap().and_hms_opt(12, 34, 12).unwrap());
+    assert_eq!(dt, NaiveDate::from_ymd(2023, 8, 29).unwrap().and_hms_opt(12, 34, 12).unwrap());
 }
 
 #[test]
@@ -248,14 +248,14 @@ fn test_core_duration_ops() {
 fn test_core_duration_max() {
     use core::time::Duration;
 
-    let mut utc_dt = NaiveDate::from_ymd_opt(2023, 8, 29).unwrap().and_hms_opt(11, 34, 12).unwrap();
+    let mut utc_dt = NaiveDate::from_ymd(2023, 8, 29).unwrap().and_hms_opt(11, 34, 12).unwrap();
     utc_dt += Duration::MAX;
 }
 
 #[test]
 fn test_datetime_timestamp() {
     let to_timestamp = |y, m, d, h, n, s| {
-        NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap().timestamp()
+        NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap().timestamp()
     };
     assert_eq!(to_timestamp(1969, 12, 31, 23, 59, 59), -1);
     assert_eq!(to_timestamp(1970, 1, 1, 0, 0, 0), 0);
@@ -348,9 +348,9 @@ fn test_datetime_from_str() {
 #[test]
 fn test_datetime_parse_from_str() {
     let ymdhms =
-        |y, m, d, h, n, s| NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
+        |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
     let ymdhmsn = |y, m, d, h, n, s, nano| {
-        NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_nano_opt(h, n, s, nano).unwrap()
+        NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano_opt(h, n, s, nano).unwrap()
     };
     assert_eq!(
         NaiveDateTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
@@ -400,7 +400,7 @@ fn test_datetime_parse_from_str() {
 #[test]
 fn test_datetime_parse_from_str_with_spaces() {
     let parse_from_str = NaiveDateTime::parse_from_str;
-    let dt = NaiveDate::from_ymd_opt(2013, 8, 9).unwrap().and_hms_opt(23, 54, 35).unwrap();
+    let dt = NaiveDate::from_ymd(2013, 8, 9).unwrap().and_hms_opt(23, 54, 35).unwrap();
     // with varying spaces - should succeed
     assert_eq!(parse_from_str(" Aug 09 2013 23:54:35", " %b %d %Y %H:%M:%S"), Ok(dt));
     assert_eq!(parse_from_str("Aug 09 2013 23:54:35 ", "%b %d %Y %H:%M:%S "), Ok(dt));
@@ -445,7 +445,7 @@ fn test_datetime_parse_from_str_with_spaces() {
 #[test]
 fn test_datetime_add_sub_invariant() {
     // issue #37
-    let base = NaiveDate::from_ymd_opt(2000, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+    let base = NaiveDate::from_ymd(2000, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
     let t = -946684799990000;
     let time = base + TimeDelta::microseconds(t);
     assert_eq!(t, time.signed_duration_since(base).num_microseconds().unwrap());
@@ -485,7 +485,7 @@ fn test_nanosecond_range() {
 
 #[test]
 fn test_and_local_timezone() {
-    let ndt = NaiveDate::from_ymd_opt(2022, 6, 15).unwrap().and_hms_opt(18, 59, 36).unwrap();
+    let ndt = NaiveDate::from_ymd(2022, 6, 15).unwrap().and_hms_opt(18, 59, 36).unwrap();
     let dt_utc = ndt.and_local_timezone(Utc).unwrap();
     assert_eq!(dt_utc.naive_local(), ndt);
     assert_eq!(dt_utc.timezone(), Utc);
@@ -498,7 +498,7 @@ fn test_and_local_timezone() {
 
 #[test]
 fn test_and_utc() {
-    let ndt = NaiveDate::from_ymd_opt(2023, 1, 30).unwrap().and_hms_opt(19, 32, 33).unwrap();
+    let ndt = NaiveDate::from_ymd(2023, 1, 30).unwrap().and_hms_opt(19, 32, 33).unwrap();
     let dt_utc = ndt.and_utc();
     assert_eq!(dt_utc.naive_local(), ndt);
     assert_eq!(dt_utc.timezone(), Utc);
@@ -507,7 +507,7 @@ fn test_and_utc() {
 #[test]
 fn test_checked_add_offset() {
     let ymdhmsm = |y, m, d, h, mn, s, mi| {
-        Some(NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi).unwrap())
+        Some(NaiveDate::from_ymd(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi).unwrap())
     };
 
     let positive_offset = FixedOffset::east(2 * 60 * 60).unwrap();
@@ -534,7 +534,7 @@ fn test_checked_add_offset() {
 #[test]
 fn test_checked_sub_offset() {
     let ymdhmsm = |y, m, d, h, mn, s, mi| {
-        Some(NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi).unwrap())
+        Some(NaiveDate::from_ymd(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi).unwrap())
     };
 
     let positive_offset = FixedOffset::east(2 * 60 * 60).unwrap();
@@ -564,7 +564,7 @@ fn test_checked_sub_offset() {
 #[test]
 fn test_overflowing_add_offset() {
     let ymdhmsm = |y, m, d, h, mn, s, mi| {
-        NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi).unwrap()
+        NaiveDate::from_ymd(y, m, d).unwrap().and_hms_milli_opt(h, mn, s, mi).unwrap()
     };
     let positive_offset = FixedOffset::east(2 * 60 * 60).unwrap();
     // regular date

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -345,7 +345,7 @@ fn test_datetime_from_str() {
 fn test_datetime_parse_from_str() {
     let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
     let ymdhmsn = |y, m, d, h, n, s, nano| {
-        NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano_opt(h, n, s, nano).unwrap()
+        NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano(h, n, s, nano).unwrap()
     };
     assert_eq!(
         NaiveDateTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -64,7 +64,7 @@ impl IsoWeek {
     /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
-    /// let d = NaiveDate::from_isoywd_opt(2015, 1, Weekday::Mon).unwrap();
+    /// let d = NaiveDate::from_isoywd(2015, 1, Weekday::Mon).unwrap();
     /// assert_eq!(d.iso_week().year(), 2015);
     /// ```
     ///
@@ -73,7 +73,7 @@ impl IsoWeek {
     ///
     /// ```
     /// # use chrono::{NaiveDate, Datelike, Weekday};
-    /// # let d = NaiveDate::from_isoywd_opt(2015, 1, Weekday::Mon).unwrap();
+    /// # let d = NaiveDate::from_isoywd(2015, 1, Weekday::Mon).unwrap();
     /// assert_eq!(d.year(), 2014);
     /// assert_eq!(d, NaiveDate::from_ymd(2014, 12, 29).unwrap());
     /// ```
@@ -91,7 +91,7 @@ impl IsoWeek {
     /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
-    /// let d = NaiveDate::from_isoywd_opt(2015, 15, Weekday::Mon).unwrap();
+    /// let d = NaiveDate::from_isoywd(2015, 15, Weekday::Mon).unwrap();
     /// assert_eq!(d.iso_week().week(), 15);
     /// ```
     #[inline]
@@ -108,7 +108,7 @@ impl IsoWeek {
     /// ```
     /// use chrono::{NaiveDate, Datelike, Weekday};
     ///
-    /// let d = NaiveDate::from_isoywd_opt(2015, 15, Weekday::Mon).unwrap();
+    /// let d = NaiveDate::from_isoywd(2015, 15, Weekday::Mon).unwrap();
     /// assert_eq!(d.iso_week().week0(), 14);
     /// ```
     #[inline]

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -75,7 +75,7 @@ impl IsoWeek {
     /// # use chrono::{NaiveDate, Datelike, Weekday};
     /// # let d = NaiveDate::from_isoywd_opt(2015, 1, Weekday::Mon).unwrap();
     /// assert_eq!(d.year(), 2014);
-    /// assert_eq!(d, NaiveDate::from_ymd_opt(2014, 12, 29).unwrap());
+    /// assert_eq!(d, NaiveDate::from_ymd(2014, 12, 29).unwrap());
     /// ```
     #[inline]
     pub const fn year(&self) -> i32 {
@@ -126,17 +126,17 @@ impl IsoWeek {
 /// ```
 /// use chrono::{NaiveDate, Datelike};
 ///
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd_opt(2015,  9,  5).unwrap().iso_week()), "2015-W36");
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd_opt(   0,  1,  3).unwrap().iso_week()), "0000-W01");
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd_opt(9999, 12, 31).unwrap().iso_week()), "9999-W52");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(2015,  9,  5).unwrap().iso_week()), "2015-W36");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(   0,  1,  3).unwrap().iso_week()), "0000-W01");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(9999, 12, 31).unwrap().iso_week()), "9999-W52");
 /// ```
 ///
 /// ISO 8601 requires an explicit sign for years before 1 BCE or after 9999 CE.
 ///
 /// ```
 /// # use chrono::{NaiveDate, Datelike};
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd_opt(    0,  1,  2).unwrap().iso_week()),  "-0001-W52");
-/// assert_eq!(format!("{:?}", NaiveDate::from_ymd_opt(10000, 12, 31).unwrap().iso_week()), "+10000-W52");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(    0,  1,  2).unwrap().iso_week()),  "-0001-W52");
+/// assert_eq!(format!("{:?}", NaiveDate::from_ymd(10000, 12, 31).unwrap().iso_week()), "+10000-W52");
 /// ```
 impl fmt::Debug for IsoWeek {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -178,24 +178,24 @@ mod tests {
 
     #[test]
     fn test_iso_week_equivalence_for_first_week() {
-        let monday = NaiveDate::from_ymd_opt(2024, 12, 30).unwrap();
-        let friday = NaiveDate::from_ymd_opt(2025, 1, 3).unwrap();
+        let monday = NaiveDate::from_ymd(2024, 12, 30).unwrap();
+        let friday = NaiveDate::from_ymd(2025, 1, 3).unwrap();
 
         assert_eq!(monday.iso_week(), friday.iso_week());
     }
 
     #[test]
     fn test_iso_week_equivalence_for_last_week() {
-        let monday = NaiveDate::from_ymd_opt(2026, 12, 28).unwrap();
-        let friday = NaiveDate::from_ymd_opt(2027, 1, 1).unwrap();
+        let monday = NaiveDate::from_ymd(2026, 12, 28).unwrap();
+        let friday = NaiveDate::from_ymd(2027, 1, 1).unwrap();
 
         assert_eq!(monday.iso_week(), friday.iso_week());
     }
 
     #[test]
     fn test_iso_week_ordering_for_first_week() {
-        let monday = NaiveDate::from_ymd_opt(2024, 12, 30).unwrap();
-        let friday = NaiveDate::from_ymd_opt(2025, 1, 3).unwrap();
+        let monday = NaiveDate::from_ymd(2024, 12, 30).unwrap();
+        let friday = NaiveDate::from_ymd(2025, 1, 3).unwrap();
 
         assert!(monday.iso_week() >= friday.iso_week());
         assert!(monday.iso_week() <= friday.iso_week());
@@ -203,8 +203,8 @@ mod tests {
 
     #[test]
     fn test_iso_week_ordering_for_last_week() {
-        let monday = NaiveDate::from_ymd_opt(2026, 12, 28).unwrap();
-        let friday = NaiveDate::from_ymd_opt(2027, 1, 1).unwrap();
+        let monday = NaiveDate::from_ymd(2026, 12, 28).unwrap();
+        let friday = NaiveDate::from_ymd(2027, 1, 1).unwrap();
 
         assert!(monday.iso_week() >= friday.iso_week());
         assert!(monday.iso_week() <= friday.iso_week());

--- a/src/naive/mod.rs
+++ b/src/naive/mod.rs
@@ -50,7 +50,7 @@ impl NaiveWeek {
     /// ```
     /// use chrono::{NaiveDate, Weekday};
     ///
-    /// let date = NaiveDate::from_ymd_opt(2022, 4, 18).unwrap();
+    /// let date = NaiveDate::from_ymd(2022, 4, 18).unwrap();
     /// let week = date.week(Weekday::Mon);
     /// assert!(week.first_day() <= date);
     /// ```
@@ -78,7 +78,7 @@ impl NaiveWeek {
     /// ```
     /// use chrono::{NaiveDate, Weekday};
     ///
-    /// let date = NaiveDate::from_ymd_opt(2022, 4, 18).unwrap();
+    /// let date = NaiveDate::from_ymd(2022, 4, 18).unwrap();
     /// let week = date.week(Weekday::Mon);
     /// assert!(week.last_day() >= date);
     /// ```
@@ -107,7 +107,7 @@ impl NaiveWeek {
     /// ```
     /// use chrono::{NaiveDate, Weekday};
     ///
-    /// let date = NaiveDate::from_ymd_opt(2022, 4, 18).unwrap();
+    /// let date = NaiveDate::from_ymd(2022, 4, 18).unwrap();
     /// let week = date.week(Weekday::Mon);
     /// let days = week.days();
     /// assert!(days.contains(&date));
@@ -153,7 +153,7 @@ mod test {
     use crate::{NaiveDate, Weekday};
     #[test]
     fn test_naiveweek() {
-        let date = NaiveDate::from_ymd_opt(2022, 5, 18).unwrap();
+        let date = NaiveDate::from_ymd(2022, 5, 18).unwrap();
         let asserts = [
             (Weekday::Mon, "Mon 2022-05-16", "Sun 2022-05-22"),
             (Weekday::Tue, "Tue 2022-05-17", "Mon 2022-05-23"),

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -77,7 +77,7 @@ mod tests;
 ///
 /// let t = NaiveTime::from_hms_milli(8, 59, 59, 1_000).unwrap();
 ///
-/// let dt1 = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_micro_opt(8, 59, 59, 1_000_000).unwrap();
+/// let dt1 = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_micro(8, 59, 59, 1_000_000).unwrap();
 ///
 /// let dt2 = NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_nano_opt(23, 59, 59, 1_000_000_000).unwrap().and_local_timezone(Utc).unwrap();
 /// # let _ = (t, dt1, dt2);

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -77,9 +77,9 @@ mod tests;
 ///
 /// let t = NaiveTime::from_hms_milli(8, 59, 59, 1_000).unwrap();
 ///
-/// let dt1 = NaiveDate::from_ymd_opt(2015, 7, 1).unwrap().and_hms_micro_opt(8, 59, 59, 1_000_000).unwrap();
+/// let dt1 = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_micro_opt(8, 59, 59, 1_000_000).unwrap();
 ///
-/// let dt2 = NaiveDate::from_ymd_opt(2015, 6, 30).unwrap().and_hms_nano_opt(23, 59, 59, 1_000_000_000).unwrap().and_local_timezone(Utc).unwrap();
+/// let dt2 = NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_nano_opt(23, 59, 59, 1_000_000_000).unwrap().and_local_timezone(Utc).unwrap();
 /// # let _ = (t, dt1, dt2);
 /// ```
 ///
@@ -163,7 +163,7 @@ mod tests;
 /// ```
 /// use chrono::{Utc, NaiveDate};
 ///
-/// let dt = NaiveDate::from_ymd_opt(2015, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_000).unwrap().and_local_timezone(Utc).unwrap();
+/// let dt = NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_000).unwrap().and_local_timezone(Utc).unwrap();
 /// assert_eq!(format!("{:?}", dt), "2015-06-30T23:59:60Z");
 /// ```
 ///
@@ -182,12 +182,12 @@ mod tests;
 ///
 /// let paramaribo_pre1945 = FixedOffset::east(-13236).unwrap(); // -03:40:36
 /// let leap_sec_2015 =
-///     NaiveDate::from_ymd_opt(2015, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_000).unwrap();
+///     NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_000).unwrap();
 /// let dt1 = paramaribo_pre1945.from_utc_datetime(&leap_sec_2015);
 /// assert_eq!(format!("{:?}", dt1), "2015-06-30T20:19:24-03:40:36");
 /// assert_eq!(format!("{:?}", dt1.time()), "20:19:24");
 ///
-/// let next_sec = NaiveDate::from_ymd_opt(2015, 7, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+/// let next_sec = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
 /// let dt2 = paramaribo_pre1945.from_utc_datetime(&next_sec);
 /// assert_eq!(format!("{:?}", dt2), "2015-06-30T20:19:24-03:40:36");
 /// assert_eq!(format!("{:?}", dt2.time()), "20:19:24");

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -187,7 +187,7 @@ mod tests;
 /// assert_eq!(format!("{:?}", dt1), "2015-06-30T20:19:24-03:40:36");
 /// assert_eq!(format!("{:?}", dt1.time()), "20:19:24");
 ///
-/// let next_sec = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
+/// let next_sec = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms(0, 0, 0).unwrap();
 /// let dt2 = paramaribo_pre1945.from_utc_datetime(&next_sec);
 /// assert_eq!(format!("{:?}", dt2), "2015-06-30T20:19:24-03:40:36");
 /// assert_eq!(format!("{:?}", dt2.time()), "20:19:24");

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -163,7 +163,7 @@ mod tests;
 /// ```
 /// use chrono::{Utc, NaiveDate};
 ///
-/// let dt = NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_000).unwrap().and_local_timezone(Utc).unwrap();
+/// let dt = NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli(23, 59, 59, 1_000).unwrap().and_local_timezone(Utc).unwrap();
 /// assert_eq!(format!("{:?}", dt), "2015-06-30T23:59:60Z");
 /// ```
 ///
@@ -182,7 +182,7 @@ mod tests;
 ///
 /// let paramaribo_pre1945 = FixedOffset::east(-13236).unwrap(); // -03:40:36
 /// let leap_sec_2015 =
-///     NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_000).unwrap();
+///     NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli(23, 59, 59, 1_000).unwrap();
 /// let dt1 = paramaribo_pre1945.from_utc_datetime(&leap_sec_2015);
 /// assert_eq!(format!("{:?}", dt1), "2015-06-30T20:19:24-03:40:36");
 /// assert_eq!(format!("{:?}", dt1.time()), "20:19:24");

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -79,7 +79,7 @@ mod tests;
 ///
 /// let dt1 = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_micro(8, 59, 59, 1_000_000).unwrap();
 ///
-/// let dt2 = NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_nano_opt(23, 59, 59, 1_000_000_000).unwrap().and_local_timezone(Utc).unwrap();
+/// let dt2 = NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_nano(23, 59, 59, 1_000_000_000).unwrap().and_local_timezone(Utc).unwrap();
 /// # let _ = (t, dt1, dt2);
 /// ```
 ///

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -307,7 +307,7 @@ mod tests {
         // issue #123
         let today = Utc::now().date_naive();
 
-        if let Ok(dt) = today.and_hms_milli_opt(15, 2, 59, 1000) {
+        if let Ok(dt) = today.and_hms_milli(15, 2, 59, 1000) {
             let timestr = dt.time().to_string();
             // the OS API may or may not support the leap second,
             // but there are only two sensible options.
@@ -318,7 +318,7 @@ mod tests {
             );
         }
 
-        if let Ok(dt) = today.and_hms_milli_opt(15, 2, 3, 1234) {
+        if let Ok(dt) = today.and_hms_milli(15, 2, 3, 1234) {
             let timestr = dt.time().to_string();
             assert!(
                 timestr == "15:02:03.234" || timestr == "15:02:04.234",

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -332,7 +332,7 @@ mod tests {
     #[cfg(windows)]
     fn test_lookup_with_dst_transitions() {
         let ymdhms =
-            |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
+            |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
 
         #[track_caller]
         #[allow(clippy::too_many_arguments)]
@@ -346,7 +346,7 @@ mod tests {
             s: u32,
             result: LocalResult<FixedOffset>,
         ) {
-            let dt = NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
+            let dt = NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
             assert_eq!(lookup_with_dst_transitions(transitions, dt), result);
         }
 

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -331,9 +331,8 @@ mod tests {
     #[test]
     #[cfg(windows)]
     fn test_lookup_with_dst_transitions() {
-        let ymdhms = |y, m, d, h, n, s| {
-            NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap()
-        };
+        let ymdhms =
+            |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
 
         #[track_caller]
         #[allow(clippy::too_many_arguments)]
@@ -347,7 +346,7 @@ mod tests {
             s: u32,
             result: LocalResult<FixedOffset>,
         ) {
-            let dt = NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
+            let dt = NaiveDate::from_ymd(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
             assert_eq!(lookup_with_dst_transitions(transitions, dt), result);
         }
 

--- a/src/offset/local/windows.rs
+++ b/src/offset/local/windows.rs
@@ -250,7 +250,7 @@ mod tests {
             (bit_shift as i64 - HECTONANOSEC_TO_UNIX_EPOCH) / HECTONANOSECS_IN_SEC
         }
 
-        let mut date = NaiveDate::from_ymd(1975, 1, 1).unwrap().and_hms_opt(0, 30, 0).unwrap();
+        let mut date = NaiveDate::from_ymd(1975, 1, 1).unwrap().and_hms(0, 30, 0).unwrap();
 
         while date.year() < 2078 {
             // Windows doesn't handle non-existing dates, it just treats it as valid.

--- a/src/offset/local/windows.rs
+++ b/src/offset/local/windows.rs
@@ -169,11 +169,11 @@ fn system_time_from_naive_date_time(st: SYSTEMTIME, year: i32) -> Option<NaiveDa
             .map(|d| d.and_time(time));
     }
     let date = if let Some(date) =
-        NaiveDate::from_weekday_of_month_opt(year, st.wMonth as u32, day_of_week, st.wDay as u8)
+        NaiveDate::from_weekday_of_month(year, st.wMonth as u32, day_of_week, st.wDay as u8)
     {
         date
     } else if st.wDay == 5 {
-        NaiveDate::from_weekday_of_month_opt(year, st.wMonth as u32, day_of_week, 4)?
+        NaiveDate::from_weekday_of_month(year, st.wMonth as u32, day_of_week, 4)?
     } else {
         return None;
     };

--- a/src/offset/local/windows.rs
+++ b/src/offset/local/windows.rs
@@ -165,7 +165,7 @@ fn system_time_from_naive_date_time(st: SYSTEMTIME, year: i32) -> Option<NaiveDa
     // Therefore we move back one day after converting the u16 value to a Weekday.
     let day_of_week = Weekday::try_from(u8::try_from(st.wDayOfWeek).ok()?).ok()?.pred();
     if st.wYear != 0 {
-        return NaiveDate::from_ymd_opt(st.wYear as i32, st.wMonth as u32, st.wDay as u32)
+        return NaiveDate::from_ymd(st.wYear as i32, st.wMonth as u32, st.wDay as u32)
             .map(|d| d.and_time(time));
     }
     let date = if let Some(date) =
@@ -250,7 +250,7 @@ mod tests {
             (bit_shift as i64 - HECTONANOSEC_TO_UNIX_EPOCH) / HECTONANOSECS_IN_SEC
         }
 
-        let mut date = NaiveDate::from_ymd_opt(1975, 1, 1).unwrap().and_hms_opt(0, 30, 0).unwrap();
+        let mut date = NaiveDate::from_ymd(1975, 1, 1).unwrap().and_hms_opt(0, 30, 0).unwrap();
 
         while date.year() < 2078 {
             // Windows doesn't handle non-existing dates, it just treats it as valid.

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -130,8 +130,7 @@ pub trait TimeZone: Sized + Clone {
         min: u32,
         sec: u32,
     ) -> LocalResult<DateTime<Self>> {
-        match NaiveDate::from_ymd_opt(year, month, day)
-            .and_then(|d| d.and_hms_opt(hour, min, sec).ok())
+        match NaiveDate::from_ymd(year, month, day).and_then(|d| d.and_hms_opt(hour, min, sec).ok())
         {
             Some(dt) => self.from_local_datetime(&dt),
             None => LocalResult::None,

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -130,8 +130,7 @@ pub trait TimeZone: Sized + Clone {
         min: u32,
         sec: u32,
     ) -> LocalResult<DateTime<Self>> {
-        match NaiveDate::from_ymd(year, month, day).and_then(|d| d.and_hms_opt(hour, min, sec).ok())
-        {
+        match NaiveDate::from_ymd(year, month, day).and_then(|d| d.and_hms(hour, min, sec).ok()) {
             Some(dt) => self.from_local_datetime(&dt),
             None => LocalResult::None,
         }

--- a/src/round.rs
+++ b/src/round.rs
@@ -756,10 +756,10 @@ mod tests {
     fn test_duration_trunc_close_to_epoch() {
         let span = TimeDelta::minutes(15);
 
-        let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_opt(0, 0, 15).unwrap();
+        let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms(0, 0, 15).unwrap();
         assert_eq!(dt.duration_trunc(span).unwrap().to_string(), "1970-01-01 00:00:00");
 
-        let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().and_hms_opt(23, 59, 45).unwrap();
+        let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().and_hms(23, 59, 45).unwrap();
         assert_eq!(dt.duration_trunc(span).unwrap().to_string(), "1969-12-31 23:45:00");
     }
 
@@ -767,10 +767,10 @@ mod tests {
     fn test_duration_round_close_to_epoch() {
         let span = TimeDelta::minutes(15);
 
-        let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_opt(0, 0, 15).unwrap();
+        let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms(0, 0, 15).unwrap();
         assert_eq!(dt.duration_round(span).unwrap().to_string(), "1970-01-01 00:00:00");
 
-        let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().and_hms_opt(23, 59, 45).unwrap();
+        let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().and_hms(23, 59, 45).unwrap();
         assert_eq!(dt.duration_round(span).unwrap().to_string(), "1970-01-01 00:00:00");
     }
 

--- a/src/round.rs
+++ b/src/round.rs
@@ -23,7 +23,7 @@ pub trait SubsecRound {
     /// # Example
     /// ``` rust
     /// # use chrono::{SubsecRound, Timelike, Utc, NaiveDate};
-    /// let dt = NaiveDate::from_ymd_opt(2018, 1, 11).unwrap().and_hms_milli_opt(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli_opt(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.round_subsecs(2).nanosecond(), 150_000_000);
     /// assert_eq!(dt.round_subsecs(1).nanosecond(), 200_000_000);
     /// ```
@@ -35,7 +35,7 @@ pub trait SubsecRound {
     /// # Example
     /// ``` rust
     /// # use chrono::{SubsecRound, Timelike, Utc, NaiveDate};
-    /// let dt = NaiveDate::from_ymd_opt(2018, 1, 11).unwrap().and_hms_milli_opt(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli_opt(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.trunc_subsecs(2).nanosecond(), 150_000_000);
     /// assert_eq!(dt.trunc_subsecs(1).nanosecond(), 100_000_000);
     /// ```
@@ -110,7 +110,7 @@ pub trait DurationRound: Sized {
     /// # Example
     /// ``` rust
     /// # use chrono::{DurationRound, TimeDelta, Utc, NaiveDate};
-    /// let dt = NaiveDate::from_ymd_opt(2018, 1, 11).unwrap().and_hms_milli_opt(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli_opt(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(
     ///     dt.duration_round(TimeDelta::milliseconds(10)).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
@@ -127,7 +127,7 @@ pub trait DurationRound: Sized {
     /// # Example
     /// ``` rust
     /// # use chrono::{DurationRound, TimeDelta, Utc, NaiveDate};
-    /// let dt = NaiveDate::from_ymd_opt(2018, 1, 11).unwrap().and_hms_milli_opt(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli_opt(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(
     ///     dt.duration_trunc(TimeDelta::milliseconds(10)).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
@@ -238,7 +238,7 @@ pub enum RoundingError {
     ///
     /// ``` rust
     /// # use chrono::{DurationRound, TimeDelta, RoundingError, Utc, NaiveDate};
-    /// let dt = NaiveDate::from_ymd_opt(2260, 12, 31).unwrap().and_hms_nano_opt(23, 59, 59, 1_75_500_000).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2260, 12, 31).unwrap().and_hms_nano_opt(23, 59, 59, 1_75_500_000).unwrap().and_local_timezone(Utc).unwrap();
     ///
     /// assert_eq!(
     ///     dt.duration_round(TimeDelta::days(300 * 365)),
@@ -294,7 +294,7 @@ mod tests {
         let pst = FixedOffset::east(8 * 60 * 60).unwrap();
         let dt = pst
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2018, 1, 11)
+                &NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
                     .and_hms_nano_opt(10, 5, 13, 84_660_684)
                     .unwrap(),
@@ -317,7 +317,7 @@ mod tests {
 
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2018, 1, 11)
+                &NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
                     .and_hms_nano_opt(10, 5, 27, 750_500_000)
                     .unwrap(),
@@ -337,7 +337,7 @@ mod tests {
     fn test_round_leap_nanos() {
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2016, 12, 31)
+                &NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
                     .and_hms_nano_opt(23, 59, 59, 1_750_500_000)
                     .unwrap(),
@@ -358,7 +358,7 @@ mod tests {
         let pst = FixedOffset::east(8 * 60 * 60).unwrap();
         let dt = pst
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2018, 1, 11)
+                &NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
                     .and_hms_nano_opt(10, 5, 13, 84_660_684)
                     .unwrap(),
@@ -381,7 +381,7 @@ mod tests {
 
         let dt = pst
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2018, 1, 11)
+                &NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
                     .and_hms_nano_opt(10, 5, 27, 750_500_000)
                     .unwrap(),
@@ -401,7 +401,7 @@ mod tests {
     fn test_trunc_leap_nanos() {
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2016, 12, 31)
+                &NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
                     .and_hms_nano_opt(23, 59, 59, 1_750_500_000)
                     .unwrap(),
@@ -421,7 +421,7 @@ mod tests {
     fn test_duration_round() {
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2016, 12, 31)
+                &NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
                     .and_hms_nano_opt(23, 59, 59, 175_500_000)
                     .unwrap(),
@@ -441,7 +441,7 @@ mod tests {
         // round up
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2012, 12, 12)
+                &NaiveDate::from_ymd(2012, 12, 12)
                     .unwrap()
                     .and_hms_milli_opt(18, 22, 30, 0)
                     .unwrap(),
@@ -454,7 +454,7 @@ mod tests {
         // round down
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2012, 12, 12)
+                &NaiveDate::from_ymd(2012, 12, 12)
                     .unwrap()
                     .and_hms_milli_opt(18, 22, 29, 999)
                     .unwrap(),
@@ -509,7 +509,7 @@ mod tests {
     fn test_duration_round_naive() {
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2016, 12, 31)
+                &NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
                     .and_hms_nano_opt(23, 59, 59, 175_500_000)
                     .unwrap(),
@@ -530,7 +530,7 @@ mod tests {
         // round up
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2012, 12, 12)
+                &NaiveDate::from_ymd(2012, 12, 12)
                     .unwrap()
                     .and_hms_milli_opt(18, 22, 30, 0)
                     .unwrap(),
@@ -544,7 +544,7 @@ mod tests {
         // round down
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2012, 12, 12)
+                &NaiveDate::from_ymd(2012, 12, 12)
                     .unwrap()
                     .and_hms_milli_opt(18, 22, 29, 999)
                     .unwrap(),
@@ -587,7 +587,7 @@ mod tests {
     fn test_duration_trunc() {
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2016, 12, 31)
+                &NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
                     .and_hms_nano_opt(23, 59, 59, 175_500_000)
                     .unwrap(),
@@ -602,7 +602,7 @@ mod tests {
         // would round up
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2012, 12, 12)
+                &NaiveDate::from_ymd(2012, 12, 12)
                     .unwrap()
                     .and_hms_milli_opt(18, 22, 30, 0)
                     .unwrap(),
@@ -615,7 +615,7 @@ mod tests {
         // would round down
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2012, 12, 12)
+                &NaiveDate::from_ymd(2012, 12, 12)
                     .unwrap()
                     .and_hms_milli_opt(18, 22, 29, 999)
                     .unwrap(),
@@ -669,7 +669,7 @@ mod tests {
     fn test_duration_trunc_naive() {
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2016, 12, 31)
+                &NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
                     .and_hms_nano_opt(23, 59, 59, 175_500_000)
                     .unwrap(),
@@ -685,7 +685,7 @@ mod tests {
         // would round up
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2012, 12, 12)
+                &NaiveDate::from_ymd(2012, 12, 12)
                     .unwrap()
                     .and_hms_milli_opt(18, 22, 30, 0)
                     .unwrap(),
@@ -699,7 +699,7 @@ mod tests {
         // would round down
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd_opt(2012, 12, 12)
+                &NaiveDate::from_ymd(2012, 12, 12)
                     .unwrap()
                     .and_hms_milli_opt(18, 22, 29, 999)
                     .unwrap(),
@@ -756,10 +756,10 @@ mod tests {
     fn test_duration_trunc_close_to_epoch() {
         let span = TimeDelta::minutes(15);
 
-        let dt = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_opt(0, 0, 15).unwrap();
+        let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_opt(0, 0, 15).unwrap();
         assert_eq!(dt.duration_trunc(span).unwrap().to_string(), "1970-01-01 00:00:00");
 
-        let dt = NaiveDate::from_ymd_opt(1969, 12, 31).unwrap().and_hms_opt(23, 59, 45).unwrap();
+        let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().and_hms_opt(23, 59, 45).unwrap();
         assert_eq!(dt.duration_trunc(span).unwrap().to_string(), "1969-12-31 23:45:00");
     }
 
@@ -767,10 +767,10 @@ mod tests {
     fn test_duration_round_close_to_epoch() {
         let span = TimeDelta::minutes(15);
 
-        let dt = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_opt(0, 0, 15).unwrap();
+        let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_opt(0, 0, 15).unwrap();
         assert_eq!(dt.duration_round(span).unwrap().to_string(), "1970-01-01 00:00:00");
 
-        let dt = NaiveDate::from_ymd_opt(1969, 12, 31).unwrap().and_hms_opt(23, 59, 45).unwrap();
+        let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().and_hms_opt(23, 59, 45).unwrap();
         assert_eq!(dt.duration_round(span).unwrap().to_string(), "1970-01-01 00:00:00");
     }
 

--- a/src/round.rs
+++ b/src/round.rs
@@ -238,7 +238,7 @@ pub enum RoundingError {
     ///
     /// ``` rust
     /// # use chrono::{DurationRound, TimeDelta, RoundingError, Utc, NaiveDate};
-    /// let dt = NaiveDate::from_ymd(2260, 12, 31).unwrap().and_hms_nano_opt(23, 59, 59, 1_75_500_000).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2260, 12, 31).unwrap().and_hms_nano(23, 59, 59, 1_75_500_000).unwrap().and_local_timezone(Utc).unwrap();
     ///
     /// assert_eq!(
     ///     dt.duration_round(TimeDelta::days(300 * 365)),
@@ -296,7 +296,7 @@ mod tests {
             .from_local_datetime(
                 &NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
-                    .and_hms_nano_opt(10, 5, 13, 84_660_684)
+                    .and_hms_nano(10, 5, 13, 84_660_684)
                     .unwrap(),
             )
             .unwrap();
@@ -319,7 +319,7 @@ mod tests {
             .from_local_datetime(
                 &NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
-                    .and_hms_nano_opt(10, 5, 27, 750_500_000)
+                    .and_hms_nano(10, 5, 27, 750_500_000)
                     .unwrap(),
             )
             .unwrap();
@@ -339,7 +339,7 @@ mod tests {
             .from_local_datetime(
                 &NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
-                    .and_hms_nano_opt(23, 59, 59, 1_750_500_000)
+                    .and_hms_nano(23, 59, 59, 1_750_500_000)
                     .unwrap(),
             )
             .unwrap();
@@ -360,7 +360,7 @@ mod tests {
             .from_local_datetime(
                 &NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
-                    .and_hms_nano_opt(10, 5, 13, 84_660_684)
+                    .and_hms_nano(10, 5, 13, 84_660_684)
                     .unwrap(),
             )
             .unwrap();
@@ -383,7 +383,7 @@ mod tests {
             .from_local_datetime(
                 &NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
-                    .and_hms_nano_opt(10, 5, 27, 750_500_000)
+                    .and_hms_nano(10, 5, 27, 750_500_000)
                     .unwrap(),
             )
             .unwrap();
@@ -403,7 +403,7 @@ mod tests {
             .from_local_datetime(
                 &NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
-                    .and_hms_nano_opt(23, 59, 59, 1_750_500_000)
+                    .and_hms_nano(23, 59, 59, 1_750_500_000)
                     .unwrap(),
             )
             .unwrap();
@@ -423,7 +423,7 @@ mod tests {
             .from_local_datetime(
                 &NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
-                    .and_hms_nano_opt(23, 59, 59, 175_500_000)
+                    .and_hms_nano(23, 59, 59, 175_500_000)
                     .unwrap(),
             )
             .unwrap();
@@ -505,7 +505,7 @@ mod tests {
             .from_local_datetime(
                 &NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
-                    .and_hms_nano_opt(23, 59, 59, 175_500_000)
+                    .and_hms_nano(23, 59, 59, 175_500_000)
                     .unwrap(),
             )
             .unwrap()
@@ -577,7 +577,7 @@ mod tests {
             .from_local_datetime(
                 &NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
-                    .and_hms_nano_opt(23, 59, 59, 175_500_000)
+                    .and_hms_nano(23, 59, 59, 175_500_000)
                     .unwrap(),
             )
             .unwrap();
@@ -653,7 +653,7 @@ mod tests {
             .from_local_datetime(
                 &NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
-                    .and_hms_nano_opt(23, 59, 59, 175_500_000)
+                    .and_hms_nano(23, 59, 59, 175_500_000)
                     .unwrap(),
             )
             .unwrap()

--- a/src/round.rs
+++ b/src/round.rs
@@ -23,7 +23,7 @@ pub trait SubsecRound {
     /// # Example
     /// ``` rust
     /// # use chrono::{SubsecRound, Timelike, Utc, NaiveDate};
-    /// let dt = NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli_opt(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.round_subsecs(2).nanosecond(), 150_000_000);
     /// assert_eq!(dt.round_subsecs(1).nanosecond(), 200_000_000);
     /// ```
@@ -35,7 +35,7 @@ pub trait SubsecRound {
     /// # Example
     /// ``` rust
     /// # use chrono::{SubsecRound, Timelike, Utc, NaiveDate};
-    /// let dt = NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli_opt(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(dt.trunc_subsecs(2).nanosecond(), 150_000_000);
     /// assert_eq!(dt.trunc_subsecs(1).nanosecond(), 100_000_000);
     /// ```
@@ -110,7 +110,7 @@ pub trait DurationRound: Sized {
     /// # Example
     /// ``` rust
     /// # use chrono::{DurationRound, TimeDelta, Utc, NaiveDate};
-    /// let dt = NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli_opt(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(
     ///     dt.duration_round(TimeDelta::milliseconds(10)).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
@@ -127,7 +127,7 @@ pub trait DurationRound: Sized {
     /// # Example
     /// ``` rust
     /// # use chrono::{DurationRound, TimeDelta, Utc, NaiveDate};
-    /// let dt = NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli_opt(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
+    /// let dt = NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli(12, 0, 0, 154).unwrap().and_local_timezone(Utc).unwrap();
     /// assert_eq!(
     ///     dt.duration_trunc(TimeDelta::milliseconds(10)).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
@@ -441,10 +441,7 @@ mod tests {
         // round up
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12)
-                    .unwrap()
-                    .and_hms_milli_opt(18, 22, 30, 0)
-                    .unwrap(),
+                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
             )
             .unwrap();
         assert_eq!(
@@ -454,10 +451,7 @@ mod tests {
         // round down
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12)
-                    .unwrap()
-                    .and_hms_milli_opt(18, 22, 29, 999)
-                    .unwrap(),
+                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
             )
             .unwrap();
         assert_eq!(
@@ -530,10 +524,7 @@ mod tests {
         // round up
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12)
-                    .unwrap()
-                    .and_hms_milli_opt(18, 22, 30, 0)
-                    .unwrap(),
+                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
             )
             .unwrap()
             .naive_utc();
@@ -544,10 +535,7 @@ mod tests {
         // round down
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12)
-                    .unwrap()
-                    .and_hms_milli_opt(18, 22, 29, 999)
-                    .unwrap(),
+                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
             )
             .unwrap()
             .naive_utc();
@@ -602,10 +590,7 @@ mod tests {
         // would round up
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12)
-                    .unwrap()
-                    .and_hms_milli_opt(18, 22, 30, 0)
-                    .unwrap(),
+                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
             )
             .unwrap();
         assert_eq!(
@@ -615,10 +600,7 @@ mod tests {
         // would round down
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12)
-                    .unwrap()
-                    .and_hms_milli_opt(18, 22, 29, 999)
-                    .unwrap(),
+                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
             )
             .unwrap();
         assert_eq!(
@@ -685,10 +667,7 @@ mod tests {
         // would round up
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12)
-                    .unwrap()
-                    .and_hms_milli_opt(18, 22, 30, 0)
-                    .unwrap(),
+                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
             )
             .unwrap()
             .naive_utc();
@@ -699,10 +678,7 @@ mod tests {
         // would round down
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12)
-                    .unwrap()
-                    .and_hms_milli_opt(18, 22, 29, 999)
-                    .unwrap(),
+                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
             )
             .unwrap()
             .naive_utc();

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -112,8 +112,8 @@ pub trait Datelike: Sized {
     ///
     /// // Don't use `with_year` if you want the ordinal date to stay the same:
     /// assert_ne!(
-    ///     NaiveDate::from_yo_opt(2020, 100).unwrap().with_year(2023).unwrap(),
-    ///     NaiveDate::from_yo_opt(2023, 100).unwrap() // result is 2023-101
+    ///     NaiveDate::from_yo(2020, 100).unwrap().with_year(2023).unwrap(),
+    ///     NaiveDate::from_yo(2023, 100).unwrap() // result is 2023-101
     /// );
     /// ```
     fn with_year(&self, year: i32) -> Option<Self>;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -104,11 +104,11 @@ pub trait Datelike: Sized {
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(
-    ///     NaiveDate::from_ymd_opt(2020, 5, 13).unwrap().with_year(2023).unwrap(),
-    ///     NaiveDate::from_ymd_opt(2023, 5, 13).unwrap()
+    ///     NaiveDate::from_ymd(2020, 5, 13).unwrap().with_year(2023).unwrap(),
+    ///     NaiveDate::from_ymd(2023, 5, 13).unwrap()
     /// );
     /// // Resulting date 2023-02-29 does not exist:
-    /// assert!(NaiveDate::from_ymd_opt(2020, 2, 29).unwrap().with_year(2023).is_none());
+    /// assert!(NaiveDate::from_ymd(2020, 2, 29).unwrap().with_year(2023).is_none());
     ///
     /// // Don't use `with_year` if you want the ordinal date to stay the same:
     /// assert_ne!(
@@ -137,11 +137,11 @@ pub trait Datelike: Sized {
     /// use chrono::{NaiveDate, Datelike};
     ///
     /// assert_eq!(
-    ///     NaiveDate::from_ymd_opt(2023, 5, 12).unwrap().with_month(9).unwrap(),
-    ///     NaiveDate::from_ymd_opt(2023, 9, 12).unwrap()
+    ///     NaiveDate::from_ymd(2023, 5, 12).unwrap().with_month(9).unwrap(),
+    ///     NaiveDate::from_ymd(2023, 9, 12).unwrap()
     /// );
     /// // Resulting date 2023-09-31 does not exist:
-    /// assert!(NaiveDate::from_ymd_opt(2023, 5, 31).unwrap().with_month(9).is_none());
+    /// assert!(NaiveDate::from_ymd(2023, 5, 31).unwrap().with_month(9).is_none());
     /// ```
     ///
     /// Don't combine multiple `Datelike::with_*` methods. The intermediate value may not exist.
@@ -151,15 +151,15 @@ pub trait Datelike: Sized {
     /// fn with_year_month(date: NaiveDate, year: i32, month: u32) -> Option<NaiveDate> {
     ///     date.with_year(year)?.with_month(month)
     /// }
-    /// let d = NaiveDate::from_ymd_opt(2020, 2, 29).unwrap();
+    /// let d = NaiveDate::from_ymd(2020, 2, 29).unwrap();
     /// assert!(with_year_month(d, 2019, 1).is_none()); // fails because of invalid intermediate value
     ///
     /// // Correct version:
     /// fn with_year_month_fixed(date: NaiveDate, year: i32, month: u32) -> Option<NaiveDate> {
-    ///     NaiveDate::from_ymd_opt(year, month, date.day())
+    ///     NaiveDate::from_ymd(year, month, date.day())
     /// }
-    /// let d = NaiveDate::from_ymd_opt(2020, 2, 29).unwrap();
-    /// assert_eq!(with_year_month_fixed(d, 2019, 1), NaiveDate::from_ymd_opt(2019, 1, 29));
+    /// let d = NaiveDate::from_ymd(2020, 2, 29).unwrap();
+    /// assert_eq!(with_year_month_fixed(d, 2019, 1), NaiveDate::from_ymd(2019, 1, 29));
     /// ```
     fn with_month(&self, month: u32) -> Option<Self>;
 
@@ -240,10 +240,10 @@ pub trait Datelike: Sized {
     /// ```
     /// use chrono::{NaiveDate, Datelike};
     ///
-    /// assert_eq!(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().num_days_from_ce(), 719_163);
-    /// assert_eq!(NaiveDate::from_ymd_opt(2, 1, 1).unwrap().num_days_from_ce(), 366);
-    /// assert_eq!(NaiveDate::from_ymd_opt(1, 1, 1).unwrap().num_days_from_ce(), 1);
-    /// assert_eq!(NaiveDate::from_ymd_opt(0, 1, 1).unwrap().num_days_from_ce(), -365);
+    /// assert_eq!(NaiveDate::from_ymd(1970, 1, 1).unwrap().num_days_from_ce(), 719_163);
+    /// assert_eq!(NaiveDate::from_ymd(2, 1, 1).unwrap().num_days_from_ce(), 366);
+    /// assert_eq!(NaiveDate::from_ymd(1, 1, 1).unwrap().num_days_from_ce(), 1);
+    /// assert_eq!(NaiveDate::from_ymd(0, 1, 1).unwrap().num_days_from_ce(), -365);
     /// ```
     fn num_days_from_ce(&self) -> i32 {
         // See test_num_days_from_ce_against_alternative_impl below for a more straightforward
@@ -370,7 +370,7 @@ mod tests {
         }
 
         for year in NaiveDate::MIN.year()..=NaiveDate::MAX.year() {
-            let jan1_year = NaiveDate::from_ymd_opt(year, 1, 1).unwrap();
+            let jan1_year = NaiveDate::from_ymd(year, 1, 1).unwrap();
             assert_eq!(
                 jan1_year.num_days_from_ce(),
                 num_days_from_ce(&jan1_year),

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -32,7 +32,7 @@ fn verify_against_date_command_local(path: &'static str, dt: NaiveDateTime) {
     // be exactly matched, or whether LocalResult::Ambigious should be handled
     // differently
 
-    let date = NaiveDate::from_ymd_opt(dt.year(), dt.month(), dt.day()).unwrap();
+    let date = NaiveDate::from_ymd(dt.year(), dt.month(), dt.day()).unwrap();
     match Local.from_local_datetime(&date.and_hms_opt(dt.hour(), 5, 1).unwrap()) {
         chrono::LocalResult::Ambiguous(a, b) => assert!(
             format!("{}\n", a) == date_command_str || format!("{}\n", b) == date_command_str
@@ -90,8 +90,8 @@ fn try_verify_against_date_command() {
     let mut children = vec![];
     for year in [1975, 1976, 1977, 2020, 2021, 2022, 2073, 2074, 2075, 2076, 2077].iter() {
         children.push(thread::spawn(|| {
-            let mut date = NaiveDate::from_ymd_opt(*year, 1, 1).unwrap().and_time(NaiveTime::MIN);
-            let end = NaiveDate::from_ymd_opt(*year + 1, 1, 1).unwrap().and_time(NaiveTime::MIN);
+            let mut date = NaiveDate::from_ymd(*year, 1, 1).unwrap().and_time(NaiveTime::MIN);
+            let end = NaiveDate::from_ymd(*year + 1, 1, 1).unwrap().and_time(NaiveTime::MIN);
             while date <= end {
                 verify_against_date_command_local(DATE_PATH, date);
                 date += chrono::TimeDelta::hours(1);
@@ -137,7 +137,7 @@ fn verify_against_date_command_format_local(path: &'static str, dt: NaiveDateTim
         .unwrap();
 
     let date_command_str = String::from_utf8(output.stdout).unwrap();
-    let date = NaiveDate::from_ymd_opt(dt.year(), dt.month(), dt.day()).unwrap();
+    let date = NaiveDate::from_ymd(dt.year(), dt.month(), dt.day()).unwrap();
     let ldt = Local
         .from_local_datetime(&date.and_hms_opt(dt.hour(), dt.minute(), dt.second()).unwrap())
         .unwrap();
@@ -154,7 +154,7 @@ fn try_verify_against_date_command_format() {
     }
     assert_run_date_version();
 
-    let mut date = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap().and_hms_opt(12, 11, 13).unwrap();
+    let mut date = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_opt(12, 11, 13).unwrap();
     while date.year() < 2008 {
         verify_against_date_command_format_local(DATE_PATH, date);
         date += chrono::TimeDelta::days(55);

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -33,7 +33,7 @@ fn verify_against_date_command_local(path: &'static str, dt: NaiveDateTime) {
     // differently
 
     let date = NaiveDate::from_ymd(dt.year(), dt.month(), dt.day()).unwrap();
-    match Local.from_local_datetime(&date.and_hms_opt(dt.hour(), 5, 1).unwrap()) {
+    match Local.from_local_datetime(&date.and_hms(dt.hour(), 5, 1).unwrap()) {
         chrono::LocalResult::Ambiguous(a, b) => assert!(
             format!("{}\n", a) == date_command_str || format!("{}\n", b) == date_command_str
         ),
@@ -139,7 +139,7 @@ fn verify_against_date_command_format_local(path: &'static str, dt: NaiveDateTim
     let date_command_str = String::from_utf8(output.stdout).unwrap();
     let date = NaiveDate::from_ymd(dt.year(), dt.month(), dt.day()).unwrap();
     let ldt = Local
-        .from_local_datetime(&date.and_hms_opt(dt.hour(), dt.minute(), dt.second()).unwrap())
+        .from_local_datetime(&date.and_hms(dt.hour(), dt.minute(), dt.second()).unwrap())
         .unwrap();
     let formated_date = format!("{}\n", ldt.format(required_format));
     assert_eq!(date_command_str, formated_date);
@@ -154,7 +154,7 @@ fn try_verify_against_date_command_format() {
     }
     assert_run_date_version();
 
-    let mut date = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms_opt(12, 11, 13).unwrap();
+    let mut date = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms(12, 11, 13).unwrap();
     while date.year() < 2008 {
         verify_against_date_command_format_local(DATE_PATH, date);
         date += chrono::TimeDelta::days(55);


### PR DESCRIPTION
This continues the renaming op all `_opt` methods after the removal of their deprecated panicking variants in #1394. Only the `NaiveDate` type was left out of that PR. Turns out for the best, as the find-and-replace touches ca. 1000 lines.

The first three commits are a cosmetic fix for some tests that I would like to backport to the main branch in a later PR (I'm collecting a couple).

The last two commits remove 4 lines that mentioned removed `*_opt` methods in comments that slipped through in #1394 and the last merge of main.