### PR TITLE
Parsing preparations

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1789,6 +1789,28 @@ where
 }
 
 /// Accepts a relaxed form of RFC3339.
+/// A space or a 'T' are acepted as the separator between the date and time
+/// parts. Additional spaces are allowed between each component.
+///
+/// All of these examples are equivalent:
+/// ```
+/// # use chrono::{DateTime, offset::FixedOffset};
+/// "2012-12-12T12:12:12Z".parse::<DateTime<FixedOffset>>()?;
+/// "2012-12-12 12:12:12Z".parse::<DateTime<FixedOffset>>()?;
+/// "2012-  12-12T12:  12:12Z".parse::<DateTime<FixedOffset>>()?;
+/// # Ok::<(), chrono::ParseError>(())
+/// ```
+impl str::FromStr for DateTime<FixedOffset> {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> ParseResult<DateTime<FixedOffset>> {
+        let mut parsed = Parsed::new();
+        parse(&mut parsed, s, [Item::Fixed(Fixed::RFC3339), Item::Space("")].iter())?;
+        parsed.to_datetime()
+    }
+}
+
+/// Accepts a relaxed form of RFC3339.
 /// A space or a 'T' are accepted as the separator between the date and time
 /// parts.
 ///

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -1292,7 +1292,7 @@ mod tests {
         check("12345678", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
         check("+1", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_SHORT));
         check("+12", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: 43_200));
-        check("+123", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_SHORT));
+        check("+123", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_LONG));
         check("+1234", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: 45_240));
         check("-1234", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: -45_240));
         check("−1234", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: -45_240)); // MINUS SIGN (U+2212)
@@ -1309,7 +1309,7 @@ mod tests {
         check("12:34:56", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
         check("+1:", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
         check("+12:", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: 43_200));
-        check("+12:3", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_SHORT));
+        check("+12:3", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_LONG));
         check("+12:34", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: 45_240));
         check("-12:34", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: -45_240));
         check("−12:34", &[internal_fixed(TimezoneOffsetPermissive)], parsed!(offset: -45_240)); // MINUS SIGN (U+2212)
@@ -1359,7 +1359,7 @@ mod tests {
         );
         check("🤠+12:34", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
         check("+12:34🤠", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_LONG));
-        check("+12:🤠34", &[internal_fixed(TimezoneOffsetPermissive)], Err(INVALID));
+        check("+12:🤠34", &[internal_fixed(TimezoneOffsetPermissive)], Err(TOO_LONG));
         check(
             "+12:34🤠",
             &[internal_fixed(TimezoneOffsetPermissive), Literal("🤠")],

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -12,7 +12,7 @@ use super::scan;
 use super::{Fixed, InternalFixed, InternalInternal, Item, Numeric, Pad, Parsed};
 use super::{ParseError, ParseResult};
 use super::{BAD_FORMAT, INVALID, OUT_OF_RANGE, TOO_LONG, TOO_SHORT};
-use crate::{DateTime, FixedOffset, Weekday};
+use crate::Weekday;
 
 fn set_weekday_with_num_days_from_sunday(p: &mut Parsed, v: i64) -> ParseResult<()> {
     p.set_weekday(match v {
@@ -506,28 +506,6 @@ where
         }
     }
     Ok(s)
-}
-
-/// Accepts a relaxed form of RFC3339.
-/// A space or a 'T' are acepted as the separator between the date and time
-/// parts. Additional spaces are allowed between each component.
-///
-/// All of these examples are equivalent:
-/// ```
-/// # use chrono::{DateTime, offset::FixedOffset};
-/// "2012-12-12T12:12:12Z".parse::<DateTime<FixedOffset>>()?;
-/// "2012-12-12 12:12:12Z".parse::<DateTime<FixedOffset>>()?;
-/// "2012-  12-12T12:  12:12Z".parse::<DateTime<FixedOffset>>()?;
-/// # Ok::<(), chrono::ParseError>(())
-/// ```
-impl str::FromStr for DateTime<FixedOffset> {
-    type Err = ParseError;
-
-    fn from_str(s: &str) -> ParseResult<DateTime<FixedOffset>> {
-        let mut parsed = Parsed::new();
-        parse(&mut parsed, s, [Item::Fixed(Fixed::RFC3339), Item::Space("")].iter())?;
-        parsed.to_datetime()
-    }
 }
 
 /// Accepts a relaxed form of RFC3339.

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -525,10 +525,7 @@ impl str::FromStr for DateTime<FixedOffset> {
 
     fn from_str(s: &str) -> ParseResult<DateTime<FixedOffset>> {
         let mut parsed = Parsed::new();
-        let (s, _) = parse_rfc3339_relaxed(&mut parsed, s)?;
-        if !s.trim_start().is_empty() {
-            return Err(TOO_LONG);
-        }
+        parse(&mut parsed, s, [Item::Fixed(Fixed::RFC3339), Item::Space("")].iter())?;
         parsed.to_datetime()
     }
 }

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -424,25 +424,16 @@ where
                     }
 
                     &Internal(InternalFixed { val: InternalInternal::Nanosecond3NoDot }) => {
-                        if s.len() < 3 {
-                            return Err(TOO_SHORT);
-                        }
                         let nano = try_consume!(scan::nanosecond_fixed(s, 3));
                         parsed.set_nanosecond(nano)?;
                     }
 
                     &Internal(InternalFixed { val: InternalInternal::Nanosecond6NoDot }) => {
-                        if s.len() < 6 {
-                            return Err(TOO_SHORT);
-                        }
                         let nano = try_consume!(scan::nanosecond_fixed(s, 6));
                         parsed.set_nanosecond(nano)?;
                     }
 
                     &Internal(InternalFixed { val: InternalInternal::Nanosecond9NoDot }) => {
-                        if s.len() < 9 {
-                            return Err(TOO_SHORT);
-                        }
                         let nano = try_consume!(scan::nanosecond_fixed(s, 9));
                         parsed.set_nanosecond(nano)?;
                     }

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -357,7 +357,7 @@ where
                     Minute => (2, false, Parsed::set_minute),
                     Second => (2, false, Parsed::set_second),
                     Nanosecond => (9, false, Parsed::set_nanosecond),
