### PR TITLE
0.5.x: Remove recently deprecated methods

### DIFF
--- a/bench/benches/chrono.rs
+++ b/bench/benches/chrono.rs
@@ -199,7 +199,7 @@ fn bench_format_manual(c: &mut Criterion) {
 
 fn bench_naivedate_add_signed(c: &mut Criterion) {
     let date = NaiveDate::from_ymd(2023, 7, 29).unwrap();
-    let extra = TimeDelta::days(25);
+    let extra = TimeDelta::days(25).unwrap();
     c.bench_function("bench_naivedate_add_signed", |b| {
         b.iter(|| black_box(date).checked_add_signed(extra).unwrap())
     });

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -49,7 +49,7 @@ impl TimeZone for DstTester {
             DstTester::TO_WINTER_MONTH_DAY.1,
         )
         .unwrap()
-        .and_time(DstTester::transition_start_local() - TimeDelta::try_hours(1).unwrap());
+        .and_time(DstTester::transition_start_local() - TimeDelta::hours(1).unwrap());
 
         let local_to_summer_transition_start = NaiveDate::from_ymd(
             local.year(),
@@ -65,7 +65,7 @@ impl TimeZone for DstTester {
             DstTester::TO_SUMMER_MONTH_DAY.1,
         )
         .unwrap()
-        .and_time(DstTester::transition_start_local() + TimeDelta::try_hours(1).unwrap());
+        .and_time(DstTester::transition_start_local() + TimeDelta::hours(1).unwrap());
 
         if *local < local_to_winter_transition_end || *local >= local_to_summer_transition_end {
             LocalResult::Single(DstTester::summer_offset())
@@ -1522,7 +1522,7 @@ fn test_min_max_setters() {
     assert_eq!(beyond_min.with_hour(beyond_min.hour()), Some(beyond_min));
     assert_eq!(
         beyond_min.with_hour(23),
-        beyond_min.checked_add_signed(TimeDelta::try_hours(1).unwrap())
+        beyond_min.checked_add_signed(TimeDelta::hours(1).unwrap())
     );
     assert_eq!(beyond_min.with_hour(5), None);
     assert_eq!(beyond_min.with_minute(0), Some(beyond_min));
@@ -1546,7 +1546,7 @@ fn test_min_max_setters() {
     assert_eq!(beyond_max.with_hour(beyond_max.hour()), Some(beyond_max));
     assert_eq!(
         beyond_max.with_hour(0),
-        beyond_max.checked_sub_signed(TimeDelta::try_hours(1).unwrap())
+        beyond_max.checked_sub_signed(TimeDelta::hours(1).unwrap())
     );
     assert_eq!(beyond_max.with_hour(5), None);
     assert_eq!(beyond_max.with_minute(beyond_max.minute()), Some(beyond_max));

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -567,12 +567,12 @@ fn test_datetime_offset() {
     let dt = Utc.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap();
     assert_eq!(dt, edt.with_ymd_and_hms(2014, 5, 6, 3, 8, 9).unwrap());
     assert_eq!(
-        dt + TimeDelta::try_seconds(3600 + 60 + 1).unwrap(),
+        dt + TimeDelta::seconds(3600 + 60 + 1).unwrap(),
         Utc.with_ymd_and_hms(2014, 5, 6, 8, 9, 10).unwrap()
     );
     assert_eq!(
         dt.signed_duration_since(edt.with_ymd_and_hms(2014, 5, 6, 10, 11, 12).unwrap()),
-        TimeDelta::try_seconds(-7 * 3600 - 3 * 60 - 3).unwrap()
+        TimeDelta::seconds(-7 * 3600 - 3 * 60 - 3).unwrap()
     );
 
     assert_eq!(*Utc.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap().offset(), Utc);
@@ -1387,20 +1387,20 @@ fn test_datetime_add_assign() {
     let datetime = naivedatetime.and_utc();
     let mut datetime_add = datetime;
 
-    datetime_add += TimeDelta::try_seconds(60).unwrap();
-    assert_eq!(datetime_add, datetime + TimeDelta::try_seconds(60).unwrap());
+    datetime_add += TimeDelta::seconds(60).unwrap();
+    assert_eq!(datetime_add, datetime + TimeDelta::seconds(60).unwrap());
 
     let timezone = FixedOffset::east(60 * 60).unwrap();
     let datetime = datetime.with_timezone(&timezone);
     let datetime_add = datetime_add.with_timezone(&timezone);
 
-    assert_eq!(datetime_add, datetime + TimeDelta::try_seconds(60).unwrap());
+    assert_eq!(datetime_add, datetime + TimeDelta::seconds(60).unwrap());
 
     let timezone = FixedOffset::west(2 * 60 * 60).unwrap();
     let datetime = datetime.with_timezone(&timezone);
     let datetime_add = datetime_add.with_timezone(&timezone);
 
-    assert_eq!(datetime_add, datetime + TimeDelta::try_seconds(60).unwrap());
+    assert_eq!(datetime_add, datetime + TimeDelta::seconds(60).unwrap());
 }
 
 #[test]

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1413,8 +1413,8 @@ fn test_datetime_add_assign_local() {
 
     // ensure we cross a DST transition
     for i in 1..=365 {
-        datetime_add += TimeDelta::try_days(1).unwrap();
-        assert_eq!(datetime_add, datetime + TimeDelta::try_days(i).unwrap())
+        datetime_add += TimeDelta::days(1).unwrap();
+        assert_eq!(datetime_add, datetime + TimeDelta::days(i).unwrap())
     }
 }
 
@@ -1628,8 +1628,8 @@ fn test_datetime_sub_assign_local() {
 
     // ensure we cross a DST transition
     for i in 1..=365 {
-        datetime_sub -= TimeDelta::try_days(1).unwrap();
-        assert_eq!(datetime_sub, datetime - TimeDelta::try_days(i).unwrap())
+        datetime_sub -= TimeDelta::days(1).unwrap();
+        assert_eq!(datetime_sub, datetime - TimeDelta::days(i).unwrap())
     }
 }
 

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1424,20 +1424,20 @@ fn test_datetime_sub_assign() {
     let datetime = naivedatetime.and_utc();
     let mut datetime_sub = datetime;
 
-    datetime_sub -= TimeDelta::try_minutes(90).unwrap();
-    assert_eq!(datetime_sub, datetime - TimeDelta::try_minutes(90).unwrap());
+    datetime_sub -= TimeDelta::minutes(90).unwrap();
+    assert_eq!(datetime_sub, datetime - TimeDelta::minutes(90).unwrap());
 
     let timezone = FixedOffset::east(60 * 60).unwrap();
     let datetime = datetime.with_timezone(&timezone);
     let datetime_sub = datetime_sub.with_timezone(&timezone);
 
-    assert_eq!(datetime_sub, datetime - TimeDelta::try_minutes(90).unwrap());
+    assert_eq!(datetime_sub, datetime - TimeDelta::minutes(90).unwrap());
 
     let timezone = FixedOffset::west(2 * 60 * 60).unwrap();
     let datetime = datetime.with_timezone(&timezone);
     let datetime_sub = datetime_sub.with_timezone(&timezone);
 
-    assert_eq!(datetime_sub, datetime - TimeDelta::try_minutes(90).unwrap());
+    assert_eq!(datetime_sub, datetime - TimeDelta::minutes(90).unwrap());
 }
 
 #[test]

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -288,7 +288,7 @@ fn test_nanosecond_range() {
     // Just beyond range
     let maximum = "2262-04-11T23:47:16.854775804UTC";
     let parsed: DateTime<Utc> = maximum.parse().unwrap();
-    let beyond_max = parsed + TimeDelta::try_milliseconds(300).unwrap();
+    let beyond_max = parsed + TimeDelta::milliseconds(300).unwrap();
     assert!(beyond_max.timestamp_nanos().is_none());
 
     // Far beyond range

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -820,7 +820,7 @@ impl Parsed {
                     59 => {}
                     // `datetime` is known to be off by one second.
                     0 => {
-                        datetime -= TimeDelta::try_seconds(1).unwrap();
+                        datetime -= TimeDelta::seconds(1).unwrap();
                     }
                     // otherwise it is impossible.
                     _ => return Err(IMPOSSIBLE),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,11 +200,11 @@
 //! // arithmetic operations
 //! let dt1 = Utc.with_ymd_and_hms(2014, 11, 14, 8, 9, 10).unwrap();
 //! let dt2 = Utc.with_ymd_and_hms(2014, 11, 14, 10, 9, 8).unwrap();
-//! assert_eq!(dt1.signed_duration_since(dt2), TimeDelta::try_seconds(-2 * 3600 + 2).unwrap());
-//! assert_eq!(dt2.signed_duration_since(dt1), TimeDelta::try_seconds(2 * 3600 - 2).unwrap());
-//! assert_eq!(Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap() + TimeDelta::try_seconds(1_000_000_000).unwrap(),
+//! assert_eq!(dt1.signed_duration_since(dt2), TimeDelta::seconds(-2 * 3600 + 2).unwrap());
+//! assert_eq!(dt2.signed_duration_since(dt1), TimeDelta::seconds(2 * 3600 - 2).unwrap());
+//! assert_eq!(Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap() + TimeDelta::seconds(1_000_000_000).unwrap(),
 //!            Utc.with_ymd_and_hms(2001, 9, 9, 1, 46, 40).unwrap());
-//! assert_eq!(Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap() - TimeDelta::try_seconds(1_000_000_000).unwrap(),
+//! assert_eq!(Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap() - TimeDelta::seconds(1_000_000_000).unwrap(),
 //!            Utc.with_ymd_and_hms(1938, 4, 24, 22, 13, 20).unwrap());
 //! ```
 //!

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -886,16 +886,16 @@ impl NaiveDate {
     ///
     /// let d = NaiveDate::from_ymd(2015, 9, 5).unwrap();
     /// assert_eq!(
-    ///     d.checked_add_signed(TimeDelta::try_days(40).unwrap()),
+    ///     d.checked_add_signed(TimeDelta::days(40).unwrap()),
     ///     Some(NaiveDate::from_ymd(2015, 10, 15).unwrap())
     /// );
     /// assert_eq!(
-    ///     d.checked_add_signed(TimeDelta::try_days(-40).unwrap()),
+    ///     d.checked_add_signed(TimeDelta::days(-40).unwrap()),
     ///     Some(NaiveDate::from_ymd(2015, 7, 27).unwrap())
     /// );
-    /// assert_eq!(d.checked_add_signed(TimeDelta::try_days(1_000_000_000).unwrap()), None);
-    /// assert_eq!(d.checked_add_signed(TimeDelta::try_days(-1_000_000_000).unwrap()), None);
-    /// assert_eq!(NaiveDate::MAX.checked_add_signed(TimeDelta::try_days(1).unwrap()), None);
+    /// assert_eq!(d.checked_add_signed(TimeDelta::days(1_000_000_000).unwrap()), None);
+    /// assert_eq!(d.checked_add_signed(TimeDelta::days(-1_000_000_000).unwrap()), None);
+    /// assert_eq!(NaiveDate::MAX.checked_add_signed(TimeDelta::days(1).unwrap()), None);
     /// ```
     #[must_use]
     pub const fn checked_add_signed(self, rhs: TimeDelta) -> Option<NaiveDate> {
@@ -919,16 +919,16 @@ impl NaiveDate {
     ///
     /// let d = NaiveDate::from_ymd(2015, 9, 5).unwrap();
     /// assert_eq!(
-    ///     d.checked_sub_signed(TimeDelta::try_days(40).unwrap()),
+    ///     d.checked_sub_signed(TimeDelta::days(40).unwrap()),
     ///     Some(NaiveDate::from_ymd(2015, 7, 27).unwrap())
     /// );
     /// assert_eq!(
-    ///     d.checked_sub_signed(TimeDelta::try_days(-40).unwrap()),
+    ///     d.checked_sub_signed(TimeDelta::days(-40).unwrap()),
     ///     Some(NaiveDate::from_ymd(2015, 10, 15).unwrap())
     /// );
-    /// assert_eq!(d.checked_sub_signed(TimeDelta::try_days(1_000_000_000).unwrap()), None);
-    /// assert_eq!(d.checked_sub_signed(TimeDelta::try_days(-1_000_000_000).unwrap()), None);
-    /// assert_eq!(NaiveDate::MIN.checked_sub_signed(TimeDelta::try_days(1).unwrap()), None);
+    /// assert_eq!(d.checked_sub_signed(TimeDelta::days(1_000_000_000).unwrap()), None);
+    /// assert_eq!(d.checked_sub_signed(TimeDelta::days(-1_000_000_000).unwrap()), None);
+    /// assert_eq!(NaiveDate::MIN.checked_sub_signed(TimeDelta::days(1).unwrap()), None);
     /// ```
     #[must_use]
     pub const fn checked_sub_signed(self, rhs: TimeDelta) -> Option<NaiveDate> {
@@ -954,26 +954,17 @@ impl NaiveDate {
     /// let since = NaiveDate::signed_duration_since;
     ///
     /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2014, 1, 1)), TimeDelta::zero());
-    /// assert_eq!(
-    ///     since(from_ymd(2014, 1, 1), from_ymd(2013, 12, 31)),
-    ///     TimeDelta::try_days(1).unwrap()
-    /// );
-    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2014, 1, 2)), TimeDelta::try_days(-1).unwrap());
-    /// assert_eq!(
-    ///     since(from_ymd(2014, 1, 1), from_ymd(2013, 9, 23)),
-    ///     TimeDelta::try_days(100).unwrap()
-    /// );
-    /// assert_eq!(
-    ///     since(from_ymd(2014, 1, 1), from_ymd(2013, 1, 1)),
-    ///     TimeDelta::try_days(365).unwrap()
-    /// );
+    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2013, 12, 31)), TimeDelta::days(1).unwrap());
+    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2014, 1, 2)), TimeDelta::days(-1).unwrap());
+    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2013, 9, 23)), TimeDelta::days(100).unwrap());
+    /// assert_eq!(since(from_ymd(2014, 1, 1), from_ymd(2013, 1, 1)), TimeDelta::days(365).unwrap());
     /// assert_eq!(
     ///     since(from_ymd(2014, 1, 1), from_ymd(2010, 1, 1)),
-    ///     TimeDelta::try_days(365 * 4 + 1).unwrap()
+    ///     TimeDelta::days(365 * 4 + 1).unwrap()
     /// );
     /// assert_eq!(
     ///     since(from_ymd(2014, 1, 1), from_ymd(1614, 1, 1)),
-    ///     TimeDelta::try_days(365 * 400 + 97).unwrap()
+    ///     TimeDelta::days(365 * 400 + 97).unwrap()
     /// );
     /// ```
     #[must_use]
@@ -987,7 +978,7 @@ impl NaiveDate {
         let days = (year1_div_400 as i64 - year2_div_400 as i64) * 146_097 + (cycle1 - cycle2);
         // The range of `TimeDelta` is ca. 585 million years, the range of `NaiveDate` ca. 525.000
         // years.
-        expect!(TimeDelta::try_days(days), "always in range")
+        expect!(TimeDelta::days(days), "always in range")
     }
 
     /// Returns the number of whole years from the given `base` until `self`.
@@ -1739,15 +1730,12 @@ impl Datelike for NaiveDate {
 ///     from_ymd(2014, 1, 1) + TimeDelta::try_seconds(-86399).unwrap(),
 ///     from_ymd(2014, 1, 1)
 /// );
-/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::try_days(1).unwrap(), from_ymd(2014, 1, 2));
-/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::try_days(-1).unwrap(), from_ymd(2013, 12, 31));
-/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::try_days(364).unwrap(), from_ymd(2014, 12, 31));
+/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(1).unwrap(), from_ymd(2014, 1, 2));
+/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(-1).unwrap(), from_ymd(2013, 12, 31));
+/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(364).unwrap(), from_ymd(2014, 12, 31));
+/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(365 * 4 + 1).unwrap(), from_ymd(2018, 1, 1));
 /// assert_eq!(
-///     from_ymd(2014, 1, 1) + TimeDelta::try_days(365 * 4 + 1).unwrap(),
-///     from_ymd(2018, 1, 1)
-/// );
-/// assert_eq!(
-///     from_ymd(2014, 1, 1) + TimeDelta::try_days(365 * 400 + 97).unwrap(),
+///     from_ymd(2014, 1, 1) + TimeDelta::days(365 * 400 + 97).unwrap(),
 ///     from_ymd(2414, 1, 1)
 /// );
 /// ```
@@ -1891,15 +1879,12 @@ impl Sub<Days> for NaiveDate {
 ///     from_ymd(2014, 1, 1) - TimeDelta::try_seconds(-86399).unwrap(),
 ///     from_ymd(2014, 1, 1)
 /// );
-/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::try_days(1).unwrap(), from_ymd(2013, 12, 31));
-/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::try_days(-1).unwrap(), from_ymd(2014, 1, 2));
-/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::try_days(364).unwrap(), from_ymd(2013, 1, 2));
+/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(1).unwrap(), from_ymd(2013, 12, 31));
+/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(-1).unwrap(), from_ymd(2014, 1, 2));
+/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(364).unwrap(), from_ymd(2013, 1, 2));
+/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(365 * 4 + 1).unwrap(), from_ymd(2010, 1, 1));
 /// assert_eq!(
-///     from_ymd(2014, 1, 1) - TimeDelta::try_days(365 * 4 + 1).unwrap(),
-///     from_ymd(2010, 1, 1)
-/// );
-/// assert_eq!(
-///     from_ymd(2014, 1, 1) - TimeDelta::try_days(365 * 400 + 97).unwrap(),
+///     from_ymd(2014, 1, 1) - TimeDelta::days(365 * 400 + 97).unwrap(),
 ///     from_ymd(1614, 1, 1)
 /// );
 /// ```
@@ -1948,17 +1933,14 @@ impl SubAssign<TimeDelta> for NaiveDate {
 /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2014, 1, 1), TimeDelta::zero());
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 12, 31), TimeDelta::try_days(1).unwrap());
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2014, 1, 2), TimeDelta::try_days(-1).unwrap());
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 9, 23), TimeDelta::try_days(100).unwrap());
-/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 1, 1), TimeDelta::try_days(365).unwrap());
-/// assert_eq!(
-///     from_ymd(2014, 1, 1) - from_ymd(2010, 1, 1),
-///     TimeDelta::try_days(365 * 4 + 1).unwrap()
-/// );
+/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 12, 31), TimeDelta::days(1).unwrap());
+/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2014, 1, 2), TimeDelta::days(-1).unwrap());
+/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 9, 23), TimeDelta::days(100).unwrap());
+/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2013, 1, 1), TimeDelta::days(365).unwrap());
+/// assert_eq!(from_ymd(2014, 1, 1) - from_ymd(2010, 1, 1), TimeDelta::days(365 * 4 + 1).unwrap());
 /// assert_eq!(
 ///     from_ymd(2014, 1, 1) - from_ymd(1614, 1, 1),
