### PR TITLE
Simplify `SerdeError`

### DIFF
--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -3,7 +3,6 @@ use serde::{de, ser};
 
 use super::DateTime;
 use crate::format::{write_rfc3339, SecondsFormat};
-use crate::naive::datetime::serde::serde_from;
 #[cfg(feature = "clock")]
 use crate::offset::Local;
 use crate::offset::{FixedOffset, Offset, TimeZone, Utc};
@@ -148,10 +147,10 @@ pub mod ts_nanoseconds {
     use core::fmt;
     use serde::{de, ser};
 
-    use crate::offset::TimeZone;
-    use crate::{DateTime, Utc};
+    use crate::serde::serde_from;
+    use crate::{DateTime, TimeZone, Utc};
 
-    use super::{serde_from, NanoSecondsTimestampVisitor};
+    use super::NanoSecondsTimestampVisitor;
 
     /// Serialize a UTC datetime into an integer number of nanoseconds since the epoch
     ///
@@ -448,9 +447,10 @@ pub mod ts_microseconds {
     use core::fmt;
     use serde::{de, ser};
 
-    use super::{serde_from, MicroSecondsTimestampVisitor};
-    use crate::offset::TimeZone;
-    use crate::{DateTime, Utc};
+    use crate::serde::serde_from;
+    use crate::{DateTime, TimeZone, Utc};
+
+    use super::MicroSecondsTimestampVisitor;
 
     /// Serialize a UTC datetime into an integer number of microseconds since the epoch
     ///
@@ -726,9 +726,10 @@ pub mod ts_milliseconds {
     use core::fmt;
     use serde::{de, ser};
 
-    use super::{serde_from, MilliSecondsTimestampVisitor};
-    use crate::offset::TimeZone;
-    use crate::{DateTime, Utc};
+    use crate::serde::serde_from;
+    use crate::{DateTime, TimeZone, Utc};
+
+    use super::MilliSecondsTimestampVisitor;
 
     /// Serialize a UTC datetime into an integer number of milliseconds since the epoch
     ///
@@ -1005,8 +1006,10 @@ pub mod ts_seconds {
     use core::fmt;
     use serde::{de, ser};
 
-    use super::{serde_from, SecondsTimestampVisitor};
+    use crate::serde::serde_from;
     use crate::{DateTime, LocalResult, TimeZone, Utc};
+
+    use super::SecondsTimestampVisitor;
 
     /// Serialize a UTC datetime into an integer number of seconds since the epoch
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -624,7 +624,59 @@ pub use naive::__BenchYearFlags;
 /// [2]: https://serde.rs/field-attrs.html#with
 #[cfg(feature = "serde")]
 pub mod serde {
+    use crate::offset::LocalResult;
+    use core::fmt;
+    use serde::de;
+
     pub use super::datetime::serde::*;
+
+    // lik? function to convert a LocalResult into a serde-ish Result
+    pub(crate) fn serde_from<T, E, V>(me: LocalResult<T>, ts: &V) -> Result<T, E>
+    where
+        E: de::Error,
+        V: fmt::Display,
+        T: fmt::Display,
+    {
+        match me {
+            LocalResult::None => Err(E::custom(ne_timestamp(ts))),
+            LocalResult::Ambiguous(min, max) => {
+                Err(E::custom(SerdeError::Ambiguous { timestamp: ts, min, max }))
+            }
+            LocalResult::Single(val) => Ok(val),
+        }
+    }
+
+    pub(crate) enum SerdeError<V: fmt::Display, D: fmt::Display> {
+        NonExistent { timestamp: V },
+        Ambiguous { timestamp: V, min: D, max: D },
+    }
+
+    /// Construct a [`SerdeError::NonExistent`]
+    pub(crate) fn ne_timestamp<T: fmt::Display>(ts: T) -> SerdeError<T, u8> {
+        SerdeError::NonExistent::<T, u8> { timestamp: ts }
+    }
+
+    impl<V: fmt::Display, D: fmt::Display> fmt::Debug for SerdeError<V, D> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "ChronoSerdeError({})", self)
+        }
+    }
+
+    // impl<V: fmt::Display, D: fmt::Debug> core::error::Error for SerdeError<V, D> {}
+    impl<V: fmt::Display, D: fmt::Display> fmt::Display for SerdeError<V, D> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match self {
+                SerdeError::NonExistent { timestamp } => {
+                    write!(f, "value is not a legal timestamp: {}", timestamp)
+                }
+                SerdeError::Ambiguous { timestamp, min, max } => write!(
+                    f,
+                    "value is an ambiguous timestamp: {}, could be either of {}, {}",
+                    timestamp, min, max
+                ),
+            }
+        }
+    }
 }
 
 /// Zero-copy serialization/deserialization with rkyv.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -624,56 +624,30 @@ pub use naive::__BenchYearFlags;
 /// [2]: https://serde.rs/field-attrs.html#with
 #[cfg(feature = "serde")]
 pub mod serde {
-    use crate::offset::LocalResult;
     use core::fmt;
     use serde::de;
 
     pub use super::datetime::serde::*;
 
-    // lik? function to convert a LocalResult into a serde-ish Result
-    pub(crate) fn serde_from<T, E, V>(me: LocalResult<T>, ts: &V) -> Result<T, E>
+    /// Create a custom `de::Error` with `SerdeError::InvalidTimestamp`.
+    pub(crate) fn invalid_ts<E, T>(value: T) -> E
     where
         E: de::Error,
-        V: fmt::Display,
         T: fmt::Display,
     {
-        match me {
-            LocalResult::None => Err(E::custom(ne_timestamp(ts))),
-            LocalResult::Ambiguous(min, max) => {
-                Err(E::custom(SerdeError::Ambiguous { timestamp: ts, min, max }))
-            }
-            LocalResult::Single(val) => Ok(val),
-        }
+        E::custom(SerdeError::InvalidTimestamp(value))
     }
 
-    pub(crate) enum SerdeError<V: fmt::Display, D: fmt::Display> {
-        NonExistent { timestamp: V },
-        Ambiguous { timestamp: V, min: D, max: D },
+    enum SerdeError<T: fmt::Display> {
+        InvalidTimestamp(T),
     }
 
-    /// Construct a [`SerdeError::NonExistent`]
-    pub(crate) fn ne_timestamp<T: fmt::Display>(ts: T) -> SerdeError<T, u8> {
-        SerdeError::NonExistent::<T, u8> { timestamp: ts }
-    }
-
-    impl<V: fmt::Display, D: fmt::Display> fmt::Debug for SerdeError<V, D> {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(f, "ChronoSerdeError({})", self)
-        }
-    }
-
-    // impl<V: fmt::Display, D: fmt::Debug> core::error::Error for SerdeError<V, D> {}
-    impl<V: fmt::Display, D: fmt::Display> fmt::Display for SerdeError<V, D> {
+    impl<T: fmt::Display> fmt::Display for SerdeError<T> {
         fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
             match self {
-                SerdeError::NonExistent { timestamp } => {
-                    write!(f, "value is not a legal timestamp: {}", timestamp)
+                SerdeError::InvalidTimestamp(ts) => {
+                    write!(f, "value is not a legal timestamp: {}", ts)
                 }
-                SerdeError::Ambiguous { timestamp, min, max } => write!(
-                    f,
-                    "value is an ambiguous timestamp: {}, could be either of {}, {}",
-                    timestamp, min, max
-                ),
             }
         }
     }

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -82,7 +82,7 @@ pub mod ts_nanoseconds {
     use core::fmt;
     use serde::{de, ser};
 
-    use crate::serde::ne_timestamp;
+    use crate::serde::invalid_ts;
     use crate::NaiveDateTime;
 
     /// Serialize a datetime into an integer number of nanoseconds since the epoch
@@ -175,7 +175,7 @@ pub mod ts_nanoseconds {
                 value.div_euclid(1_000_000_000),
                 (value.rem_euclid(1_000_000_000)) as u32,
             )
-            .ok_or_else(|| E::custom(ne_timestamp(value)))
+            .ok_or_else(|| invalid_ts(value))
         }
 
         fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
@@ -186,7 +186,7 @@ pub mod ts_nanoseconds {
                 (value / 1_000_000_000) as i64,
                 (value % 1_000_000_000) as u32,
             )
-            .ok_or_else(|| E::custom(ne_timestamp(value)))
+            .ok_or_else(|| invalid_ts(value))
         }
     }
 }
