### PR TITLE
`Mdf` performance and docs

### DIFF
--- a/bench/benches/chrono.rs
+++ b/bench/benches/chrono.rs
@@ -8,6 +8,16 @@ use chrono::prelude::*;
 use chrono::Locale;
 use chrono::{DateTime, FixedOffset, Local, TimeDelta, Utc, __BenchYearFlags};
 
+fn bench_date_from_ymd(c: &mut Criterion) {
+    c.bench_function("bench_date_from_ymd", |b| {
+        let expected = NaiveDate::from_ymd_opt(2024, 2, 12);
+        b.iter(|| {
+            let (y, m, d) = black_box((2024, 2, 12));
+            assert_eq!(NaiveDate::from_ymd_opt(y, m, d), expected)
+        })
+    });
+}
+
 fn bench_datetime_parse_from_rfc2822(c: &mut Criterion) {
     c.bench_function("bench_datetime_parse_from_rfc2822", |b| {
         b.iter(|| {
@@ -213,6 +223,7 @@ fn bench_datetime_with(c: &mut Criterion) {
 
 criterion_group!(
     benches,
+    bench_date_from_ymd,
     bench_datetime_parse_from_rfc2822,
     bench_datetime_parse_from_rfc3339,
     bench_datetime_from_str,

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -1398,10 +1398,11 @@ impl NaiveDate {
     /// Create a new `NaiveDate` from a raw year-ordinal-flags `i32`.
     ///
     /// In a valid value an ordinal is never `0`, and neither are the year flags. This method
-    /// doesn't do any validation; it only panics if the value is `0`.
+    /// doesn't do any validation.
     #[inline]
     const fn from_yof(yof: i32) -> NaiveDate {
-        NaiveDate { yof: expect!(NonZeroI32::new(yof), "invalid internal value") }
+        debug_assert!(yof != 0);
+        NaiveDate { yof: unsafe { NonZeroI32::new_unchecked(yof) } }
     }
 
     /// Get the raw year-ordinal-flags `i32`.

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -149,10 +149,10 @@ impl NaiveDate {
     /// Makes a new `NaiveDate` from year and packed month-day-flags.
     /// Does not check whether the flags are correct for the provided year.
     const fn from_mdf(year: i32, mdf: Mdf) -> Option<NaiveDate> {
-        match mdf.ordinal() {
-            Some(ordinal) => NaiveDate::from_ordinal_and_flags(year, ordinal, mdf.year_flags()),
-            None => None, // Non-existing date
+        if year < MIN_YEAR || year > MAX_YEAR {
+            return None; // Out-of-range
         }
+        Some(NaiveDate::from_yof((year << 13) | try_opt!(mdf.ordinal_and_flags())))
     }
 
     /// Makes a new `NaiveDate` from the [calendar date](#calendar-date)

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -120,7 +120,7 @@ pub(super) const MAX_MDL: u32 = (12 << 6) | (31 << 1) | 1;
 // The next table are adjustment values to convert a date encoded as month-day-leapyear to
 // ordinal-leapyear. OL = MDL - adjustment.
 // Dates that do not exist are encoded as `XX`.
-const XX: i8 = -128;
+const XX: i8 = 0;
 const MDL_TO_OL: &[i8; MAX_MDL as usize + 1] = &[
     XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX,
     XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX, XX,
@@ -255,7 +255,7 @@ impl Mdf {
         let mdl = mdf >> 3;
         if mdl <= MAX_MDL {
             // Array is indexed from `[1..=MAX_MDL]`, with a `0` index having a meaningless value.
-            MDL_TO_OL[mdl as usize] >= 0
+            MDL_TO_OL[mdl as usize] > 0
         } else {
             // Panicking here would be reasonable, but we are just going on with a safe value.
             false

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -336,6 +336,24 @@ impl Mdf {
     pub(super) const fn year_flags(&self) -> YearFlags {
         YearFlags((self.0 & 0b1111) as u8)
     }
+
+    /// Returns the ordinal that corresponds to this `Mdf`, encoded as a value including year flags.
+    ///
+    /// This does a table lookup to calculate the corresponding ordinal. It will return an error if
+    /// the `Mdl` turns out not to be a valid date.
+    ///
+    /// # Errors
+    ///
+    /// Returns `None` if `month == 0` or `day == 0`, or if a the given day does not exist in the
+    /// given month.
+    #[inline]
+    pub(super) const fn ordinal_and_flags(&self) -> Option<i32> {
+        let mdl = self.0 >> 3;
+        match MDL_TO_OL[mdl as usize] {
+            XX => None,
+            v => Some(self.0 as i32 - ((v as i32) << 3)),
+        }
+    }
 }
 
 impl fmt::Debug for Mdf {

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -327,7 +327,7 @@ impl Mdf {
         let mdl = self.0 >> 3;
         match MDL_TO_OL[mdl as usize] {
             XX => None,
-            v => Some((mdl - v as i32 as u32) >> 1),
+            v => Some((mdl - v as u8 as u32) >> 1),
         }
     }
 

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -4,32 +4,47 @@
 
 use core::fmt;
 
-/// The year flags (aka the dominical letter).
+/// Year flags (aka the dominical letter).
+///
+/// `YearFlags` are used as the last four bits of `NaiveDate`, `Mdf` and `IsoWeek`.
 ///
 /// There are 14 possible classes of year in the Gregorian calendar:
 /// common and leap years starting with Monday through Sunday.
-/// The `YearFlags` stores this information into 4 bits `abbb`,
-/// where `a` is `1` for the common year (simplifies the `Of` validation)
-/// and `bbb` is a non-zero `Weekday` (mapping `Mon` to 7) of the last day in the past year
-/// (simplifies the day of week calculation from the 1-based ordinal).
+///
+/// The `YearFlags` stores this information into 4 bits `LWWW`. `L` is the leap year flag, with `1`
+/// for the common year (this simplifies validating an ordinal in `NaiveDate`). `WWW` is a non-zero
+/// `Weekday` of the last day in the preceding year.
 #[allow(unreachable_pub)] // public as an alias for benchmarks only
 #[derive(PartialEq, Eq, Copy, Clone, Hash)]
 pub struct YearFlags(pub(super) u8);
 
-pub(super) const A: YearFlags = YearFlags(0o15);
-pub(super) const AG: YearFlags = YearFlags(0o05);
-pub(super) const B: YearFlags = YearFlags(0o14);
-pub(super) const BA: YearFlags = YearFlags(0o04);
-pub(super) const C: YearFlags = YearFlags(0o13);
-pub(super) const CB: YearFlags = YearFlags(0o03);
-pub(super) const D: YearFlags = YearFlags(0o12);
-pub(super) const DC: YearFlags = YearFlags(0o02);
-pub(super) const E: YearFlags = YearFlags(0o11);
-pub(super) const ED: YearFlags = YearFlags(0o01);
-pub(super) const F: YearFlags = YearFlags(0o17);
-pub(super) const FE: YearFlags = YearFlags(0o07);
-pub(super) const G: YearFlags = YearFlags(0o16);
-pub(super) const GF: YearFlags = YearFlags(0o06);
+// Weekday of the last day in the preceding year.
+// Allows for quick day of week calculation from the 1-based ordinal.
+const YEAR_STARTS_AFTER_MONDAY: u8 = 7; // non-zero to allow use with `NonZero*`.
+const YEAR_STARTS_AFTER_THUESDAY: u8 = 1;
+const YEAR_STARTS_AFTER_WEDNESDAY: u8 = 2;
+const YEAR_STARTS_AFTER_THURSDAY: u8 = 3;
+const YEAR_STARTS_AFTER_FRIDAY: u8 = 4;
+const YEAR_STARTS_AFTER_SATURDAY: u8 = 5;
+const YEAR_STARTS_AFTER_SUNDAY: u8 = 6;
+
+const COMMON_YEAR: u8 = 1 << 3;
+const LEAP_YEAR: u8 = 0 << 3;
+
+pub(super) const A: YearFlags = YearFlags(COMMON_YEAR | YEAR_STARTS_AFTER_SATURDAY);
+pub(super) const AG: YearFlags = YearFlags(LEAP_YEAR | YEAR_STARTS_AFTER_SATURDAY);
+pub(super) const B: YearFlags = YearFlags(COMMON_YEAR | YEAR_STARTS_AFTER_FRIDAY);
+pub(super) const BA: YearFlags = YearFlags(LEAP_YEAR | YEAR_STARTS_AFTER_FRIDAY);
+pub(super) const C: YearFlags = YearFlags(COMMON_YEAR | YEAR_STARTS_AFTER_THURSDAY);
+pub(super) const CB: YearFlags = YearFlags(LEAP_YEAR | YEAR_STARTS_AFTER_THURSDAY);
+pub(super) const D: YearFlags = YearFlags(COMMON_YEAR | YEAR_STARTS_AFTER_WEDNESDAY);
+pub(super) const DC: YearFlags = YearFlags(LEAP_YEAR | YEAR_STARTS_AFTER_WEDNESDAY);
+pub(super) const E: YearFlags = YearFlags(COMMON_YEAR | YEAR_STARTS_AFTER_THUESDAY);
+pub(super) const ED: YearFlags = YearFlags(LEAP_YEAR | YEAR_STARTS_AFTER_THUESDAY);
+pub(super) const F: YearFlags = YearFlags(COMMON_YEAR | YEAR_STARTS_AFTER_MONDAY);
+pub(super) const FE: YearFlags = YearFlags(LEAP_YEAR | YEAR_STARTS_AFTER_MONDAY);
+pub(super) const G: YearFlags = YearFlags(COMMON_YEAR | YEAR_STARTS_AFTER_SUNDAY);
+pub(super) const GF: YearFlags = YearFlags(LEAP_YEAR | YEAR_STARTS_AFTER_SUNDAY);
 
 const YEAR_TO_FLAGS: &[YearFlags; 400] = &[
     BA, G, F, E, DC, B, A, G, FE, D, C, B, AG, F, E, D, CB, A, G, F, ED, C, B, A, GF, E, D, C, BA,

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -249,19 +249,6 @@ impl Mdf {
         Mdf(((ol as u32 + OL_TO_MDL[ol as usize] as u32) << 3) | flags as u32)
     }
 
-    #[cfg(test)]
-    pub(super) const fn valid(&self) -> bool {
-        let Mdf(mdf) = *self;
-        let mdl = mdf >> 3;
-        if mdl <= MAX_MDL {
-            // Array is indexed from `[1..=MAX_MDL]`, with a `0` index having a meaningless value.
-            MDL_TO_OL[mdl as usize] > 0
-        } else {
-            // Panicking here would be reasonable, but we are just going on with a safe value.
-            false
-        }
-    }
-
     /// Returns the month of this `Mdf`.
     #[inline]
     pub(super) const fn month(&self) -> u32 {
@@ -353,6 +340,12 @@ impl Mdf {
             XX => None,
             v => Some(self.0 as i32 - ((v as i32) << 3)),
         }
+    }
+
+    #[cfg(test)]
+    fn valid(&self) -> bool {
+        let mdl = self.0 >> 3;
+        MDL_TO_OL[mdl as usize] > 0
     }
 }
 

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -114,8 +114,8 @@ impl fmt::Debug for YearFlags {
 }
 
 // OL: (ordinal << 1) | leap year flag
-pub(super) const MAX_OL: u32 = 366 << 1; // `(366 << 1) | 1` would be day 366 in a non-leap year
-pub(super) const MAX_MDL: u32 = (12 << 6) | (31 << 1) | 1;
+const MAX_OL: u32 = 366 << 1; // `(366 << 1) | 1` would be day 366 in a non-leap year
+const MAX_MDL: u32 = (12 << 6) | (31 << 1) | 1;
 
 // The next table are adjustment values to convert a date encoded as month-day-leapyear to
 // ordinal-leapyear. OL = MDL - adjustment.

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -232,7 +232,7 @@ impl Mdf {
     /// Returns `None` if `month > 12` or `day > 31`.
     #[inline]
     pub(super) const fn new(month: u32, day: u32, YearFlags(flags): YearFlags) -> Option<Mdf> {
-        match month >= 1 && month <= 12 && day >= 1 && day <= 31 {
+        match month <= 12 && day <= 31 {
             true => Some(Mdf((month << 9) | (day << 4) | flags as u32)),
             false => None,
         }
@@ -557,12 +557,9 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_returns_none() {
+    fn test_mdf_new_range() {
         let flags = YearFlags::from_year(2023);
-        assert!(Mdf::new(0, 1, flags).is_none());
         assert!(Mdf::new(13, 1, flags).is_none());
-        assert!(Mdf::new(1, 0, flags).is_none());
         assert!(Mdf::new(1, 32, flags).is_none());
-        assert!(Mdf::new(2, 31, flags).is_some());
     }
 }


### PR DESCRIPTION
The `Mdf` types reason for existence is to have a way to convert between ordinal dates and month-day dates efficiently. It is a core part of the performance of chrono, we use it internally all over the place. Before converting it to return `Result`s in the 0.5 branch I need a benchmark to not materially regress its performance.

Turns out I already regressed it by ca. 25% (at least according to the new benchmark) since chrono 0.4.24 :scream:.
After the benchmark in the first commit, the next three commits recover this lost performance by reverting needless checks:
- #1043 introduced checks in `Mdf::new` that are also covered by the table lookup `Mdf` exists for.
- #1432 tries to make `NaiveDate::from_mdf` share code with `NaiveDate::from_ordinal_and_flags`. It looks clean, but that introduces a bunch of unneeded checks. I added a dedicated method `Mdf::ordinal_and_flags` and made `NaiveDate::from_mdf` use that.
- #1207 introduced a useless check against zero with `NonZeroI32::new`.

Then there are two commits that improve the performance a little bit more.
And while working on it I wrote some doc comments for the methods on `Mdf`.

### Benchmark results

Chrono 0.4.24
```
bench_date_from_ymd     time:   [4.3541 ns 4.3737 ns 4.3958 ns]
```

Before
```
bench_date_from_ymd     time:   [5.5149 ns 5.5508 ns 5.5919 ns]
```

After
```
bench_date_from_ymd     time:   [4.2512 ns 4.2572 ns 4.2637 ns]
```

----

I have the commits that extend this PR to convert an `Mdf` to return `Result`s ready, but would like to base them on this PR to the main branch.