-///     TimeDelta::try_days(365 * 400 + 97).unwrap()
+///     TimeDelta::days(365 * 400 + 97).unwrap()
 /// );
 /// ```
 impl Sub<NaiveDate> for NaiveDate {

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -1725,11 +1725,8 @@ impl Datelike for NaiveDate {
 /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::zero(), from_ymd(2014, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::try_seconds(86399).unwrap(), from_ymd(2014, 1, 1));
-/// assert_eq!(
-///     from_ymd(2014, 1, 1) + TimeDelta::try_seconds(-86399).unwrap(),
-///     from_ymd(2014, 1, 1)
-/// );
+/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::seconds(86399).unwrap(), from_ymd(2014, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::seconds(-86399).unwrap(), from_ymd(2014, 1, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(1).unwrap(), from_ymd(2014, 1, 2));
 /// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(-1).unwrap(), from_ymd(2013, 12, 31));
 /// assert_eq!(from_ymd(2014, 1, 1) + TimeDelta::days(364).unwrap(), from_ymd(2014, 12, 31));
@@ -1874,11 +1871,8 @@ impl Sub<Days> for NaiveDate {
 /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::zero(), from_ymd(2014, 1, 1));
-/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::try_seconds(86399).unwrap(), from_ymd(2014, 1, 1));
-/// assert_eq!(
-///     from_ymd(2014, 1, 1) - TimeDelta::try_seconds(-86399).unwrap(),
-///     from_ymd(2014, 1, 1)
-/// );
+/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::seconds(86399).unwrap(), from_ymd(2014, 1, 1));
+/// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::seconds(-86399).unwrap(), from_ymd(2014, 1, 1));
 /// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(1).unwrap(), from_ymd(2013, 12, 31));
 /// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(-1).unwrap(), from_ymd(2014, 1, 2));
 /// assert_eq!(from_ymd(2014, 1, 1) - TimeDelta::days(364).unwrap(), from_ymd(2013, 1, 2));

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -454,28 +454,24 @@ fn test_date_add() {
     check((2014, 1, 1), TimeDelta::try_seconds(86399).unwrap(), Some((2014, 1, 1)));
     // always round towards zero
     check((2014, 1, 1), TimeDelta::try_seconds(-86399).unwrap(), Some((2014, 1, 1)));
-    check((2014, 1, 1), TimeDelta::try_days(1).unwrap(), Some((2014, 1, 2)));
-    check((2014, 1, 1), TimeDelta::try_days(-1).unwrap(), Some((2013, 12, 31)));
-    check((2014, 1, 1), TimeDelta::try_days(364).unwrap(), Some((2014, 12, 31)));
-    check((2014, 1, 1), TimeDelta::try_days(365 * 4 + 1).unwrap(), Some((2018, 1, 1)));
-    check((2014, 1, 1), TimeDelta::try_days(365 * 400 + 97).unwrap(), Some((2414, 1, 1)));
+    check((2014, 1, 1), TimeDelta::days(1).unwrap(), Some((2014, 1, 2)));
+    check((2014, 1, 1), TimeDelta::days(-1).unwrap(), Some((2013, 12, 31)));
+    check((2014, 1, 1), TimeDelta::days(364).unwrap(), Some((2014, 12, 31)));
+    check((2014, 1, 1), TimeDelta::days(365 * 4 + 1).unwrap(), Some((2018, 1, 1)));
+    check((2014, 1, 1), TimeDelta::days(365 * 400 + 97).unwrap(), Some((2414, 1, 1)));
 
-    check((-7, 1, 1), TimeDelta::try_days(365 * 12 + 3).unwrap(), Some((5, 1, 1)));
+    check((-7, 1, 1), TimeDelta::days(365 * 12 + 3).unwrap(), Some((5, 1, 1)));
 
     // overflow check
     check(
         (0, 1, 1),
-        TimeDelta::try_days(MAX_DAYS_FROM_YEAR_0 as i64).unwrap(),
+        TimeDelta::days(MAX_DAYS_FROM_YEAR_0 as i64).unwrap(),
         Some((MAX_YEAR, 12, 31)),
     );
-    check((0, 1, 1), TimeDelta::try_days(MAX_DAYS_FROM_YEAR_0 as i64 + 1).unwrap(), None);
+    check((0, 1, 1), TimeDelta::days(MAX_DAYS_FROM_YEAR_0 as i64 + 1).unwrap(), None);
     check((0, 1, 1), TimeDelta::max_value(), None);
-    check(
-        (0, 1, 1),
-        TimeDelta::try_days(MIN_DAYS_FROM_YEAR_0 as i64).unwrap(),
-        Some((MIN_YEAR, 1, 1)),
-    );
-    check((0, 1, 1), TimeDelta::try_days(MIN_DAYS_FROM_YEAR_0 as i64 - 1).unwrap(), None);
+    check((0, 1, 1), TimeDelta::days(MIN_DAYS_FROM_YEAR_0 as i64).unwrap(), Some((MIN_YEAR, 1, 1)));
+    check((0, 1, 1), TimeDelta::days(MIN_DAYS_FROM_YEAR_0 as i64 - 1).unwrap(), None);
     check((0, 1, 1), TimeDelta::min_value(), None);
 }
 
@@ -489,14 +485,14 @@ fn test_date_sub() {
     }
 
     check((2014, 1, 1), (2014, 1, 1), TimeDelta::zero());
-    check((2014, 1, 2), (2014, 1, 1), TimeDelta::try_days(1).unwrap());
-    check((2014, 12, 31), (2014, 1, 1), TimeDelta::try_days(364).unwrap());
-    check((2015, 1, 3), (2014, 1, 1), TimeDelta::try_days(365 + 2).unwrap());
-    check((2018, 1, 1), (2014, 1, 1), TimeDelta::try_days(365 * 4 + 1).unwrap());
-    check((2414, 1, 1), (2014, 1, 1), TimeDelta::try_days(365 * 400 + 97).unwrap());
+    check((2014, 1, 2), (2014, 1, 1), TimeDelta::days(1).unwrap());
+    check((2014, 12, 31), (2014, 1, 1), TimeDelta::days(364).unwrap());
+    check((2015, 1, 3), (2014, 1, 1), TimeDelta::days(365 + 2).unwrap());
+    check((2018, 1, 1), (2014, 1, 1), TimeDelta::days(365 * 4 + 1).unwrap());
+    check((2414, 1, 1), (2014, 1, 1), TimeDelta::days(365 * 400 + 97).unwrap());
 
-    check((MAX_YEAR, 12, 31), (0, 1, 1), TimeDelta::try_days(MAX_DAYS_FROM_YEAR_0 as i64).unwrap());
-    check((MIN_YEAR, 1, 1), (0, 1, 1), TimeDelta::try_days(MIN_DAYS_FROM_YEAR_0 as i64).unwrap());
+    check((MAX_YEAR, 12, 31), (0, 1, 1), TimeDelta::days(MAX_DAYS_FROM_YEAR_0 as i64).unwrap());
+    check((MIN_YEAR, 1, 1), (0, 1, 1), TimeDelta::days(MIN_DAYS_FROM_YEAR_0 as i64).unwrap());
 }
 
 #[test]
@@ -544,9 +540,9 @@ fn test_date_sub_days() {
 fn test_date_addassignment() {
     let ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     let mut date = ymd(2016, 10, 1);
-    date += TimeDelta::try_days(10).unwrap();
+    date += TimeDelta::days(10).unwrap();
     assert_eq!(date, ymd(2016, 10, 11));
-    date += TimeDelta::try_days(30).unwrap();
+    date += TimeDelta::days(30).unwrap();
     assert_eq!(date, ymd(2016, 11, 10));
 }
 
@@ -554,9 +550,9 @@ fn test_date_addassignment() {
 fn test_date_subassignment() {
     let ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
     let mut date = ymd(2016, 10, 11);
-    date -= TimeDelta::try_days(10).unwrap();
+    date -= TimeDelta::days(10).unwrap();
     assert_eq!(date, ymd(2016, 10, 1));
-    date -= TimeDelta::try_days(2).unwrap();
+    date -= TimeDelta::days(2).unwrap();
     assert_eq!(date, ymd(2016, 9, 29));
 }
 

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -451,9 +451,9 @@ fn test_date_add() {
     }
 
     check((2014, 1, 1), TimeDelta::zero(), Some((2014, 1, 1)));
-    check((2014, 1, 1), TimeDelta::try_seconds(86399).unwrap(), Some((2014, 1, 1)));
+    check((2014, 1, 1), TimeDelta::seconds(86399).unwrap(), Some((2014, 1, 1)));
     // always round towards zero
-    check((2014, 1, 1), TimeDelta::try_seconds(-86399).unwrap(), Some((2014, 1, 1)));
+    check((2014, 1, 1), TimeDelta::seconds(-86399).unwrap(), Some((2014, 1, 1)));
     check((2014, 1, 1), TimeDelta::days(1).unwrap(), Some((2014, 1, 2)));
     check((2014, 1, 1), TimeDelta::days(-1).unwrap(), Some((2013, 12, 31)));
     check((2014, 1, 1), TimeDelta::days(364).unwrap(), Some((2014, 12, 31)));

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -254,20 +254,17 @@ impl NaiveDateTime {
     /// let d = from_ymd(2016, 7, 8);
     /// let hms = |h, m, s| d.and_hms(h, m, s).unwrap();
     /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::zero()), Some(hms(3, 5, 7)));
+    /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::seconds(1).unwrap()), Some(hms(3, 5, 8)));
     /// assert_eq!(
-    ///     hms(3, 5, 7).checked_add_signed(TimeDelta::try_seconds(1).unwrap()),
-    ///     Some(hms(3, 5, 8))
-    /// );
-    /// assert_eq!(
-    ///     hms(3, 5, 7).checked_add_signed(TimeDelta::try_seconds(-1).unwrap()),
+    ///     hms(3, 5, 7).checked_add_signed(TimeDelta::seconds(-1).unwrap()),
     ///     Some(hms(3, 5, 6))
     /// );
     /// assert_eq!(
-    ///     hms(3, 5, 7).checked_add_signed(TimeDelta::try_seconds(3600 + 60).unwrap()),
+    ///     hms(3, 5, 7).checked_add_signed(TimeDelta::seconds(3600 + 60).unwrap()),
     ///     Some(hms(4, 6, 7))
     /// );
     /// assert_eq!(
-    ///     hms(3, 5, 7).checked_add_signed(TimeDelta::try_seconds(86_400).unwrap()),
+    ///     hms(3, 5, 7).checked_add_signed(TimeDelta::seconds(86_400).unwrap()),
     ///     Some(from_ymd(2016, 7, 9).and_hms(3, 5, 7).unwrap())
     /// );
     ///
@@ -302,9 +299,9 @@ impl NaiveDateTime {
     ///            Some(hmsm(3, 5, 59, 1_800)));
     /// assert_eq!(leap.checked_add_signed(TimeDelta::try_milliseconds(800).unwrap()),
     ///            Some(hmsm(3, 6, 0, 100)));
-    /// assert_eq!(leap.checked_add_signed(TimeDelta::try_seconds(10).unwrap()),
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::seconds(10).unwrap()),
     ///            Some(hmsm(3, 6, 9, 300)));
-    /// assert_eq!(leap.checked_add_signed(TimeDelta::try_seconds(-10).unwrap()),
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::seconds(-10).unwrap()),
     ///            Some(hmsm(3, 5, 50, 300)));
     /// assert_eq!(leap.checked_add_signed(TimeDelta::days(1).unwrap()),
     ///            Some(from_ymd(2016, 7, 9).and_hms_milli(3, 5, 59, 300).unwrap()));
@@ -312,7 +309,7 @@ impl NaiveDateTime {
     #[must_use]
     pub const fn checked_add_signed(self, rhs: TimeDelta) -> Option<NaiveDateTime> {
         let (time, remainder) = self.time.overflowing_add_signed(rhs);
-        let remainder = try_opt!(TimeDelta::try_seconds(remainder));
+        let remainder = try_opt!(TimeDelta::seconds(remainder));
         let date = try_opt!(self.date.checked_add_signed(remainder));
         Some(NaiveDateTime { date, time })
     }
@@ -438,20 +435,17 @@ impl NaiveDateTime {
     /// let d = from_ymd(2016, 7, 8);
     /// let hms = |h, m, s| d.and_hms(h, m, s).unwrap();
     /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::zero()), Some(hms(3, 5, 7)));
+    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::seconds(1).unwrap()), Some(hms(3, 5, 6)));
     /// assert_eq!(
-    ///     hms(3, 5, 7).checked_sub_signed(TimeDelta::try_seconds(1).unwrap()),
-    ///     Some(hms(3, 5, 6))
-    /// );
-    /// assert_eq!(
-    ///     hms(3, 5, 7).checked_sub_signed(TimeDelta::try_seconds(-1).unwrap()),
+    ///     hms(3, 5, 7).checked_sub_signed(TimeDelta::seconds(-1).unwrap()),
     ///     Some(hms(3, 5, 8))
     /// );
     /// assert_eq!(
-    ///     hms(3, 5, 7).checked_sub_signed(TimeDelta::try_seconds(3600 + 60).unwrap()),
+    ///     hms(3, 5, 7).checked_sub_signed(TimeDelta::seconds(3600 + 60).unwrap()),
     ///     Some(hms(2, 4, 7))
     /// );
     /// assert_eq!(
-    ///     hms(3, 5, 7).checked_sub_signed(TimeDelta::try_seconds(86_400).unwrap()),
+    ///     hms(3, 5, 7).checked_sub_signed(TimeDelta::seconds(86_400).unwrap()),
     ///     Some(from_ymd(2016, 7, 7).and_hms(3, 5, 7).unwrap())
     /// );
     ///
