### PR TITLE
CI: Lint benchmarks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,10 +29,10 @@ jobs:
           cargo clippy --target=x86_64-pc-windows-msvc --all-targets --color=always \
             -- -D warnings
       - run: |
-          cargo clippy --manifest-path fuzz/Cargo.toml --color=always \
+          cargo clippy --manifest-path fuzz/Cargo.toml --all-targets --color=always \
             -- -D warnings
       - run: |
-          cargo clippy --manifest-path bench/Cargo.toml --color=always \
+          cargo clippy --manifest-path bench/Cargo.toml --all-targets --color=always \
             -- -D warnings
         env:
           RUSTFLAGS: "-Dwarnings"

--- a/bench/benches/chrono.rs
+++ b/bench/benches/chrono.rs
@@ -208,7 +208,7 @@ fn bench_format_manual(c: &mut Criterion) {
 
 fn bench_naivedate_add_signed(c: &mut Criterion) {
     let date = NaiveDate::from_ymd_opt(2023, 7, 29).unwrap();
-    let extra = TimeDelta::days(25);
+    let extra = TimeDelta::try_days(25).unwrap();
     c.bench_function("bench_naivedate_add_signed", |b| {
         b.iter(|| black_box(date).checked_add_signed(extra).unwrap())
     });


### PR DESCRIPTION
A CI run on #1488 showed that our CI wasn't checking for warnings in the benchmarks. We need to call clippy with `--all-targets`.