### PR TITLE
Improve error checking of `SYSTEMTIME` values

### DIFF
--- a/src/offset/local/windows.rs
+++ b/src/offset/local/windows.rs
@@ -140,9 +140,17 @@ impl TzInfo {
             }
             tz_info.assume_init()
         };
+        let std_offset = (tz_info.Bias)
+            .checked_add(tz_info.StandardBias)
+            .and_then(|o| o.checked_mul(60))
+            .and_then(FixedOffset::west_opt)?;
+        let dst_offset = (tz_info.Bias)
+            .checked_add(tz_info.DaylightBias)
+            .and_then(|o| o.checked_mul(60))
+            .and_then(FixedOffset::west_opt)?;
         Some(TzInfo {
-            std_offset: FixedOffset::west_opt((tz_info.Bias + tz_info.StandardBias) * 60)?,
-            dst_offset: FixedOffset::west_opt((tz_info.Bias + tz_info.DaylightBias) * 60)?,
+            std_offset,
+            dst_offset,
             std_transition: naive_date_time_from_system_time(tz_info.StandardDate, year).ok()?,
             dst_transition: naive_date_time_from_system_time(tz_info.DaylightDate, year).ok()?,
         })


### PR DESCRIPTION
Add more checks that values are in range in the Windows `SYSTEMTIME` type.
We should be able to trust the Windows API; still it is good to have complete checks.