### PR TITLE
Remove unnessary Copy and Send impls

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -49,7 +49,7 @@ mod tests;
 /// There are some constructors implemented here (the `from_*` methods), but
 /// the general-purpose constructors are all via the methods on the
 /// [`TimeZone`](./offset/trait.TimeZone.html) implementations.
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
@@ -1385,10 +1385,6 @@ impl<Tz: TimeZone> Timelike for DateTime<Tz> {
         map_local(self, |datetime| datetime.with_nanosecond(nano))
     }
 }
-
-// we need them as automatic impls cannot handle associated types
-impl<Tz: TimeZone> Copy for DateTime<Tz> where <Tz as TimeZone>::Offset: Copy {}
-unsafe impl<Tz: TimeZone> Send for DateTime<Tz> where <Tz as TimeZone>::Offset: Send {}
 
 impl<Tz: TimeZone, Tz2: TimeZone> PartialEq<DateTime<Tz2>> for DateTime<Tz> {
     fn eq(&self, other: &DateTime<Tz2>) -> bool {

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1866,3 +1866,12 @@ fn nano_roundrip() {
         assert_eq!(nanos, nanos2);
     }
 }
+
+#[test]
+fn test_datetime_utc_is_copy_and_send() {
+    fn is_copy<T: Copy>(_: T) {}
+    fn is_send<T: Send>(_: T) {}
+
+    is_copy(DateTime::<Utc>::MIN_UTC);
+    is_send(DateTime::<Utc>::MIN_UTC);
+}


### PR DESCRIPTION
Fuchsia is doing an [audit of chrono 0.4.34](http://fxrev.dev/999580), and we noticed an unncessary unsafe of `Send` for `DateTime`. While it's valid since `Tz::Offset` is `Send`, and `NaiveDateTime` only has `u32` fields, there's a potential hazard if `NaiveDateTime` ever grows unsendable fields (unlikely as that is).

This (and the `Copy` impl) were added 9 years ago to fix #25, which stemmed from early versions of associate traits not working properly with auto-traits. This has since been fixed, and is no longer necessary with the MSRV 1.61.0.

To make sure this stays working, it includes a test that makes sure that `DateTime<Utc>` is `Send` and `Copy` just to be safe.