### PR TITLE
CI: only run `cargo hack check` on Linux

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
   features_check:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The `cargo hack-check` runs take ca. 10 minutes longer to run on Windows and MacOS then the other CI jobs.
None of our features interact with our platform integration code, so these CI jobs always succeed if the other jobs do.
Seems removing them is an easy way to cut our CI times to a third.

(Sorry, tiny PR.)