### PR TITLE
Rewite caching in `local::unix` module

### DIFF
--- a/src/offset/local/tz_info/timezone.rs
+++ b/src/offset/local/tz_info/timezone.rs
@@ -33,7 +33,7 @@ impl TimeZone {
     }
 
     /// Construct a time zone from a POSIX TZ string, as described in [the POSIX documentation of the `TZ` environment variable](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html).
-    fn from_posix_tz(tz_string: &str) -> Result<Self, Error> {
+    pub(crate) fn from_posix_tz(tz_string: &str) -> Result<Self, Error> {
         if tz_string.is_empty() {
             return Err(Error::InvalidTzString("empty TZ string"));
         }

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -124,11 +124,17 @@ impl Cache {
         let env_tz = env::var("TZ").ok();
         self.source = Source::new(env_tz.as_deref());
         self.zone = Some(
-            TimeZone::local(env_tz.as_deref())
+            self.read_from_tz_env_or_localtime(env_tz.as_deref())
                 .ok()
                 .or_else(fallback_timezone)
                 .unwrap_or_else(TimeZone::utc),
         );
+    }
+
+    /// Read the `TZ` environment variable or the TZif file that it points to.
+    /// Read from `/etc/localtime` if the variable is not set.
+    fn read_from_tz_env_or_localtime(&self, env_tz: Option<&str>) -> Result<TimeZone, ()> {
+        TimeZone::local(env_tz).map_err(|_| ())
     }
 }
 

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -105,14 +105,39 @@ fn current_zone(var: Option<&str>) -> TimeZone {
 
 impl Cache {
     fn offset(&mut self, d: NaiveDateTime, local: bool) -> MappedLocalTime<FixedOffset> {
+        self.refresh_cache();
+
+        if !local {
+            let offset = self
+                .zone
+                .find_local_time_type(d.and_utc().timestamp())
+                .expect("unable to select local time type")
+                .offset();
+
+            return match FixedOffset::east_opt(offset) {
+                Some(offset) => MappedLocalTime::Single(offset),
+                None => MappedLocalTime::None,
+            };
+        }
+
+        // we pass through the year as the year of a local point in time must either be valid in that locale, or
+        // the entire time was skipped in which case we will return MappedLocalTime::None anyway.
+        self.zone
+            .find_local_time_type_from_local(d.and_utc().timestamp(), d.year())
+            .expect("unable to select local time type")
+            .and_then(|o| FixedOffset::east_opt(o.offset()))
+    }
+
+    // Refresh our cached data if necessary.
+    //
+    // If the cache has been around for less than a second then we reuse it unconditionally. This is
+    // a reasonable tradeoff because the timezone generally won't be changing _that_ often, but if
+    // the time zone does change, it will reflect sufficiently quickly from an application user's
+    // perspective.
+    fn refresh_cache(&mut self) {
         let now = SystemTime::now();
 
         match now.duration_since(self.last_checked) {
-            // If the cache has been around for less than a second then we reuse it
-            // unconditionally. This is a reasonable tradeoff because the timezone
-            // generally won't be changing _that_ often, but if the time zone does
-            // change, it will reflect sufficiently quickly from an application
-            // user's perspective.
             Ok(d) if d.as_secs() < 1 => (),
             Ok(_) | Err(_) => {
                 let env_tz = env::var("TZ").ok();
@@ -147,25 +172,5 @@ impl Cache {
                 self.source = new_source;
             }
         }
-
-        if !local {
-            let offset = self
-                .zone
-                .find_local_time_type(d.and_utc().timestamp())
-                .expect("unable to select local time type")
-                .offset();
-
-            return match FixedOffset::east_opt(offset) {
-                Some(offset) => MappedLocalTime::Single(offset),
-                None => MappedLocalTime::None,
-            };
-        }
-
-        // we pass through the year as the year of a local point in time must either be valid in that locale, or
-        // the entire time was skipped in which case we will return MappedLocalTime::None anyway.
-        self.zone
-            .find_local_time_type_from_local(d.and_utc().timestamp(), d.year())
-            .expect("unable to select local time type")
-            .and_then(|o| FixedOffset::east_opt(o.offset()))
     }
 }

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -15,16 +15,29 @@ use super::{FixedOffset, NaiveDateTime};
 use crate::{Datelike, MappedLocalTime};
 
 pub(super) fn offset_from_utc_datetime(utc: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
-    offset(utc, false)
+    TZ_INFO.with(|cache| {
+        let mut cache_ref = cache.borrow_mut();
+        let tz_info = cache_ref.tz_info();
+        let offset = tz_info
+            .find_local_time_type(utc.and_utc().timestamp())
+            .expect("unable to select local time type")
+            .offset();
+
+        match FixedOffset::east_opt(offset) {
+            Some(offset) => MappedLocalTime::Single(offset),
+            None => MappedLocalTime::None,
+        }
+    })
 }
 
 pub(super) fn offset_from_local_datetime(local: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
-    offset(local, true)
-}
-
-fn offset(d: &NaiveDateTime, local: bool) -> MappedLocalTime<FixedOffset> {
-    TZ_INFO.with(|maybe_cache| {
-        maybe_cache.borrow_mut().offset(*d, local)
+    TZ_INFO.with(|cache| {
+        let mut cache_ref = cache.borrow_mut();
+        let tz_info = cache_ref.tz_info();
+        tz_info
+            .find_local_time_type_from_local(local.and_utc().timestamp(), local.year())
+            .expect("unable to select local time type")
+            .and_then(|o| FixedOffset::east_opt(o.offset()))
     })
 }
 
@@ -85,32 +98,9 @@ fn current_zone(var: Option<&str>) -> TimeZone {
 }
 
 impl Cache {
-    fn offset(&mut self, d: NaiveDateTime, local: bool) -> MappedLocalTime<FixedOffset> {
+    fn tz_info(&mut self) -> &TimeZone {
         self.refresh_cache();
-
-        if !local {
-            let offset = self
-                .zone
-                .as_ref()
-                .unwrap()
-                .find_local_time_type(d.and_utc().timestamp())
-                .expect("unable to select local time type")
-                .offset();
-
-            return match FixedOffset::east_opt(offset) {
-                Some(offset) => MappedLocalTime::Single(offset),
-                None => MappedLocalTime::None,
-            };
-        }
-
-        // we pass through the year as the year of a local point in time must either be valid in that locale, or
-        // the entire time was skipped in which case we will return MappedLocalTime::None anyway.
-        self.zone
-            .as_ref()
-            .unwrap()
-            .find_local_time_type_from_local(d.and_utc().timestamp(), d.year())
-            .expect("unable to select local time type")
-            .and_then(|o| FixedOffset::east_opt(o.offset()))
+        self.zone.as_ref().unwrap()
     }
 
     // Refresh our cached data if necessary.

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -189,6 +189,16 @@ impl CachedTzInfo {
         const ZONE_INFO_DIRECTORIES: [&str; 4] =
             ["/usr/share/zoneinfo", "/share/zoneinfo", "/etc/zoneinfo", "/usr/share/lib/zoneinfo"];
 
+        // Use the value of the `TZDIR` environment variable if set.
+        if let Some(tz_dir) = env::var_os("TZDIR") {
+            if !tz_dir.is_empty() {
+                let path = PathBuf::from(tz_dir);
+                if path.exists() {
+                    return Ok(path);
+                }
+            }
+        }
+
         for dir in &ZONE_INFO_DIRECTORIES {
             let path = PathBuf::from(dir);
             if path.exists() {

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -47,13 +47,13 @@ pub(super) fn offset_from_local_datetime(local: &NaiveDateTime) -> MappedLocalTi
     })
 }
 
-struct Cache {
+struct CachedTzInfo {
     zone: Option<TimeZone>,
     source: Source,
     last_checked: SystemTime,
 }
 
-impl Cache {
+impl CachedTzInfo {
     fn tz_info(&mut self) -> &TimeZone {
         self.refresh_cache();
         self.zone.as_ref().unwrap()
@@ -200,8 +200,8 @@ impl Cache {
 }
 
 thread_local! {
-    static TZ_INFO: RefCell<Cache> = const { RefCell::new(
-        Cache {
+    static TZ_INFO: RefCell<CachedTzInfo> = const { RefCell::new(
+        CachedTzInfo {
             zone: None,
             source: Source::Uninitialized,
             last_checked: SystemTime::UNIX_EPOCH,

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -136,41 +136,45 @@ impl Cache {
     // perspective.
     fn refresh_cache(&mut self) {
         let now = SystemTime::now();
-
-        match now.duration_since(self.last_checked) {
-            Ok(d) if d.as_secs() < 1 => (),
-            Ok(_) | Err(_) => {
-                let env_tz = env::var("TZ").ok();
-                let env_ref = env_tz.as_deref();
-                let new_source = Source::new(env_ref);
-
-                let out_of_date = match (&self.source, &new_source) {
-                    // change from env to file or file to env, must recreate the zone
-                    (Source::Environment { .. }, Source::LocalTime { .. })
-                    | (Source::LocalTime { .. }, Source::Environment { .. }) => true,
-                    // stay as file, but mtime has changed
-                    (Source::LocalTime { mtime: old_mtime }, Source::LocalTime { mtime })
-                        if old_mtime != mtime =>
-                    {
-                        true
-                    }
-                    // stay as env, but hash of variable has changed
-                    (Source::Environment { hash: old_hash }, Source::Environment { hash })
-                        if old_hash != hash =>
-                    {
-                        true
-                    }
-                    // cache can be reused
-                    _ => false,
-                };
-
-                if out_of_date {
-                    self.zone = current_zone(env_ref);
-                }
-
-                self.last_checked = now;
-                self.source = new_source;
+        if let Ok(d) = now.duration_since(self.last_checked) {
+            if d.as_secs() < 1 {
+                return;
             }
+        }
+
+        if self.needs_update() {
+            let env_tz = env::var("TZ").ok();
+            let env_ref = env_tz.as_deref();
+            self.source = Source::new(env_ref);
+            self.zone = current_zone(env_ref);
+        }
+        self.last_checked = now;
+    }
+
+    /// Check if any of the `TZ` environment variable or `/etc/localtime` have changed.
+    fn needs_update(&self) -> bool {
+        let env_tz = env::var("TZ").ok();
+        let env_ref = env_tz.as_deref();
+        let new_source = Source::new(env_ref);
+
+        match (&self.source, &new_source) {
+            // change from env to file or file to env, must recreate the zone
+            (Source::Environment { .. }, Source::LocalTime { .. })
+            | (Source::LocalTime { .. }, Source::Environment { .. }) => true,
+            // stay as file, but mtime has changed
+            (Source::LocalTime { mtime: old_mtime }, Source::LocalTime { mtime })
+                if old_mtime != mtime =>
+            {
+                true
+            }
+            // stay as env, but hash of variable has changed
+            (Source::Environment { hash: old_hash }, Source::Environment { hash })
+                if old_hash != hash =>
+            {
+                true
+            }
+            // cache can be reused
+            _ => false,
         }
     }
 }

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -41,37 +41,6 @@ pub(super) fn offset_from_local_datetime(local: &NaiveDateTime) -> MappedLocalTi
     })
 }
 
-thread_local! {
-    static TZ_INFO: RefCell<Cache> = const { RefCell::new(
-        Cache {
-            zone: None,
-            source: Source::Uninitialized,
-            last_checked: SystemTime::UNIX_EPOCH,
-        }
-    ) };
-}
-
-#[derive(PartialEq)]
-enum Source {
-    Environment { hash: u64 },
-    LocalTime,
-    Uninitialized,
-}
-
-impl Source {
-    fn new(env_tz: Option<&str>) -> Source {
-        match env_tz {
-            Some(tz) => {
-                let mut hasher = hash_map::DefaultHasher::new();
-                hasher.write(tz.as_bytes());
-                let hash = hasher.finish();
-                Source::Environment { hash }
-            }
-            None => Source::LocalTime,
-        }
-    }
-}
-
 struct Cache {
     zone: Option<TimeZone>,
     source: Source,
@@ -145,6 +114,37 @@ impl Cache {
                 }
             }
             _ => true,
+        }
+    }
+}
+
+thread_local! {
+    static TZ_INFO: RefCell<Cache> = const { RefCell::new(
+        Cache {
+            zone: None,
+            source: Source::Uninitialized,
+            last_checked: SystemTime::UNIX_EPOCH,
+        }
+    ) };
+}
+
+#[derive(PartialEq)]
+enum Source {
+    Environment { hash: u64 },
+    LocalTime,
+    Uninitialized,
+}
+
+impl Source {
+    fn new(env_tz: Option<&str>) -> Source {
+        match env_tz {
+            Some(tz) => {
+                let mut hasher = hash_map::DefaultHasher::new();
+                hasher.write(tz.as_bytes());
+                let hash = hasher.finish();
+                Source::Environment { hash }
+            }
+            None => Source::LocalTime,
         }
     }
 }


### PR DESCRIPTION
### Existing code

At a high level, the `unix` module tries to find the current time zone, load the data for it and cache the result.

1. To detect changes the caching code looks if the `TZ` environment variable has changed or if the modification time of the `/etc/localtime` symlink has changed.
2. To update the time zone info, the first step is in `tz_info::timezone::TimeZone::local`. If the `TZ` variable is set it can load TZ data from the following sources:
  - a POSIX TZ string
  - a named time zone, loaded from the `ZONE_INFO_DIRECTORIES`
  - an absolute path
  - the `/etc/localtime` symlink
  - an empty `TZ` variable is an error
3. If the `TZ` variable is not set it uses the `/etc/localtime` symlink.
4. `unix::current_zone` then specifies `unix::fallback` as a third fallback.
   This gets the time zone name using the `iana_time_zone` crate, and tries to load it from `TZDB_LOCATION` (which is currently not the same as `ZONE_INFO_DIRECTORIES`).
5. A final fallback is to default to UTC.

Problems with this setup are that the logic lives in different places, that the caching code does not detect changes except the most limited form, and that the logic to look up the `zoneinfo` directory is implemented in two different ways.

### New code

Everything related to loading the time zone data is implemented as methods on a `CachedTzInfo` type.
Caching and updating happens with the methods:
- `CachedTzInfo::tz_info()`
  - `refresh_cache()`
    - `needs_update()`
      - `tz_env_var_changed()`
      - `symlink_changed()`
      - `tz_name_changed()`
    - `read_tz_info()`
      - `read_from_tz_env()`
      - `read_from_symlink()`
      - `read_with_tz_name()`
        - `tzdb_dir()`

I kept methods such as `read_with_tz_name()` and `tz_name_changed()` close together so it is easier to see they work similar.

The `CachedTzInfo` type remembers the last source that was succesfull, and stores all information needed to check the cache is up to date: `TZ` variable, time zone name, path, and `zoneinfo` directory.

New functionality is that we cache the directory with the time zone database, and respect the `TZDIR` environment variable (fixes #1265).

All potential error sources are returned with a `Result</* */, ()>` type.

---

This is a rewrite, I can't pretend it to be a refactor.