### PR TITLE
0.5: Converting the API to return Results (part 2): `Mdf` type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,13 @@ pub enum Error {
     ///
     /// An example is creating a `NaiveTime` with 25 as the hour value.
     InvalidArgument,
+
+    /// The result, or an intermediate value necessary for calculating a result, would be out of
+    /// range.
+    ///
+    /// An example is a date for the year 500.000, which is out of the range supported by chrono's
+    /// types.
+    OutOfRange,
 }
 
 impl fmt::Display for Error {
@@ -25,6 +32,7 @@ impl fmt::Display for Error {
         match self {
             Error::DoesNotExist => write!(f, "date or datetime does not exist"),
             Error::InvalidArgument => write!(f, "invalid parameter"),
+            Error::OutOfRange => write!(f, "date outside of the supported range"),
         }
     }
 }

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -390,7 +390,7 @@ impl Parsed {
         let (verified, parsed_date) = match (given_year, given_isoyear, self) {
             (Some(year), _, &Parsed { month: Some(month), day: Some(day), .. }) => {
                 // year, month, day
-                let date = NaiveDate::from_ymd(year, month, day).ok_or(OUT_OF_RANGE)?;
+                let date = NaiveDate::from_ymd(year, month, day).map_err(|_| OUT_OF_RANGE)?;
                 (verify_isoweekdate(date) && verify_ordinal(date), date)
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,20 +129,20 @@
 //! # fn doctest() -> Option<()> {
 //!
 //! let dt = Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap(); // `2014-07-08T09:10:11Z`
-//! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms(9, 10, 11).unwrap().and_local_timezone(Utc).unwrap());
+//! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms(9, 10, 11).unwrap().and_local_timezone(Utc).unwrap());
 //!
 //! // July 8 is 188th day of the year 2014 (`o` for "ordinal")
 //! assert_eq!(dt, NaiveDate::from_yo(2014, 189)?.and_hms(9, 10, 11).unwrap().and_utc());
 //! // July 8 is Tuesday in ISO week 28 of the year 2014.
 //! assert_eq!(dt, NaiveDate::from_isoywd(2014, 28, Weekday::Tue)?.and_hms(9, 10, 11).unwrap().and_utc());
 //!
-//! let dt = NaiveDate::from_ymd(2014, 7, 8)?.and_hms_milli(9, 10, 11, 12).unwrap().and_local_timezone(Utc).unwrap(); // `2014-07-08T09:10:11.012Z`
-//! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_micro(9, 10, 11, 12_000).unwrap().and_local_timezone(Utc).unwrap());
-//! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8)?.and_hms_nano(9, 10, 11, 12_000_000).unwrap().and_local_timezone(Utc).unwrap());
+//! let dt = NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_milli(9, 10, 11, 12).unwrap().and_local_timezone(Utc).unwrap(); // `2014-07-08T09:10:11.012Z`
+//! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_micro(9, 10, 11, 12_000).unwrap().and_local_timezone(Utc).unwrap());
+//! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_nano(9, 10, 11, 12_000_000).unwrap().and_local_timezone(Utc).unwrap());
 //!
 //! // dynamic verification
 //! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 21, 15, 33),
-//!            LocalResult::Single(NaiveDate::from_ymd(2014, 7, 8)?.and_hms(21, 15, 33).unwrap().and_utc()));
+//!            LocalResult::Single(NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms(21, 15, 33).unwrap().and_utc()));
 //! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 80, 15, 33), LocalResult::None);
 //! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 38, 21, 15, 33), LocalResult::None);
 //!

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -21,7 +21,7 @@ use crate::naive::{Days, IsoWeek, NaiveDate, NaiveTime};
 use crate::offset::Utc;
 use crate::time_delta::NANOS_PER_SEC;
 use crate::{
-    expect, try_opt, DateTime, Datelike, FixedOffset, LocalResult, Months, TimeDelta, TimeZone,
+    expect, ok, try_opt, DateTime, Datelike, FixedOffset, LocalResult, Months, TimeDelta, TimeZone,
     Timelike, Weekday,
 };
 
@@ -1045,7 +1045,7 @@ impl NaiveDateTime {
 
     /// The Unix Epoch, 1970-01-01 00:00:00.
     pub const UNIX_EPOCH: Self =
-        expect!(NaiveDate::from_ymd(1970, 1, 1), "").and_time(NaiveTime::MIN);
+        expect!(ok!(NaiveDate::from_ymd(1970, 1, 1)), "").and_time(NaiveTime::MIN);
 }
 
 impl From<NaiveDate> for NaiveDateTime {

--- a/src/offset/local/windows.rs
+++ b/src/offset/local/windows.rs
@@ -166,6 +166,7 @@ fn system_time_from_naive_date_time(st: SYSTEMTIME, year: i32) -> Option<NaiveDa
     let day_of_week = Weekday::try_from(u8::try_from(st.wDayOfWeek).ok()?).ok()?.pred();
     if st.wYear != 0 {
         return NaiveDate::from_ymd(st.wYear as i32, st.wMonth as u32, st.wDay as u32)
+            .ok()
             .map(|d| d.and_time(time));
     }
     let date = if let Some(date) =

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -130,9 +130,9 @@ pub trait TimeZone: Sized + Clone {
         min: u32,
         sec: u32,
     ) -> LocalResult<DateTime<Self>> {
-        match NaiveDate::from_ymd(year, month, day).and_then(|d| d.and_hms(hour, min, sec).ok()) {
-            Some(dt) => self.from_local_datetime(&dt),
-            None => LocalResult::None,
+        match NaiveDate::from_ymd(year, month, day).and_then(|d| d.and_hms(hour, min, sec)) {
+            Ok(dt) => self.from_local_datetime(&dt),
+            Err(_) => LocalResult::None,
         }
     }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -146,7 +146,7 @@ pub trait Datelike: Sized {
     ///
     /// Don't combine multiple `Datelike::with_*` methods. The intermediate value may not exist.
     /// ```
-    /// use chrono::{NaiveDate, Datelike};
+    /// use chrono::{Error, NaiveDate, Datelike};
     ///
     /// fn with_year_month(date: NaiveDate, year: i32, month: u32) -> Option<NaiveDate> {
     ///     date.with_year(year)?.with_month(month)
@@ -155,7 +155,7 @@ pub trait Datelike: Sized {
     /// assert!(with_year_month(d, 2019, 1).is_none()); // fails because of invalid intermediate value
     ///
     /// // Correct version:
-    /// fn with_year_month_fixed(date: NaiveDate, year: i32, month: u32) -> Option<NaiveDate> {
+    /// fn with_year_month_fixed(date: NaiveDate, year: i32, month: u32) -> Result<NaiveDate, Error> {
     ///     NaiveDate::from_ymd(year, month, date.day())
     /// }
     /// let d = NaiveDate::from_ymd(2020, 2, 29).unwrap();


### PR DESCRIPTION
# :tada:

This and #1436 are the last ingredients before we can convert a good portion of the `naive` module to return `Result`s.

In the first commit I adjusted four methods on `Mdf` to return a `Result`.

To ensure we correctly return either `InvalidParameter` or `DoesNotExist` on error, the `MDL_TO_OL` lookup table can now encode a second error case. We had 128 unused negative values available to do so, and it doesn't cost us any performance (compared to always returning the same variant).

The second commit changes `NaiveDate::from_ymd_opt` to return a `Result` to have something to benchmark against.

### Benchmark
```
bench_date_from_ymd     time:   [4.5764 ns 4.5945 ns 4.6141 ns]
```

Compared to returning an `Option` this is a slight regression of 8% with `main`, and compared to 0.4.24 a regression of ca. 5%. In my opinion it stays in the right ballpark, and seems to be unavoidable.

### Alternative
As an alternative I tried what happens if `Mdf` returns an `Option`, and we map it to an error in the callers. That brings ca. 20% overhead compared to `main`, and is a lot less nice to work with. Better to return `Result`s everywhere.

cc @Zomtir