### PR TITLE
Disable wasmbind feature by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ name = "chrono"
 
 [features]
 # Don't forget to adjust `ALL_NON_EXCLUSIVE_FEATURES` in CI scripts when adding a feature or an optional dependency.
-default = ["clock", "std", "wasmbind"]
+default = ["clock", "std"]
 alloc = []
 libc = []
 winapi = ["windows-targets"]


### PR DESCRIPTION
This removes `wasmbind` from the default feature set, which stops chrono from implicitly depending upon wasm-bindgen and js-sys. This is helpful for a few reasons:

* It reduces the default dependency set by default for non-wasm projects, which shrinks the download size.

* Projects like Fuchsia have a policy where 3rd party crates need to be audited. While we don't use wasm-bindgen, we can't opt out of it by setting `default-features = false` because of [feature unification] ends up enabling chrono's default feature. See this [cargo issue] for more details. `wasm-bindgen` is large and complicated, so it's pretty expensive for us to update.

While I'd love to land this in the main branch, it's technically a breaking issue since downstream dependencies are probably not enabling the `wasmbind` feature if they need it.

Fixes #1164

[feature unification]: https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
[cargo issue]: https://github.com/rust-lang/cargo/issues/4463