### PR TITLE
Backport cosmetic fixes from #1436

### DIFF
--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -167,33 +167,33 @@ fn test_date_from_ymd() {
 
 #[test]
 fn test_date_from_yo() {
-    let yo_opt = NaiveDate::from_yo_opt;
+    let from_yo = NaiveDate::from_yo_opt;
     let ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
 
-    assert_eq!(yo_opt(2012, 0), None);
-    assert_eq!(yo_opt(2012, 1), Some(ymd(2012, 1, 1)));
-    assert_eq!(yo_opt(2012, 2), Some(ymd(2012, 1, 2)));
-    assert_eq!(yo_opt(2012, 32), Some(ymd(2012, 2, 1)));
-    assert_eq!(yo_opt(2012, 60), Some(ymd(2012, 2, 29)));
-    assert_eq!(yo_opt(2012, 61), Some(ymd(2012, 3, 1)));
-    assert_eq!(yo_opt(2012, 100), Some(ymd(2012, 4, 9)));
-    assert_eq!(yo_opt(2012, 200), Some(ymd(2012, 7, 18)));
-    assert_eq!(yo_opt(2012, 300), Some(ymd(2012, 10, 26)));
-    assert_eq!(yo_opt(2012, 366), Some(ymd(2012, 12, 31)));
-    assert_eq!(yo_opt(2012, 367), None);
-    assert_eq!(yo_opt(2012, 1 << 28 | 60), None);
+    assert_eq!(from_yo(2012, 0), None);
+    assert_eq!(from_yo(2012, 1), Some(ymd(2012, 1, 1)));
+    assert_eq!(from_yo(2012, 2), Some(ymd(2012, 1, 2)));
+    assert_eq!(from_yo(2012, 32), Some(ymd(2012, 2, 1)));
+    assert_eq!(from_yo(2012, 60), Some(ymd(2012, 2, 29)));
+    assert_eq!(from_yo(2012, 61), Some(ymd(2012, 3, 1)));
+    assert_eq!(from_yo(2012, 100), Some(ymd(2012, 4, 9)));
+    assert_eq!(from_yo(2012, 200), Some(ymd(2012, 7, 18)));
+    assert_eq!(from_yo(2012, 300), Some(ymd(2012, 10, 26)));
+    assert_eq!(from_yo(2012, 366), Some(ymd(2012, 12, 31)));
+    assert_eq!(from_yo(2012, 367), None);
+    assert_eq!(from_yo(2012, 1 << 28 | 60), None);
 
-    assert_eq!(yo_opt(2014, 0), None);
-    assert_eq!(yo_opt(2014, 1), Some(ymd(2014, 1, 1)));
-    assert_eq!(yo_opt(2014, 2), Some(ymd(2014, 1, 2)));
-    assert_eq!(yo_opt(2014, 32), Some(ymd(2014, 2, 1)));
-    assert_eq!(yo_opt(2014, 59), Some(ymd(2014, 2, 28)));
-    assert_eq!(yo_opt(2014, 60), Some(ymd(2014, 3, 1)));
-    assert_eq!(yo_opt(2014, 100), Some(ymd(2014, 4, 10)));
-    assert_eq!(yo_opt(2014, 200), Some(ymd(2014, 7, 19)));
-    assert_eq!(yo_opt(2014, 300), Some(ymd(2014, 10, 27)));
-    assert_eq!(yo_opt(2014, 365), Some(ymd(2014, 12, 31)));
-    assert_eq!(yo_opt(2014, 366), None);
+    assert_eq!(from_yo(2014, 0), None);
+    assert_eq!(from_yo(2014, 1), Some(ymd(2014, 1, 1)));
+    assert_eq!(from_yo(2014, 2), Some(ymd(2014, 1, 2)));
+    assert_eq!(from_yo(2014, 32), Some(ymd(2014, 2, 1)));
+    assert_eq!(from_yo(2014, 59), Some(ymd(2014, 2, 28)));
+    assert_eq!(from_yo(2014, 60), Some(ymd(2014, 3, 1)));
+    assert_eq!(from_yo(2014, 100), Some(ymd(2014, 4, 10)));
+    assert_eq!(from_yo(2014, 200), Some(ymd(2014, 7, 19)));
+    assert_eq!(from_yo(2014, 300), Some(ymd(2014, 10, 27)));
+    assert_eq!(from_yo(2014, 365), Some(ymd(2014, 12, 31)));
+    assert_eq!(from_yo(2014, 366), None);
 }
 
 #[test]

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -151,18 +151,18 @@ fn test_readme_doomsday() {
 
 #[test]
 fn test_date_from_ymd() {
-    let ymd_opt = NaiveDate::from_ymd_opt;
+    let from_ymd = NaiveDate::from_ymd_opt;
 
-    assert!(ymd_opt(2012, 0, 1).is_none());
-    assert!(ymd_opt(2012, 1, 1).is_some());
-    assert!(ymd_opt(2012, 2, 29).is_some());
-    assert!(ymd_opt(2014, 2, 29).is_none());
-    assert!(ymd_opt(2014, 3, 0).is_none());
-    assert!(ymd_opt(2014, 3, 1).is_some());
-    assert!(ymd_opt(2014, 3, 31).is_some());
-    assert!(ymd_opt(2014, 3, 32).is_none());
-    assert!(ymd_opt(2014, 12, 31).is_some());
-    assert!(ymd_opt(2014, 13, 1).is_none());
+    assert!(from_ymd(2012, 0, 1).is_none());
+    assert!(from_ymd(2012, 1, 1).is_some());
+    assert!(from_ymd(2012, 2, 29).is_some());
+    assert!(from_ymd(2014, 2, 29).is_none());
+    assert!(from_ymd(2014, 3, 0).is_none());
+    assert!(from_ymd(2014, 3, 1).is_some());
+    assert!(from_ymd(2014, 3, 31).is_some());
+    assert!(from_ymd(2014, 3, 32).is_none());
+    assert!(from_ymd(2014, 12, 31).is_some());
+    assert!(from_ymd(2014, 13, 1).is_none());
 }
 
 #[test]

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -198,31 +198,31 @@ fn test_date_from_yo() {
 
 #[test]
 fn test_date_from_isoywd() {
-    let isoywd_opt = NaiveDate::from_isoywd_opt;
+    let from_isoywd = NaiveDate::from_isoywd_opt;
     let ymd = |y, m, d| NaiveDate::from_ymd_opt(y, m, d).unwrap();
 
-    assert_eq!(isoywd_opt(2004, 0, Weekday::Sun), None);
-    assert_eq!(isoywd_opt(2004, 1, Weekday::Mon), Some(ymd(2003, 12, 29)));
-    assert_eq!(isoywd_opt(2004, 1, Weekday::Sun), Some(ymd(2004, 1, 4)));
-    assert_eq!(isoywd_opt(2004, 2, Weekday::Mon), Some(ymd(2004, 1, 5)));
-    assert_eq!(isoywd_opt(2004, 2, Weekday::Sun), Some(ymd(2004, 1, 11)));
-    assert_eq!(isoywd_opt(2004, 52, Weekday::Mon), Some(ymd(2004, 12, 20)));
-    assert_eq!(isoywd_opt(2004, 52, Weekday::Sun), Some(ymd(2004, 12, 26)));
-    assert_eq!(isoywd_opt(2004, 53, Weekday::Mon), Some(ymd(2004, 12, 27)));
-    assert_eq!(isoywd_opt(2004, 53, Weekday::Sun), Some(ymd(2005, 1, 2)));
-    assert_eq!(isoywd_opt(2004, 54, Weekday::Mon), None);
+    assert_eq!(from_isoywd(2004, 0, Weekday::Sun), None);
+    assert_eq!(from_isoywd(2004, 1, Weekday::Mon), Some(ymd(2003, 12, 29)));
+    assert_eq!(from_isoywd(2004, 1, Weekday::Sun), Some(ymd(2004, 1, 4)));
+    assert_eq!(from_isoywd(2004, 2, Weekday::Mon), Some(ymd(2004, 1, 5)));
+    assert_eq!(from_isoywd(2004, 2, Weekday::Sun), Some(ymd(2004, 1, 11)));
+    assert_eq!(from_isoywd(2004, 52, Weekday::Mon), Some(ymd(2004, 12, 20)));
+    assert_eq!(from_isoywd(2004, 52, Weekday::Sun), Some(ymd(2004, 12, 26)));
+    assert_eq!(from_isoywd(2004, 53, Weekday::Mon), Some(ymd(2004, 12, 27)));
+    assert_eq!(from_isoywd(2004, 53, Weekday::Sun), Some(ymd(2005, 1, 2)));
+    assert_eq!(from_isoywd(2004, 54, Weekday::Mon), None);
 
-    assert_eq!(isoywd_opt(2011, 0, Weekday::Sun), None);
-    assert_eq!(isoywd_opt(2011, 1, Weekday::Mon), Some(ymd(2011, 1, 3)));
-    assert_eq!(isoywd_opt(2011, 1, Weekday::Sun), Some(ymd(2011, 1, 9)));
-    assert_eq!(isoywd_opt(2011, 2, Weekday::Mon), Some(ymd(2011, 1, 10)));
-    assert_eq!(isoywd_opt(2011, 2, Weekday::Sun), Some(ymd(2011, 1, 16)));
+    assert_eq!(from_isoywd(2011, 0, Weekday::Sun), None);
+    assert_eq!(from_isoywd(2011, 1, Weekday::Mon), Some(ymd(2011, 1, 3)));
+    assert_eq!(from_isoywd(2011, 1, Weekday::Sun), Some(ymd(2011, 1, 9)));
+    assert_eq!(from_isoywd(2011, 2, Weekday::Mon), Some(ymd(2011, 1, 10)));
+    assert_eq!(from_isoywd(2011, 2, Weekday::Sun), Some(ymd(2011, 1, 16)));
 
-    assert_eq!(isoywd_opt(2018, 51, Weekday::Mon), Some(ymd(2018, 12, 17)));
-    assert_eq!(isoywd_opt(2018, 51, Weekday::Sun), Some(ymd(2018, 12, 23)));
-    assert_eq!(isoywd_opt(2018, 52, Weekday::Mon), Some(ymd(2018, 12, 24)));
-    assert_eq!(isoywd_opt(2018, 52, Weekday::Sun), Some(ymd(2018, 12, 30)));
-    assert_eq!(isoywd_opt(2018, 53, Weekday::Mon), None);
+    assert_eq!(from_isoywd(2018, 51, Weekday::Mon), Some(ymd(2018, 12, 17)));
+    assert_eq!(from_isoywd(2018, 51, Weekday::Sun), Some(ymd(2018, 12, 23)));
+    assert_eq!(from_isoywd(2018, 52, Weekday::Mon), Some(ymd(2018, 12, 24)));
+    assert_eq!(from_isoywd(2018, 52, Weekday::Sun), Some(ymd(2018, 12, 30)));
+    assert_eq!(from_isoywd(2018, 53, Weekday::Mon), None);
 }
 
 #[test]


### PR DESCRIPTION
The first three commits from #1436 where made to be usable on the main branch. It seems useful to keep the branches as similar as possible.