@@ -371,7 +371,7 @@ pub mod ts_microseconds {
     use core::fmt;
     use serde::{de, ser};
 
-    use crate::serde::ne_timestamp;
+    use crate::serde::invalid_ts;
     use crate::NaiveDateTime;
 
     /// Serialize a datetime into an integer number of microseconds since the epoch
@@ -450,8 +450,7 @@ pub mod ts_microseconds {
         where
             E: de::Error,
         {
-            NaiveDateTime::from_timestamp_micros(value)
-                .ok_or_else(|| E::custom(ne_timestamp(value)))
+            NaiveDateTime::from_timestamp_micros(value).ok_or_else(|| invalid_ts(value))
         }
 
         fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
@@ -462,7 +461,7 @@ pub mod ts_microseconds {
                 (value / 1_000_000) as i64,
                 ((value % 1_000_000) * 1_000) as u32,
             )
-            .ok_or_else(|| E::custom(ne_timestamp(value)))
+            .ok_or_else(|| invalid_ts(value))
         }
     }
 }
@@ -635,7 +634,7 @@ pub mod ts_milliseconds {
     use core::fmt;
     use serde::{de, ser};
 
-    use crate::serde::ne_timestamp;
+    use crate::serde::invalid_ts;
     use crate::NaiveDateTime;
 
     /// Serialize a datetime into an integer number of milliseconds since the epoch
@@ -714,8 +713,7 @@ pub mod ts_milliseconds {
         where
             E: de::Error,
         {
-            NaiveDateTime::from_timestamp_millis(value)
-                .ok_or_else(|| E::custom(ne_timestamp(value)))
+            NaiveDateTime::from_timestamp_millis(value).ok_or_else(|| invalid_ts(value))
         }
 
         fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
@@ -726,7 +724,7 @@ pub mod ts_milliseconds {
                 (value / 1000) as i64,
                 ((value % 1000) * 1_000_000) as u32,
             )
-            .ok_or_else(|| E::custom(ne_timestamp(value)))
+            .ok_or_else(|| invalid_ts(value))
         }
     }
 }
