### PR TITLE
0.5: Convert API to return `Result`: `Datelike::with_year`

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -570,7 +570,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     pub fn with_year(&self, year: i32) -> Option<DateTime<Tz>> {
         map_local(self, |dt| match dt.year() == year {
             true => Some(dt),
-            false => dt.with_year(year),
+            false => dt.with_year(year).ok(),
         })
     }
 

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -367,14 +367,14 @@ fn test_date_weekday() {
 #[test]
 fn test_date_with_fields() {
     let d = NaiveDate::from_ymd(2000, 2, 29).unwrap();
-    assert_eq!(d.with_year(-400), Some(NaiveDate::from_ymd(-400, 2, 29).unwrap()));
-    assert_eq!(d.with_year(-100), None);
-    assert_eq!(d.with_year(1600), Some(NaiveDate::from_ymd(1600, 2, 29).unwrap()));
-    assert_eq!(d.with_year(1900), None);
-    assert_eq!(d.with_year(2000), Some(NaiveDate::from_ymd(2000, 2, 29).unwrap()));
-    assert_eq!(d.with_year(2001), None);
-    assert_eq!(d.with_year(2004), Some(NaiveDate::from_ymd(2004, 2, 29).unwrap()));
-    assert_eq!(d.with_year(i32::MAX), None);
+    assert_eq!(d.with_year(-400), NaiveDate::from_ymd(-400, 2, 29));
+    assert_eq!(d.with_year(-100), Err(Error::DoesNotExist));
+    assert_eq!(d.with_year(1600), NaiveDate::from_ymd(1600, 2, 29));
+    assert_eq!(d.with_year(1900), Err(Error::DoesNotExist));
+    assert_eq!(d.with_year(2000), NaiveDate::from_ymd(2000, 2, 29));
+    assert_eq!(d.with_year(2001), Err(Error::DoesNotExist));
+    assert_eq!(d.with_year(2004), NaiveDate::from_ymd(2004, 2, 29));
+    assert_eq!(d.with_year(i32::MAX), Err(Error::OutOfRange));
 
     let d = NaiveDate::from_ymd(2000, 4, 30).unwrap();
     assert_eq!(d.with_month(0), None);

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -728,28 +728,22 @@ impl NaiveDateTime {
     ///
     /// # Errors
     ///
-    /// Returns `None` if:
-    /// - The resulting date does not exist (February 29 in a non-leap year).
-    /// - The year is out of range for a `NaiveDate`.
+    /// Returns:
+    /// - [`Error::DoesNotExist`] if the resulting date does not exist.
+    /// - [`Error::OutOfRange`] if `year` is out of range for a `NaiveDate`.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
-    /// use chrono::{NaiveDate, NaiveDateTime};
-    ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
-    /// assert_eq!(
-    ///     dt.with_year(2016),
-    ///     Some(NaiveDate::from_ymd(2016, 9, 25).unwrap().and_hms(12, 34, 56).unwrap())
-    /// );
-    /// assert_eq!(
-    ///     dt.with_year(-308),
-    ///     Some(NaiveDate::from_ymd(-308, 9, 25).unwrap().and_hms(12, 34, 56).unwrap())
-    /// );
+    /// # use chrono::{NaiveDate, NaiveDateTime, Error};
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25)?.and_hms(12, 34, 56)?;
+    /// assert_eq!(dt.with_year(2016), NaiveDate::from_ymd(2016, 9, 25)?.and_hms(12, 34, 56));
+    /// assert_eq!(dt.with_year(-308), NaiveDate::from_ymd(-308, 9, 25)?.and_hms(12, 34, 56));
+    /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn with_year(&self, year: i32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { date: try_opt!(self.date.with_year(year)), ..*self })
+    pub const fn with_year(&self, year: i32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { date: try_err!(self.date.with_year(year)), ..*self })
     }
 
     /// Makes a new `NaiveDateTime` with the month number (starting from 1) changed.


### PR DESCRIPTION
Follow up commit for #1444. Split from #1445.

- Converts `Datelike::with_year` to return `Result<T,E>`
- Converts the implementations `NaiveDate::with_year` and `NaiveDateTime::with_year` to return `Result<T,E>`
- Converts the implementation `DateTime<Tz>::with_year` to return `Result<T,E>` as well
  - Adds `DateTime<Tz>::map_local_result` as transitionary helper function to prevent dependency on `DateTime<Tz>::map_local`
  - Adds `LocalResult<T>::map_result_unique` to have a transitionary, centralized mapping function until #1448 is settled

The function `map_result_unique` is NOT meant to outline future behaviour in any form. The idea is that there is some centralized mapping to a `Result` that can easily tracked for the purpose of #1448. Local (non-central) mappings will be prone to spread inconsistent behaviour.

However the future of `LocalResult` looks like, it will be easy to track the current usage and adapt the implementation and documentation by searching for the `map_result_unique` usage. For that reason I did not document the behaviour of `map_result_unique` anywhere else than in `src/offset/mod.rs`, but referenced it instead.

cc @pitdicker 