-                    Timestamp => (usize::MAX, false, Parsed::set_timestamp),
+                    Timestamp => (usize::MAX, true, Parsed::set_timestamp),
 
                     // for the future expansion
                     Internal(ref int) => match int._dummy {},
@@ -366,8 +366,7 @@ where
                 s = s.trim_start();
                 let v = if signed {
                     if s.starts_with('-') {
-                        let v = try_consume!(scan::number(&s[1..], 1, usize::MAX));
-                        0i64.checked_sub(v).ok_or(OUT_OF_RANGE)?
+                        try_consume!(scan::negative_number(&s[1..], 1, usize::MAX))
                     } else if s.starts_with('+') {
                         try_consume!(scan::number(&s[1..], 1, usize::MAX))
                     } else {
@@ -765,6 +764,7 @@ mod tests {
         check("  +   42", &[Space("  "), num(Year)], Err(INVALID));
         check("-", &[num(Year)], Err(TOO_SHORT));
         check("+", &[num(Year)], Err(TOO_SHORT));
+        check("-9223372036854775808", &[num(Timestamp)], parsed!(timestamp: i64::MIN));
 
         // unsigned numeric
         check("345", &[num(Ordinal)], parsed!(ordinal: 345));

--- a/src/format/scan.rs
+++ b/src/format/scan.rs
@@ -181,7 +181,7 @@ pub(super) fn space(s: &str) -> ParseResult<&str> {
 }
 
 /// Consumes any number (including zero) of colon or spaces.
-pub(crate) fn colon_or_space(s: &str) -> ParseResult<&str> {
+pub(super) fn colon_or_space(s: &str) -> ParseResult<&str> {
     Ok(s.trim_start_matches(|c: char| c == ':' || c.is_whitespace()))
 }
 
@@ -199,7 +199,7 @@ pub(crate) fn colon_or_space(s: &str) -> ParseResult<&str> {
 /// This is part of [RFC 3339 & ISO 8601].
 ///
 /// [RFC 3339 & ISO 8601]: https://en.wikipedia.org/w/index.php?title=ISO_8601&oldid=1114309368#Time_offsets_from_UTC
-pub(crate) fn timezone_offset<F>(
+pub(super) fn timezone_offset<F>(
     mut s: &str,
     mut consume_colon: F,
     allow_zulu: bool,

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -10,7 +10,7 @@ use core::str::FromStr;
 use rkyv::{Archive, Deserialize, Serialize};
 
 use super::{MappedLocalTime, Offset, TimeZone};
-use crate::format::{scan, ParseError, OUT_OF_RANGE};
+use crate::format::{parse, Fixed, Item, ParseError, Parsed};
 use crate::naive::{NaiveDate, NaiveDateTime};
 
 /// The time zone with fixed offset, from UTC-23:59:59 to UTC+23:59:59.
@@ -118,9 +118,11 @@ impl FixedOffset {
 /// Parsing a `str` into a `FixedOffset` uses the format [`%z`](crate::format::strftime).
 impl FromStr for FixedOffset {
     type Err = ParseError;
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let (_, offset) = scan::timezone_offset(s, scan::colon_or_space, false, false, true)?;
-        Self::east_opt(offset).ok_or(OUT_OF_RANGE)
+        let mut parsed = Parsed::new();
+        parse(&mut parsed, s, [Item::Fixed(Fixed::TimezoneOffset)].iter())?;
+        parsed.to_fixed_offset()
     }
 }
 


### PR DESCRIPTION
These issues came up when trying to convert our parsing code to the new error types (only 750 errors to go... :laughing:).

I would like to restrict the visibility of `ParseError` to the `format` module on 0.5, and make all parsing go through `format::parsed`.
That means the `FromStr` implementations of `DateTime<FixedOffset>` and `FixedOffset` should use the standard parsing methods instead of reaching directly for the functions in `format::{parse, scan}`.

In `timezone_offset` I simplified digit parsing a bit because it did not have quite the places to hook up new error values as I wanted. It remains a pretty broken parser though.

Further I noticed a `0i64.checked_sub(v).ok_or(OUT_OF_RANGE)` line. Subtracting a positive `i64` from `0` can never fail. Then I noticed we don't support parsing negative timestamps at all! That is fixed in the last commit. Parsing `i64::MIN` was a little tricky.