@@ -895,7 +893,7 @@ pub mod ts_seconds {
     use core::fmt;
     use serde::{de, ser};
 
-    use crate::serde::ne_timestamp;
+    use crate::serde::invalid_ts;
     use crate::NaiveDateTime;
 
     /// Serialize a datetime into an integer number of seconds since the epoch
@@ -967,16 +965,14 @@ pub mod ts_seconds {
         where
             E: de::Error,
         {
-            NaiveDateTime::from_timestamp_opt(value, 0)
-                .ok_or_else(|| E::custom(ne_timestamp(value)))
+            NaiveDateTime::from_timestamp_opt(value, 0).ok_or_else(|| invalid_ts(value))
         }
 
         fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
         where
             E: de::Error,
         {
-            NaiveDateTime::from_timestamp_opt(value as i64, 0)
-                .ok_or_else(|| E::custom(ne_timestamp(value)))
+            NaiveDateTime::from_timestamp_opt(value as i64, 0).ok_or_else(|| invalid_ts(value))
         }
     }
 }

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -972,7 +972,11 @@ pub mod ts_seconds {
         where
             E: de::Error,
         {
-            NaiveDateTime::from_timestamp_opt(value as i64, 0).ok_or_else(|| invalid_ts(value))
+            if value > i64::MAX as u64 {
+                Err(invalid_ts(value))
+            } else {
+                NaiveDateTime::from_timestamp_opt(value as i64, 0).ok_or_else(|| invalid_ts(value))
+            }
         }
     }
 }

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -2,7 +2,6 @@ use core::fmt;
 use serde::{de, ser};
 
 use super::NaiveDateTime;
