### PR TITLE
Add range checks to `Parsed::set` and hide fields in docs

### DIFF
--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -125,89 +125,47 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 #[allow(clippy::manual_non_exhaustive)]
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
 pub struct Parsed {
-    /// Year.
-    ///
-    /// This can be negative, unlike [`year_div_100`](#structfield.year_div_100)
-    /// and [`year_mod_100`](#structfield.year_mod_100) fields.
+    #[doc(hidden)]
     pub year: Option<i32>,
-
-    /// Year divided by 100. Implies that the year is >= 1 BCE when set.
-    ///
-    /// Due to the common usage, if this field is missing but
-    /// [`year_mod_100`](#structfield.year_mod_100) is present,
-    /// it is inferred to 19 when `year_mod_100 >= 70` and 20 otherwise.
+    #[doc(hidden)]
     pub year_div_100: Option<i32>,
-
-    /// Year modulo 100. Implies that the year is >= 1 BCE when set.
+    #[doc(hidden)]
     pub year_mod_100: Option<i32>,
-
-    /// Year in the [ISO week date](../naive/struct.NaiveDate.html#week-date).
-    ///
-    /// This can be negative, unlike [`isoyear_div_100`](#structfield.isoyear_div_100) and
-    /// [`isoyear_mod_100`](#structfield.isoyear_mod_100) fields.
+    #[doc(hidden)]
     pub isoyear: Option<i32>,
-
-    /// Year in the [ISO week date](../naive/struct.NaiveDate.html#week-date), divided by 100.
-    /// Implies that the year is >= 1 BCE when set.
-    ///
-    /// Due to the common usage, if this field is missing but
-    /// [`isoyear_mod_100`](#structfield.isoyear_mod_100) is present,
-    /// it is inferred to 19 when `isoyear_mod_100 >= 70` and 20 otherwise.
+    #[doc(hidden)]
     pub isoyear_div_100: Option<i32>,
-
-    /// Year in the [ISO week date](../naive/struct.NaiveDate.html#week-date), modulo 100.
-    /// Implies that the year is >= 1 BCE when set.
+    #[doc(hidden)]
     pub isoyear_mod_100: Option<i32>,
-
-    /// Month (1--12).
+    #[doc(hidden)]
     pub month: Option<u32>,
-
-    /// Week number, where the week 1 starts at the first Sunday of January
-    /// (0--53, 1--53 or 1--52 depending on the year).
+    #[doc(hidden)]
     pub week_from_sun: Option<u32>,
-
-    /// Week number, where the week 1 starts at the first Monday of January
-    /// (0--53, 1--53 or 1--52 depending on the year).
+    #[doc(hidden)]
     pub week_from_mon: Option<u32>,
-
-    /// [ISO week number](../naive/struct.NaiveDate.html#week-date)
-    /// (1--52 or 1--53 depending on the year).
+    #[doc(hidden)]
     pub isoweek: Option<u32>,
-
-    /// Day of the week.
+    #[doc(hidden)]
     pub weekday: Option<Weekday>,
-
-    /// Day of the year (1--365 or 1--366 depending on the year).
+    #[doc(hidden)]
     pub ordinal: Option<u32>,
-
-    /// Day of the month (1--28, 1--29, 1--30 or 1--31 depending on the month).
+    #[doc(hidden)]
     pub day: Option<u32>,
-
-    /// Hour number divided by 12 (0--1). 0 indicates AM and 1 indicates PM.
+    #[doc(hidden)]
     pub hour_div_12: Option<u32>,
-
-    /// Hour number modulo 12 (0--11).
+    #[doc(hidden)]
     pub hour_mod_12: Option<u32>,
-
-    /// Minute number (0--59).
+    #[doc(hidden)]
     pub minute: Option<u32>,
-
-    /// Second number (0--60, accounting for leap seconds).
+    #[doc(hidden)]
     pub second: Option<u32>,
-
-    /// The number of nanoseconds since the whole second (0--999,999,999).
+    #[doc(hidden)]
     pub nanosecond: Option<u32>,
-
-    /// The number of non-leap seconds since the midnight UTC on January 1, 1970.
-    ///
-    /// This can be off by one if [`second`](#structfield.second) is 60 (a leap second).
+    #[doc(hidden)]
     pub timestamp: Option<i64>,
-
-    /// Offset from the local time to UTC, in seconds.
+    #[doc(hidden)]
     pub offset: Option<i32>,
-
-    /// A dummy field to make this type not fully destructible (required for API stability).
-    // TODO: Change this to `#[non_exhaustive]` (on the enum) with the next breaking release.
+    #[doc(hidden)]
     _dummy: (),
 }
 

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -11,13 +11,15 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 
 /// A type to hold parsed fields of date and time that can check all fields are consistent.
 ///
