### PR TITLE
CI: test cross-compiling to `x86_64-unknown-illumos` instead of Solaris

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,7 +169,7 @@ jobs:
     strategy:
       matrix:
         target:
-          - x86_64-sun-solaris
+          - x86_64-unknown-illumos
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Apparently cross dropped support for the `x86_64-sun-solaris` target (https://github.com/cross-rs/cross/pull/1432), making our CI fail.