-use crate::offset::LocalResult;
 
 /// Serialize a `NaiveDateTime` as an RFC 3339 string
 ///
@@ -83,7 +82,7 @@ pub mod ts_nanoseconds {
     use core::fmt;
     use serde::{de, ser};
 
-    use super::ne_timestamp;
+    use crate::serde::ne_timestamp;
     use crate::NaiveDateTime;
 
     /// Serialize a datetime into an integer number of nanoseconds since the epoch
@@ -372,7 +371,7 @@ pub mod ts_microseconds {
     use core::fmt;
     use serde::{de, ser};
 
-    use super::ne_timestamp;
+    use crate::serde::ne_timestamp;
     use crate::NaiveDateTime;
 
     /// Serialize a datetime into an integer number of microseconds since the epoch
@@ -636,7 +635,7 @@ pub mod ts_milliseconds {
     use core::fmt;
     use serde::{de, ser};
 
-    use super::ne_timestamp;
+    use crate::serde::ne_timestamp;
     use crate::NaiveDateTime;
 
     /// Serialize a datetime into an integer number of milliseconds since the epoch
@@ -896,7 +895,7 @@ pub mod ts_seconds {
     use core::fmt;
     use serde::{de, ser};
 
-    use super::ne_timestamp;
+    use crate::serde::ne_timestamp;
     use crate::NaiveDateTime;
 
     /// Serialize a datetime into an integer number of seconds since the epoch
@@ -1105,54 +1104,6 @@ pub mod ts_seconds_option {
             E: de::Error,
         {
             Ok(None)
-        }
-    }
-}
-
-// lik? function to convert a LocalResult into a serde-ish Result
-pub(crate) fn serde_from<T, E, V>(me: LocalResult<T>, ts: &V) -> Result<T, E>
-where
-    E: de::Error,
-    V: fmt::Display,
-    T: fmt::Display,
-{
-    match me {
-        LocalResult::None => Err(E::custom(ne_timestamp(ts))),
-        LocalResult::Ambiguous(min, max) => {
-            Err(E::custom(SerdeError::Ambiguous { timestamp: ts, min, max }))
-        }
-        LocalResult::Single(val) => Ok(val),
-    }
-}
-
-enum SerdeError<V: fmt::Display, D: fmt::Display> {
-    NonExistent { timestamp: V },
-    Ambiguous { timestamp: V, min: D, max: D },
-}
-
-/// Construct a [`SerdeError::NonExistent`]
-fn ne_timestamp<T: fmt::Display>(ts: T) -> SerdeError<T, u8> {
-    SerdeError::NonExistent::<T, u8> { timestamp: ts }
-}
-
-impl<V: fmt::Display, D: fmt::Display> fmt::Debug for SerdeError<V, D> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "ChronoSerdeError({})", self)
-    }
-}
-
-// impl<V: fmt::Display, D: fmt::Debug> core::error::Error for SerdeError<V, D> {}
-impl<V: fmt::Display, D: fmt::Display> fmt::Display for SerdeError<V, D> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            SerdeError::NonExistent { timestamp } => {
-                write!(f, "value is not a legal timestamp: {}", timestamp)
-            }
-            SerdeError::Ambiguous { timestamp, min, max } => write!(
-                f,
-                "value is an ambiguous timestamp: {}, could be either of {}, {}",
-                timestamp, min, max
-            ),
         }
     }
 }


### PR DESCRIPTION
While investigating all the CI failures on #1454 I noticed our serde code tries to convert `LocalResult`s to a custom error type.
This can all be done in a much simpler way.

I did keep around a simple error enum because it allows reporting the invalid value.
It currently has only one variant for deserialization errors for UNIX timestamps. We could simplify it further, or leave room for adding more formats to deserialize.

Also included is the fix from #1396 for an invalid cast in the `ts_seconds` module for `NaiveDateTime`.