@@ -484,7 +478,7 @@ impl NaiveDateTime {
     ///            Some(hmsm(3, 5, 59, 1_100)));
     /// assert_eq!(leap.checked_sub_signed(TimeDelta::try_milliseconds(500).unwrap()),
     ///            Some(hmsm(3, 5, 59, 800)));
-    /// assert_eq!(leap.checked_sub_signed(TimeDelta::try_seconds(60).unwrap()),
+    /// assert_eq!(leap.checked_sub_signed(TimeDelta::seconds(60).unwrap()),
     ///            Some(hmsm(3, 5, 0, 300)));
     /// assert_eq!(leap.checked_sub_signed(TimeDelta::days(1).unwrap()),
     ///            Some(from_ymd(2016, 7, 7).and_hms_milli(3, 6, 0, 300).unwrap()));
@@ -492,7 +486,7 @@ impl NaiveDateTime {
     #[must_use]
     pub const fn checked_sub_signed(self, rhs: TimeDelta) -> Option<NaiveDateTime> {
         let (time, remainder) = self.time.overflowing_sub_signed(rhs);
-        let remainder = try_opt!(TimeDelta::try_seconds(remainder));
+        let remainder = try_opt!(TimeDelta::seconds(remainder));
         let date = try_opt!(self.date.checked_sub_signed(remainder));
         Some(NaiveDateTime { date, time })
     }
@@ -568,14 +562,14 @@ impl NaiveDateTime {
     /// let d = from_ymd(2016, 7, 8);
     /// assert_eq!(
     ///     d.and_hms(3, 5, 7).unwrap().signed_duration_since(d.and_hms(2, 4, 6).unwrap()),
-    ///     TimeDelta::try_seconds(3600 + 60 + 1).unwrap()
+    ///     TimeDelta::seconds(3600 + 60 + 1).unwrap()
     /// );
     ///
     /// // July 8 is 190th day in the year 2016
     /// let d0 = from_ymd(2016, 1, 1);
     /// assert_eq!(
     ///     d.and_hms_milli(0, 7, 6, 500).unwrap().signed_duration_since(d0.and_hms(0, 0, 0).unwrap()),
-    ///     TimeDelta::try_seconds(189 * 86_400 + 7 * 60 + 6).unwrap()
+    ///     TimeDelta::seconds(189 * 86_400 + 7 * 60 + 6).unwrap()
     ///         + TimeDelta::try_milliseconds(500).unwrap()
     /// );
     /// ```
@@ -589,11 +583,11 @@ impl NaiveDateTime {
     /// let leap = from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500).unwrap();
     /// assert_eq!(
     ///     leap.signed_duration_since(from_ymd(2015, 6, 30).and_hms(23, 0, 0).unwrap()),
-    ///     TimeDelta::try_seconds(3600).unwrap() + TimeDelta::try_milliseconds(500).unwrap()
+    ///     TimeDelta::seconds(3600).unwrap() + TimeDelta::try_milliseconds(500).unwrap()
     /// );
     /// assert_eq!(
     ///     from_ymd(2015, 7, 1).and_hms(1, 0, 0).unwrap().signed_duration_since(leap),
-    ///     TimeDelta::try_seconds(3600).unwrap() - TimeDelta::try_milliseconds(500).unwrap()
+    ///     TimeDelta::seconds(3600).unwrap() - TimeDelta::try_milliseconds(500).unwrap()
     /// );
     /// ```
     #[must_use]
@@ -1345,11 +1339,11 @@ impl Timelike for NaiveDateTime {
 /// let d = from_ymd(2016, 7, 8);
 /// let hms = |h, m, s| d.and_hms(h, m, s).unwrap();
 /// assert_eq!(hms(3, 5, 7) + TimeDelta::zero(), hms(3, 5, 7));
-/// assert_eq!(hms(3, 5, 7) + TimeDelta::try_seconds(1).unwrap(), hms(3, 5, 8));
-/// assert_eq!(hms(3, 5, 7) + TimeDelta::try_seconds(-1).unwrap(), hms(3, 5, 6));
-/// assert_eq!(hms(3, 5, 7) + TimeDelta::try_seconds(3600 + 60).unwrap(), hms(4, 6, 7));
+/// assert_eq!(hms(3, 5, 7) + TimeDelta::seconds(1).unwrap(), hms(3, 5, 8));
+/// assert_eq!(hms(3, 5, 7) + TimeDelta::seconds(-1).unwrap(), hms(3, 5, 6));
+/// assert_eq!(hms(3, 5, 7) + TimeDelta::seconds(3600 + 60).unwrap(), hms(4, 6, 7));
 /// assert_eq!(
-///     hms(3, 5, 7) + TimeDelta::try_seconds(86_400).unwrap(),
+///     hms(3, 5, 7) + TimeDelta::seconds(86_400).unwrap(),
 ///     from_ymd(2016, 7, 9).and_hms(3, 5, 7).unwrap()
 /// );
 /// assert_eq!(
@@ -1373,8 +1367,8 @@ impl Timelike for NaiveDateTime {
 /// assert_eq!(leap + TimeDelta::try_milliseconds(-500).unwrap(), hmsm(3, 5, 59, 800));
 /// assert_eq!(leap + TimeDelta::try_milliseconds(500).unwrap(), hmsm(3, 5, 59, 1_800));
 /// assert_eq!(leap + TimeDelta::try_milliseconds(800).unwrap(), hmsm(3, 6, 0, 100));
-/// assert_eq!(leap + TimeDelta::try_seconds(10).unwrap(), hmsm(3, 6, 9, 300));
-/// assert_eq!(leap + TimeDelta::try_seconds(-10).unwrap(), hmsm(3, 5, 50, 300));
+/// assert_eq!(leap + TimeDelta::seconds(10).unwrap(), hmsm(3, 6, 9, 300));
+/// assert_eq!(leap + TimeDelta::seconds(-10).unwrap(), hmsm(3, 5, 50, 300));
 /// assert_eq!(leap + TimeDelta::days(1).unwrap(),
 ///            from_ymd(2016, 7, 9).and_hms_milli(3, 5, 59, 300).unwrap());
 /// ```
@@ -1530,11 +1524,11 @@ impl Add<Months> for NaiveDateTime {
 /// let d = from_ymd(2016, 7, 8);
 /// let hms = |h, m, s| d.and_hms(h, m, s).unwrap();
 /// assert_eq!(hms(3, 5, 7) - TimeDelta::zero(), hms(3, 5, 7));
-/// assert_eq!(hms(3, 5, 7) - TimeDelta::try_seconds(1).unwrap(), hms(3, 5, 6));
-/// assert_eq!(hms(3, 5, 7) - TimeDelta::try_seconds(-1).unwrap(), hms(3, 5, 8));
-/// assert_eq!(hms(3, 5, 7) - TimeDelta::try_seconds(3600 + 60).unwrap(), hms(2, 4, 7));
+/// assert_eq!(hms(3, 5, 7) - TimeDelta::seconds(1).unwrap(), hms(3, 5, 6));
+/// assert_eq!(hms(3, 5, 7) - TimeDelta::seconds(-1).unwrap(), hms(3, 5, 8));
+/// assert_eq!(hms(3, 5, 7) - TimeDelta::seconds(3600 + 60).unwrap(), hms(2, 4, 7));
 /// assert_eq!(
-///     hms(3, 5, 7) - TimeDelta::try_seconds(86_400).unwrap(),
+///     hms(3, 5, 7) - TimeDelta::seconds(86_400).unwrap(),
 ///     from_ymd(2016, 7, 7).and_hms(3, 5, 7).unwrap()
 /// );
 /// assert_eq!(
@@ -1557,7 +1551,7 @@ impl Add<Months> for NaiveDateTime {
 /// assert_eq!(leap - TimeDelta::zero(), hmsm(3, 5, 59, 1_300));
 /// assert_eq!(leap - TimeDelta::try_milliseconds(200).unwrap(), hmsm(3, 5, 59, 1_100));
 /// assert_eq!(leap - TimeDelta::try_milliseconds(500).unwrap(), hmsm(3, 5, 59, 800));
-/// assert_eq!(leap - TimeDelta::try_seconds(60).unwrap(), hmsm(3, 5, 0, 300));
+/// assert_eq!(leap - TimeDelta::seconds(60).unwrap(), hmsm(3, 5, 0, 300));
 /// assert_eq!(leap - TimeDelta::days(1).unwrap(),
 ///            from_ymd(2016, 7, 7).and_hms_milli(3, 6, 0, 300).unwrap());
 /// ```
@@ -1701,14 +1695,14 @@ impl Sub<Months> for NaiveDateTime {
 /// let d = from_ymd(2016, 7, 8);
 /// assert_eq!(
 ///     d.and_hms(3, 5, 7).unwrap() - d.and_hms(2, 4, 6).unwrap(),
-///     TimeDelta::try_seconds(3600 + 60 + 1).unwrap()
+///     TimeDelta::seconds(3600 + 60 + 1).unwrap()
 /// );
 ///
 /// // July 8 is 190th day in the year 2016
 /// let d0 = from_ymd(2016, 1, 1);
 /// assert_eq!(
 ///     d.and_hms_milli(0, 7, 6, 500).unwrap() - d0.and_hms(0, 0, 0).unwrap(),
-///     TimeDelta::try_seconds(189 * 86_400 + 7 * 60 + 6).unwrap()
+///     TimeDelta::seconds(189 * 86_400 + 7 * 60 + 6).unwrap()
 ///         + TimeDelta::try_milliseconds(500).unwrap()
 /// );
 /// ```
@@ -1722,11 +1716,11 @@ impl Sub<Months> for NaiveDateTime {
 /// let leap = from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500).unwrap();
 /// assert_eq!(
 ///     leap - from_ymd(2015, 6, 30).and_hms(23, 0, 0).unwrap(),
-///     TimeDelta::try_seconds(3600).unwrap() + TimeDelta::try_milliseconds(500).unwrap()
+///     TimeDelta::seconds(3600).unwrap() + TimeDelta::try_milliseconds(500).unwrap()
 /// );
 /// assert_eq!(
 ///     from_ymd(2015, 7, 1).and_hms(1, 0, 0).unwrap() - leap,
-///     TimeDelta::try_seconds(3600).unwrap() - TimeDelta::try_milliseconds(500).unwrap()
+///     TimeDelta::seconds(3600).unwrap() - TimeDelta::try_milliseconds(500).unwrap()
 /// );
 /// ```
 impl Sub<NaiveDateTime> for NaiveDateTime {

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -270,7 +270,7 @@ impl NaiveDateTime {
     ///
     /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli).unwrap();
     /// assert_eq!(
-    ///     hmsm(3, 5, 7, 980).checked_add_signed(TimeDelta::try_milliseconds(450).unwrap()),
+    ///     hmsm(3, 5, 7, 980).checked_add_signed(TimeDelta::milliseconds(450).unwrap()),
     ///     Some(hmsm(3, 5, 8, 430))
     /// );
     /// ```
@@ -293,11 +293,11 @@ impl NaiveDateTime {
     /// let leap = hmsm(3, 5, 59, 1_300);
     /// assert_eq!(leap.checked_add_signed(TimeDelta::zero()),
     ///            Some(hmsm(3, 5, 59, 1_300)));
-    /// assert_eq!(leap.checked_add_signed(TimeDelta::try_milliseconds(-500).unwrap()),
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::milliseconds(-500).unwrap()),
     ///            Some(hmsm(3, 5, 59, 800)));
-    /// assert_eq!(leap.checked_add_signed(TimeDelta::try_milliseconds(500).unwrap()),
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::milliseconds(500).unwrap()),
     ///            Some(hmsm(3, 5, 59, 1_800)));
-    /// assert_eq!(leap.checked_add_signed(TimeDelta::try_milliseconds(800).unwrap()),
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::milliseconds(800).unwrap()),
     ///            Some(hmsm(3, 6, 0, 100)));
     /// assert_eq!(leap.checked_add_signed(TimeDelta::seconds(10).unwrap()),
     ///            Some(hmsm(3, 6, 9, 300)));
@@ -451,7 +451,7 @@ impl NaiveDateTime {
     ///
     /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli).unwrap();
     /// assert_eq!(
-    ///     hmsm(3, 5, 7, 450).checked_sub_signed(TimeDelta::try_milliseconds(670).unwrap()),
+    ///     hmsm(3, 5, 7, 450).checked_sub_signed(TimeDelta::milliseconds(670).unwrap()),
     ///     Some(hmsm(3, 5, 6, 780))
     /// );
     /// ```
@@ -474,9 +474,9 @@ impl NaiveDateTime {
     /// let leap = hmsm(3, 5, 59, 1_300);
     /// assert_eq!(leap.checked_sub_signed(TimeDelta::zero()),
     ///            Some(hmsm(3, 5, 59, 1_300)));
-    /// assert_eq!(leap.checked_sub_signed(TimeDelta::try_milliseconds(200).unwrap()),
+    /// assert_eq!(leap.checked_sub_signed(TimeDelta::milliseconds(200).unwrap()),
     ///            Some(hmsm(3, 5, 59, 1_100)));
-    /// assert_eq!(leap.checked_sub_signed(TimeDelta::try_milliseconds(500).unwrap()),
+    /// assert_eq!(leap.checked_sub_signed(TimeDelta::milliseconds(500).unwrap()),
     ///            Some(hmsm(3, 5, 59, 800)));
     /// assert_eq!(leap.checked_sub_signed(TimeDelta::seconds(60).unwrap()),
     ///            Some(hmsm(3, 5, 0, 300)));
@@ -570,7 +570,7 @@ impl NaiveDateTime {
     /// assert_eq!(
     ///     d.and_hms_milli(0, 7, 6, 500).unwrap().signed_duration_since(d0.and_hms(0, 0, 0).unwrap()),
     ///     TimeDelta::seconds(189 * 86_400 + 7 * 60 + 6).unwrap()
-    ///         + TimeDelta::try_milliseconds(500).unwrap()
+    ///         + TimeDelta::milliseconds(500).unwrap()
     /// );
     /// ```
     ///
@@ -583,11 +583,11 @@ impl NaiveDateTime {
     /// let leap = from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500).unwrap();
     /// assert_eq!(
     ///     leap.signed_duration_since(from_ymd(2015, 6, 30).and_hms(23, 0, 0).unwrap()),
-    ///     TimeDelta::seconds(3600).unwrap() + TimeDelta::try_milliseconds(500).unwrap()
+    ///     TimeDelta::seconds(3600).unwrap() + TimeDelta::milliseconds(500).unwrap()
     /// );
     /// assert_eq!(
     ///     from_ymd(2015, 7, 1).and_hms(1, 0, 0).unwrap().signed_duration_since(leap),
-    ///     TimeDelta::seconds(3600).unwrap() - TimeDelta::try_milliseconds(500).unwrap()
+    ///     TimeDelta::seconds(3600).unwrap() - TimeDelta::milliseconds(500).unwrap()
     /// );
     /// ```
     #[must_use]
@@ -1352,7 +1352,7 @@ impl Timelike for NaiveDateTime {
 /// );
 ///
 /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli).unwrap();
-/// assert_eq!(hmsm(3, 5, 7, 980) + TimeDelta::try_milliseconds(450).unwrap(), hmsm(3, 5, 8, 430));
+/// assert_eq!(hmsm(3, 5, 7, 980) + TimeDelta::milliseconds(450).unwrap(), hmsm(3, 5, 8, 430));
 /// ```
 ///
 /// Leap seconds are handled,
@@ -1364,9 +1364,9 @@ impl Timelike for NaiveDateTime {
 /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli).unwrap();
 /// let leap = hmsm(3, 5, 59, 1_300);
 /// assert_eq!(leap + TimeDelta::zero(), hmsm(3, 5, 59, 1_300));
-/// assert_eq!(leap + TimeDelta::try_milliseconds(-500).unwrap(), hmsm(3, 5, 59, 800));
-/// assert_eq!(leap + TimeDelta::try_milliseconds(500).unwrap(), hmsm(3, 5, 59, 1_800));
-/// assert_eq!(leap + TimeDelta::try_milliseconds(800).unwrap(), hmsm(3, 6, 0, 100));
+/// assert_eq!(leap + TimeDelta::milliseconds(-500).unwrap(), hmsm(3, 5, 59, 800));
+/// assert_eq!(leap + TimeDelta::milliseconds(500).unwrap(), hmsm(3, 5, 59, 1_800));
+/// assert_eq!(leap + TimeDelta::milliseconds(800).unwrap(), hmsm(3, 6, 0, 100));
 /// assert_eq!(leap + TimeDelta::seconds(10).unwrap(), hmsm(3, 6, 9, 300));
 /// assert_eq!(leap + TimeDelta::seconds(-10).unwrap(), hmsm(3, 5, 50, 300));
 /// assert_eq!(leap + TimeDelta::days(1).unwrap(),
@@ -1537,7 +1537,7 @@ impl Add<Months> for NaiveDateTime {
 /// );
 ///
 /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli).unwrap();
-/// assert_eq!(hmsm(3, 5, 7, 450) - TimeDelta::try_milliseconds(670).unwrap(), hmsm(3, 5, 6, 780));
+/// assert_eq!(hmsm(3, 5, 7, 450) - TimeDelta::milliseconds(670).unwrap(), hmsm(3, 5, 6, 780));
 /// ```
 ///
 /// Leap seconds are handled,
@@ -1549,8 +1549,8 @@ impl Add<Months> for NaiveDateTime {
 /// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli).unwrap();
 /// let leap = hmsm(3, 5, 59, 1_300);
 /// assert_eq!(leap - TimeDelta::zero(), hmsm(3, 5, 59, 1_300));
-/// assert_eq!(leap - TimeDelta::try_milliseconds(200).unwrap(), hmsm(3, 5, 59, 1_100));
-/// assert_eq!(leap - TimeDelta::try_milliseconds(500).unwrap(), hmsm(3, 5, 59, 800));
+/// assert_eq!(leap - TimeDelta::milliseconds(200).unwrap(), hmsm(3, 5, 59, 1_100));
+/// assert_eq!(leap - TimeDelta::milliseconds(500).unwrap(), hmsm(3, 5, 59, 800));
 /// assert_eq!(leap - TimeDelta::seconds(60).unwrap(), hmsm(3, 5, 0, 300));
 /// assert_eq!(leap - TimeDelta::days(1).unwrap(),
 ///            from_ymd(2016, 7, 7).and_hms_milli(3, 6, 0, 300).unwrap());
@@ -1703,7 +1703,7 @@ impl Sub<Months> for NaiveDateTime {
 /// assert_eq!(
 ///     d.and_hms_milli(0, 7, 6, 500).unwrap() - d0.and_hms(0, 0, 0).unwrap(),
 ///     TimeDelta::seconds(189 * 86_400 + 7 * 60 + 6).unwrap()
-///         + TimeDelta::try_milliseconds(500).unwrap()
+///         + TimeDelta::milliseconds(500).unwrap()
 /// );
 /// ```
 ///
@@ -1716,11 +1716,11 @@ impl Sub<Months> for NaiveDateTime {
 /// let leap = from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500).unwrap();
 /// assert_eq!(
 ///     leap - from_ymd(2015, 6, 30).and_hms(23, 0, 0).unwrap(),
-///     TimeDelta::seconds(3600).unwrap() + TimeDelta::try_milliseconds(500).unwrap()
+///     TimeDelta::seconds(3600).unwrap() + TimeDelta::milliseconds(500).unwrap()
 /// );
 /// assert_eq!(
 ///     from_ymd(2015, 7, 1).and_hms(1, 0, 0).unwrap() - leap,
-///     TimeDelta::seconds(3600).unwrap() - TimeDelta::try_milliseconds(500).unwrap()
+///     TimeDelta::seconds(3600).unwrap() - TimeDelta::milliseconds(500).unwrap()
 /// );
 /// ```
 impl Sub<NaiveDateTime> for NaiveDateTime {

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -283,7 +283,7 @@ impl NaiveDateTime {
     /// ```
     /// # use chrono::{TimeDelta, NaiveDate};
     /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms(h, m, s).unwrap();
-    /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::try_days(1_000_000_000).unwrap()), None);
+    /// assert_eq!(hms(3, 5, 7).checked_add_signed(TimeDelta::days(1_000_000_000).unwrap()), None);
     /// ```
     ///
     /// Leap seconds are handled,
@@ -306,7 +306,7 @@ impl NaiveDateTime {
     ///            Some(hmsm(3, 6, 9, 300)));
     /// assert_eq!(leap.checked_add_signed(TimeDelta::try_seconds(-10).unwrap()),
     ///            Some(hmsm(3, 5, 50, 300)));
-    /// assert_eq!(leap.checked_add_signed(TimeDelta::try_days(1).unwrap()),
+    /// assert_eq!(leap.checked_add_signed(TimeDelta::days(1).unwrap()),
     ///            Some(from_ymd(2016, 7, 9).and_hms_milli(3, 5, 59, 300).unwrap()));
     /// ```
     #[must_use]
@@ -467,7 +467,7 @@ impl NaiveDateTime {
     /// ```
     /// # use chrono::{TimeDelta, NaiveDate};
     /// # let hms = |h, m, s| NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms(h, m, s).unwrap();
-    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::try_days(1_000_000_000).unwrap()), None);
+    /// assert_eq!(hms(3, 5, 7).checked_sub_signed(TimeDelta::days(1_000_000_000).unwrap()), None);
     /// ```
     ///
     /// Leap seconds are handled,
@@ -486,7 +486,7 @@ impl NaiveDateTime {
     ///            Some(hmsm(3, 5, 59, 800)));
     /// assert_eq!(leap.checked_sub_signed(TimeDelta::try_seconds(60).unwrap()),
     ///            Some(hmsm(3, 5, 0, 300)));
-    /// assert_eq!(leap.checked_sub_signed(TimeDelta::try_days(1).unwrap()),
+    /// assert_eq!(leap.checked_sub_signed(TimeDelta::days(1).unwrap()),
     ///            Some(from_ymd(2016, 7, 7).and_hms_milli(3, 6, 0, 300).unwrap()));
     /// ```
     #[must_use]
@@ -1353,7 +1353,7 @@ impl Timelike for NaiveDateTime {
 ///     from_ymd(2016, 7, 9).and_hms(3, 5, 7).unwrap()
 /// );
 /// assert_eq!(
-///     hms(3, 5, 7) + TimeDelta::try_days(365).unwrap(),
+///     hms(3, 5, 7) + TimeDelta::days(365).unwrap(),
 ///     from_ymd(2017, 7, 8).and_hms(3, 5, 7).unwrap()
 /// );
 ///
@@ -1375,7 +1375,7 @@ impl Timelike for NaiveDateTime {
 /// assert_eq!(leap + TimeDelta::try_milliseconds(800).unwrap(), hmsm(3, 6, 0, 100));
 /// assert_eq!(leap + TimeDelta::try_seconds(10).unwrap(), hmsm(3, 6, 9, 300));
 /// assert_eq!(leap + TimeDelta::try_seconds(-10).unwrap(), hmsm(3, 5, 50, 300));
-/// assert_eq!(leap + TimeDelta::try_days(1).unwrap(),
+/// assert_eq!(leap + TimeDelta::days(1).unwrap(),
 ///            from_ymd(2016, 7, 9).and_hms_milli(3, 5, 59, 300).unwrap());
 /// ```
 ///
@@ -1538,7 +1538,7 @@ impl Add<Months> for NaiveDateTime {
 ///     from_ymd(2016, 7, 7).and_hms(3, 5, 7).unwrap()
 /// );
 /// assert_eq!(
-///     hms(3, 5, 7) - TimeDelta::try_days(365).unwrap(),
+///     hms(3, 5, 7) - TimeDelta::days(365).unwrap(),
 ///     from_ymd(2015, 7, 9).and_hms(3, 5, 7).unwrap()
 /// );
 ///
@@ -1558,7 +1558,7 @@ impl Add<Months> for NaiveDateTime {
 /// assert_eq!(leap - TimeDelta::try_milliseconds(200).unwrap(), hmsm(3, 5, 59, 1_100));
 /// assert_eq!(leap - TimeDelta::try_milliseconds(500).unwrap(), hmsm(3, 5, 59, 800));
 /// assert_eq!(leap - TimeDelta::try_seconds(60).unwrap(), hmsm(3, 5, 0, 300));
-/// assert_eq!(leap - TimeDelta::try_days(1).unwrap(),
+/// assert_eq!(leap - TimeDelta::days(1).unwrap(),
 ///            from_ymd(2016, 7, 7).and_hms_milli(3, 6, 0, 300).unwrap());
 /// ```
 ///

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -15,7 +15,7 @@ fn test_datetime_add() {
         assert_eq!(lhs.checked_add_signed(rhs), sum);
         assert_eq!(lhs.checked_sub_signed(-rhs), sum);
     }
-    let seconds = |s| TimeDelta::try_seconds(s).unwrap();
+    let seconds = |s| TimeDelta::seconds(s).unwrap();
 
     check((2014, 5, 6, 7, 8, 9), seconds(3600 + 60 + 1), Some((2014, 5, 6, 8, 9, 10)));
     check((2014, 5, 6, 7, 8, 9), seconds(-(3600 + 60 + 1)), Some((2014, 5, 6, 6, 7, 8)));
@@ -52,19 +52,19 @@ fn test_datetime_sub() {
     assert_eq!(since(ymdhms(2014, 5, 6, 7, 8, 9), ymdhms(2014, 5, 6, 7, 8, 9)), TimeDelta::zero());
     assert_eq!(
         since(ymdhms(2014, 5, 6, 7, 8, 10), ymdhms(2014, 5, 6, 7, 8, 9)),
-        TimeDelta::try_seconds(1).unwrap()
+        TimeDelta::seconds(1).unwrap()
     );
     assert_eq!(
         since(ymdhms(2014, 5, 6, 7, 8, 9), ymdhms(2014, 5, 6, 7, 8, 10)),
-        TimeDelta::try_seconds(-1).unwrap()
+        TimeDelta::seconds(-1).unwrap()
     );
     assert_eq!(
         since(ymdhms(2014, 5, 7, 7, 8, 9), ymdhms(2014, 5, 6, 7, 8, 10)),
-        TimeDelta::try_seconds(86399).unwrap()
+        TimeDelta::seconds(86399).unwrap()
     );
     assert_eq!(
         since(ymdhms(2001, 9, 9, 1, 46, 39), ymdhms(1970, 1, 1, 0, 0, 0)),
-        TimeDelta::try_seconds(999_999_999).unwrap()
+        TimeDelta::seconds(999_999_999).unwrap()
     );
 }
 

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -74,7 +74,7 @@ fn test_datetime_addassignment() {
     let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
     date += TimeDelta::try_minutes(10_000_000).unwrap();
     assert_eq!(date, ymdhms(2035, 10, 6, 20, 50, 10));
-    date += TimeDelta::try_days(10).unwrap();
+    date += TimeDelta::days(10).unwrap();
     assert_eq!(date, ymdhms(2035, 10, 16, 20, 50, 10));
 }
 
@@ -84,7 +84,7 @@ fn test_datetime_subassignment() {
     let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
     date -= TimeDelta::try_minutes(10_000_000).unwrap();
     assert_eq!(date, ymdhms(1997, 9, 26, 23, 30, 10));
-    date -= TimeDelta::try_days(10).unwrap();
+    date -= TimeDelta::days(10).unwrap();
     assert_eq!(date, ymdhms(1997, 9, 16, 23, 30, 10));
 }
 

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -72,7 +72,7 @@ fn test_datetime_sub() {
 fn test_datetime_addassignment() {
     let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
     let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
-    date += TimeDelta::try_minutes(10_000_000).unwrap();
+    date += TimeDelta::minutes(10_000_000).unwrap();
     assert_eq!(date, ymdhms(2035, 10, 6, 20, 50, 10));
     date += TimeDelta::days(10).unwrap();
     assert_eq!(date, ymdhms(2035, 10, 16, 20, 50, 10));
@@ -82,7 +82,7 @@ fn test_datetime_addassignment() {
 fn test_datetime_subassignment() {
     let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
     let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
-    date -= TimeDelta::try_minutes(10_000_000).unwrap();
+    date -= TimeDelta::minutes(10_000_000).unwrap();
     assert_eq!(date, ymdhms(1997, 9, 26, 23, 30, 10));
     date -= TimeDelta::days(10).unwrap();
     assert_eq!(date, ymdhms(1997, 9, 16, 23, 30, 10));

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -641,23 +641,23 @@ impl NaiveTime {
     /// );
     /// assert_eq!(
     ///     since(from_hmsm(3, 5, 7, 900), from_hmsm(3, 5, 0, 900)),
-    ///     TimeDelta::try_seconds(7).unwrap()
+    ///     TimeDelta::seconds(7).unwrap()
     /// );
     /// assert_eq!(
     ///     since(from_hmsm(3, 5, 7, 900), from_hmsm(3, 0, 7, 900)),
-    ///     TimeDelta::try_seconds(5 * 60).unwrap()
+    ///     TimeDelta::seconds(5 * 60).unwrap()
     /// );
     /// assert_eq!(
     ///     since(from_hmsm(3, 5, 7, 900), from_hmsm(0, 5, 7, 900)),
-    ///     TimeDelta::try_seconds(3 * 3600).unwrap()
+    ///     TimeDelta::seconds(3 * 3600).unwrap()
     /// );
     /// assert_eq!(
     ///     since(from_hmsm(3, 5, 7, 900), from_hmsm(4, 5, 7, 900)),
-    ///     TimeDelta::try_seconds(-3600).unwrap()
+    ///     TimeDelta::seconds(-3600).unwrap()
     /// );
     /// assert_eq!(
     ///     since(from_hmsm(3, 5, 7, 900), from_hmsm(2, 4, 6, 800)),
-    ///     TimeDelta::try_seconds(3600 + 60 + 1).unwrap() + TimeDelta::try_milliseconds(100).unwrap()
+    ///     TimeDelta::seconds(3600 + 60 + 1).unwrap() + TimeDelta::try_milliseconds(100).unwrap()
     /// );
     /// ```
     ///
@@ -669,15 +669,15 @@ impl NaiveTime {
     /// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
     /// # let since = NaiveTime::signed_duration_since;
     /// assert_eq!(since(from_hmsm(3, 0, 59, 1_000), from_hmsm(3, 0, 59, 0)),
-    ///            TimeDelta::try_seconds(1).unwrap());
+    ///            TimeDelta::seconds(1).unwrap());
     /// assert_eq!(since(from_hmsm(3, 0, 59, 1_500), from_hmsm(3, 0, 59, 0)),
     ///            TimeDelta::try_milliseconds(1500).unwrap());
     /// assert_eq!(since(from_hmsm(3, 0, 59, 1_000), from_hmsm(3, 0, 0, 0)),
-    ///            TimeDelta::try_seconds(60).unwrap());
+    ///            TimeDelta::seconds(60).unwrap());
     /// assert_eq!(since(from_hmsm(3, 0, 0, 0), from_hmsm(2, 59, 59, 1_000)),
-    ///            TimeDelta::try_seconds(1).unwrap());
+    ///            TimeDelta::seconds(1).unwrap());
     /// assert_eq!(since(from_hmsm(3, 0, 59, 1_000), from_hmsm(2, 59, 59, 1_000)),
-    ///            TimeDelta::try_seconds(61).unwrap());
+    ///            TimeDelta::seconds(61).unwrap());
     /// ```
     #[must_use]
     pub const fn signed_duration_since(self, rhs: NaiveTime) -> TimeDelta {
@@ -1084,14 +1084,11 @@ impl Timelike for NaiveTime {
 /// let from_hmsm = |h, m, s, milli| NaiveTime::from_hms_milli(h, m, s, milli).unwrap();
 ///
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::zero(), from_hmsm(3, 5, 7, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::try_seconds(1).unwrap(), from_hmsm(3, 5, 8, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::try_seconds(-1).unwrap(), from_hmsm(3, 5, 6, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::seconds(1).unwrap(), from_hmsm(3, 5, 8, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::seconds(-1).unwrap(), from_hmsm(3, 5, 6, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::seconds(60 + 4).unwrap(), from_hmsm(3, 6, 11, 0));
 /// assert_eq!(
-///     from_hmsm(3, 5, 7, 0) + TimeDelta::try_seconds(60 + 4).unwrap(),
-///     from_hmsm(3, 6, 11, 0)
-/// );
-/// assert_eq!(
-///     from_hmsm(3, 5, 7, 0) + TimeDelta::try_seconds(7 * 60 * 60 - 6 * 60).unwrap(),
+///     from_hmsm(3, 5, 7, 0) + TimeDelta::seconds(7 * 60 * 60 - 6 * 60).unwrap(),
 ///     from_hmsm(9, 59, 7, 0)
 /// );
 /// assert_eq!(
@@ -1113,8 +1110,8 @@ impl Timelike for NaiveTime {
 /// ```
 /// # use chrono::{TimeDelta, NaiveTime};
 /// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
-/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::try_seconds(22*60*60).unwrap(), from_hmsm(1, 5, 7, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::try_seconds(-8*60*60).unwrap(), from_hmsm(19, 5, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::seconds(22*60*60).unwrap(), from_hmsm(1, 5, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::seconds(-8*60*60).unwrap(), from_hmsm(19, 5, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::days(800).unwrap(), from_hmsm(3, 5, 7, 0));
 /// ```
 ///
@@ -1128,8 +1125,8 @@ impl Timelike for NaiveTime {
 /// assert_eq!(leap + TimeDelta::try_milliseconds(-500).unwrap(), from_hmsm(3, 5, 59, 800));
 /// assert_eq!(leap + TimeDelta::try_milliseconds(500).unwrap(), from_hmsm(3, 5, 59, 1_800));
 /// assert_eq!(leap + TimeDelta::try_milliseconds(800).unwrap(), from_hmsm(3, 6, 0, 100));
-/// assert_eq!(leap + TimeDelta::try_seconds(10).unwrap(), from_hmsm(3, 6, 9, 300));
-/// assert_eq!(leap + TimeDelta::try_seconds(-10).unwrap(), from_hmsm(3, 5, 50, 300));
+/// assert_eq!(leap + TimeDelta::seconds(10).unwrap(), from_hmsm(3, 6, 9, 300));
+/// assert_eq!(leap + TimeDelta::seconds(-10).unwrap(), from_hmsm(3, 5, 50, 300));
 /// assert_eq!(leap + TimeDelta::days(1).unwrap(), from_hmsm(3, 5, 59, 300));
 /// ```
 ///
@@ -1214,13 +1211,10 @@ impl Add<FixedOffset> for NaiveTime {
 /// let from_hmsm = |h, m, s, milli| NaiveTime::from_hms_milli(h, m, s, milli).unwrap();
 ///
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::zero(), from_hmsm(3, 5, 7, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::try_seconds(1).unwrap(), from_hmsm(3, 5, 6, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::seconds(1).unwrap(), from_hmsm(3, 5, 6, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::seconds(60 + 5).unwrap(), from_hmsm(3, 4, 2, 0));
 /// assert_eq!(
-///     from_hmsm(3, 5, 7, 0) - TimeDelta::try_seconds(60 + 5).unwrap(),
-///     from_hmsm(3, 4, 2, 0)
-/// );
-/// assert_eq!(
-///     from_hmsm(3, 5, 7, 0) - TimeDelta::try_seconds(2 * 60 * 60 + 6 * 60).unwrap(),
+///     from_hmsm(3, 5, 7, 0) - TimeDelta::seconds(2 * 60 * 60 + 6 * 60).unwrap(),
 ///     from_hmsm(0, 59, 7, 0)
 /// );
 /// assert_eq!(
@@ -1238,7 +1232,7 @@ impl Add<FixedOffset> for NaiveTime {
 /// ```
 /// # use chrono::{TimeDelta, NaiveTime};
 /// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
-/// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::try_seconds(8*60*60).unwrap(), from_hmsm(19, 5, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::seconds(8*60*60).unwrap(), from_hmsm(19, 5, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::days(800).unwrap(), from_hmsm(3, 5, 7, 0));
 /// ```
 ///
@@ -1251,7 +1245,7 @@ impl Add<FixedOffset> for NaiveTime {
 /// assert_eq!(leap - TimeDelta::zero(), from_hmsm(3, 5, 59, 1_300));
 /// assert_eq!(leap - TimeDelta::try_milliseconds(200).unwrap(), from_hmsm(3, 5, 59, 1_100));
 /// assert_eq!(leap - TimeDelta::try_milliseconds(500).unwrap(), from_hmsm(3, 5, 59, 800));
-/// assert_eq!(leap - TimeDelta::try_seconds(60).unwrap(), from_hmsm(3, 5, 0, 300));
+/// assert_eq!(leap - TimeDelta::seconds(60).unwrap(), from_hmsm(3, 5, 0, 300));
 /// assert_eq!(leap - TimeDelta::days(1).unwrap(), from_hmsm(3, 6, 0, 300));
 /// ```
 ///
@@ -1347,25 +1341,22 @@ impl Sub<FixedOffset> for NaiveTime {
 ///     from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 6, 925),
 ///     TimeDelta::try_milliseconds(975).unwrap()
 /// );
-/// assert_eq!(
-///     from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 0, 900),
-///     TimeDelta::try_seconds(7).unwrap()
-/// );
+/// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 0, 900), TimeDelta::seconds(7).unwrap());
 /// assert_eq!(
 ///     from_hmsm(3, 5, 7, 900) - from_hmsm(3, 0, 7, 900),
-///     TimeDelta::try_seconds(5 * 60).unwrap()
+///     TimeDelta::seconds(5 * 60).unwrap()
 /// );
 /// assert_eq!(
 ///     from_hmsm(3, 5, 7, 900) - from_hmsm(0, 5, 7, 900),
-///     TimeDelta::try_seconds(3 * 3600).unwrap()
+///     TimeDelta::seconds(3 * 3600).unwrap()
 /// );
 /// assert_eq!(
 ///     from_hmsm(3, 5, 7, 900) - from_hmsm(4, 5, 7, 900),
-///     TimeDelta::try_seconds(-3600).unwrap()
+///     TimeDelta::seconds(-3600).unwrap()
 /// );
 /// assert_eq!(
 ///     from_hmsm(3, 5, 7, 900) - from_hmsm(2, 4, 6, 800),
-///     TimeDelta::try_seconds(3600 + 60 + 1).unwrap() + TimeDelta::try_milliseconds(100).unwrap()
+///     TimeDelta::seconds(3600 + 60 + 1).unwrap() + TimeDelta::try_milliseconds(100).unwrap()
 /// );
 /// ```
 ///
@@ -1375,13 +1366,13 @@ impl Sub<FixedOffset> for NaiveTime {
 /// ```
 /// # use chrono::{TimeDelta, NaiveTime};
 /// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
-/// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(3, 0, 59, 0), TimeDelta::try_seconds(1).unwrap());
+/// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(3, 0, 59, 0), TimeDelta::seconds(1).unwrap());
 /// assert_eq!(from_hmsm(3, 0, 59, 1_500) - from_hmsm(3, 0, 59, 0),
 ///            TimeDelta::try_milliseconds(1500).unwrap());
-/// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(3, 0, 0, 0), TimeDelta::try_seconds(60).unwrap());
-/// assert_eq!(from_hmsm(3, 0, 0, 0) - from_hmsm(2, 59, 59, 1_000), TimeDelta::try_seconds(1).unwrap());
+/// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(3, 0, 0, 0), TimeDelta::seconds(60).unwrap());
+/// assert_eq!(from_hmsm(3, 0, 0, 0) - from_hmsm(2, 59, 59, 1_000), TimeDelta::seconds(1).unwrap());
 /// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(2, 59, 59, 1_000),
-///            TimeDelta::try_seconds(61).unwrap());
+///            TimeDelta::seconds(61).unwrap());
 /// ```
 impl Sub<NaiveTime> for NaiveTime {
     type Output = TimeDelta;

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -1115,7 +1115,7 @@ impl Timelike for NaiveTime {
 /// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::try_seconds(22*60*60).unwrap(), from_hmsm(1, 5, 7, 0));
 /// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::try_seconds(-8*60*60).unwrap(), from_hmsm(19, 5, 7, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::try_days(800).unwrap(), from_hmsm(3, 5, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) + TimeDelta::days(800).unwrap(), from_hmsm(3, 5, 7, 0));
 /// ```
 ///
 /// Leap seconds are handled, but the addition assumes that it is the only leap second happened.
@@ -1130,7 +1130,7 @@ impl Timelike for NaiveTime {
 /// assert_eq!(leap + TimeDelta::try_milliseconds(800).unwrap(), from_hmsm(3, 6, 0, 100));
 /// assert_eq!(leap + TimeDelta::try_seconds(10).unwrap(), from_hmsm(3, 6, 9, 300));
 /// assert_eq!(leap + TimeDelta::try_seconds(-10).unwrap(), from_hmsm(3, 5, 50, 300));
-/// assert_eq!(leap + TimeDelta::try_days(1).unwrap(), from_hmsm(3, 5, 59, 300));
+/// assert_eq!(leap + TimeDelta::days(1).unwrap(), from_hmsm(3, 5, 59, 300));
 /// ```
 ///
 /// [leap second handling]: crate::NaiveTime#leap-second-handling
@@ -1239,7 +1239,7 @@ impl Add<FixedOffset> for NaiveTime {
 /// # use chrono::{TimeDelta, NaiveTime};
 /// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
 /// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::try_seconds(8*60*60).unwrap(), from_hmsm(19, 5, 7, 0));
-/// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::try_days(800).unwrap(), from_hmsm(3, 5, 7, 0));
+/// assert_eq!(from_hmsm(3, 5, 7, 0) - TimeDelta::days(800).unwrap(), from_hmsm(3, 5, 7, 0));
 /// ```
 ///
 /// Leap seconds are handled, but the subtraction assumes that it is the only leap second happened.
@@ -1252,7 +1252,7 @@ impl Add<FixedOffset> for NaiveTime {
 /// assert_eq!(leap - TimeDelta::try_milliseconds(200).unwrap(), from_hmsm(3, 5, 59, 1_100));
 /// assert_eq!(leap - TimeDelta::try_milliseconds(500).unwrap(), from_hmsm(3, 5, 59, 800));
 /// assert_eq!(leap - TimeDelta::try_seconds(60).unwrap(), from_hmsm(3, 5, 0, 300));
-/// assert_eq!(leap - TimeDelta::try_days(1).unwrap(), from_hmsm(3, 6, 0, 300));
+/// assert_eq!(leap - TimeDelta::days(1).unwrap(), from_hmsm(3, 6, 0, 300));
 /// ```
 ///
 /// [leap second handling]: crate::NaiveTime#leap-second-handling

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -531,15 +531,15 @@ impl NaiveTime {
     /// let from_hms = |h, m, s| NaiveTime::from_hms(h, m, s).unwrap();
     ///
     /// assert_eq!(
-    ///     from_hms(3, 4, 5).overflowing_add_signed(TimeDelta::try_hours(11).unwrap()),
+    ///     from_hms(3, 4, 5).overflowing_add_signed(TimeDelta::hours(11).unwrap()),
     ///     (from_hms(14, 4, 5), 0)
     /// );
     /// assert_eq!(
-    ///     from_hms(3, 4, 5).overflowing_add_signed(TimeDelta::try_hours(23).unwrap()),
+    ///     from_hms(3, 4, 5).overflowing_add_signed(TimeDelta::hours(23).unwrap()),
     ///     (from_hms(2, 4, 5), 86_400)
     /// );
     /// assert_eq!(
-    ///     from_hms(3, 4, 5).overflowing_add_signed(TimeDelta::try_hours(-7).unwrap()),
+    ///     from_hms(3, 4, 5).overflowing_add_signed(TimeDelta::hours(-7).unwrap()),
     ///     (from_hms(20, 4, 5), -86_400)
     /// );
     /// ```
@@ -593,15 +593,15 @@ impl NaiveTime {
     /// let from_hms = |h, m, s| NaiveTime::from_hms(h, m, s).unwrap();
     ///
     /// assert_eq!(
-    ///     from_hms(3, 4, 5).overflowing_sub_signed(TimeDelta::try_hours(2).unwrap()),
+    ///     from_hms(3, 4, 5).overflowing_sub_signed(TimeDelta::hours(2).unwrap()),
     ///     (from_hms(1, 4, 5), 0)
     /// );
     /// assert_eq!(
-    ///     from_hms(3, 4, 5).overflowing_sub_signed(TimeDelta::try_hours(17).unwrap()),
+    ///     from_hms(3, 4, 5).overflowing_sub_signed(TimeDelta::hours(17).unwrap()),
     ///     (from_hms(10, 4, 5), 86_400)
     /// );
     /// assert_eq!(
-    ///     from_hms(3, 4, 5).overflowing_sub_signed(TimeDelta::try_hours(-22).unwrap()),
+    ///     from_hms(3, 4, 5).overflowing_sub_signed(TimeDelta::hours(-22).unwrap()),
     ///     (from_hms(1, 4, 5), -86_400)
     /// );
     /// ```

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -633,11 +633,11 @@ impl NaiveTime {
     /// assert_eq!(since(from_hmsm(3, 5, 7, 900), from_hmsm(3, 5, 7, 900)), TimeDelta::zero());
     /// assert_eq!(
     ///     since(from_hmsm(3, 5, 7, 900), from_hmsm(3, 5, 7, 875)),
-    ///     TimeDelta::try_milliseconds(25).unwrap()
+    ///     TimeDelta::milliseconds(25).unwrap()
     /// );
     /// assert_eq!(
     ///     since(from_hmsm(3, 5, 7, 900), from_hmsm(3, 5, 6, 925)),
-    ///     TimeDelta::try_milliseconds(975).unwrap()
+    ///     TimeDelta::milliseconds(975).unwrap()
     /// );
     /// assert_eq!(
     ///     since(from_hmsm(3, 5, 7, 900), from_hmsm(3, 5, 0, 900)),
@@ -657,7 +657,7 @@ impl NaiveTime {
     /// );
     /// assert_eq!(
     ///     since(from_hmsm(3, 5, 7, 900), from_hmsm(2, 4, 6, 800)),
-    ///     TimeDelta::seconds(3600 + 60 + 1).unwrap() + TimeDelta::try_milliseconds(100).unwrap()
+    ///     TimeDelta::seconds(3600 + 60 + 1).unwrap() + TimeDelta::milliseconds(100).unwrap()
     /// );
     /// ```
     ///
@@ -671,7 +671,7 @@ impl NaiveTime {
     /// assert_eq!(since(from_hmsm(3, 0, 59, 1_000), from_hmsm(3, 0, 59, 0)),
     ///            TimeDelta::seconds(1).unwrap());
     /// assert_eq!(since(from_hmsm(3, 0, 59, 1_500), from_hmsm(3, 0, 59, 0)),
-    ///            TimeDelta::try_milliseconds(1500).unwrap());
+    ///            TimeDelta::milliseconds(1500).unwrap());
     /// assert_eq!(since(from_hmsm(3, 0, 59, 1_000), from_hmsm(3, 0, 0, 0)),
     ///            TimeDelta::seconds(60).unwrap());
     /// assert_eq!(since(from_hmsm(3, 0, 0, 0), from_hmsm(2, 59, 59, 1_000)),
@@ -1092,15 +1092,15 @@ impl Timelike for NaiveTime {
 ///     from_hmsm(9, 59, 7, 0)
 /// );
 /// assert_eq!(
-///     from_hmsm(3, 5, 7, 0) + TimeDelta::try_milliseconds(80).unwrap(),
+///     from_hmsm(3, 5, 7, 0) + TimeDelta::milliseconds(80).unwrap(),
 ///     from_hmsm(3, 5, 7, 80)
 /// );
 /// assert_eq!(
-///     from_hmsm(3, 5, 7, 950) + TimeDelta::try_milliseconds(280).unwrap(),
+///     from_hmsm(3, 5, 7, 950) + TimeDelta::milliseconds(280).unwrap(),
 ///     from_hmsm(3, 5, 8, 230)
 /// );
 /// assert_eq!(
-///     from_hmsm(3, 5, 7, 950) + TimeDelta::try_milliseconds(-980).unwrap(),
+///     from_hmsm(3, 5, 7, 950) + TimeDelta::milliseconds(-980).unwrap(),
 ///     from_hmsm(3, 5, 6, 970)
 /// );
 /// ```
@@ -1122,9 +1122,9 @@ impl Timelike for NaiveTime {
 /// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
 /// let leap = from_hmsm(3, 5, 59, 1_300);
 /// assert_eq!(leap + TimeDelta::zero(), from_hmsm(3, 5, 59, 1_300));
-/// assert_eq!(leap + TimeDelta::try_milliseconds(-500).unwrap(), from_hmsm(3, 5, 59, 800));
-/// assert_eq!(leap + TimeDelta::try_milliseconds(500).unwrap(), from_hmsm(3, 5, 59, 1_800));
-/// assert_eq!(leap + TimeDelta::try_milliseconds(800).unwrap(), from_hmsm(3, 6, 0, 100));
+/// assert_eq!(leap + TimeDelta::milliseconds(-500).unwrap(), from_hmsm(3, 5, 59, 800));
+/// assert_eq!(leap + TimeDelta::milliseconds(500).unwrap(), from_hmsm(3, 5, 59, 1_800));
+/// assert_eq!(leap + TimeDelta::milliseconds(800).unwrap(), from_hmsm(3, 6, 0, 100));
 /// assert_eq!(leap + TimeDelta::seconds(10).unwrap(), from_hmsm(3, 6, 9, 300));
 /// assert_eq!(leap + TimeDelta::seconds(-10).unwrap(), from_hmsm(3, 5, 50, 300));
 /// assert_eq!(leap + TimeDelta::days(1).unwrap(), from_hmsm(3, 5, 59, 300));
@@ -1218,11 +1218,11 @@ impl Add<FixedOffset> for NaiveTime {
 ///     from_hmsm(0, 59, 7, 0)
 /// );
 /// assert_eq!(
-///     from_hmsm(3, 5, 7, 0) - TimeDelta::try_milliseconds(80).unwrap(),
+///     from_hmsm(3, 5, 7, 0) - TimeDelta::milliseconds(80).unwrap(),
 ///     from_hmsm(3, 5, 6, 920)
 /// );
 /// assert_eq!(
-///     from_hmsm(3, 5, 7, 950) - TimeDelta::try_milliseconds(280).unwrap(),
+///     from_hmsm(3, 5, 7, 950) - TimeDelta::milliseconds(280).unwrap(),
 ///     from_hmsm(3, 5, 7, 670)
 /// );
 /// ```
@@ -1243,8 +1243,8 @@ impl Add<FixedOffset> for NaiveTime {
 /// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
 /// let leap = from_hmsm(3, 5, 59, 1_300);
 /// assert_eq!(leap - TimeDelta::zero(), from_hmsm(3, 5, 59, 1_300));
-/// assert_eq!(leap - TimeDelta::try_milliseconds(200).unwrap(), from_hmsm(3, 5, 59, 1_100));
-/// assert_eq!(leap - TimeDelta::try_milliseconds(500).unwrap(), from_hmsm(3, 5, 59, 800));
+/// assert_eq!(leap - TimeDelta::milliseconds(200).unwrap(), from_hmsm(3, 5, 59, 1_100));
+/// assert_eq!(leap - TimeDelta::milliseconds(500).unwrap(), from_hmsm(3, 5, 59, 800));
 /// assert_eq!(leap - TimeDelta::seconds(60).unwrap(), from_hmsm(3, 5, 0, 300));
 /// assert_eq!(leap - TimeDelta::days(1).unwrap(), from_hmsm(3, 6, 0, 300));
 /// ```
@@ -1335,11 +1335,11 @@ impl Sub<FixedOffset> for NaiveTime {
 /// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 7, 900), TimeDelta::zero());
 /// assert_eq!(
 ///     from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 7, 875),
-///     TimeDelta::try_milliseconds(25).unwrap()
+///     TimeDelta::milliseconds(25).unwrap()
 /// );
 /// assert_eq!(
 ///     from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 6, 925),
-///     TimeDelta::try_milliseconds(975).unwrap()
+///     TimeDelta::milliseconds(975).unwrap()
 /// );
 /// assert_eq!(from_hmsm(3, 5, 7, 900) - from_hmsm(3, 5, 0, 900), TimeDelta::seconds(7).unwrap());
 /// assert_eq!(
@@ -1356,7 +1356,7 @@ impl Sub<FixedOffset> for NaiveTime {
 /// );
 /// assert_eq!(
 ///     from_hmsm(3, 5, 7, 900) - from_hmsm(2, 4, 6, 800),
-///     TimeDelta::seconds(3600 + 60 + 1).unwrap() + TimeDelta::try_milliseconds(100).unwrap()
+///     TimeDelta::seconds(3600 + 60 + 1).unwrap() + TimeDelta::milliseconds(100).unwrap()
 /// );
 /// ```
 ///
@@ -1368,7 +1368,7 @@ impl Sub<FixedOffset> for NaiveTime {
 /// # let from_hmsm = |h, m, s, milli| { NaiveTime::from_hms_milli(h, m, s, milli).unwrap() };
 /// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(3, 0, 59, 0), TimeDelta::seconds(1).unwrap());
 /// assert_eq!(from_hmsm(3, 0, 59, 1_500) - from_hmsm(3, 0, 59, 0),
-///            TimeDelta::try_milliseconds(1500).unwrap());
+///            TimeDelta::milliseconds(1500).unwrap());
 /// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(3, 0, 0, 0), TimeDelta::seconds(60).unwrap());
 /// assert_eq!(from_hmsm(3, 0, 0, 0) - from_hmsm(2, 59, 59, 1_000), TimeDelta::seconds(1).unwrap());
 /// assert_eq!(from_hmsm(3, 0, 59, 1_000) - from_hmsm(2, 59, 59, 1_000),

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -105,8 +105,8 @@ fn test_time_add() {
     check!(hmsm(3, 5, 59, 1_300), TimeDelta::try_milliseconds(100).unwrap(), hmsm(3, 5, 59, 1_400));
     check!(hmsm(3, 5, 59, 1_300), TimeDelta::try_milliseconds(800).unwrap(), hmsm(3, 6, 0, 100));
     check!(hmsm(3, 5, 59, 1_300), TimeDelta::try_milliseconds(1800).unwrap(), hmsm(3, 6, 1, 100));
-    check!(hmsm(3, 5, 59, 900), TimeDelta::try_seconds(86399).unwrap(), hmsm(3, 5, 58, 900)); // overwrap
-    check!(hmsm(3, 5, 59, 900), TimeDelta::try_seconds(-86399).unwrap(), hmsm(3, 6, 0, 900));
+    check!(hmsm(3, 5, 59, 900), TimeDelta::seconds(86399).unwrap(), hmsm(3, 5, 58, 900)); // overwrap
+    check!(hmsm(3, 5, 59, 900), TimeDelta::seconds(-86399).unwrap(), hmsm(3, 6, 0, 900));
     check!(hmsm(3, 5, 59, 900), TimeDelta::days(12345).unwrap(), hmsm(3, 5, 59, 900));
     check!(hmsm(3, 5, 59, 1_300), TimeDelta::days(1).unwrap(), hmsm(3, 5, 59, 300));
     check!(hmsm(3, 5, 59, 1_300), TimeDelta::days(-1).unwrap(), hmsm(3, 6, 0, 300));
@@ -178,11 +178,11 @@ fn test_time_sub() {
 
     check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 900), TimeDelta::zero());
     check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 600), TimeDelta::try_milliseconds(300).unwrap());
-    check!(hmsm(3, 5, 7, 200), hmsm(2, 4, 6, 200), TimeDelta::try_seconds(3600 + 60 + 1).unwrap());
+    check!(hmsm(3, 5, 7, 200), hmsm(2, 4, 6, 200), TimeDelta::seconds(3600 + 60 + 1).unwrap());
     check!(
         hmsm(3, 5, 7, 200),
         hmsm(2, 4, 6, 300),
-        TimeDelta::try_seconds(3600 + 60).unwrap() + TimeDelta::try_milliseconds(900).unwrap()
+        TimeDelta::seconds(3600 + 60).unwrap() + TimeDelta::try_milliseconds(900).unwrap()
     );
 
     // treats the leap second as if it coincides with the prior non-leap second,

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -107,9 +107,9 @@ fn test_time_add() {
     check!(hmsm(3, 5, 59, 1_300), TimeDelta::try_milliseconds(1800).unwrap(), hmsm(3, 6, 1, 100));
     check!(hmsm(3, 5, 59, 900), TimeDelta::try_seconds(86399).unwrap(), hmsm(3, 5, 58, 900)); // overwrap
     check!(hmsm(3, 5, 59, 900), TimeDelta::try_seconds(-86399).unwrap(), hmsm(3, 6, 0, 900));
-    check!(hmsm(3, 5, 59, 900), TimeDelta::try_days(12345).unwrap(), hmsm(3, 5, 59, 900));
-    check!(hmsm(3, 5, 59, 1_300), TimeDelta::try_days(1).unwrap(), hmsm(3, 5, 59, 300));
-    check!(hmsm(3, 5, 59, 1_300), TimeDelta::try_days(-1).unwrap(), hmsm(3, 6, 0, 300));
+    check!(hmsm(3, 5, 59, 900), TimeDelta::days(12345).unwrap(), hmsm(3, 5, 59, 900));
+    check!(hmsm(3, 5, 59, 1_300), TimeDelta::days(1).unwrap(), hmsm(3, 5, 59, 300));
+    check!(hmsm(3, 5, 59, 1_300), TimeDelta::days(-1).unwrap(), hmsm(3, 6, 0, 300));
 
     // regression tests for #37
     check!(hmsm(0, 0, 0, 0), TimeDelta::try_milliseconds(-990).unwrap(), hmsm(23, 59, 59, 10));
@@ -135,11 +135,11 @@ fn test_time_overflowing_add() {
 
     // overflowing_add_signed with leap seconds may be counter-intuitive
     assert_eq!(
-        hmsm(3, 4, 59, 1_678).overflowing_add_signed(TimeDelta::try_days(1).unwrap()),
+        hmsm(3, 4, 59, 1_678).overflowing_add_signed(TimeDelta::days(1).unwrap()),
         (hmsm(3, 4, 59, 678), 86_400)
     );
     assert_eq!(
-        hmsm(3, 4, 59, 1_678).overflowing_add_signed(TimeDelta::try_days(-1).unwrap()),
+        hmsm(3, 4, 59, 1_678).overflowing_add_signed(TimeDelta::days(-1).unwrap()),
         (hmsm(3, 5, 0, 678), -86_400)
     );
 }

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -121,15 +121,15 @@ fn test_time_overflowing_add() {
     let hmsm = |h, m, s, ms| NaiveTime::from_hms_milli(h, m, s, ms).unwrap();
 
     assert_eq!(
-        hmsm(3, 4, 5, 678).overflowing_add_signed(TimeDelta::try_hours(11).unwrap()),
+        hmsm(3, 4, 5, 678).overflowing_add_signed(TimeDelta::hours(11).unwrap()),
         (hmsm(14, 4, 5, 678), 0)
     );
     assert_eq!(
-        hmsm(3, 4, 5, 678).overflowing_add_signed(TimeDelta::try_hours(23).unwrap()),
+        hmsm(3, 4, 5, 678).overflowing_add_signed(TimeDelta::hours(23).unwrap()),
         (hmsm(2, 4, 5, 678), 86_400)
     );
     assert_eq!(
-        hmsm(3, 4, 5, 678).overflowing_add_signed(TimeDelta::try_hours(-7).unwrap()),
+        hmsm(3, 4, 5, 678).overflowing_add_signed(TimeDelta::hours(-7).unwrap()),
         (hmsm(20, 4, 5, 678), -86_400)
     );
 
@@ -148,9 +148,9 @@ fn test_time_overflowing_add() {
 fn test_time_addassignment() {
     let hms = |h, m, s| NaiveTime::from_hms(h, m, s).unwrap();
     let mut time = hms(12, 12, 12);
-    time += TimeDelta::try_hours(10).unwrap();
+    time += TimeDelta::hours(10).unwrap();
     assert_eq!(time, hms(22, 12, 12));
-    time += TimeDelta::try_hours(10).unwrap();
+    time += TimeDelta::hours(10).unwrap();
     assert_eq!(time, hms(8, 12, 12));
 }
 
@@ -158,9 +158,9 @@ fn test_time_addassignment() {
 fn test_time_subassignment() {
     let hms = |h, m, s| NaiveTime::from_hms(h, m, s).unwrap();
     let mut time = hms(12, 12, 12);
-    time -= TimeDelta::try_hours(10).unwrap();
+    time -= TimeDelta::hours(10).unwrap();
     assert_eq!(time, hms(2, 12, 12));
-    time -= TimeDelta::try_hours(10).unwrap();
+    time -= TimeDelta::hours(10).unwrap();
     assert_eq!(time, hms(16, 12, 12));
 }
 

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -94,17 +94,13 @@ fn test_time_add() {
     let hmsm = |h, m, s, ms| NaiveTime::from_hms_milli(h, m, s, ms).unwrap();
 
     check!(hmsm(3, 5, 59, 900), TimeDelta::zero(), hmsm(3, 5, 59, 900));
-    check!(hmsm(3, 5, 59, 900), TimeDelta::try_milliseconds(100).unwrap(), hmsm(3, 6, 0, 0));
-    check!(hmsm(3, 5, 59, 1_300), TimeDelta::try_milliseconds(-1800).unwrap(), hmsm(3, 5, 58, 500));
-    check!(hmsm(3, 5, 59, 1_300), TimeDelta::try_milliseconds(-800).unwrap(), hmsm(3, 5, 59, 500));
-    check!(
-        hmsm(3, 5, 59, 1_300),
-        TimeDelta::try_milliseconds(-100).unwrap(),
-        hmsm(3, 5, 59, 1_200)
-    );
-    check!(hmsm(3, 5, 59, 1_300), TimeDelta::try_milliseconds(100).unwrap(), hmsm(3, 5, 59, 1_400));
-    check!(hmsm(3, 5, 59, 1_300), TimeDelta::try_milliseconds(800).unwrap(), hmsm(3, 6, 0, 100));
-    check!(hmsm(3, 5, 59, 1_300), TimeDelta::try_milliseconds(1800).unwrap(), hmsm(3, 6, 1, 100));
+    check!(hmsm(3, 5, 59, 900), TimeDelta::milliseconds(100).unwrap(), hmsm(3, 6, 0, 0));
+    check!(hmsm(3, 5, 59, 1_300), TimeDelta::milliseconds(-1800).unwrap(), hmsm(3, 5, 58, 500));
+    check!(hmsm(3, 5, 59, 1_300), TimeDelta::milliseconds(-800).unwrap(), hmsm(3, 5, 59, 500));
+    check!(hmsm(3, 5, 59, 1_300), TimeDelta::milliseconds(-100).unwrap(), hmsm(3, 5, 59, 1_200));
+    check!(hmsm(3, 5, 59, 1_300), TimeDelta::milliseconds(100).unwrap(), hmsm(3, 5, 59, 1_400));
+    check!(hmsm(3, 5, 59, 1_300), TimeDelta::milliseconds(800).unwrap(), hmsm(3, 6, 0, 100));
+    check!(hmsm(3, 5, 59, 1_300), TimeDelta::milliseconds(1800).unwrap(), hmsm(3, 6, 1, 100));
     check!(hmsm(3, 5, 59, 900), TimeDelta::seconds(86399).unwrap(), hmsm(3, 5, 58, 900)); // overwrap
     check!(hmsm(3, 5, 59, 900), TimeDelta::seconds(-86399).unwrap(), hmsm(3, 6, 0, 900));
     check!(hmsm(3, 5, 59, 900), TimeDelta::days(12345).unwrap(), hmsm(3, 5, 59, 900));
@@ -112,8 +108,8 @@ fn test_time_add() {
     check!(hmsm(3, 5, 59, 1_300), TimeDelta::days(-1).unwrap(), hmsm(3, 6, 0, 300));
 
     // regression tests for #37
-    check!(hmsm(0, 0, 0, 0), TimeDelta::try_milliseconds(-990).unwrap(), hmsm(23, 59, 59, 10));
-    check!(hmsm(0, 0, 0, 0), TimeDelta::try_milliseconds(-9990).unwrap(), hmsm(23, 59, 50, 10));
+    check!(hmsm(0, 0, 0, 0), TimeDelta::milliseconds(-990).unwrap(), hmsm(23, 59, 59, 10));
+    check!(hmsm(0, 0, 0, 0), TimeDelta::milliseconds(-9990).unwrap(), hmsm(23, 59, 50, 10));
 }
 
 #[test]
@@ -177,24 +173,24 @@ fn test_time_sub() {
     let hmsm = |h, m, s, ms| NaiveTime::from_hms_milli(h, m, s, ms).unwrap();
 
     check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 900), TimeDelta::zero());
-    check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 600), TimeDelta::try_milliseconds(300).unwrap());
+    check!(hmsm(3, 5, 7, 900), hmsm(3, 5, 7, 600), TimeDelta::milliseconds(300).unwrap());
     check!(hmsm(3, 5, 7, 200), hmsm(2, 4, 6, 200), TimeDelta::seconds(3600 + 60 + 1).unwrap());
     check!(
         hmsm(3, 5, 7, 200),
         hmsm(2, 4, 6, 300),
-        TimeDelta::seconds(3600 + 60).unwrap() + TimeDelta::try_milliseconds(900).unwrap()
+        TimeDelta::seconds(3600 + 60).unwrap() + TimeDelta::milliseconds(900).unwrap()
     );
 
     // treats the leap second as if it coincides with the prior non-leap second,
     // as required by `time1 - time2 = duration` and `time2 - time1 = -duration` equivalence.
-    check!(hmsm(3, 6, 0, 200), hmsm(3, 5, 59, 1_800), TimeDelta::try_milliseconds(400).unwrap());
-    //check!(hmsm(3, 5, 7, 1_200), hmsm(3, 5, 6, 1_800), TimeDelta::try_milliseconds(1400).unwrap());
-    //check!(hmsm(3, 5, 7, 1_200), hmsm(3, 5, 6, 800), TimeDelta::try_milliseconds(1400).unwrap());
+    check!(hmsm(3, 6, 0, 200), hmsm(3, 5, 59, 1_800), TimeDelta::milliseconds(400).unwrap());
+    //check!(hmsm(3, 5, 7, 1_200), hmsm(3, 5, 6, 1_800), TimeDelta::milliseconds(1400).unwrap());
+    //check!(hmsm(3, 5, 7, 1_200), hmsm(3, 5, 6, 800), TimeDelta::milliseconds(1400).unwrap());
 
     // additional equality: `time1 + duration = time2` is equivalent to
     // `time2 - time1 = duration` IF AND ONLY IF `time2` represents a non-leap second.
-    assert_eq!(hmsm(3, 5, 6, 800) + TimeDelta::try_milliseconds(400).unwrap(), hmsm(3, 5, 7, 200));
-    //assert_eq!(hmsm(3, 5, 6, 1_800) + TimeDelta::try_milliseconds(400).unwrap(), hmsm(3, 5, 7, 200));
+    assert_eq!(hmsm(3, 5, 6, 800) + TimeDelta::milliseconds(400).unwrap(), hmsm(3, 5, 7, 200));
+    //assert_eq!(hmsm(3, 5, 6, 1_800) + TimeDelta::milliseconds(400).unwrap(), hmsm(3, 5, 7, 200));
 }
 
 #[test]

--- a/src/offset/local/windows.rs
+++ b/src/offset/local/windows.rs
@@ -258,7 +258,7 @@ mod tests {
             if let Some(our_result) = Local.from_local_datetime(&date).earliest() {
                 assert_eq!(from_local_time(&date), our_result);
             }
-            date += TimeDelta::try_hours(1).unwrap();
+            date += TimeDelta::hours(1).unwrap();
         }
     }
 }

--- a/src/round.rs
+++ b/src/round.rs
@@ -513,7 +513,7 @@ mod tests {
             "2020-10-28 00:00:00 +01:00"
         );
         assert_eq!(
-            dt.duration_round(TimeDelta::try_weeks(1).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::weeks(1).unwrap()).unwrap().to_string(),
             "2020-10-29 00:00:00 +01:00"
         );
 
@@ -524,7 +524,7 @@ mod tests {
             "2020-10-28 00:00:00 -01:00"
         );
         assert_eq!(
-            dt.duration_round(TimeDelta::try_weeks(1).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::weeks(1).unwrap()).unwrap().to_string(),
             "2020-10-29 00:00:00 -01:00"
         );
     }
@@ -661,7 +661,7 @@ mod tests {
             "2020-10-27 00:00:00 +01:00"
         );
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_weeks(1).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::weeks(1).unwrap()).unwrap().to_string(),
             "2020-10-22 00:00:00 +01:00"
         );
 
@@ -672,7 +672,7 @@ mod tests {
             "2020-10-27 00:00:00 -01:00"
         );
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_weeks(1).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::weeks(1).unwrap()).unwrap().to_string(),
             "2020-10-22 00:00:00 -01:00"
         );
     }

--- a/src/round.rs
+++ b/src/round.rs
@@ -498,7 +498,7 @@ mod tests {
             "2012-12-12 18:30:00 UTC"
         );
         assert_eq!(
-            dt.duration_round(TimeDelta::try_hours(1).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::hours(1).unwrap()).unwrap().to_string(),
             "2012-12-12 18:00:00 UTC"
         );
         assert_eq!(
@@ -583,7 +583,7 @@ mod tests {
             "2012-12-12 18:30:00"
         );
         assert_eq!(
-            dt.duration_round(TimeDelta::try_hours(1).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::hours(1).unwrap()).unwrap().to_string(),
             "2012-12-12 18:00:00"
         );
         assert_eq!(
@@ -646,7 +646,7 @@ mod tests {
             "2012-12-12 18:00:00 UTC"
         );
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_hours(1).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::hours(1).unwrap()).unwrap().to_string(),
             "2012-12-12 18:00:00 UTC"
         );
         assert_eq!(
@@ -725,7 +725,7 @@ mod tests {
             "2012-12-12 18:00:00"
         );
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_hours(1).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::hours(1).unwrap()).unwrap().to_string(),
             "2012-12-12 18:00:00"
         );
         assert_eq!(

--- a/src/round.rs
+++ b/src/round.rs
@@ -475,7 +475,7 @@ mod tests {
             )
             .unwrap();
         assert_eq!(
-            dt.duration_round(TimeDelta::try_minutes(5).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(5).unwrap()).unwrap().to_string(),
             "2012-12-12 18:25:00 UTC"
         );
         // round down
@@ -485,16 +485,16 @@ mod tests {
             )
             .unwrap();
         assert_eq!(
-            dt.duration_round(TimeDelta::try_minutes(5).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(5).unwrap()).unwrap().to_string(),
             "2012-12-12 18:20:00 UTC"
         );
 
         assert_eq!(
-            dt.duration_round(TimeDelta::try_minutes(10).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(10).unwrap()).unwrap().to_string(),
             "2012-12-12 18:20:00 UTC"
         );
         assert_eq!(
-            dt.duration_round(TimeDelta::try_minutes(30).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(30).unwrap()).unwrap().to_string(),
             "2012-12-12 18:30:00 UTC"
         );
         assert_eq!(
@@ -559,7 +559,7 @@ mod tests {
             .unwrap()
             .naive_utc();
         assert_eq!(
-            dt.duration_round(TimeDelta::try_minutes(5).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(5).unwrap()).unwrap().to_string(),
             "2012-12-12 18:25:00"
         );
         // round down
@@ -570,16 +570,16 @@ mod tests {
             .unwrap()
             .naive_utc();
         assert_eq!(
-            dt.duration_round(TimeDelta::try_minutes(5).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(5).unwrap()).unwrap().to_string(),
             "2012-12-12 18:20:00"
         );
 
         assert_eq!(
-            dt.duration_round(TimeDelta::try_minutes(10).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(10).unwrap()).unwrap().to_string(),
             "2012-12-12 18:20:00"
         );
         assert_eq!(
-            dt.duration_round(TimeDelta::try_minutes(30).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(30).unwrap()).unwrap().to_string(),
             "2012-12-12 18:30:00"
         );
         assert_eq!(
@@ -596,7 +596,7 @@ mod tests {
     fn test_duration_round_pre_epoch() {
         let dt = Utc.with_ymd_and_hms(1969, 12, 12, 12, 12, 12).unwrap();
         assert_eq!(
-            dt.duration_round(TimeDelta::try_minutes(10).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::minutes(10).unwrap()).unwrap().to_string(),
             "1969-12-12 12:10:00 UTC"
         );
     }
@@ -624,7 +624,7 @@ mod tests {
             )
             .unwrap();
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_minutes(5).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(5).unwrap()).unwrap().to_string(),
             "2012-12-12 18:20:00 UTC"
         );
         // would round down
@@ -634,15 +634,15 @@ mod tests {
             )
             .unwrap();
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_minutes(5).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(5).unwrap()).unwrap().to_string(),
             "2012-12-12 18:20:00 UTC"
         );
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_minutes(10).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(10).unwrap()).unwrap().to_string(),
             "2012-12-12 18:20:00 UTC"
         );
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_minutes(30).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(30).unwrap()).unwrap().to_string(),
             "2012-12-12 18:00:00 UTC"
         );
         assert_eq!(
@@ -702,7 +702,7 @@ mod tests {
             .unwrap()
             .naive_utc();
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_minutes(5).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(5).unwrap()).unwrap().to_string(),
             "2012-12-12 18:20:00"
         );
         // would round down
@@ -713,15 +713,15 @@ mod tests {
             .unwrap()
             .naive_utc();
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_minutes(5).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(5).unwrap()).unwrap().to_string(),
             "2012-12-12 18:20:00"
         );
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_minutes(10).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(10).unwrap()).unwrap().to_string(),
             "2012-12-12 18:20:00"
         );
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_minutes(30).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(30).unwrap()).unwrap().to_string(),
             "2012-12-12 18:00:00"
         );
         assert_eq!(
@@ -738,7 +738,7 @@ mod tests {
     fn test_duration_trunc_pre_epoch() {
         let dt = Utc.with_ymd_and_hms(1969, 12, 12, 12, 12, 12).unwrap();
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_minutes(10).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::minutes(10).unwrap()).unwrap().to_string(),
             "1969-12-12 12:10:00 UTC"
         );
     }
@@ -760,7 +760,7 @@ mod tests {
 
     #[test]
     fn test_duration_trunc_close_to_epoch() {
-        let span = TimeDelta::try_minutes(15).unwrap();
+        let span = TimeDelta::minutes(15).unwrap();
 
         let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms(0, 0, 15).unwrap();
         assert_eq!(dt.duration_trunc(span).unwrap().to_string(), "1970-01-01 00:00:00");
@@ -771,7 +771,7 @@ mod tests {
 
     #[test]
     fn test_duration_round_close_to_epoch() {
-        let span = TimeDelta::try_minutes(15).unwrap();
+        let span = TimeDelta::minutes(15).unwrap();
 
         let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms(0, 0, 15).unwrap();
         assert_eq!(dt.duration_round(span).unwrap().to_string(), "1970-01-01 00:00:00");

--- a/src/round.rs
+++ b/src/round.rs
@@ -131,7 +131,7 @@ pub trait DurationRound: Sized {
     ///     "2018-01-11 12:00:00.150 UTC"
     /// );
     /// assert_eq!(
-    ///     dt.duration_round(TimeDelta::try_days(1).unwrap()).unwrap().to_string(),
+    ///     dt.duration_round(TimeDelta::days(1).unwrap()).unwrap().to_string(),
     ///     "2018-01-12 00:00:00 UTC"
     /// );
     /// ```
@@ -153,7 +153,7 @@ pub trait DurationRound: Sized {
     ///     "2018-01-11 12:00:00.150 UTC"
     /// );
     /// assert_eq!(
-    ///     dt.duration_trunc(TimeDelta::try_days(1).unwrap()).unwrap().to_string(),
+    ///     dt.duration_trunc(TimeDelta::days(1).unwrap()).unwrap().to_string(),
     ///     "2018-01-11 00:00:00 UTC"
     /// );
     /// ```
@@ -268,7 +268,7 @@ pub enum RoundingError {
     ///     .unwrap();
     ///
     /// assert_eq!(
-    ///     dt.duration_round(TimeDelta::try_days(300 * 365).unwrap()),
+    ///     dt.duration_round(TimeDelta::days(300 * 365).unwrap()),
     ///     Err(RoundingError::DurationExceedsLimit)
     /// );
     /// ```
@@ -281,7 +281,7 @@ pub enum RoundingError {
     /// let dt = Utc.with_ymd_and_hms(2300, 12, 12, 0, 0, 0).unwrap();
     ///
     /// assert_eq!(
-    ///     dt.duration_round(TimeDelta::try_days(1).unwrap()),
+    ///     dt.duration_round(TimeDelta::days(1).unwrap()),
     ///     Err(RoundingError::TimestampExceedsLimit)
     /// );
     /// ```
@@ -502,14 +502,14 @@ mod tests {
             "2012-12-12 18:00:00 UTC"
         );
         assert_eq!(
-            dt.duration_round(TimeDelta::try_days(1).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::days(1).unwrap()).unwrap().to_string(),
             "2012-12-13 00:00:00 UTC"
         );
 
         // timezone east
         let dt = FixedOffset::east(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
         assert_eq!(
-            dt.duration_round(TimeDelta::try_days(1).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::days(1).unwrap()).unwrap().to_string(),
             "2020-10-28 00:00:00 +01:00"
         );
         assert_eq!(
@@ -520,7 +520,7 @@ mod tests {
         // timezone west
         let dt = FixedOffset::west(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
         assert_eq!(
-            dt.duration_round(TimeDelta::try_days(1).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::days(1).unwrap()).unwrap().to_string(),
             "2020-10-28 00:00:00 -01:00"
         );
         assert_eq!(
@@ -587,7 +587,7 @@ mod tests {
             "2012-12-12 18:00:00"
         );
         assert_eq!(
-            dt.duration_round(TimeDelta::try_days(1).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::days(1).unwrap()).unwrap().to_string(),
             "2012-12-13 00:00:00"
         );
     }
@@ -650,14 +650,14 @@ mod tests {
             "2012-12-12 18:00:00 UTC"
         );
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_days(1).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::days(1).unwrap()).unwrap().to_string(),
             "2012-12-12 00:00:00 UTC"
         );
 
         // timezone east
         let dt = FixedOffset::east(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_days(1).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::days(1).unwrap()).unwrap().to_string(),
             "2020-10-27 00:00:00 +01:00"
         );
         assert_eq!(
@@ -668,7 +668,7 @@ mod tests {
         // timezone west
         let dt = FixedOffset::west(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_days(1).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::days(1).unwrap()).unwrap().to_string(),
             "2020-10-27 00:00:00 -01:00"
         );
         assert_eq!(
@@ -729,7 +729,7 @@ mod tests {
             "2012-12-12 18:00:00"
         );
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_days(1).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::days(1).unwrap()).unwrap().to_string(),
             "2012-12-12 00:00:00"
         );
     }

--- a/src/round.rs
+++ b/src/round.rs
@@ -127,7 +127,7 @@ pub trait DurationRound: Sized {
     ///     .and_local_timezone(Utc)
     ///     .unwrap();
     /// assert_eq!(
-    ///     dt.duration_round(TimeDelta::try_milliseconds(10).unwrap()).unwrap().to_string(),
+    ///     dt.duration_round(TimeDelta::milliseconds(10).unwrap()).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
     /// );
     /// assert_eq!(
@@ -149,7 +149,7 @@ pub trait DurationRound: Sized {
     ///     .and_local_timezone(Utc)
     ///     .unwrap();
     /// assert_eq!(
-    ///     dt.duration_trunc(TimeDelta::try_milliseconds(10).unwrap()).unwrap().to_string(),
+    ///     dt.duration_trunc(TimeDelta::milliseconds(10).unwrap()).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
     /// );
     /// assert_eq!(
@@ -464,7 +464,7 @@ mod tests {
         );
 
         assert_eq!(
-            dt.duration_round(TimeDelta::try_milliseconds(10).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::milliseconds(10).unwrap()).unwrap().to_string(),
             "2016-12-31 23:59:59.180 UTC"
         );
 
@@ -547,7 +547,7 @@ mod tests {
         );
 
         assert_eq!(
-            dt.duration_round(TimeDelta::try_milliseconds(10).unwrap()).unwrap().to_string(),
+            dt.duration_round(TimeDelta::milliseconds(10).unwrap()).unwrap().to_string(),
             "2016-12-31 23:59:59.180"
         );
 
@@ -613,7 +613,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_milliseconds(10).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::milliseconds(10).unwrap()).unwrap().to_string(),
             "2016-12-31 23:59:59.170 UTC"
         );
 
@@ -690,7 +690,7 @@ mod tests {
             .naive_utc();
 
         assert_eq!(
-            dt.duration_trunc(TimeDelta::try_milliseconds(10).unwrap()).unwrap().to_string(),
+            dt.duration_trunc(TimeDelta::milliseconds(10).unwrap()).unwrap().to_string(),
             "2016-12-31 23:59:59.170"
         );
 

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -126,7 +126,7 @@ impl TimeDelta {
     ///
     /// Returns `None` when the `TimeDelta` would be out of bounds.
     #[inline]
-    pub const fn try_hours(hours: i64) -> Option<TimeDelta> {
+    pub const fn hours(hours: i64) -> Option<TimeDelta> {
         TimeDelta::try_seconds(try_opt!(hours.checked_mul(SECS_PER_HOUR)))
     }
 
@@ -1131,7 +1131,7 @@ mod tests {
     fn test_duration_const() {
         const ONE_WEEK: TimeDelta = expect!(TimeDelta::weeks(1), "");
         const ONE_DAY: TimeDelta = expect!(TimeDelta::days(1), "");
-        const ONE_HOUR: TimeDelta = expect!(TimeDelta::try_hours(1), "");
+        const ONE_HOUR: TimeDelta = expect!(TimeDelta::hours(1), "");
         const ONE_MINUTE: TimeDelta = expect!(TimeDelta::try_minutes(1), "");
         const ONE_SECOND: TimeDelta = expect!(TimeDelta::try_seconds(1), "");
         const ONE_MILLI: TimeDelta = expect!(TimeDelta::try_milliseconds(1), "");

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -16,7 +16,7 @@ use core::{fmt, i64};
 #[cfg(feature = "std")]
 use std::error::Error;
 
-use crate::{expect, try_opt};
+use crate::try_opt;
 
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
@@ -94,21 +94,6 @@ impl TimeDelta {
 
     /// Makes a new `TimeDelta` with the given number of weeks.
     ///
-    /// Equivalent to `TimeDelta::seconds(weeks * 7 * 24 * 60 * 60)` with
-    /// overflow checks.
-    ///
-    /// # Panics
-    ///
-    /// Panics when the duration is out of bounds.
-    #[inline]
-    #[must_use]
-    #[deprecated(since = "0.4.35", note = "Use `TimeDelta::try_weeks` instead")]
-    pub const fn weeks(weeks: i64) -> TimeDelta {
-        expect!(TimeDelta::try_weeks(weeks), "TimeDelta::weeks out of bounds")
-    }
-
-    /// Makes a new `TimeDelta` with the given number of weeks.
-    ///
     /// Equivalent to `TimeDelta::try_seconds(weeks * 7 * 24 * 60 * 60)` with
     /// overflow checks.
     ///
@@ -118,21 +103,6 @@ impl TimeDelta {
     #[inline]
     pub const fn try_weeks(weeks: i64) -> Option<TimeDelta> {
         TimeDelta::try_seconds(try_opt!(weeks.checked_mul(SECS_PER_WEEK)))
-    }
-
-    /// Makes a new `TimeDelta` with the given number of days.
-    ///
-    /// Equivalent to `TimeDelta::seconds(days * 24 * 60 * 60)` with overflow
-    /// checks.
-    ///
-    /// # Panics
-    ///
-    /// Panics when the `TimeDelta` would be out of bounds.
-    #[inline]
-    #[must_use]
-    #[deprecated(since = "0.4.35", note = "Use `TimeDelta::try_days` instead")]
-    pub const fn days(days: i64) -> TimeDelta {
-        expect!(TimeDelta::try_days(days), "TimeDelta::days out of bounds")
     }
 
     /// Makes a new `TimeDelta` with the given number of days.
@@ -150,20 +120,6 @@ impl TimeDelta {
 
     /// Makes a new `TimeDelta` with the given number of hours.
     ///
-    /// Equivalent to `TimeDelta::seconds(hours * 60 * 60)` with overflow checks.
-    ///
-    /// # Panics
-    ///
-    /// Panics when the `TimeDelta` would be out of bounds.
-    #[inline]
-    #[must_use]
-    #[deprecated(since = "0.4.35", note = "Use `TimeDelta::try_hours` instead")]
-    pub const fn hours(hours: i64) -> TimeDelta {
-        expect!(TimeDelta::try_hours(hours), "TimeDelta::hours out of bounds")
-    }
-
-    /// Makes a new `TimeDelta` with the given number of hours.
-    ///
     /// Equivalent to `TimeDelta::try_seconds(hours * 60 * 60)` with overflow checks.
     ///
     /// # Errors
@@ -172,20 +128,6 @@ impl TimeDelta {
     #[inline]
     pub const fn try_hours(hours: i64) -> Option<TimeDelta> {
         TimeDelta::try_seconds(try_opt!(hours.checked_mul(SECS_PER_HOUR)))
-    }
-
-    /// Makes a new `TimeDelta` with the given number of minutes.
-    ///
-    /// Equivalent to `TimeDelta::seconds(minutes * 60)` with overflow checks.
-    ///
-    /// # Panics
-    ///
-    /// Panics when the `TimeDelta` would be out of bounds.
-    #[inline]
-    #[must_use]
-    #[deprecated(since = "0.4.35", note = "Use `TimeDelta::try_minutes` instead")]
-    pub const fn minutes(minutes: i64) -> TimeDelta {
-        expect!(TimeDelta::try_minutes(minutes), "TimeDelta::minutes out of bounds")
     }
 
     /// Makes a new `TimeDelta` with the given number of minutes.
@@ -202,19 +144,6 @@ impl TimeDelta {
 
     /// Makes a new `TimeDelta` with the given number of seconds.
     ///
-    /// # Panics
-    ///
-    /// Panics when `seconds` is more than `i64::MAX / 1_000` or less than `-i64::MAX / 1_000`
-    /// (in this context, this is the same as `i64::MIN / 1_000` due to rounding).
-    #[inline]
-    #[must_use]
-    #[deprecated(since = "0.4.35", note = "Use `TimeDelta::try_seconds` instead")]
-    pub const fn seconds(seconds: i64) -> TimeDelta {
-        expect!(TimeDelta::try_seconds(seconds), "TimeDelta::seconds out of bounds")
-    }
-
-    /// Makes a new `TimeDelta` with the given number of seconds.
-    ///
     /// # Errors
     ///
     /// Returns `None` when `seconds` is more than `i64::MAX / 1_000` or less than
@@ -223,18 +152,6 @@ impl TimeDelta {
     #[inline]
     pub const fn try_seconds(seconds: i64) -> Option<TimeDelta> {
         TimeDelta::new(seconds, 0)
-    }
-
-    /// Makes a new `TimeDelta` with the given number of milliseconds.
-    ///
-    /// # Panics
-    ///
-    /// Panics when the `TimeDelta` would be out of bounds, i.e. when `milliseconds` is more than
-    /// `i64::MAX` or less than `-i64::MAX`. Notably, this is not the same as `i64::MIN`.
-    #[inline]
-    #[deprecated(since = "0.4.35", note = "Use `TimeDelta::try_milliseconds` instead")]
-    pub const fn milliseconds(milliseconds: i64) -> TimeDelta {
-        expect!(TimeDelta::try_milliseconds(milliseconds), "TimeDelta::milliseconds out of bounds")
     }
 
     /// Makes a new `TimeDelta` with the given number of milliseconds.
@@ -688,13 +605,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
-    #[should_panic(expected = "TimeDelta::seconds out of bounds")]
-    fn test_duration_seconds_max_overflow_panic() {
-        let _ = TimeDelta::seconds(i64::MAX / 1_000 + 1);
-    }
-
-    #[test]
     fn test_duration_seconds_min_allowed() {
         let duration = TimeDelta::try_seconds(i64::MIN / 1_000).unwrap(); // Same as -i64::MAX / 1_000 due to rounding
         assert_eq!(duration.num_seconds(), i64::MIN / 1_000); // Same as -i64::MAX / 1_000 due to rounding
@@ -707,13 +617,6 @@ mod tests {
     #[test]
     fn test_duration_seconds_min_underflow() {
         assert!(TimeDelta::try_seconds(-i64::MAX / 1_000 - 1).is_none());
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    #[should_panic(expected = "TimeDelta::seconds out of bounds")]
-    fn test_duration_seconds_min_underflow_panic() {
-        let _ = TimeDelta::seconds(-i64::MAX / 1_000 - 1);
     }
 
     #[test]
@@ -770,17 +673,6 @@ mod tests {
             .unwrap()
             .checked_sub(&TimeDelta::try_milliseconds(1).unwrap())
             .is_none());
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    #[should_panic(expected = "TimeDelta::milliseconds out of bounds")]
-    fn test_duration_milliseconds_min_underflow_panic() {
-        // Here we ensure that trying to create a value one millisecond below the
-        // minimum storable value will fail. This test is necessary because the
-        // storable range is -i64::MAX, but the constructor type of i64 will allow
-        // i64::MIN, which is one value below.
-        let _ = TimeDelta::milliseconds(i64::MIN); // Same as -i64::MAX - 1
     }
 
     #[test]

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -94,7 +94,7 @@ impl TimeDelta {
 
     /// Makes a new `TimeDelta` with the given number of weeks.
     ///
-    /// Equivalent to `TimeDelta::try_seconds(weeks * 7 * 24 * 60 * 60)` with
+    /// Equivalent to `TimeDelta::seconds(weeks * 7 * 24 * 60 * 60)` with
     /// overflow checks.
     ///
     /// # Errors
@@ -102,12 +102,12 @@ impl TimeDelta {
     /// Returns `None` when the `TimeDelta` would be out of bounds.
     #[inline]
     pub const fn weeks(weeks: i64) -> Option<TimeDelta> {
-        TimeDelta::try_seconds(try_opt!(weeks.checked_mul(SECS_PER_WEEK)))
+        TimeDelta::seconds(try_opt!(weeks.checked_mul(SECS_PER_WEEK)))
     }
 
     /// Makes a new `TimeDelta` with the given number of days.
     ///
-    /// Equivalent to `TimeDelta::try_seconds(days * 24 * 60 * 60)` with overflow
+    /// Equivalent to `TimeDelta::seconds(days * 24 * 60 * 60)` with overflow
     /// checks.
     ///
     /// # Errors
@@ -115,31 +115,31 @@ impl TimeDelta {
     /// Returns `None` when the `TimeDelta` would be out of bounds.
     #[inline]
     pub const fn days(days: i64) -> Option<TimeDelta> {
-        TimeDelta::try_seconds(try_opt!(days.checked_mul(SECS_PER_DAY)))
+        TimeDelta::seconds(try_opt!(days.checked_mul(SECS_PER_DAY)))
     }
 
     /// Makes a new `TimeDelta` with the given number of hours.
     ///
-    /// Equivalent to `TimeDelta::try_seconds(hours * 60 * 60)` with overflow checks.
+    /// Equivalent to `TimeDelta::seconds(hours * 60 * 60)` with overflow checks.
     ///
     /// # Errors
     ///
     /// Returns `None` when the `TimeDelta` would be out of bounds.
     #[inline]
     pub const fn hours(hours: i64) -> Option<TimeDelta> {
-        TimeDelta::try_seconds(try_opt!(hours.checked_mul(SECS_PER_HOUR)))
+        TimeDelta::seconds(try_opt!(hours.checked_mul(SECS_PER_HOUR)))
     }
 
     /// Makes a new `TimeDelta` with the given number of minutes.
     ///
-    /// Equivalent to `TimeDelta::try_seconds(minutes * 60)` with overflow checks.
+    /// Equivalent to `TimeDelta::seconds(minutes * 60)` with overflow checks.
     ///
     /// # Errors
     ///
     /// Returns `None` when the `TimeDelta` would be out of bounds.
     #[inline]
     pub const fn minutes(minutes: i64) -> Option<TimeDelta> {
-        TimeDelta::try_seconds(try_opt!(minutes.checked_mul(SECS_PER_MINUTE)))
+        TimeDelta::seconds(try_opt!(minutes.checked_mul(SECS_PER_MINUTE)))
     }
 
     /// Makes a new `TimeDelta` with the given number of seconds.
@@ -150,7 +150,7 @@ impl TimeDelta {
     /// `-i64::MAX / 1_000` (in this context, this is the same as `i64::MIN / 1_000` due to
     /// rounding).
     #[inline]
-    pub const fn try_seconds(seconds: i64) -> Option<TimeDelta> {
+    pub const fn seconds(seconds: i64) -> Option<TimeDelta> {
         TimeDelta::new(seconds, 0)
     }
 
@@ -545,7 +545,7 @@ mod tests {
     #[test]
     fn test_duration() {
         let days = |d| TimeDelta::days(d).unwrap();
-        let seconds = |s| TimeDelta::try_seconds(s).unwrap();
+        let seconds = |s| TimeDelta::seconds(s).unwrap();
 
         assert!(seconds(1) != TimeDelta::zero());
         assert_eq!(seconds(1) + seconds(2), seconds(3));
@@ -570,10 +570,10 @@ mod tests {
         assert_eq!(TimeDelta::zero().num_days(), 0);
         assert_eq!(TimeDelta::days(1).unwrap().num_days(), 1);
         assert_eq!(TimeDelta::days(-1).unwrap().num_days(), -1);
-        assert_eq!(TimeDelta::try_seconds(86_399).unwrap().num_days(), 0);
-        assert_eq!(TimeDelta::try_seconds(86_401).unwrap().num_days(), 1);
-        assert_eq!(TimeDelta::try_seconds(-86_399).unwrap().num_days(), 0);
-        assert_eq!(TimeDelta::try_seconds(-86_401).unwrap().num_days(), -1);
+        assert_eq!(TimeDelta::seconds(86_399).unwrap().num_days(), 0);
+        assert_eq!(TimeDelta::seconds(86_401).unwrap().num_days(), 1);
+        assert_eq!(TimeDelta::seconds(-86_399).unwrap().num_days(), 0);
+        assert_eq!(TimeDelta::seconds(-86_401).unwrap().num_days(), -1);
         assert_eq!(TimeDelta::days(i32::MAX as i64).unwrap().num_days(), i32::MAX as i64);
         assert_eq!(TimeDelta::days(i32::MIN as i64).unwrap().num_days(), i32::MIN as i64);
     }
@@ -581,8 +581,8 @@ mod tests {
     #[test]
     fn test_duration_num_seconds() {
         assert_eq!(TimeDelta::zero().num_seconds(), 0);
-        assert_eq!(TimeDelta::try_seconds(1).unwrap().num_seconds(), 1);
-        assert_eq!(TimeDelta::try_seconds(-1).unwrap().num_seconds(), -1);
+        assert_eq!(TimeDelta::seconds(1).unwrap().num_seconds(), 1);
+        assert_eq!(TimeDelta::seconds(-1).unwrap().num_seconds(), -1);
         assert_eq!(TimeDelta::try_milliseconds(999).unwrap().num_seconds(), 0);
         assert_eq!(TimeDelta::try_milliseconds(1001).unwrap().num_seconds(), 1);
         assert_eq!(TimeDelta::try_milliseconds(-999).unwrap().num_seconds(), 0);
@@ -591,7 +591,7 @@ mod tests {
 
     #[test]
     fn test_duration_seconds_max_allowed() {
-        let duration = TimeDelta::try_seconds(i64::MAX / 1_000).unwrap();
+        let duration = TimeDelta::seconds(i64::MAX / 1_000).unwrap();
         assert_eq!(duration.num_seconds(), i64::MAX / 1_000);
         assert_eq!(
             duration.secs as i128 * 1_000_000_000 + duration.nanos as i128,
@@ -601,12 +601,12 @@ mod tests {
 
     #[test]
     fn test_duration_seconds_max_overflow() {
-        assert!(TimeDelta::try_seconds(i64::MAX / 1_000 + 1).is_none());
+        assert!(TimeDelta::seconds(i64::MAX / 1_000 + 1).is_none());
     }
 
     #[test]
     fn test_duration_seconds_min_allowed() {
-        let duration = TimeDelta::try_seconds(i64::MIN / 1_000).unwrap(); // Same as -i64::MAX / 1_000 due to rounding
+        let duration = TimeDelta::seconds(i64::MIN / 1_000).unwrap(); // Same as -i64::MAX / 1_000 due to rounding
         assert_eq!(duration.num_seconds(), i64::MIN / 1_000); // Same as -i64::MAX / 1_000 due to rounding
         assert_eq!(
             duration.secs as i128 * 1_000_000_000 + duration.nanos as i128,
@@ -616,7 +616,7 @@ mod tests {
 
     #[test]
     fn test_duration_seconds_min_underflow() {
-        assert!(TimeDelta::try_seconds(-i64::MAX / 1_000 - 1).is_none());
+        assert!(TimeDelta::seconds(-i64::MAX / 1_000 - 1).is_none());
     }
 
     #[test]
@@ -976,29 +976,29 @@ mod tests {
         assert_eq!(TimeDelta::zero() * i32::MIN, TimeDelta::zero());
         assert_eq!(TimeDelta::nanoseconds(1) * 0, TimeDelta::zero());
         assert_eq!(TimeDelta::nanoseconds(1) * 1, TimeDelta::nanoseconds(1));
-        assert_eq!(TimeDelta::nanoseconds(1) * 1_000_000_000, TimeDelta::try_seconds(1).unwrap());
-        assert_eq!(TimeDelta::nanoseconds(1) * -1_000_000_000, -TimeDelta::try_seconds(1).unwrap());
-        assert_eq!(-TimeDelta::nanoseconds(1) * 1_000_000_000, -TimeDelta::try_seconds(1).unwrap());
+        assert_eq!(TimeDelta::nanoseconds(1) * 1_000_000_000, TimeDelta::seconds(1).unwrap());
+        assert_eq!(TimeDelta::nanoseconds(1) * -1_000_000_000, -TimeDelta::seconds(1).unwrap());
+        assert_eq!(-TimeDelta::nanoseconds(1) * 1_000_000_000, -TimeDelta::seconds(1).unwrap());
         assert_eq!(
             TimeDelta::nanoseconds(30) * 333_333_333,
-            TimeDelta::try_seconds(10).unwrap() - TimeDelta::nanoseconds(10)
+            TimeDelta::seconds(10).unwrap() - TimeDelta::nanoseconds(10)
         );
         assert_eq!(
             (TimeDelta::nanoseconds(1)
-                + TimeDelta::try_seconds(1).unwrap()
+                + TimeDelta::seconds(1).unwrap()
                 + TimeDelta::days(1).unwrap())
                 * 3,
             TimeDelta::nanoseconds(3)
-                + TimeDelta::try_seconds(3).unwrap()
+                + TimeDelta::seconds(3).unwrap()
                 + TimeDelta::days(3).unwrap()
         );
         assert_eq!(
             TimeDelta::try_milliseconds(1500).unwrap() * -2,
-            TimeDelta::try_seconds(-3).unwrap()
+            TimeDelta::seconds(-3).unwrap()
         );
         assert_eq!(
             TimeDelta::try_milliseconds(-1500).unwrap() * 2,
-            TimeDelta::try_seconds(-3).unwrap()
+            TimeDelta::seconds(-3).unwrap()
         );
     }
 
@@ -1010,47 +1010,38 @@ mod tests {
         assert_eq!(TimeDelta::nanoseconds(123_456_789) / -1, -TimeDelta::nanoseconds(123_456_789));
         assert_eq!(-TimeDelta::nanoseconds(123_456_789) / -1, TimeDelta::nanoseconds(123_456_789));
         assert_eq!(-TimeDelta::nanoseconds(123_456_789) / 1, -TimeDelta::nanoseconds(123_456_789));
-        assert_eq!(TimeDelta::try_seconds(1).unwrap() / 3, TimeDelta::nanoseconds(333_333_333));
-        assert_eq!(TimeDelta::try_seconds(4).unwrap() / 3, TimeDelta::nanoseconds(1_333_333_333));
-        assert_eq!(
-            TimeDelta::try_seconds(-1).unwrap() / 2,
-            TimeDelta::try_milliseconds(-500).unwrap()
-        );
-        assert_eq!(
-            TimeDelta::try_seconds(1).unwrap() / -2,
-            TimeDelta::try_milliseconds(-500).unwrap()
-        );
-        assert_eq!(
-            TimeDelta::try_seconds(-1).unwrap() / -2,
-            TimeDelta::try_milliseconds(500).unwrap()
-        );
-        assert_eq!(TimeDelta::try_seconds(-4).unwrap() / 3, TimeDelta::nanoseconds(-1_333_333_333));
-        assert_eq!(TimeDelta::try_seconds(-4).unwrap() / -3, TimeDelta::nanoseconds(1_333_333_333));
+        assert_eq!(TimeDelta::seconds(1).unwrap() / 3, TimeDelta::nanoseconds(333_333_333));
+        assert_eq!(TimeDelta::seconds(4).unwrap() / 3, TimeDelta::nanoseconds(1_333_333_333));
+        assert_eq!(TimeDelta::seconds(-1).unwrap() / 2, TimeDelta::try_milliseconds(-500).unwrap());
+        assert_eq!(TimeDelta::seconds(1).unwrap() / -2, TimeDelta::try_milliseconds(-500).unwrap());
+        assert_eq!(TimeDelta::seconds(-1).unwrap() / -2, TimeDelta::try_milliseconds(500).unwrap());
+        assert_eq!(TimeDelta::seconds(-4).unwrap() / 3, TimeDelta::nanoseconds(-1_333_333_333));
+        assert_eq!(TimeDelta::seconds(-4).unwrap() / -3, TimeDelta::nanoseconds(1_333_333_333));
     }
 
     #[test]
     fn test_duration_sum() {
-        let duration_list_1 = [TimeDelta::zero(), TimeDelta::try_seconds(1).unwrap()];
+        let duration_list_1 = [TimeDelta::zero(), TimeDelta::seconds(1).unwrap()];
         let sum_1: TimeDelta = duration_list_1.iter().sum();
-        assert_eq!(sum_1, TimeDelta::try_seconds(1).unwrap());
+        assert_eq!(sum_1, TimeDelta::seconds(1).unwrap());
 
         let duration_list_2 = [
             TimeDelta::zero(),
-            TimeDelta::try_seconds(1).unwrap(),
-            TimeDelta::try_seconds(6).unwrap(),
-            TimeDelta::try_seconds(10).unwrap(),
+            TimeDelta::seconds(1).unwrap(),
+            TimeDelta::seconds(6).unwrap(),
+            TimeDelta::seconds(10).unwrap(),
         ];
         let sum_2: TimeDelta = duration_list_2.iter().sum();
-        assert_eq!(sum_2, TimeDelta::try_seconds(17).unwrap());
+        assert_eq!(sum_2, TimeDelta::seconds(17).unwrap());
 
         let duration_arr = [
             TimeDelta::zero(),
-            TimeDelta::try_seconds(1).unwrap(),
-            TimeDelta::try_seconds(6).unwrap(),
-            TimeDelta::try_seconds(10).unwrap(),
+            TimeDelta::seconds(1).unwrap(),
+            TimeDelta::seconds(6).unwrap(),
+            TimeDelta::seconds(10).unwrap(),
         ];
         let sum_3: TimeDelta = duration_arr.into_iter().sum();
-        assert_eq!(sum_3, TimeDelta::try_seconds(17).unwrap());
+        assert_eq!(sum_3, TimeDelta::seconds(17).unwrap());
     }
 
     #[test]
@@ -1058,7 +1049,7 @@ mod tests {
         assert_eq!(TimeDelta::zero().to_string(), "P0D");
         assert_eq!(TimeDelta::days(42).unwrap().to_string(), "PT3628800S");
         assert_eq!(TimeDelta::days(-42).unwrap().to_string(), "-PT3628800S");
-        assert_eq!(TimeDelta::try_seconds(42).unwrap().to_string(), "PT42S");
+        assert_eq!(TimeDelta::seconds(42).unwrap().to_string(), "PT42S");
         assert_eq!(TimeDelta::try_milliseconds(42).unwrap().to_string(), "PT0.042S");
         assert_eq!(TimeDelta::microseconds(42).to_string(), "PT0.000042S");
         assert_eq!(TimeDelta::nanoseconds(42).to_string(), "PT0.000000042S");
@@ -1066,7 +1057,7 @@ mod tests {
             (TimeDelta::days(7).unwrap() + TimeDelta::try_milliseconds(6543).unwrap()).to_string(),
             "PT604806.543S"
         );
-        assert_eq!(TimeDelta::try_seconds(-86_401).unwrap().to_string(), "-PT86401S");
+        assert_eq!(TimeDelta::seconds(-86_401).unwrap().to_string(), "-PT86401S");
         assert_eq!(TimeDelta::nanoseconds(-1).to_string(), "-PT0.000000001S");
 
         // the format specifier should have no effect on `TimeDelta`
@@ -1081,8 +1072,8 @@ mod tests {
 
     #[test]
     fn test_to_std() {
-        assert_eq!(TimeDelta::try_seconds(1).unwrap().to_std(), Ok(Duration::new(1, 0)));
-        assert_eq!(TimeDelta::try_seconds(86_401).unwrap().to_std(), Ok(Duration::new(86_401, 0)));
+        assert_eq!(TimeDelta::seconds(1).unwrap().to_std(), Ok(Duration::new(1, 0)));
+        assert_eq!(TimeDelta::seconds(86_401).unwrap().to_std(), Ok(Duration::new(86_401, 0)));
         assert_eq!(
             TimeDelta::try_milliseconds(123).unwrap().to_std(),
             Ok(Duration::new(0, 123_000_000))
@@ -1093,18 +1084,15 @@ mod tests {
         );
         assert_eq!(TimeDelta::nanoseconds(777).to_std(), Ok(Duration::new(0, 777)));
         assert_eq!(MAX.to_std(), Ok(Duration::new(9_223_372_036_854_775, 807_000_000)));
-        assert_eq!(TimeDelta::try_seconds(-1).unwrap().to_std(), Err(OutOfRangeError(())));
+        assert_eq!(TimeDelta::seconds(-1).unwrap().to_std(), Err(OutOfRangeError(())));
         assert_eq!(TimeDelta::try_milliseconds(-1).unwrap().to_std(), Err(OutOfRangeError(())));
     }
 
     #[test]
     fn test_from_std() {
+        assert_eq!(Ok(TimeDelta::seconds(1).unwrap()), TimeDelta::from_std(Duration::new(1, 0)));
         assert_eq!(
-            Ok(TimeDelta::try_seconds(1).unwrap()),
-            TimeDelta::from_std(Duration::new(1, 0))
-        );
-        assert_eq!(
-            Ok(TimeDelta::try_seconds(86_401).unwrap()),
+            Ok(TimeDelta::seconds(86_401).unwrap()),
             TimeDelta::from_std(Duration::new(86_401, 0))
         );
         assert_eq!(
@@ -1133,7 +1121,7 @@ mod tests {
         const ONE_DAY: TimeDelta = expect!(TimeDelta::days(1), "");
         const ONE_HOUR: TimeDelta = expect!(TimeDelta::hours(1), "");
         const ONE_MINUTE: TimeDelta = expect!(TimeDelta::minutes(1), "");
-        const ONE_SECOND: TimeDelta = expect!(TimeDelta::try_seconds(1), "");
+        const ONE_SECOND: TimeDelta = expect!(TimeDelta::seconds(1), "");
         const ONE_MILLI: TimeDelta = expect!(TimeDelta::try_milliseconds(1), "");
         const ONE_MICRO: TimeDelta = TimeDelta::microseconds(1);
         const ONE_NANO: TimeDelta = TimeDelta::nanoseconds(1);
@@ -1156,7 +1144,7 @@ mod tests {
         assert!(ONE_NANO != TimeDelta::zero());
         assert_eq!(
             combo,
-            TimeDelta::try_seconds(86400 * 7 + 86400 + 3600 + 60 + 1).unwrap()
+            TimeDelta::seconds(86400 * 7 + 86400 + 3600 + 60 + 1).unwrap()
                 + TimeDelta::nanoseconds(1 + 1_000 + 1_000_000)
         );
     }
@@ -1164,7 +1152,7 @@ mod tests {
     #[test]
     #[cfg(feature = "rkyv-validation")]
     fn test_rkyv_validation() {
-        let duration = TimeDelta::try_seconds(1).unwrap();
+        let duration = TimeDelta::seconds(1).unwrap();
         let bytes = rkyv::to_bytes::<_, 16>(&duration).unwrap();
         assert_eq!(rkyv::from_bytes::<TimeDelta>(&bytes).unwrap(), duration);
     }

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -26,7 +26,7 @@ const NANOS_PER_MICRO: i32 = 1000;
 /// The number of nanoseconds in a millisecond.
 const NANOS_PER_MILLI: i32 = 1_000_000;
 /// The number of nanoseconds in seconds.
-pub(crate) const NANOS_PER_SEC: i32 = 1_000_000_000;
+const NANOS_PER_SEC: i32 = 1_000_000_000;
 /// The number of microseconds per second.
 const MICROS_PER_SEC: i64 = 1_000_000;
 /// The number of milliseconds per second.

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -101,7 +101,7 @@ impl TimeDelta {
     ///
     /// Returns `None` when the `TimeDelta` would be out of bounds.
     #[inline]
-    pub const fn try_weeks(weeks: i64) -> Option<TimeDelta> {
+    pub const fn weeks(weeks: i64) -> Option<TimeDelta> {
         TimeDelta::try_seconds(try_opt!(weeks.checked_mul(SECS_PER_WEEK)))
     }
 
@@ -1136,7 +1136,7 @@ mod tests {
 
     #[test]
     fn test_duration_const() {
-        const ONE_WEEK: TimeDelta = expect!(TimeDelta::try_weeks(1), "");
+        const ONE_WEEK: TimeDelta = expect!(TimeDelta::weeks(1), "");
         const ONE_DAY: TimeDelta = expect!(TimeDelta::try_days(1), "");
         const ONE_HOUR: TimeDelta = expect!(TimeDelta::try_hours(1), "");
         const ONE_MINUTE: TimeDelta = expect!(TimeDelta::try_minutes(1), "");

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -138,7 +138,7 @@ impl TimeDelta {
     ///
     /// Returns `None` when the `TimeDelta` would be out of bounds.
     #[inline]
-    pub const fn try_minutes(minutes: i64) -> Option<TimeDelta> {
+    pub const fn minutes(minutes: i64) -> Option<TimeDelta> {
         TimeDelta::try_seconds(try_opt!(minutes.checked_mul(SECS_PER_MINUTE)))
     }
 
@@ -560,7 +560,7 @@ mod tests {
         assert_eq!(-(days(3) + seconds(70)), days(-4) + seconds(86_400 - 70));
 
         let mut d = TimeDelta::default();
-        d += TimeDelta::try_minutes(1).unwrap();
+        d += TimeDelta::minutes(1).unwrap();
         d -= seconds(30);
         assert_eq!(d, seconds(30));
     }
@@ -1132,7 +1132,7 @@ mod tests {
         const ONE_WEEK: TimeDelta = expect!(TimeDelta::weeks(1), "");
         const ONE_DAY: TimeDelta = expect!(TimeDelta::days(1), "");
         const ONE_HOUR: TimeDelta = expect!(TimeDelta::hours(1), "");
-        const ONE_MINUTE: TimeDelta = expect!(TimeDelta::try_minutes(1), "");
+        const ONE_MINUTE: TimeDelta = expect!(TimeDelta::minutes(1), "");
         const ONE_SECOND: TimeDelta = expect!(TimeDelta::try_seconds(1), "");
         const ONE_MILLI: TimeDelta = expect!(TimeDelta::try_milliseconds(1), "");
         const ONE_MICRO: TimeDelta = TimeDelta::microseconds(1);

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -114,7 +114,7 @@ impl TimeDelta {
     ///
     /// Returns `None` when the `TimeDelta` would be out of bounds.
     #[inline]
-    pub const fn try_days(days: i64) -> Option<TimeDelta> {
+    pub const fn days(days: i64) -> Option<TimeDelta> {
         TimeDelta::try_seconds(try_opt!(days.checked_mul(SECS_PER_DAY)))
     }
 
@@ -544,7 +544,7 @@ mod tests {
 
     #[test]
     fn test_duration() {
-        let days = |d| TimeDelta::try_days(d).unwrap();
+        let days = |d| TimeDelta::days(d).unwrap();
         let seconds = |s| TimeDelta::try_seconds(s).unwrap();
 
         assert!(seconds(1) != TimeDelta::zero());
@@ -568,14 +568,14 @@ mod tests {
     #[test]
     fn test_duration_num_days() {
         assert_eq!(TimeDelta::zero().num_days(), 0);
-        assert_eq!(TimeDelta::try_days(1).unwrap().num_days(), 1);
-        assert_eq!(TimeDelta::try_days(-1).unwrap().num_days(), -1);
+        assert_eq!(TimeDelta::days(1).unwrap().num_days(), 1);
+        assert_eq!(TimeDelta::days(-1).unwrap().num_days(), -1);
         assert_eq!(TimeDelta::try_seconds(86_399).unwrap().num_days(), 0);
         assert_eq!(TimeDelta::try_seconds(86_401).unwrap().num_days(), 1);
         assert_eq!(TimeDelta::try_seconds(-86_399).unwrap().num_days(), 0);
         assert_eq!(TimeDelta::try_seconds(-86_401).unwrap().num_days(), -1);
-        assert_eq!(TimeDelta::try_days(i32::MAX as i64).unwrap().num_days(), i32::MAX as i64);
-        assert_eq!(TimeDelta::try_days(i32::MIN as i64).unwrap().num_days(), i32::MIN as i64);
+        assert_eq!(TimeDelta::days(i32::MAX as i64).unwrap().num_days(), i32::MAX as i64);
+        assert_eq!(TimeDelta::days(i32::MIN as i64).unwrap().num_days(), i32::MIN as i64);
     }
 
     #[test]
@@ -688,19 +688,19 @@ mod tests {
         // overflow checks
         const MICROS_PER_DAY: i64 = 86_400_000_000;
         assert_eq!(
-            TimeDelta::try_days(i64::MAX / MICROS_PER_DAY).unwrap().num_microseconds(),
+            TimeDelta::days(i64::MAX / MICROS_PER_DAY).unwrap().num_microseconds(),
             Some(i64::MAX / MICROS_PER_DAY * MICROS_PER_DAY)
         );
         assert_eq!(
-            TimeDelta::try_days(-i64::MAX / MICROS_PER_DAY).unwrap().num_microseconds(),
+            TimeDelta::days(-i64::MAX / MICROS_PER_DAY).unwrap().num_microseconds(),
             Some(-i64::MAX / MICROS_PER_DAY * MICROS_PER_DAY)
         );
         assert_eq!(
-            TimeDelta::try_days(i64::MAX / MICROS_PER_DAY + 1).unwrap().num_microseconds(),
+            TimeDelta::days(i64::MAX / MICROS_PER_DAY + 1).unwrap().num_microseconds(),
             None
         );
         assert_eq!(
-            TimeDelta::try_days(-i64::MAX / MICROS_PER_DAY - 1).unwrap().num_microseconds(),
+            TimeDelta::days(-i64::MAX / MICROS_PER_DAY - 1).unwrap().num_microseconds(),
             None
         );
     }
@@ -792,21 +792,15 @@ mod tests {
         // overflow checks
         const NANOS_PER_DAY: i64 = 86_400_000_000_000;
         assert_eq!(
-            TimeDelta::try_days(i64::MAX / NANOS_PER_DAY).unwrap().num_nanoseconds(),
+            TimeDelta::days(i64::MAX / NANOS_PER_DAY).unwrap().num_nanoseconds(),
             Some(i64::MAX / NANOS_PER_DAY * NANOS_PER_DAY)
         );
         assert_eq!(
-            TimeDelta::try_days(-i64::MAX / NANOS_PER_DAY).unwrap().num_nanoseconds(),
+            TimeDelta::days(-i64::MAX / NANOS_PER_DAY).unwrap().num_nanoseconds(),
             Some(-i64::MAX / NANOS_PER_DAY * NANOS_PER_DAY)
         );
-        assert_eq!(
-            TimeDelta::try_days(i64::MAX / NANOS_PER_DAY + 1).unwrap().num_nanoseconds(),
-            None
-        );
-        assert_eq!(
-            TimeDelta::try_days(-i64::MAX / NANOS_PER_DAY - 1).unwrap().num_nanoseconds(),
-            None
-        );
+        assert_eq!(TimeDelta::days(i64::MAX / NANOS_PER_DAY + 1).unwrap().num_nanoseconds(), None);
+        assert_eq!(TimeDelta::days(-i64::MAX / NANOS_PER_DAY - 1).unwrap().num_nanoseconds(), None);
     }
     #[test]
     fn test_duration_nanoseconds_max_allowed() {
@@ -992,11 +986,11 @@ mod tests {
         assert_eq!(
             (TimeDelta::nanoseconds(1)
                 + TimeDelta::try_seconds(1).unwrap()
-                + TimeDelta::try_days(1).unwrap())
+                + TimeDelta::days(1).unwrap())
                 * 3,
             TimeDelta::nanoseconds(3)
                 + TimeDelta::try_seconds(3).unwrap()
-                + TimeDelta::try_days(3).unwrap()
+                + TimeDelta::days(3).unwrap()
         );
         assert_eq!(
             TimeDelta::try_milliseconds(1500).unwrap() * -2,
@@ -1062,15 +1056,14 @@ mod tests {
     #[test]
     fn test_duration_fmt() {
         assert_eq!(TimeDelta::zero().to_string(), "P0D");
-        assert_eq!(TimeDelta::try_days(42).unwrap().to_string(), "PT3628800S");
-        assert_eq!(TimeDelta::try_days(-42).unwrap().to_string(), "-PT3628800S");
+        assert_eq!(TimeDelta::days(42).unwrap().to_string(), "PT3628800S");
+        assert_eq!(TimeDelta::days(-42).unwrap().to_string(), "-PT3628800S");
         assert_eq!(TimeDelta::try_seconds(42).unwrap().to_string(), "PT42S");
         assert_eq!(TimeDelta::try_milliseconds(42).unwrap().to_string(), "PT0.042S");
         assert_eq!(TimeDelta::microseconds(42).to_string(), "PT0.000042S");
         assert_eq!(TimeDelta::nanoseconds(42).to_string(), "PT0.000000042S");
         assert_eq!(
-            (TimeDelta::try_days(7).unwrap() + TimeDelta::try_milliseconds(6543).unwrap())
-                .to_string(),
+            (TimeDelta::days(7).unwrap() + TimeDelta::try_milliseconds(6543).unwrap()).to_string(),
             "PT604806.543S"
         );
         assert_eq!(TimeDelta::try_seconds(-86_401).unwrap().to_string(), "-PT86401S");
@@ -1080,7 +1073,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{:30}",
-                TimeDelta::try_days(1).unwrap() + TimeDelta::try_milliseconds(2345).unwrap()
+                TimeDelta::days(1).unwrap() + TimeDelta::try_milliseconds(2345).unwrap()
             ),
             "PT86402.345S"
         );
@@ -1137,7 +1130,7 @@ mod tests {
     #[test]
     fn test_duration_const() {
         const ONE_WEEK: TimeDelta = expect!(TimeDelta::weeks(1), "");
-        const ONE_DAY: TimeDelta = expect!(TimeDelta::try_days(1), "");
+        const ONE_DAY: TimeDelta = expect!(TimeDelta::days(1), "");
         const ONE_HOUR: TimeDelta = expect!(TimeDelta::try_hours(1), "");
         const ONE_MINUTE: TimeDelta = expect!(TimeDelta::try_minutes(1), "");
         const ONE_SECOND: TimeDelta = expect!(TimeDelta::try_seconds(1), "");

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -161,7 +161,7 @@ impl TimeDelta {
     /// Returns `None` the `TimeDelta` would be out of bounds, i.e. when `milliseconds` is more
     /// than `i64::MAX` or less than `-i64::MAX`. Notably, this is not the same as `i64::MIN`.
     #[inline]
-    pub const fn try_milliseconds(milliseconds: i64) -> Option<TimeDelta> {
+    pub const fn milliseconds(milliseconds: i64) -> Option<TimeDelta> {
         // We don't need to compare against MAX, as this function accepts an
         // i64, and MAX is aligned to i64::MAX milliseconds.
         if milliseconds < -i64::MAX {
@@ -583,10 +583,10 @@ mod tests {
         assert_eq!(TimeDelta::zero().num_seconds(), 0);
         assert_eq!(TimeDelta::seconds(1).unwrap().num_seconds(), 1);
         assert_eq!(TimeDelta::seconds(-1).unwrap().num_seconds(), -1);
-        assert_eq!(TimeDelta::try_milliseconds(999).unwrap().num_seconds(), 0);
-        assert_eq!(TimeDelta::try_milliseconds(1001).unwrap().num_seconds(), 1);
-        assert_eq!(TimeDelta::try_milliseconds(-999).unwrap().num_seconds(), 0);
-        assert_eq!(TimeDelta::try_milliseconds(-1001).unwrap().num_seconds(), -1);
+        assert_eq!(TimeDelta::milliseconds(999).unwrap().num_seconds(), 0);
+        assert_eq!(TimeDelta::milliseconds(1001).unwrap().num_seconds(), 1);
+        assert_eq!(TimeDelta::milliseconds(-999).unwrap().num_seconds(), 0);
+        assert_eq!(TimeDelta::milliseconds(-1001).unwrap().num_seconds(), -1);
     }
 
     #[test]
@@ -622,8 +622,8 @@ mod tests {
     #[test]
     fn test_duration_num_milliseconds() {
         assert_eq!(TimeDelta::zero().num_milliseconds(), 0);
-        assert_eq!(TimeDelta::try_milliseconds(1).unwrap().num_milliseconds(), 1);
-        assert_eq!(TimeDelta::try_milliseconds(-1).unwrap().num_milliseconds(), -1);
+        assert_eq!(TimeDelta::milliseconds(1).unwrap().num_milliseconds(), 1);
+        assert_eq!(TimeDelta::milliseconds(-1).unwrap().num_milliseconds(), -1);
         assert_eq!(TimeDelta::microseconds(999).num_milliseconds(), 0);
         assert_eq!(TimeDelta::microseconds(1001).num_milliseconds(), 1);
         assert_eq!(TimeDelta::microseconds(-999).num_milliseconds(), 0);
@@ -634,7 +634,7 @@ mod tests {
     fn test_duration_milliseconds_max_allowed() {
         // The maximum number of milliseconds acceptable through the constructor is
         // equal to the number that can be stored in a TimeDelta.
-        let duration = TimeDelta::try_milliseconds(i64::MAX).unwrap();
+        let duration = TimeDelta::milliseconds(i64::MAX).unwrap();
         assert_eq!(duration.num_milliseconds(), i64::MAX);
         assert_eq!(
             duration.secs as i128 * 1_000_000_000 + duration.nanos as i128,
@@ -646,9 +646,9 @@ mod tests {
     fn test_duration_milliseconds_max_overflow() {
         // Here we ensure that trying to add one millisecond to the maximum storable
         // value will fail.
-        assert!(TimeDelta::try_milliseconds(i64::MAX)
+        assert!(TimeDelta::milliseconds(i64::MAX)
             .unwrap()
-            .checked_add(&TimeDelta::try_milliseconds(1).unwrap())
+            .checked_add(&TimeDelta::milliseconds(1).unwrap())
             .is_none());
     }
 
@@ -657,7 +657,7 @@ mod tests {
         // The minimum number of milliseconds acceptable through the constructor is
         // not equal to the number that can be stored in a TimeDelta - there is a
         // difference of one (i64::MIN vs -i64::MAX).
-        let duration = TimeDelta::try_milliseconds(-i64::MAX).unwrap();
+        let duration = TimeDelta::milliseconds(-i64::MAX).unwrap();
         assert_eq!(duration.num_milliseconds(), -i64::MAX);
         assert_eq!(
             duration.secs as i128 * 1_000_000_000 + duration.nanos as i128,
@@ -669,9 +669,9 @@ mod tests {
     fn test_duration_milliseconds_min_underflow() {
         // Here we ensure that trying to subtract one millisecond from the minimum
         // storable value will fail.
-        assert!(TimeDelta::try_milliseconds(-i64::MAX)
+        assert!(TimeDelta::milliseconds(-i64::MAX)
             .unwrap()
-            .checked_sub(&TimeDelta::try_milliseconds(1).unwrap())
+            .checked_sub(&TimeDelta::milliseconds(1).unwrap())
             .is_none());
     }
 
@@ -719,7 +719,7 @@ mod tests {
         // microseconds by creating a TimeDelta with the maximum number of
         // milliseconds and then checking that the number of microseconds matches
         // the storage limit.
-        let duration = TimeDelta::try_milliseconds(i64::MAX).unwrap();
+        let duration = TimeDelta::milliseconds(i64::MAX).unwrap();
         assert!(duration.num_microseconds().is_none());
         assert_eq!(
             duration.secs as i128 * 1_000_000_000 + duration.nanos as i128,
@@ -738,7 +738,7 @@ mod tests {
         );
         // Here we ensure that trying to add one microsecond to the maximum storable
         // value will fail.
-        assert!(TimeDelta::try_milliseconds(i64::MAX)
+        assert!(TimeDelta::milliseconds(i64::MAX)
             .unwrap()
             .checked_add(&TimeDelta::microseconds(1))
             .is_none());
@@ -758,7 +758,7 @@ mod tests {
         // microseconds by creating a TimeDelta with the minimum number of
         // milliseconds and then checking that the number of microseconds matches
         // the storage limit.
-        let duration = TimeDelta::try_milliseconds(-i64::MAX).unwrap();
+        let duration = TimeDelta::milliseconds(-i64::MAX).unwrap();
         assert!(duration.num_microseconds().is_none());
         assert_eq!(
             duration.secs as i128 * 1_000_000_000 + duration.nanos as i128,
@@ -777,7 +777,7 @@ mod tests {
         );
         // Here we ensure that trying to subtract one microsecond from the minimum
         // storable value will fail.
-        assert!(TimeDelta::try_milliseconds(-i64::MAX)
+        assert!(TimeDelta::milliseconds(-i64::MAX)
             .unwrap()
             .checked_sub(&TimeDelta::microseconds(1))
             .is_none());
@@ -816,7 +816,7 @@ mod tests {
         // Here we create a TimeDelta with the maximum possible number of nanoseconds
         // by creating a TimeDelta with the maximum number of milliseconds and then
         // checking that the number of nanoseconds matches the storage limit.
-        let duration = TimeDelta::try_milliseconds(i64::MAX).unwrap();
+        let duration = TimeDelta::milliseconds(i64::MAX).unwrap();
         assert!(duration.num_nanoseconds().is_none());
         assert_eq!(
             duration.secs as i128 * 1_000_000_000 + duration.nanos as i128,
@@ -836,7 +836,7 @@ mod tests {
         );
         // Here we ensure that trying to add one nanosecond to the maximum storable
         // value will fail.
-        assert!(TimeDelta::try_milliseconds(i64::MAX)
+        assert!(TimeDelta::milliseconds(i64::MAX)
             .unwrap()
             .checked_add(&TimeDelta::nanoseconds(1))
             .is_none());
@@ -856,7 +856,7 @@ mod tests {
         // Here we create a TimeDelta with the minimum possible number of nanoseconds
         // by creating a TimeDelta with the minimum number of milliseconds and then
         // checking that the number of nanoseconds matches the storage limit.
-        let duration = TimeDelta::try_milliseconds(-i64::MAX).unwrap();
+        let duration = TimeDelta::milliseconds(-i64::MAX).unwrap();
         assert!(duration.num_nanoseconds().is_none());
         assert_eq!(
             duration.secs as i128 * 1_000_000_000 + duration.nanos as i128,
@@ -876,7 +876,7 @@ mod tests {
         );
         // Here we ensure that trying to subtract one nanosecond from the minimum
         // storable value will fail.
-        assert!(TimeDelta::try_milliseconds(-i64::MAX)
+        assert!(TimeDelta::milliseconds(-i64::MAX)
             .unwrap()
             .checked_sub(&TimeDelta::nanoseconds(1))
             .is_none());
@@ -888,7 +888,7 @@ mod tests {
             MAX.secs as i128 * 1_000_000_000 + MAX.nanos as i128,
             i64::MAX as i128 * 1_000_000
         );
-        assert_eq!(MAX, TimeDelta::try_milliseconds(i64::MAX).unwrap());
+        assert_eq!(MAX, TimeDelta::milliseconds(i64::MAX).unwrap());
         assert_eq!(MAX.num_milliseconds(), i64::MAX);
         assert_eq!(MAX.num_microseconds(), None);
         assert_eq!(MAX.num_nanoseconds(), None);
@@ -900,7 +900,7 @@ mod tests {
             MIN.secs as i128 * 1_000_000_000 + MIN.nanos as i128,
             -i64::MAX as i128 * 1_000_000
         );
-        assert_eq!(MIN, TimeDelta::try_milliseconds(-i64::MAX).unwrap());
+        assert_eq!(MIN, TimeDelta::milliseconds(-i64::MAX).unwrap());
         assert_eq!(MIN.num_milliseconds(), -i64::MAX);
         assert_eq!(MIN.num_microseconds(), None);
         assert_eq!(MIN.num_nanoseconds(), None);
@@ -908,7 +908,7 @@ mod tests {
 
     #[test]
     fn test_duration_ord() {
-        let milliseconds = |ms| TimeDelta::try_milliseconds(ms).unwrap();
+        let milliseconds = |ms| TimeDelta::milliseconds(ms).unwrap();
 
         assert!(milliseconds(1) < milliseconds(2));
         assert!(milliseconds(2) > milliseconds(1));
@@ -928,7 +928,7 @@ mod tests {
 
     #[test]
     fn test_duration_checked_ops() {
-        let milliseconds = |ms| TimeDelta::try_milliseconds(ms).unwrap();
+        let milliseconds = |ms| TimeDelta::milliseconds(ms).unwrap();
 
         assert_eq!(
             milliseconds(i64::MAX).checked_add(&milliseconds(0)),
@@ -955,7 +955,7 @@ mod tests {
 
     #[test]
     fn test_duration_abs() {
-        let milliseconds = |ms| TimeDelta::try_milliseconds(ms).unwrap();
+        let milliseconds = |ms| TimeDelta::milliseconds(ms).unwrap();
 
         assert_eq!(milliseconds(1300).abs(), milliseconds(1300));
         assert_eq!(milliseconds(1000).abs(), milliseconds(1000));
@@ -992,14 +992,8 @@ mod tests {
                 + TimeDelta::seconds(3).unwrap()
                 + TimeDelta::days(3).unwrap()
         );
-        assert_eq!(
-            TimeDelta::try_milliseconds(1500).unwrap() * -2,
-            TimeDelta::seconds(-3).unwrap()
-        );
-        assert_eq!(
-            TimeDelta::try_milliseconds(-1500).unwrap() * 2,
-            TimeDelta::seconds(-3).unwrap()
-        );
+        assert_eq!(TimeDelta::milliseconds(1500).unwrap() * -2, TimeDelta::seconds(-3).unwrap());
+        assert_eq!(TimeDelta::milliseconds(-1500).unwrap() * 2, TimeDelta::seconds(-3).unwrap());
     }
 
     #[test]
@@ -1012,9 +1006,9 @@ mod tests {
         assert_eq!(-TimeDelta::nanoseconds(123_456_789) / 1, -TimeDelta::nanoseconds(123_456_789));
         assert_eq!(TimeDelta::seconds(1).unwrap() / 3, TimeDelta::nanoseconds(333_333_333));
         assert_eq!(TimeDelta::seconds(4).unwrap() / 3, TimeDelta::nanoseconds(1_333_333_333));
-        assert_eq!(TimeDelta::seconds(-1).unwrap() / 2, TimeDelta::try_milliseconds(-500).unwrap());
-        assert_eq!(TimeDelta::seconds(1).unwrap() / -2, TimeDelta::try_milliseconds(-500).unwrap());
-        assert_eq!(TimeDelta::seconds(-1).unwrap() / -2, TimeDelta::try_milliseconds(500).unwrap());
+        assert_eq!(TimeDelta::seconds(-1).unwrap() / 2, TimeDelta::milliseconds(-500).unwrap());
+        assert_eq!(TimeDelta::seconds(1).unwrap() / -2, TimeDelta::milliseconds(-500).unwrap());
+        assert_eq!(TimeDelta::seconds(-1).unwrap() / -2, TimeDelta::milliseconds(500).unwrap());
         assert_eq!(TimeDelta::seconds(-4).unwrap() / 3, TimeDelta::nanoseconds(-1_333_333_333));
         assert_eq!(TimeDelta::seconds(-4).unwrap() / -3, TimeDelta::nanoseconds(1_333_333_333));
     }
@@ -1050,11 +1044,11 @@ mod tests {
         assert_eq!(TimeDelta::days(42).unwrap().to_string(), "PT3628800S");
         assert_eq!(TimeDelta::days(-42).unwrap().to_string(), "-PT3628800S");
         assert_eq!(TimeDelta::seconds(42).unwrap().to_string(), "PT42S");
-        assert_eq!(TimeDelta::try_milliseconds(42).unwrap().to_string(), "PT0.042S");
+        assert_eq!(TimeDelta::milliseconds(42).unwrap().to_string(), "PT0.042S");
         assert_eq!(TimeDelta::microseconds(42).to_string(), "PT0.000042S");
         assert_eq!(TimeDelta::nanoseconds(42).to_string(), "PT0.000000042S");
         assert_eq!(
-            (TimeDelta::days(7).unwrap() + TimeDelta::try_milliseconds(6543).unwrap()).to_string(),
+            (TimeDelta::days(7).unwrap() + TimeDelta::milliseconds(6543).unwrap()).to_string(),
             "PT604806.543S"
         );
         assert_eq!(TimeDelta::seconds(-86_401).unwrap().to_string(), "-PT86401S");
@@ -1062,10 +1056,7 @@ mod tests {
 
         // the format specifier should have no effect on `TimeDelta`
         assert_eq!(
-            format!(
-                "{:30}",
-                TimeDelta::days(1).unwrap() + TimeDelta::try_milliseconds(2345).unwrap()
-            ),
+            format!("{:30}", TimeDelta::days(1).unwrap() + TimeDelta::milliseconds(2345).unwrap()),
             "PT86402.345S"
         );
     }
@@ -1075,17 +1066,17 @@ mod tests {
         assert_eq!(TimeDelta::seconds(1).unwrap().to_std(), Ok(Duration::new(1, 0)));
         assert_eq!(TimeDelta::seconds(86_401).unwrap().to_std(), Ok(Duration::new(86_401, 0)));
         assert_eq!(
-            TimeDelta::try_milliseconds(123).unwrap().to_std(),
+            TimeDelta::milliseconds(123).unwrap().to_std(),
             Ok(Duration::new(0, 123_000_000))
         );
         assert_eq!(
-            TimeDelta::try_milliseconds(123_765).unwrap().to_std(),
+            TimeDelta::milliseconds(123_765).unwrap().to_std(),
             Ok(Duration::new(123, 765_000_000))
         );
         assert_eq!(TimeDelta::nanoseconds(777).to_std(), Ok(Duration::new(0, 777)));
         assert_eq!(MAX.to_std(), Ok(Duration::new(9_223_372_036_854_775, 807_000_000)));
         assert_eq!(TimeDelta::seconds(-1).unwrap().to_std(), Err(OutOfRangeError(())));
-        assert_eq!(TimeDelta::try_milliseconds(-1).unwrap().to_std(), Err(OutOfRangeError(())));
+        assert_eq!(TimeDelta::milliseconds(-1).unwrap().to_std(), Err(OutOfRangeError(())));
     }
 
     #[test]
@@ -1096,11 +1087,11 @@ mod tests {
             TimeDelta::from_std(Duration::new(86_401, 0))
         );
         assert_eq!(
-            Ok(TimeDelta::try_milliseconds(123).unwrap()),
+            Ok(TimeDelta::milliseconds(123).unwrap()),
             TimeDelta::from_std(Duration::new(0, 123_000_000))
         );
         assert_eq!(
-            Ok(TimeDelta::try_milliseconds(123_765).unwrap()),
+            Ok(TimeDelta::milliseconds(123_765).unwrap()),
             TimeDelta::from_std(Duration::new(123, 765_000_000))
         );
         assert_eq!(Ok(TimeDelta::nanoseconds(777)), TimeDelta::from_std(Duration::new(0, 777)));
@@ -1122,7 +1113,7 @@ mod tests {
         const ONE_HOUR: TimeDelta = expect!(TimeDelta::hours(1), "");
         const ONE_MINUTE: TimeDelta = expect!(TimeDelta::minutes(1), "");
         const ONE_SECOND: TimeDelta = expect!(TimeDelta::seconds(1), "");
-        const ONE_MILLI: TimeDelta = expect!(TimeDelta::try_milliseconds(1), "");
+        const ONE_MILLI: TimeDelta = expect!(TimeDelta::milliseconds(1), "");
         const ONE_MICRO: TimeDelta = TimeDelta::microseconds(1);
         const ONE_NANO: TimeDelta = TimeDelta::nanoseconds(1);
         let combo: TimeDelta = ONE_WEEK

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -94,7 +94,7 @@ fn try_verify_against_date_command() {
             let end = NaiveDate::from_ymd(*year + 1, 1, 1).unwrap().and_time(NaiveTime::MIN);
             while date <= end {
                 verify_against_date_command_local(DATE_PATH, date);
-                date += chrono::TimeDelta::try_hours(1).unwrap();
+                date += chrono::TimeDelta::hours(1).unwrap();
             }
         }));
     }

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -25,7 +25,7 @@ fn now() {
     let actual = NaiveDateTime::parse_from_str(&now, "%s").unwrap().and_utc();
     let diff = utc - actual;
     assert!(
-        diff < chrono::TimeDelta::try_minutes(5).unwrap(),
+        diff < chrono::TimeDelta::minutes(5).unwrap(),
         "expected {} - {} == {} < 5m (env var: {})",
         utc,
         actual,


### PR DESCRIPTION
Remove recently deprecated methods from `NaiveDateTime` and `TimeDelta`.

Not much to see beyond deletes, and find-replace-rustfmt.