-/// There are two classes of methods:
+/// There are three classes of methods:
 ///
 /// - `set_*` methods to set fields you have available. They do a basic range check, and if the
 ///   same field is set more than once it is checked for consistency.
 ///
 /// - `to_*` methods try to make a concrete date and time value out of set fields.
 ///   They fully check that all fields are consistent and whether the date/datetime exists.
+///
+/// - Methods to inspect the parsed fields.
 ///
 /// `Parsed` is used internally by all parsing functions in chrono. It is a public type so that it
 /// can be used to write custom parsers that reuse the resolving algorithm, or to inspect the
@@ -116,7 +118,7 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 /// assert!(result.is_err());
 /// if result.is_err() {
 ///     // What is the weekday?
-///     assert_eq!(parsed.weekday, Some(Weekday::Thu));
+///     assert_eq!(parsed.weekday(), Some(Weekday::Thu));
 /// }
 /// # Ok::<(), chrono::ParseError>(())
 /// ```
@@ -232,9 +234,10 @@ impl Parsed {
         Parsed::default()
     }
 
-    /// Set the 'year' field to the given value.
+    /// Set the [`year`](Parsed::year) field to the given value.
     ///
-    /// The value can be negative, unlike the 'year divided by 100' and 'year modulo 100' fields.
+    /// The value can be negative, unlike the [`year_div_100`](Parsed::year_div_100) and
+    /// [`year_mod_100`](Parsed::year_mod_100) fields.
     ///
     /// # Errors
     ///
