### PR TITLE
Convert `FixedOffset::{east, west}` to return `Result`

### DIFF
--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -926,7 +926,7 @@ impl Parsed {
     /// - `OUT_OF_RANGE` if the offset is out of range for a `FixedOffset`.
     /// - `NOT_ENOUGH` if the offset field is not set.
     pub fn to_fixed_offset(&self) -> ParseResult<FixedOffset> {
-        FixedOffset::east(self.offset.ok_or(NOT_ENOUGH)?).ok_or(OUT_OF_RANGE)
+        FixedOffset::east(self.offset.ok_or(NOT_ENOUGH)?).map_err(|_| OUT_OF_RANGE)
     }
 
     /// Returns a parsed timezone-aware date and time out of given fields.
@@ -955,7 +955,7 @@ impl Parsed {
             (None, None) => return Err(NOT_ENOUGH),
         };
         let datetime = self.to_naive_datetime_with_offset(offset)?;
-        let offset = FixedOffset::east(offset).ok_or(OUT_OF_RANGE)?;
+        let offset = FixedOffset::east(offset).map_err(|_| OUT_OF_RANGE)?;
 
         match offset.from_local_datetime(&datetime) {
             LocalResult::None => Err(IMPOSSIBLE),

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -156,8 +156,8 @@ impl Cache {
                 .offset();
 
             return match FixedOffset::east(offset) {
-                Some(offset) => LocalResult::Single(offset),
-                None => LocalResult::None,
+                Ok(offset) => LocalResult::Single(offset),
+                Err(_) => LocalResult::None,
             };
         }
 

--- a/src/offset/local/windows.rs
+++ b/src/offset/local/windows.rs
@@ -142,8 +142,8 @@ impl TzInfo {
             tz_info.assume_init()
         };
         Some(TzInfo {
-            std_offset: FixedOffset::west((tz_info.Bias + tz_info.StandardBias) * 60)?,
-            dst_offset: FixedOffset::west((tz_info.Bias + tz_info.DaylightBias) * 60)?,
+            std_offset: FixedOffset::west((tz_info.Bias + tz_info.StandardBias) * 60).ok()?,
+            dst_offset: FixedOffset::west((tz_info.Bias + tz_info.DaylightBias) * 60).ok()?,
             std_transition: system_time_from_naive_date_time(tz_info.StandardDate, year),
             dst_transition: system_time_from_naive_date_time(tz_info.DaylightDate, year),
         })


### PR DESCRIPTION
The easiest methods to convert yet!

Both `Error::InvalidArgument` and `Error::OutOfRange` could be reasonable return types.

The real-world limit of offsets is currently 14 hours, which puts area's using it 2 hours to the other side of the international date line.
The type limit is generous and somewhat arbitrarily limited to be less than 24 hours. At some point it turned out limiting the offset to less than a day keeps the surrounding code saner.

Because the limit is artificial and specific to chrono I went with `Error::OutOfRange`.

cc @Zomtir.