### PR TITLE
Convert `NaiveDate/NaiveDateTime::checked_(add/sub)_days` to return `Result`

### DIFF
--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -499,10 +499,10 @@ fn test_date_signed_duration_since() {
 
 #[test]
 fn test_date_add_days() {
-    fn check(lhs: Option<NaiveDate>, days: Days, rhs: Option<NaiveDate>) {
+    fn check(lhs: Result<NaiveDate, Error>, days: Days, rhs: Result<NaiveDate, Error>) {
         assert_eq!(lhs.unwrap().checked_add_days(days), rhs);
     }
-    let ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).ok();
+    let ymd = NaiveDate::from_ymd;
 
     check(ymd(2014, 1, 1), Days::new(0), ymd(2014, 1, 1));
     // always round towards zero
@@ -514,16 +514,16 @@ fn test_date_add_days() {
     check(ymd(-7, 1, 1), Days::new(365 * 12 + 3), ymd(5, 1, 1));
 
     // overflow check
-    check(ymd(0, 1, 1), Days::new(MAX_DAYS_FROM_YEAR_0.try_into().unwrap()), ymd(MAX_YEAR, 12, 31));
-    check(ymd(0, 1, 1), Days::new(u64::try_from(MAX_DAYS_FROM_YEAR_0).unwrap() + 1), None);
+    check(ymd(0, 1, 1), Days::new(MAX_DAYS_FROM_YEAR_0 as u64), ymd(MAX_YEAR, 12, 31));
+    check(ymd(0, 1, 1), Days::new(MAX_DAYS_FROM_YEAR_0 as u64 + 1), Err(Error::OutOfRange));
 }
 
 #[test]
 fn test_date_sub_days() {
-    fn check(lhs: Option<NaiveDate>, days: Days, rhs: Option<NaiveDate>) {
+    fn check(lhs: Result<NaiveDate, Error>, days: Days, rhs: Result<NaiveDate, Error>) {
         assert_eq!(lhs.unwrap().checked_sub_days(days), rhs);
     }
-    let ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).ok();
+    let ymd = NaiveDate::from_ymd;
 
     check(ymd(2014, 1, 1), Days::new(0), ymd(2014, 1, 1));
     check(ymd(2014, 1, 2), Days::new(1), ymd(2014, 1, 1));
@@ -532,12 +532,8 @@ fn test_date_sub_days() {
     check(ymd(2018, 1, 1), Days::new(365 * 4 + 1), ymd(2014, 1, 1));
     check(ymd(2414, 1, 1), Days::new(365 * 400 + 97), ymd(2014, 1, 1));
 
-    check(ymd(MAX_YEAR, 12, 31), Days::new(MAX_DAYS_FROM_YEAR_0.try_into().unwrap()), ymd(0, 1, 1));
-    check(
-        ymd(0, 1, 1),
-        Days::new((-MIN_DAYS_FROM_YEAR_0).try_into().unwrap()),
-        ymd(MIN_YEAR, 1, 1),
-    );
+    check(ymd(MAX_YEAR, 12, 31), Days::new(MAX_DAYS_FROM_YEAR_0 as u64), ymd(0, 1, 1));
+    check(ymd(0, 1, 1), Days::new((-MIN_DAYS_FROM_YEAR_0) as u64), ymd(MIN_YEAR, 1, 1));
 }
 
 #[test]

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -529,18 +529,16 @@ impl NaiveDateTime {
 
     /// Add a duration in [`Days`] to the date part of the `NaiveDateTime`
     ///
-    /// Returns `None` if the resulting date would be out of range.
-    #[must_use]
-    pub const fn checked_add_days(self, days: Days) -> Option<Self> {
-        Some(Self { date: try_opt!(self.date.checked_add_days(days)), ..self })
+    /// Returns [`Error::OutOfRange`] if the resulting date would be out of range.
+    pub const fn checked_add_days(self, days: Days) -> Result<Self, Error> {
+        Ok(Self { date: try_err!(self.date.checked_add_days(days)), ..self })
     }
 
     /// Subtract a duration in [`Days`] from the date part of the `NaiveDateTime`
     ///
-    /// Returns `None` if the resulting date would be out of range.
-    #[must_use]
-    pub const fn checked_sub_days(self, days: Days) -> Option<Self> {
-        Some(Self { date: try_opt!(self.date.checked_sub_days(days)), ..self })
+    /// Returns [`Error::OutOfRange`] if the resulting date would be out of range.
+    pub const fn checked_sub_days(self, days: Days) -> Result<Self, Error> {
+        Ok(Self { date: try_err!(self.date.checked_sub_days(days)), ..self })
     }
 
     /// Subtracts another `NaiveDateTime` from the current date and time.

--- a/src/naive/mod.rs
+++ b/src/naive/mod.rs
@@ -6,8 +6,8 @@
 
 use core::ops::RangeInclusive;
 
-use crate::expect;
 use crate::Weekday;
+use crate::{expect, ok};
 
 pub(crate) mod date;
 pub(crate) mod datetime;
@@ -63,7 +63,7 @@ impl NaiveWeek {
         // Do not construct an intermediate date beyond `self.date`, because that may be out of
         // range if `date` is close to `NaiveDate::MAX`.
         let days = start - ref_day - if start > ref_day { 7 } else { 0 };
-        expect!(self.date.add_days(days), "first weekday out of range for `NaiveDate`")
+        expect!(ok!(self.date.add_days(days)), "first weekday out of range for `NaiveDate`")
     }
 
     /// Returns a date representing the last day of the week.
@@ -91,7 +91,7 @@ impl NaiveWeek {
         // Do not construct an intermediate date before `self.date` (like with `first_day()`),
         // because that may be out of range if `date` is close to `NaiveDate::MIN`.
         let days = end - ref_day + if end < ref_day { 7 } else { 0 };
-        expect!(self.date.add_days(days), "last weekday out of range for `NaiveDate`")
+        expect!(ok!(self.date.add_days(days)), "last weekday out of range for `NaiveDate`")
     }
 
     /// Returns a [`RangeInclusive<T>`] representing the whole week bounded by


### PR DESCRIPTION
This pull request targets the issue #1469.

- Adds a `try_opt_ok` macro to simplify unwrapping `Result` in an `Option` context
- Adds a `try_add` macro to improve handling of ` i32::checked_add()`
  - If merged, can also be used for other cases mentioned in #1445
- Convert `NaiveDate/NaiveDateTime::checked_(add/sub)_days` to return `Result`

cc @pitdicker