@@ -246,7 +249,7 @@ impl Parsed {
         set_if_consistent(&mut self.year, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
-    /// Set the 'year divided by 100' field to the given value.
+    /// Set the [`year_div_100`](Parsed::year_div_100) field to the given value.
     ///
     /// # Errors
     ///
@@ -261,12 +264,13 @@ impl Parsed {
         set_if_consistent(&mut self.year_div_100, value as i32)
     }
 
-    /// Set the 'year modulo 100' field to the given value.
+    /// Set the [`year_mod_100`](Parsed::year_mod_100) field to the given value.
     ///
     /// When set it implies that the year is not negative.
     ///
-    /// If this field is set while the 'year divided by 100' field is missing (and the full 'year'
-    /// field is also not set), it assumes a default value for the 'year divided by 100' field.
+    /// If this field is set while the [`year_div_100`](Parsed::year_div_100) field is missing (and
+    /// the full [`year`](Parsed::year) field is also not set), it assumes a default value for the
+    /// [`year_div_100`](Parsed::year_div_100) field.
     /// The default is 19 when `year_mod_100 >= 70` and 20 otherwise.
     ///
     /// # Errors
@@ -282,9 +286,11 @@ impl Parsed {
         set_if_consistent(&mut self.year_mod_100, value as i32)
     }
 
-    /// Set the 'year' field that is part of an [ISO 8601 week date] to the given value.
+    /// Set the [`isoyear`](Parsed::isoyear) field, that is part of an [ISO 8601 week date], to the
+    /// given value.
     ///
-    /// The value can be negative, unlike the 'year divided by 100' and 'year modulo 100' fields.
+    /// The value can be negative, unlike the [`isoyear_div_100`](Parsed::isoyear_div_100) and
+    /// [`isoyear_mod_100`](Parsed::isoyear_mod_100) fields.
     ///
     /// [ISO 8601 week date]: crate::NaiveDate#week-date
     ///
@@ -298,8 +304,8 @@ impl Parsed {
         set_if_consistent(&mut self.isoyear, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
     }
 
-    /// Set the 'year divided by 100' field that is part of an [ISO 8601 week date] to the given
-    /// value.
+    /// Set the [`isoyear_div_100`](Parsed::isoyear_div_100) field, that is part of an
+    /// [ISO 8601 week date], to the given value.
     ///
     /// [ISO 8601 week date]: crate::NaiveDate#week-date
     ///
@@ -316,12 +322,14 @@ impl Parsed {
         set_if_consistent(&mut self.isoyear_div_100, value as i32)
     }
 
-    /// Set the 'year modulo 100' that is part of an [ISO 8601 week date] field to the given value.
+    /// Set the [`isoyear_mod_100`](Parsed::isoyear_mod_100) field, that is part of an
+    /// [ISO 8601 week date], to the given value.
     ///
     /// When set it implies that the year is not negative.
     ///
-    /// If this field is set while the 'year divided by 100' field is missing (and the full `year`
-    /// field is also not set), it assumes a default value for the 'year divided by 100' field.
+    /// If this field is set while the [`isoyear_div_100`](Parsed::isoyear_div_100) field is missing
+    /// (and the full [`isoyear`](Parsed::isoyear) field is also not set), it assumes a default
+    /// value for the [`isoyear_div_100`](Parsed::isoyear_div_100) field.
     /// The default is 19 when `year_mod_100 >= 70` and 20 otherwise.
     ///
     /// [ISO 8601 week date]: crate::NaiveDate#week-date
@@ -339,7 +347,7 @@ impl Parsed {
         set_if_consistent(&mut self.isoyear_mod_100, value as i32)
     }
 
-    /// Set the 'month' field to the given value.
+    /// Set the [`month`](Parsed::month) field to the given value.
     ///
     /// # Errors
     ///
@@ -354,7 +362,7 @@ impl Parsed {
         set_if_consistent(&mut self.month, value as u32)
     }
 
-    /// Set the 'week number starting with Sunday' field to the given value.
+    /// Set the [`week_from_sun`](Parsed::week_from_sun) week number field to the given value.
     ///
     /// Week 1 starts at the first Sunday of January.
     ///
@@ -371,6 +379,7 @@ impl Parsed {
         set_if_consistent(&mut self.week_from_sun, value as u32)
     }
 
+    /// Set the [`week_from_mon`](Parsed::week_from_mon) week number field to the given value.
     /// Set the 'week number starting with Monday' field to the given value.
     ///
     /// Week 1 starts at the first Monday of January.
@@ -388,9 +397,9 @@ impl Parsed {
         set_if_consistent(&mut self.week_from_mon, value as u32)
     }
 
-    /// Set the '[ISO 8601 week number]' field to the given value.
+    /// Set the [`isoweek`](Parsed::isoweek) field for an [ISO 8601 week date] to the given value.
     ///
-    /// [ISO 8601 week number]: crate::NaiveDate#week-date
+    /// [ISO 8601 week date]: crate::NaiveDate#week-date
     ///
     /// # Errors
     ///
@@ -405,7 +414,7 @@ impl Parsed {
         set_if_consistent(&mut self.isoweek, value as u32)
     }
 
-    /// Set the 'day of the week' field to the given value.
+    /// Set the [`weekday`](Parsed::weekday) field to the given value.
     ///
     /// # Errors
     ///
@@ -415,7 +424,7 @@ impl Parsed {
         set_if_consistent(&mut self.weekday, value)
     }
 
-    /// Set the 'ordinal' (day of the year) field to the given value.
+    /// Set the [`ordinal`](Parsed::ordinal) (day of the year) field to the given value.
     ///
     /// # Errors
     ///
@@ -430,7 +439,7 @@ impl Parsed {
         set_if_consistent(&mut self.ordinal, value as u32)
     }
 
-    /// Set the 'day of the month' field to the given value.
+    /// Set the [`day`](Parsed::day) of the month field to the given value.
     ///
     /// # Errors
     ///
@@ -445,7 +454,7 @@ impl Parsed {
         set_if_consistent(&mut self.day, value as u32)
     }
 
-    /// Set the 'am/pm' field to the given value.
+    /// Set the [`hour_div_12`](Parsed::hour_div_12) am/pm field to the given value.
     ///
     /// `false` indicates AM and `true` indicates PM.
     ///
@@ -457,7 +466,8 @@ impl Parsed {
         set_if_consistent(&mut self.hour_div_12, value as u32)
     }
 
-    /// Set the 'hour number in 12-hour clocks' field to the given value.
+    /// Set the [`hour_mod_12`](Parsed::hour_mod_12) field, for the hour number in 12-hour clocks,
+    /// to the given value.
     ///
     /// Value must be in the canonical range of 1-12.
     /// It will internally be stored as 0-11 (`value % 12`).
@@ -478,9 +488,8 @@ impl Parsed {
         set_if_consistent(&mut self.hour_mod_12, value as u32)
     }
 
-    /// Set the 'hour' field to the given value.
-    ///
-    /// Internally this sets the 'hour modulo 12' and 'am/pm' fields.
+    /// Set the [`hour_div_12`](Parsed::hour_div_12) and [`hour_mod_12`](Parsed::hour_mod_12)
+    /// fields to the given value for a 24-hour clock.
     ///
     /// # Errors
     ///
@@ -499,7 +508,7 @@ impl Parsed {
         set_if_consistent(&mut self.hour_mod_12, hour_mod_12)
     }
 
-    /// Set the 'minute' field to the given value.
+    /// Set the [`minute`](Parsed::minute) field to the given value.
     ///
     /// # Errors
     ///
@@ -514,7 +523,7 @@ impl Parsed {
         set_if_consistent(&mut self.minute, value as u32)
     }
 
-    /// Set the 'second' field to the given value.
+    /// Set the [`second`](Parsed::second) field to the given value.
     ///
     /// The value can be 60 in the case of a leap second.
     ///
@@ -531,7 +540,7 @@ impl Parsed {
         set_if_consistent(&mut self.second, value as u32)
     }
 
-    /// Set the 'nanosecond' field to the given value.
+    /// Set the [`nanosecond`](Parsed::nanosecond) field to the given value.
     ///
     /// This is the number of nanoseconds since the whole second.
     ///
@@ -548,7 +557,7 @@ impl Parsed {
         set_if_consistent(&mut self.nanosecond, value as u32)
     }
 
-    /// Set the 'timestamp' field to the given value.
+    /// Set the [`timestamp`](Parsed::timestamp) field to the given value.
     ///
     /// A Unix timestamp is defined as the number of non-leap seconds since midnight UTC on
     /// January 1, 1970.
@@ -561,9 +570,9 @@ impl Parsed {
         set_if_consistent(&mut self.timestamp, value)
     }
 
-    /// Set the 'offset from local time to UTC' field to the given value.
+    /// Set the [`offset`](Parsed::offset) field to the given value.
     ///
-    /// The offset is in seconds.
+    /// The offset is in seconds from local time to UTC.
     ///
     /// # Errors
     ///
@@ -1052,6 +1061,175 @@ impl Parsed {
                 }
             }
         }
+    }
+
+    /// Get the `year` field if set.
+    ///
+    /// See also [`set_year()`](Parsed::set_year).
+    #[inline]
+    pub fn year(&self) -> Option<i32> {
+        self.year
+    }
+
+    /// Get the `year_div_100` field if set.
+    ///
+    /// See also [`set_year_div_100()`](Parsed::set_year_div_100).
+    #[inline]
+    pub fn year_div_100(&self) -> Option<i32> {
+        self.year_div_100
+    }
+
+    /// Get the `year_mod_100` field if set.
+    ///
+    /// See also [`set_year_mod_100()`](Parsed::set_year_mod_100).
+    #[inline]
+    pub fn year_mod_100(&self) -> Option<i32> {
+        self.year_mod_100
+    }
+
+    /// Get the `isoyear` field that is part of an [ISO 8601 week date] if set.
+    ///
+    /// See also [`set_isoyear()`](Parsed::set_isoyear).
+    ///
+    /// [ISO 8601 week date]: crate::NaiveDate#week-date
+    #[inline]
+    pub fn isoyear(&self) -> Option<i32> {
+        self.isoyear
+    }
+
+    /// Get the `isoyear_div_100` field that is part of an [ISO 8601 week date] if set.
+    ///
+    /// See also [`set_isoyear_div_100()`](Parsed::set_isoyear_div_100).
+    ///
+    /// [ISO 8601 week date]: crate::NaiveDate#week-date
+    #[inline]
+    pub fn isoyear_div_100(&self) -> Option<i32> {
+        self.isoyear_div_100
+    }
+
+    /// Get the `isoyear_mod_100` field that is part of an [ISO 8601 week date] if set.
+    ///
+    /// See also [`set_isoyear_mod_100()`](Parsed::set_isoyear_mod_100).
+    ///
+    /// [ISO 8601 week date]: crate::NaiveDate#week-date
+    #[inline]
+    pub fn isoyear_mod_100(&self) -> Option<i32> {
+        self.isoyear_mod_100
+    }
+
+    /// Get the `month` field if set.
+    ///
+    /// See also [`set_month()`](Parsed::set_month).
+    #[inline]
+    pub fn month(&self) -> Option<u32> {
+        self.month
+    }
+
+    /// Get the `week_from_sun` field if set.
+    ///
+    /// See also [`set_week_from_sun()`](Parsed::set_week_from_sun).
+    #[inline]
+    pub fn week_from_sun(&self) -> Option<u32> {
+        self.week_from_sun
+    }
+
+    /// Get the `week_from_mon` field if set.
+    ///
+    /// See also [`set_week_from_mon()`](Parsed::set_week_from_mon).
+    #[inline]
+    pub fn week_from_mon(&self) -> Option<u32> {
+        self.week_from_mon
+    }
+
+    /// Get the `isoweek` field that is part of an [ISO 8601 week date] if set.
+    ///
+    /// See also [`set_isoweek()`](Parsed::set_isoweek).
+    ///
+    /// [ISO 8601 week date]: crate::NaiveDate#week-date
+    #[inline]
+    pub fn isoweek(&self) -> Option<u32> {
+        self.isoweek
+    }
+
+    /// Get the `weekday` field if set.
+    ///
+    /// See also [`set_weekday()`](Parsed::set_weekday).
+    #[inline]
+    pub fn weekday(&self) -> Option<Weekday> {
+        self.weekday
+    }
+
+    /// Get the `ordinal` (day of the year) field if set.
+    ///
+    /// See also [`set_ordinal()`](Parsed::set_ordinal).
+    #[inline]
+    pub fn ordinal(&self) -> Option<u32> {
+        self.ordinal
+    }
+
+    /// Get the `day` of the month field if set.
+    ///
+    /// See also [`set_day()`](Parsed::set_day).
+    #[inline]
+    pub fn day(&self) -> Option<u32> {
+        self.day
+    }
+
+    /// Get the `hour_div_12` field (am/pm) if set.
+    ///
+    /// 0 indicates AM and 1 indicates PM.
+    ///
+    /// See also [`set_ampm()`](Parsed::set_ampm) and [`set_hour()`](Parsed::set_hour).
+    #[inline]
+    pub fn hour_div_12(&self) -> Option<u32> {
+        self.hour_div_12
+    }
+
+    /// Get the `hour_mod_12` field if set.
+    ///
+    /// See also [`set_hour12()`](Parsed::set_hour12) and [`set_hour()`](Parsed::set_hour).
+    pub fn hour_mod_12(&self) -> Option<u32> {
+        self.hour_mod_12
+    }
+
+    /// Get the `minute` field if set.
+    ///
+    /// See also [`set_minute()`](Parsed::set_minute).
+    #[inline]
+    pub fn minute(&self) -> Option<u32> {
+        self.minute
+    }
+
+    /// Get the `second` field if set.
+    ///
+    /// See also [`set_second()`](Parsed::set_second).
+    #[inline]
+    pub fn second(&self) -> Option<u32> {
+        self.second
+    }
+
+    /// Get the `nanosecond` field if set.
+    ///
+    /// See also [`set_nanosecond()`](Parsed::set_nanosecond).
+    #[inline]
+    pub fn nanosecond(&self) -> Option<u32> {
+        self.nanosecond
+    }
+
+    /// Get the `timestamp` field if set.
+    ///
+    /// See also [`set_timestamp()`](Parsed::set_timestamp).
+    #[inline]
+    pub fn timestamp(&self) -> Option<i64> {
+        self.timestamp
+    }
+
+    /// Get the `offset` field if set.
+    ///
+    /// See also [`set_offset()`](Parsed::set_offset).
+    #[inline]
+    pub fn offset(&self) -> Option<i32> {
+        self.offset
     }
 }
 

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -255,10 +255,10 @@ impl Parsed {
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
     pub fn set_year_div_100(&mut self, value: i64) -> ParseResult<()> {
-        if value < 0 {
+        if !(0..=i32::MAX as i64).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.year_div_100, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.year_div_100, value as i32)
     }
 
     /// Set the 'year modulo 100' field to the given value.
@@ -271,16 +271,15 @@ impl Parsed {
     ///
     /// # Errors
     ///
-    /// May return `OUT_OF_RANGE` if `value` is negative or if it is greater than 99.
-    /// Currently only checks the value is positive and not out of range for an `i32`.
+    /// Returns `OUT_OF_RANGE` if `value` is negative or if it is greater than 99.
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
     pub fn set_year_mod_100(&mut self, value: i64) -> ParseResult<()> {
-        if value < 0 {
+        if !(0..100).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.year_mod_100, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+        set_if_consistent(&mut self.year_mod_100, value as i32)
     }
 
     /// Set the 'year' field that is part of an [ISO 8601 week date] to the given value.
@@ -311,13 +310,10 @@ impl Parsed {
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
     pub fn set_isoyear_div_100(&mut self, value: i64) -> ParseResult<()> {
-        if value < 0 {
+        if !(0..=i32::MAX as i64).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(
-            &mut self.isoyear_div_100,
-            i32::try_from(value).map_err(|_| OUT_OF_RANGE)?,
-        )
+        set_if_consistent(&mut self.isoyear_div_100, value as i32)
     }
 
     /// Set the 'year modulo 100' that is part of an [ISO 8601 week date] field to the given value.
@@ -332,32 +328,30 @@ impl Parsed {
     ///
     /// # Errors
     ///
-    /// May return `OUT_OF_RANGE` if `value` is negative or if it is greater than 99.
-    /// Currently only checks the value is positive and not out of range for an `i32`.
+    /// Returns `OUT_OF_RANGE` if `value` is negative or if it is greater than 99.
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
     pub fn set_isoyear_mod_100(&mut self, value: i64) -> ParseResult<()> {
-        if value < 0 {
+        if !(0..100).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(
-            &mut self.isoyear_mod_100,
-            i32::try_from(value).map_err(|_| OUT_OF_RANGE)?,
-        )
+        set_if_consistent(&mut self.isoyear_mod_100, value as i32)
     }
 
     /// Set the 'month' field to the given value.
     ///
     /// # Errors
     ///
-    /// May return `OUT_OF_RANGE` if `value` is not in the range 1-12.
-    /// Currently only checks the value is not out of range for a `u32`.
+    /// Returns `OUT_OF_RANGE` if `value` is not in the range 1-12.
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
     pub fn set_month(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.month, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+        if !(1..=12).contains(&value) {
+            return Err(OUT_OF_RANGE);
+        }
+        set_if_consistent(&mut self.month, value as u32)
     }
 
     /// Set the 'week number starting with Sunday' field to the given value.
@@ -366,13 +360,15 @@ impl Parsed {
     ///
     /// # Errors
     ///
-    /// May return `OUT_OF_RANGE` if `value` is not in the range 0-53.
-    /// Currently only checks the value is not out of range for a `u32`.
+    /// Returns `OUT_OF_RANGE` if `value` is not in the range 0-53.
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
     pub fn set_week_from_sun(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.week_from_sun, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+        if !(0..=53).contains(&value) {
+            return Err(OUT_OF_RANGE);
+        }
+        set_if_consistent(&mut self.week_from_sun, value as u32)
     }
 
     /// Set the 'week number starting with Monday' field to the given value.
@@ -381,13 +377,15 @@ impl Parsed {
     ///
     /// # Errors
     ///
-    /// May return `OUT_OF_RANGE` if `value` is not in the range 0-53.
-    /// Currently only checks the value is not out of range for a `u32`.
+    /// Returns `OUT_OF_RANGE` if `value` is not in the range 0-53.
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
     pub fn set_week_from_mon(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.week_from_mon, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+        if !(0..=53).contains(&value) {
+            return Err(OUT_OF_RANGE);
+        }
+        set_if_consistent(&mut self.week_from_mon, value as u32)
     }
 
     /// Set the '[ISO 8601 week number]' field to the given value.
@@ -396,20 +394,22 @@ impl Parsed {
     ///
     /// # Errors
     ///
-    /// May return `OUT_OF_RANGE` if `value` is not in the range 1-53.
-    /// Currently only checks the value is not out of range for a `u32`.
+    /// Returns `OUT_OF_RANGE` if `value` is not in the range 1-53.
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
     pub fn set_isoweek(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.isoweek, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+        if !(1..=53).contains(&value) {
+            return Err(OUT_OF_RANGE);
+        }
+        set_if_consistent(&mut self.isoweek, value as u32)
     }
 
     /// Set the 'day of the week' field to the given value.
     ///
     /// # Errors
     ///
-    /// May return `IMPOSSIBLE` if this field was already set to a different value.
+    /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
     pub fn set_weekday(&mut self, value: Weekday) -> ParseResult<()> {
         set_if_consistent(&mut self.weekday, value)
@@ -419,26 +419,30 @@ impl Parsed {
     ///
     /// # Errors
     ///
-    /// May return `OUT_OF_RANGE` if `value` is not in the range 1-366.
-    /// Currently only checks the value is not out of range for a `u32`.
+    /// Returns `OUT_OF_RANGE` if `value` is not in the range 1-366.
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
     pub fn set_ordinal(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.ordinal, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+        if !(1..=366).contains(&value) {
+            return Err(OUT_OF_RANGE);
+        }
+        set_if_consistent(&mut self.ordinal, value as u32)
     }
 
     /// Set the 'day of the month' field to the given value.
     ///
     /// # Errors
     ///
-    /// May return `OUT_OF_RANGE` if `value` is not in the range 1-31.
-    /// Currently only checks the value is not out of range for a `u32`.
+    /// Returns `OUT_OF_RANGE` if `value` is not in the range 1-31.
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
     pub fn set_day(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.day, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+        if !(1..=31).contains(&value) {
+            return Err(OUT_OF_RANGE);
+        }
+        set_if_consistent(&mut self.day, value as u32)
     }
 
     /// Set the 'am/pm' field to the given value.
@@ -450,7 +454,7 @@ impl Parsed {
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
     pub fn set_ampm(&mut self, value: bool) -> ParseResult<()> {
-        set_if_consistent(&mut self.hour_div_12, u32::from(value))
+        set_if_consistent(&mut self.hour_div_12, value as u32)
     }
 
     /// Set the 'hour number in 12-hour clocks' field to the given value.
@@ -464,11 +468,14 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_hour12(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_hour12(&mut self, mut value: i64) -> ParseResult<()> {
         if !(1..=12).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.hour_mod_12, value as u32 % 12)
+        if value == 12 {
+            value = 0
+        }
+        set_if_consistent(&mut self.hour_mod_12, value as u32)
     }
 
     /// Set the 'hour' field to the given value.
@@ -483,23 +490,28 @@ impl Parsed {
     /// Returns `IMPOSSIBLE` one of the fields was already set to a different value.
     #[inline]
     pub fn set_hour(&mut self, value: i64) -> ParseResult<()> {
-        let v = u32::try_from(value).map_err(|_| OUT_OF_RANGE)?;
-        set_if_consistent(&mut self.hour_div_12, v / 12)?;
-        set_if_consistent(&mut self.hour_mod_12, v % 12)?;
-        Ok(())
+        let (hour_div_12, hour_mod_12) = match value {
+            hour @ 0..=11 => (0, hour as u32),
+            hour @ 12..=23 => (1, hour as u32 - 12),
+            _ => return Err(OUT_OF_RANGE),
+        };
+        set_if_consistent(&mut self.hour_div_12, hour_div_12)?;
+        set_if_consistent(&mut self.hour_mod_12, hour_mod_12)
     }
 
     /// Set the 'minute' field to the given value.
     ///
     /// # Errors
     ///
-    /// May return `OUT_OF_RANGE` if `value` is not in the range 0-59.
-    /// Currently only checks the value is not out of range for a `u32`.
+    /// Returns `OUT_OF_RANGE` if `value` is not in the range 0-59.
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
     pub fn set_minute(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.minute, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+        if !(0..=59).contains(&value) {
+            return Err(OUT_OF_RANGE);
+        }
+        set_if_consistent(&mut self.minute, value as u32)
     }
 
     /// Set the 'second' field to the given value.
@@ -508,13 +520,15 @@ impl Parsed {
     ///
     /// # Errors
     ///
-    /// May return `OUT_OF_RANGE` if `value` is not in the range 0-60.
-    /// Currently only checks the value is not out of range for a `u32`.
+    /// Returns `OUT_OF_RANGE` if `value` is not in the range 0-60.
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
     pub fn set_second(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.second, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+        if !(0..=60).contains(&value) {
+            return Err(OUT_OF_RANGE);
+        }
+        set_if_consistent(&mut self.second, value as u32)
     }
 
     /// Set the 'nanosecond' field to the given value.
@@ -523,13 +537,15 @@ impl Parsed {
     ///
     /// # Errors
     ///
-    /// May return `OUT_OF_RANGE` if `value` is not in the range 0-999,999,999.
-    /// Currently only checks the value is not out of range for a `u32`.
+    /// Returns `OUT_OF_RANGE` if `value` is not in the range 0-999,999,999.
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
     pub fn set_nanosecond(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.nanosecond, u32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+        if !(0..=999_999_999).contains(&value) {
+            return Err(OUT_OF_RANGE);
+        }
+        set_if_consistent(&mut self.nanosecond, value as u32)
     }
 
     /// Set the 'timestamp' field to the given value.
@@ -1117,6 +1133,102 @@ mod tests {
         assert_eq!(p.set_timestamp(1_234_567_890), Ok(()));
         assert_eq!(p.set_timestamp(1_234_567_889), Err(IMPOSSIBLE));
         assert_eq!(p.set_timestamp(1_234_567_891), Err(IMPOSSIBLE));
+    }
+
+    #[test]
+    fn test_parsed_set_range() {
+        assert_eq!(Parsed::new().set_year(i32::MIN as i64 - 1), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_year(i32::MIN as i64).is_ok());
+        assert!(Parsed::new().set_year(i32::MAX as i64).is_ok());
+        assert_eq!(Parsed::new().set_year(i32::MAX as i64 + 1), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_year_div_100(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_year_div_100(0).is_ok());
+        assert!(Parsed::new().set_year_div_100(i32::MAX as i64).is_ok());
+        assert_eq!(Parsed::new().set_year_div_100(i32::MAX as i64 + 1), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_year_mod_100(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_year_mod_100(0).is_ok());
+        assert!(Parsed::new().set_year_mod_100(99).is_ok());
+        assert_eq!(Parsed::new().set_year_mod_100(100), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_isoyear(i32::MIN as i64 - 1), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_isoyear(i32::MIN as i64).is_ok());
+        assert!(Parsed::new().set_isoyear(i32::MAX as i64).is_ok());
+        assert_eq!(Parsed::new().set_isoyear(i32::MAX as i64 + 1), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_isoyear_div_100(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_isoyear_div_100(0).is_ok());
+        assert!(Parsed::new().set_isoyear_div_100(99).is_ok());
+        assert_eq!(Parsed::new().set_isoyear_div_100(i32::MAX as i64 + 1), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_isoyear_mod_100(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_isoyear_mod_100(0).is_ok());
+        assert!(Parsed::new().set_isoyear_mod_100(99).is_ok());
+        assert_eq!(Parsed::new().set_isoyear_mod_100(100), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_month(0), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_month(1).is_ok());
+        assert!(Parsed::new().set_month(12).is_ok());
+        assert_eq!(Parsed::new().set_month(13), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_week_from_sun(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_week_from_sun(0).is_ok());
+        assert!(Parsed::new().set_week_from_sun(53).is_ok());
+        assert_eq!(Parsed::new().set_week_from_sun(54), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_week_from_mon(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_week_from_mon(0).is_ok());
+        assert!(Parsed::new().set_week_from_mon(53).is_ok());
+        assert_eq!(Parsed::new().set_week_from_mon(54), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_isoweek(0), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_isoweek(1).is_ok());
+        assert!(Parsed::new().set_isoweek(53).is_ok());
+        assert_eq!(Parsed::new().set_isoweek(54), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_ordinal(0), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_ordinal(1).is_ok());
+        assert!(Parsed::new().set_ordinal(366).is_ok());
+        assert_eq!(Parsed::new().set_ordinal(367), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_day(0), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_day(1).is_ok());
+        assert!(Parsed::new().set_day(31).is_ok());
+        assert_eq!(Parsed::new().set_day(32), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_hour12(0), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_hour12(1).is_ok());
+        assert!(Parsed::new().set_hour12(12).is_ok());
+        assert_eq!(Parsed::new().set_hour12(13), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_hour(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_hour(0).is_ok());
+        assert!(Parsed::new().set_hour(23).is_ok());
+        assert_eq!(Parsed::new().set_hour(24), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_minute(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_minute(0).is_ok());
+        assert!(Parsed::new().set_minute(59).is_ok());
+        assert_eq!(Parsed::new().set_minute(60), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_second(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_second(0).is_ok());
+        assert!(Parsed::new().set_second(60).is_ok());
+        assert_eq!(Parsed::new().set_second(61), Err(OUT_OF_RANGE));
+
+        assert_eq!(Parsed::new().set_nanosecond(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_nanosecond(0).is_ok());
+        assert!(Parsed::new().set_nanosecond(999_999_999).is_ok());
+        assert_eq!(Parsed::new().set_nanosecond(1_000_000_000), Err(OUT_OF_RANGE));
+
+        assert!(Parsed::new().set_timestamp(i64::MIN).is_ok());
+        assert!(Parsed::new().set_timestamp(i64::MAX).is_ok());
+
+        assert_eq!(Parsed::new().set_offset(i32::MIN as i64 - 1), Err(OUT_OF_RANGE));
+        assert!(Parsed::new().set_offset(i32::MIN as i64).is_ok());
+        assert!(Parsed::new().set_offset(i32::MAX as i64).is_ok());
+        assert_eq!(Parsed::new().set_offset(i32::MAX as i64 + 1), Err(OUT_OF_RANGE));
     }
 
     #[test]


### PR DESCRIPTION
This does not remove the range checks from the `Parsed::to_*` methods, because as long as the fields are public they can be set to an out of range value. Something to do on the 0.5.x branch.