### PR TITLE
Explore time zone lookup errors

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -366,6 +366,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
             .checked_add_months(rhs)?
             .and_local_timezone(Tz::from_offset(&self.offset))
             .single()
+            .ok()
     }
 
     /// Subtracts given `TimeDelta` from the current date and time.
@@ -399,6 +400,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
             .checked_sub_months(rhs)?
             .and_local_timezone(Tz::from_offset(&self.offset))
             .single()
+            .ok()
     }
 
     /// Add a duration in [`Days`] to the date part of the `DateTime`.
@@ -415,6 +417,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
             .checked_add_days(days)?
             .and_local_timezone(TimeZone::from_offset(&self.offset))
             .single()
+            .ok()
     }
 
     /// Subtract a duration in [`Days`] from the date part of the `DateTime`.
@@ -431,6 +434,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
             .checked_sub_days(days)?
             .and_local_timezone(TimeZone::from_offset(&self.offset))
             .single()
+            .ok()
     }
 
     /// Subtracts another `DateTime` from the current date and time.
@@ -732,7 +736,7 @@ where
     F: FnMut(NaiveDateTime) -> Option<NaiveDateTime>,
 {
     f(dt.overflowing_naive_local())
-        .and_then(|datetime| dt.timezone().from_local_datetime(&datetime).single())
+        .and_then(|datetime| dt.timezone().from_local_datetime(&datetime).single().ok())
         .filter(|dt| dt >= &DateTime::<Utc>::MIN_UTC && dt <= &DateTime::<Utc>::MAX_UTC)
 }
 
@@ -1645,7 +1649,7 @@ impl TryFrom<SystemTime> for DateTime<Utc> {
                 }
             }
         };
-        Utc.timestamp(sec, nsec).single().ok_or(OutOfRange::new())
+        Utc.timestamp(sec, nsec).single().map_err(|_| OutOfRange::new())
     }
 }
 

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -80,7 +80,7 @@ impl TimeZone for DstTester {
         } else if *local >= local_to_summer_transition_start
             && *local < local_to_summer_transition_end
         {
-            LocalResult::None
+            LocalResult::InGap
         } else {
             panic!("Unexpected local time {}", local)
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,18 @@
 //! Error type
 use core::fmt;
 
+use crate::offset::TzLookupError;
+
 /// Error type for date and time operations.
 #[non_exhaustive]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Error {
+    /// There is not enough information to create a date/time.
+    ///
+    /// An example is parsing a string with not enough date/time fields, or the result of a
+    /// time that is ambiguous during a time zone transitions (due to for example DST).
+    Ambiguous,
+
     /// A date or datetime does not exist.
     ///
     /// Examples are:
@@ -25,14 +33,19 @@ pub enum Error {
     /// An example is a date for the year 500.000, which is out of the range supported by chrono's
     /// types.
     OutOfRange,
+
+    /// Lookup of a local datetime in a timezone failed.
+    TzLookupFailure(TzLookupError),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            Error::Ambiguous => write!(f, "not enough information for a concrete date/time"),
             Error::DoesNotExist => write!(f, "date or datetime does not exist"),
             Error::InvalidArgument => write!(f, "invalid parameter"),
             Error::OutOfRange => write!(f, "date outside of the supported range"),
+            Error::TzLookupFailure(e) => fmt::Display::fmt(&e, f),
         }
     }
 }

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -629,11 +629,7 @@ impl Parsed {
         let datetime = self.to_naive_datetime_with_offset(offset)?;
         let offset = FixedOffset::east(offset).ok_or(OUT_OF_RANGE)?;
 
-        match offset.from_local_datetime(&datetime) {
-            LocalResult::None => Err(IMPOSSIBLE),
-            LocalResult::Single(t) => Ok(t),
-            LocalResult::Ambiguous(..) => Err(NOT_ENOUGH),
-        }
+        Ok(offset.from_local_datetime(&datetime).single().unwrap())
     }
 
     /// Returns a parsed timezone-aware date and time out of given fields,
@@ -670,7 +666,6 @@ impl Parsed {
         // it will be 0 otherwise, but this is fine as the algorithm ignores offset for that case.
         let datetime = self.to_naive_datetime_with_offset(guessed_offset)?;
         match tz.from_local_datetime(&datetime) {
-            LocalResult::None => Err(IMPOSSIBLE),
             LocalResult::Single(t) => {
                 if check_offset(&t) {
                     Ok(t)
@@ -687,6 +682,7 @@ impl Parsed {
                     (true, true) => Err(NOT_ENOUGH),
                 }
             }
+            LocalResult::InGap | LocalResult::Error(_) => Err(IMPOSSIBLE),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@
 //!
 #![cfg_attr(not(feature = "now"), doc = "```ignore")]
 #![cfg_attr(feature = "now", doc = "```rust")]
-//! use chrono::offset::LocalResult;
+//! use chrono::offset::{LocalResult, TzLookupError};
 //! use chrono::prelude::*;
 //!
 //! # fn doctest() -> Option<()> {
@@ -143,8 +143,8 @@
 //! // dynamic verification
 //! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 21, 15, 33),
 //!            LocalResult::Single(NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms(21, 15, 33).unwrap().and_utc()));
-//! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 80, 15, 33), LocalResult::None);
-//! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 38, 21, 15, 33), LocalResult::None);
+//! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 80, 15, 33), LocalResult::Error(TzLookupError::Other));
+//! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 38, 21, 15, 33), LocalResult::Error(TzLookupError::Other));
 //!
 //! # #[cfg(feature = "clock")] {
 //! // other time zone objects can be used to construct a local datetime.

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -1,4 +1,5 @@
 use super::NaiveDateTime;
+use crate::offset::TzLookupError;
 use crate::{Datelike, FixedOffset, LocalResult, NaiveDate, TimeDelta, Utc};
 
 #[test]
@@ -563,13 +564,13 @@ fn test_and_timezone_min_max_dates() {
         if offset_hour >= 0 {
             assert_eq!(local_max.unwrap().naive_local(), NaiveDateTime::MAX);
         } else {
-            assert_eq!(local_max, LocalResult::None);
+            assert_eq!(local_max, LocalResult::Error(TzLookupError::OutOfRange));
         }
         let local_min = NaiveDateTime::MIN.and_local_timezone(offset);
         if offset_hour <= 0 {
             assert_eq!(local_min.unwrap().naive_local(), NaiveDateTime::MIN);
         } else {
-            assert_eq!(local_min, LocalResult::None);
+            assert_eq!(local_min, LocalResult::Error(TzLookupError::OutOfRange));
         }
     }
 }

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -235,7 +235,7 @@ fn lookup_with_dst_transitions(
                     } else if dt == wall_latest {
                         LocalResult::Single(t.offset_after)
                     } else {
-                        LocalResult::None
+                        LocalResult::InGap
                     }
                 }
             };

--- a/src/offset/local/tz_info/mod.rs
+++ b/src/offset/local/tz_info/mod.rs
@@ -10,6 +10,8 @@ use std::{error, fmt, io};
 mod timezone;
 pub(crate) use timezone::TimeZone;
 
+use crate::offset::TzLookupError;
+
 mod parser;
 mod rule;
 
@@ -97,6 +99,29 @@ impl From<SystemTimeError> for Error {
 impl From<Utf8Error> for Error {
     fn from(error: Utf8Error) -> Self {
         Error::Utf8(error)
+    }
+}
+
+impl From<Error> for TzLookupError {
+    fn from(error: Error) -> TzLookupError {
+        match error {
+            Error::DateTime(_) => TzLookupError::InvalidTimeZoneData,
+            Error::FindLocalTimeType(_) => TzLookupError::InvalidTimeZoneData,
+            Error::LocalTimeType(_) => TzLookupError::InvalidTimeZoneData,
+            Error::InvalidSlice(_) => TzLookupError::InvalidTimeZoneData,
+            Error::InvalidTzString(_) => TzLookupError::InvalidTzString,
+            Error::InvalidTzFile(_) => TzLookupError::InvalidTimeZoneData,
+            Error::Io(_) => TzLookupError::InvalidTimeZoneData,
+            Error::OutOfRange(_) => TzLookupError::InvalidTimeZoneData,
+            Error::ParseInt(_) => TzLookupError::InvalidTimeZoneData,
+            Error::ProjectDateTime(_) => TzLookupError::InvalidTimeZoneData,
+            Error::SystemTime(_) => TzLookupError::InvalidTimeZoneData,
+            Error::TransitionRule(_) => TzLookupError::InvalidTimeZoneData,
+            Error::TimeZone(_) => TzLookupError::InvalidTimeZoneData,
+            Error::UnsupportedTzFile(_) => TzLookupError::InvalidTimeZoneData,
+            Error::UnsupportedTzString(_) => TzLookupError::InvalidTzString,
+            Error::Utf8(_) => TzLookupError::InvalidTimeZoneData,
+        }
     }
 }
 

--- a/src/offset/local/tz_info/rule.rs
+++ b/src/offset/local/tz_info/rule.rs
@@ -264,7 +264,7 @@ impl AlternateTime {
                     } else if local_time > dst_start_transition_start
                         && local_time < dst_start_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(crate::LocalResult::InGap)
                     } else if local_time >= dst_start_transition_end
                         && local_time < dst_end_transition_end
                     {
@@ -292,7 +292,7 @@ impl AlternateTime {
                     } else if local_time >= dst_start_transition_start
                         && local_time < dst_start_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(crate::LocalResult::InGap)
                     } else {
                         Ok(crate::LocalResult::Single(self.dst))
                     }
@@ -317,7 +317,7 @@ impl AlternateTime {
                     } else if local_time >= dst_end_transition_start
                         && local_time < dst_end_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(crate::LocalResult::InGap)
                     } else {
                         Ok(crate::LocalResult::Single(self.std))
                     }
@@ -329,7 +329,7 @@ impl AlternateTime {
                     } else if local_time > dst_end_transition_start
                         && local_time < dst_end_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(crate::LocalResult::InGap)
                     } else if local_time >= dst_end_transition_end
                         && local_time < dst_start_transition_end
                     {

--- a/src/offset/local/tz_info/timezone.rs
+++ b/src/offset/local/tz_info/timezone.rs
@@ -275,7 +275,7 @@ impl<'a> TimeZoneRef<'a> {
                         if local_leap_time <= transition_start {
                             return Ok(crate::LocalResult::Single(prev));
                         } else if local_leap_time < transition_end {
-                            return Ok(crate::LocalResult::None);
+                            return Ok(crate::LocalResult::InGap);
                         } else if local_leap_time == transition_end {
                             return Ok(crate::LocalResult::Single(after_ltt));
                         }

--- a/src/offset/local/windows.rs
+++ b/src/offset/local/windows.rs
@@ -16,6 +16,7 @@ use std::ptr;
 use super::win_bindings::{GetTimeZoneInformationForYear, SYSTEMTIME, TIME_ZONE_INFORMATION};
 
 use crate::offset::local::{lookup_with_dst_transitions, Transition};
+use crate::offset::TzLookupError;
 use crate::{Datelike, FixedOffset, LocalResult, NaiveDate, NaiveDateTime, NaiveTime, Weekday};
 
 // We don't use `SystemTimeToTzSpecificLocalTime` because it doesn't support the same range of dates
@@ -30,8 +31,8 @@ pub(super) fn offset_from_utc_datetime(utc: &NaiveDateTime) -> LocalResult<Fixed
     // using the rules for the year of the corresponding local time. But this matches what
     // `SystemTimeToTzSpecificLocalTime` is documented to do.
     let tz_info = match TzInfo::for_year(utc.year()) {
-        Some(tz_info) => tz_info,
-        None => return LocalResult::None,
+        Ok(tz_info) => tz_info,
+        Err(e) => return LocalResult::Error(e),
     };
     let offset = match (tz_info.std_transition, tz_info.dst_transition) {
         (Some(std_transition), Some(dst_transition)) => {
@@ -73,8 +74,8 @@ pub(super) fn offset_from_utc_datetime(utc: &NaiveDateTime) -> LocalResult<Fixed
 // current year and compute it ourselves, like we do on Unix.
 pub(super) fn offset_from_local_datetime(local: &NaiveDateTime) -> LocalResult<FixedOffset> {
     let tz_info = match TzInfo::for_year(local.year()) {
-        Some(tz_info) => tz_info,
-        None => return LocalResult::None,
+        Ok(tz_info) => tz_info,
+        Err(e) => return LocalResult::Error(e),
     };
     // Create a sorted slice of transitions and use `lookup_with_dst_transitions`.
     match (tz_info.std_transition, tz_info.dst_transition) {
@@ -128,7 +129,7 @@ struct TzInfo {
 }
 
 impl TzInfo {
-    fn for_year(year: i32) -> Option<TzInfo> {
+    fn for_year(year: i32) -> Result<TzInfo, TzLookupError> {
         // The API limits years to 1601..=30827.
         // Working with timezones and daylight saving time this far into the past or future makes
         // little sense. But whatever is extrapolated for 1601 or 30827 is what can be extrapolated
@@ -137,13 +138,23 @@ impl TzInfo {
         let tz_info = unsafe {
             let mut tz_info = MaybeUninit::<TIME_ZONE_INFORMATION>::uninit();
             if GetTimeZoneInformationForYear(ref_year, ptr::null_mut(), tz_info.as_mut_ptr()) == 0 {
-                return None;
+                return Err(TzLookupError::last_os_error());
             }
             tz_info.assume_init()
         };
-        Some(TzInfo {
-            std_offset: FixedOffset::west((tz_info.Bias + tz_info.StandardBias) * 60)?,
-            dst_offset: FixedOffset::west((tz_info.Bias + tz_info.DaylightBias) * 60)?,
+        let std_offset = (tz_info.Bias)
+            .checked_add(tz_info.StandardBias)
+            .and_then(|o| o.checked_mul(60))
+            .and_then(FixedOffset::west)
+            .ok_or(TzLookupError::InvalidTimeZoneData)?;
+        let dst_offset = (tz_info.Bias)
+            .checked_add(tz_info.DaylightBias)
+            .and_then(|o| o.checked_mul(60))
+            .and_then(FixedOffset::west)
+            .ok_or(TzLookupError::InvalidTimeZoneData)?;
+        Ok(TzInfo {
+            std_offset,
+            dst_offset,
             std_transition: system_time_from_naive_date_time(tz_info.StandardDate, year),
             dst_transition: system_time_from_naive_date_time(tz_info.DaylightDate, year),
         })

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -35,43 +35,52 @@ pub(crate) mod utc;
 pub use self::utc::Utc;
 
 /// The conversion result from the local time to the timezone-aware datetime types.
-#[derive(Clone, PartialEq, Debug, Copy, Eq, Hash)]
+#[derive(Clone, PartialEq, Debug, Copy, Eq)]
 pub enum LocalResult<T> {
-    /// Given local time representation is invalid.
-    /// This can occur when, for example, the positive timezone transition.
-    None,
     /// Given local time representation has a single unique result.
     Single(T),
+
     /// Given local time representation has multiple results and thus ambiguous.
     /// This can occur when, for example, the negative timezone transition.
     Ambiguous(T /* min */, T /* max */),
+
+    /// Given local time representation is invalid.
+    /// This can occur when, for example, the positive timezone transition.
+    InGap,
+
+    /// Error type
+    Error(TzLookupError),
 }
 
 impl<T> LocalResult<T> {
     /// Returns `Some` only when the conversion result is unique, or `None` otherwise.
     #[must_use]
-    pub fn single(self) -> Option<T> {
+    pub fn single(self) -> Result<T, Error> {
         match self {
-            LocalResult::Single(t) => Some(t),
-            _ => None,
+            LocalResult::Single(t) => Ok(t),
+            LocalResult::Ambiguous(_, _) => Err(Error::Ambiguous),
+            LocalResult::InGap => Err(Error::DoesNotExist),
+            LocalResult::Error(e) => Err(e.into()),
         }
     }
 
     /// Returns `Some` for the earliest possible conversion result, or `None` if none.
     #[must_use]
-    pub fn earliest(self) -> Option<T> {
+    pub fn earliest(self) -> Result<T, Error> {
         match self {
-            LocalResult::Single(t) | LocalResult::Ambiguous(t, _) => Some(t),
-            _ => None,
+            LocalResult::Single(t) | LocalResult::Ambiguous(t, _) => Ok(t),
+            LocalResult::InGap => Err(Error::DoesNotExist),
+            LocalResult::Error(e) => Err(e.into()),
         }
     }
 
     /// Returns `Some` for the latest possible conversion result, or `None` if none.
     #[must_use]
-    pub fn latest(self) -> Option<T> {
+    pub fn latest(self) -> Result<T, Error> {
         match self {
-            LocalResult::Single(t) | LocalResult::Ambiguous(_, t) => Some(t),
-            _ => None,
+            LocalResult::Single(t) | LocalResult::Ambiguous(_, t) => Ok(t),
+            LocalResult::InGap => Err(Error::DoesNotExist),
+            LocalResult::Error(e) => Err(e.into()),
         }
     }
 
@@ -79,9 +88,10 @@ impl<T> LocalResult<T> {
     #[must_use]
     pub fn map<U, F: FnMut(T) -> U>(self, mut f: F) -> LocalResult<U> {
         match self {
-            LocalResult::None => LocalResult::None,
             LocalResult::Single(v) => LocalResult::Single(f(v)),
             LocalResult::Ambiguous(min, max) => LocalResult::Ambiguous(f(min), f(max)),
+            LocalResult::InGap => LocalResult::InGap,
+            LocalResult::Error(e) => LocalResult::Error(e),
         }
     }
 }
@@ -92,11 +102,12 @@ impl<T: fmt::Debug> LocalResult<T> {
     #[track_caller]
     pub fn unwrap(self) -> T {
         match self {
-            LocalResult::None => panic!("No such local time"),
             LocalResult::Single(t) => t,
             LocalResult::Ambiguous(t1, t2) => {
                 panic!("Ambiguous local time, ranging from {:?} to {:?}", t1, t2)
             }
+            LocalResult::InGap => panic!("No such local time"),
+            LocalResult::Error(e) => panic!("{}", e),
         }
     }
 }
@@ -132,7 +143,7 @@ pub trait TimeZone: Sized + Clone {
     ) -> LocalResult<DateTime<Self>> {
         match NaiveDate::from_ymd(year, month, day).and_then(|d| d.and_hms(hour, min, sec)) {
             Ok(dt) => self.from_local_datetime(&dt),
-            Err(_) => LocalResult::None,
+            Err(_) => LocalResult::Error(TzLookupError::Other), // FIXME: change return type
         }
     }
 
@@ -159,7 +170,7 @@ pub trait TimeZone: Sized + Clone {
     fn timestamp(&self, secs: i64, nsecs: u32) -> LocalResult<DateTime<Self>> {
         match NaiveDateTime::from_timestamp(secs, nsecs) {
             Some(dt) => LocalResult::Single(self.from_utc_datetime(&dt)),
-            None => LocalResult::None,
+            None => LocalResult::Error(TzLookupError::Other), // FIXME: change return type
         }
     }
 
@@ -183,7 +194,7 @@ pub trait TimeZone: Sized + Clone {
     fn timestamp_millis(&self, millis: i64) -> LocalResult<DateTime<Self>> {
         match NaiveDateTime::from_timestamp_millis(millis) {
             Some(dt) => LocalResult::Single(self.from_utc_datetime(&dt)),
-            None => LocalResult::None,
+            None => LocalResult::Error(TzLookupError::Other), // FIXME: change return type
         }
     }
 
@@ -221,7 +232,7 @@ pub trait TimeZone: Sized + Clone {
     fn timestamp_micros(&self, micros: i64) -> LocalResult<DateTime<Self>> {
         match NaiveDateTime::from_timestamp_micros(micros) {
             Some(dt) => LocalResult::Single(self.from_utc_datetime(&dt)),
-            None => LocalResult::None,
+            None => LocalResult::Error(TzLookupError::Other), // FIXME: change return type
         }
     }
 
@@ -234,13 +245,11 @@ pub trait TimeZone: Sized + Clone {
     /// Converts the local `NaiveDateTime` to the timezone-aware `DateTime` if possible.
     #[allow(clippy::wrong_self_convention)]
     fn from_local_datetime(&self, local: &NaiveDateTime) -> LocalResult<DateTime<Self>> {
-        // Return `LocalResult::None` when the offset pushes a value out of range, instead of
-        // panicking.
         match self.offset_from_local_datetime(local) {
-            LocalResult::None => LocalResult::None,
+            LocalResult::InGap => LocalResult::InGap,
             LocalResult::Single(offset) => match local.checked_sub_offset(offset.fix()) {
                 Some(dt) => LocalResult::Single(DateTime::from_naive_utc_and_offset(dt, offset)),
-                None => LocalResult::None,
+                None => LocalResult::Error(TzLookupError::OutOfRange),
             },
             LocalResult::Ambiguous(o1, o2) => {
                 match (local.checked_sub_offset(o1.fix()), local.checked_sub_offset(o2.fix())) {
@@ -248,9 +257,10 @@ pub trait TimeZone: Sized + Clone {
                         DateTime::from_naive_utc_and_offset(d1, o1),
                         DateTime::from_naive_utc_and_offset(d2, o2),
                     ),
-                    _ => LocalResult::None,
+                    _ => LocalResult::Error(TzLookupError::OutOfRange),
                 }
             }
+            LocalResult::Error(e) => LocalResult::Error(e),
         }
     }
 
@@ -264,7 +274,6 @@ pub trait TimeZone: Sized + Clone {
         DateTime::from_naive_utc_and_offset(*utc, self.offset_from_utc_datetime(utc))
     }
 }
-
 
 /// Error type for time zone lookups.
 #[non_exhaustive]
@@ -290,6 +299,9 @@ pub enum TzLookupError {
 
     /// The result would be out of range.
     OutOfRange,
+
+    /// FIXME: temporary variant until the return type of some methods is changed to `Result`.
+    Other,
 }
 
 impl fmt::Display for TzLookupError {
@@ -300,11 +312,16 @@ impl fmt::Display for TzLookupError {
                 let io_error = std::io::Error::from_raw_os_error(*code);
                 fmt::Display::fmt(&io_error, f)
             }
-            TzLookupError::InvalidTzString => write!(f, "`TZ` environment variable set to an invalid value"),
+            TzLookupError::InvalidTzString => {
+                write!(f, "`TZ` environment variable set to an invalid value")
+            }
             TzLookupError::NoTzdb => write!(f, "unable to locate an IANA time zone database"),
             TzLookupError::TimeZoneNotFound => write!(f, "the specified time zone is not found"),
-            TzLookupError::InvalidTimeZoneData => write!(f, "error when reading/validating the time zone data"),
+            TzLookupError::InvalidTimeZoneData => {
+                write!(f, "error when reading/validating the time zone data")
+            }
             TzLookupError::OutOfRange => write!(f, "date or offset outside of the supported range"),
+            TzLookupError::Other => write!(f, "FIXME: temporary error type"),
         }
     }
 }
@@ -315,6 +332,13 @@ impl std::error::Error for TzLookupError {}
 impl From<TzLookupError> for Error {
     fn from(error: TzLookupError) -> Self {
         Error::TzLookupFailure(error)
+    }
+}
+
+impl TzLookupError {
+    /// TODO
+    pub fn last_os_error() -> Self {
+        TzLookupError::OsError(std::io::Error::last_os_error().raw_os_error().unwrap())
     }
 }
 
@@ -337,13 +361,13 @@ mod tests {
             if offset_hour >= 0 {
                 assert_eq!(local_max.unwrap().naive_local(), NaiveDateTime::MAX);
             } else {
-                assert_eq!(local_max, LocalResult::None);
+                assert_eq!(local_max, LocalResult::Error(TzLookupError::OutOfRange));
             }
             let local_min = offset.from_local_datetime(&NaiveDateTime::MIN);
             if offset_hour <= 0 {
                 assert_eq!(local_min.unwrap().naive_local(), NaiveDateTime::MIN);
             } else {
-                assert_eq!(local_min, LocalResult::None);
+                assert_eq!(local_min, LocalResult::Error(TzLookupError::OutOfRange));
             }
         }
     }

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -308,10 +308,7 @@ impl fmt::Display for TzLookupError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             TzLookupError::TimeZoneUnknown => write!(f, "unable to determine the local time zone"),
-            TzLookupError::OsError(code) => {
-                let io_error = std::io::Error::from_raw_os_error(*code);
-                fmt::Display::fmt(&io_error, f)
-            }
+            TzLookupError::OsError(code) => write!(f, "TODO"),
             TzLookupError::InvalidTzString => {
                 write!(f, "`TZ` environment variable set to an invalid value")
             }
@@ -327,7 +324,14 @@ impl fmt::Display for TzLookupError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for TzLookupError {}
+impl std::error::Error for TzLookupError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            MyError::OsError(code) => Some(std::io::Error::from_raw_os_error(*code)),
+            _ => None,
+        }
+    }
+}
 
 impl From<TzLookupError> for Error {
     fn from(error: TzLookupError) -> Self {

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -40,9 +40,10 @@ fn verify_against_date_command_local(path: &'static str, dt: NaiveDateTime) {
         chrono::LocalResult::Single(a) => {
             assert_eq!(format!("{}\n", a), date_command_str);
         }
-        chrono::LocalResult::None => {
+        chrono::LocalResult::InGap => {
             assert_eq!("", date_command_str);
         }
+        chrono::LocalResult::Error(e) => panic!("{}", e),
     }
 }
 


### PR DESCRIPTION
To have something to talk about for #1448.

The Windows code is pretty clean and has `OsError` and `InvalidTimeZoneData` as error causes.

The Unix code remains in dire need of a refactoring.
I've tried to hook it up reasonably well to the error causes `InvalidTzString`, `TimeZoneUnknown`, `TimeZoneNotFound`, and `InvalidTimeZoneData`. `NoTzdb` isn't hooked up yet.