### PR TITLE
0.5: Make fields of `Parsed` private

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -882,7 +882,7 @@ impl DateTime<FixedOffset> {
     /// ```
     pub fn parse_from_rfc2822(s: &str) -> ParseResult<DateTime<FixedOffset>> {
         const ITEMS: &[Item<'static>] = &[Item::Fixed(Fixed::RFC2822)];
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         parse(&mut parsed, s, ITEMS.iter())?;
         parsed.to_datetime()
     }
@@ -901,7 +901,7 @@ impl DateTime<FixedOffset> {
     /// also simultaneously valid RFC 3339 values, but not all RFC 3339 values are valid ISO 8601
     /// values (or the other way around).
     pub fn parse_from_rfc3339(s: &str) -> ParseResult<DateTime<FixedOffset>> {
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         let (s, _) = parse_rfc3339(&mut parsed, s)?;
         if !s.is_empty() {
             return Err(TOO_LONG);
@@ -936,7 +936,7 @@ impl DateTime<FixedOffset> {
     /// );
     /// ```
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<DateTime<FixedOffset>> {
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         parse(&mut parsed, s, StrftimeItems::new(fmt))?;
         parsed.to_datetime()
     }
@@ -973,7 +973,7 @@ impl DateTime<FixedOffset> {
         s: &'a str,
         fmt: &str,
     ) -> ParseResult<(DateTime<FixedOffset>, &'a str)> {
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         let remainder = parse_and_remainder(&mut parsed, s, StrftimeItems::new(fmt))?;
         parsed.to_datetime().map(|d| (d, remainder))
     }

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -14,7 +14,7 @@ use super::{ParseError, ParseResult};
 use super::{BAD_FORMAT, INVALID, OUT_OF_RANGE, TOO_LONG, TOO_SHORT};
 use crate::{DateTime, FixedOffset, Weekday};
 
-fn set_weekday_with_num_days_from_sunday(p: &mut Parsed, v: i64) -> ParseResult<()> {
+fn set_weekday_with_num_days_from_sunday(p: &mut Parsed, v: i64) -> ParseResult<&mut Parsed> {
     p.set_weekday(match v {
         0 => Weekday::Sun,
         1 => Weekday::Mon,
@@ -27,7 +27,7 @@ fn set_weekday_with_num_days_from_sunday(p: &mut Parsed, v: i64) -> ParseResult<
     })
 }
 
-fn set_weekday_with_number_from_monday(p: &mut Parsed, v: i64) -> ParseResult<()> {
+fn set_weekday_with_number_from_monday(p: &mut Parsed, v: i64) -> ParseResult<&mut Parsed> {
     p.set_weekday(match v {
         1 => Weekday::Mon,
         2 => Weekday::Tue,
@@ -339,7 +339,7 @@ where
 
             Item::Numeric(ref spec, ref _pad) => {
                 use super::Numeric::*;
-                type Setter = fn(&mut Parsed, i64) -> ParseResult<()>;
+                type Setter = fn(&mut Parsed, i64) -> ParseResult<&mut Parsed>;
 
                 let (width, signed, set): (usize, bool, Setter) = match *spec {
                     Year => (4, true, Parsed::set_year),

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -527,7 +527,7 @@ impl str::FromStr for DateTime<FixedOffset> {
     type Err = ParseError;
 
     fn from_str(s: &str) -> ParseResult<DateTime<FixedOffset>> {
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         let (s, _) = parse_rfc3339_relaxed(&mut parsed, s)?;
         if !s.trim_start().is_empty() {
             return Err(TOO_LONG);
@@ -722,7 +722,7 @@ mod tests {
         use crate::format::Item::{Literal, Space};
         use crate::format::Numeric::*;
 
-        let p = Parsed::new;
+        let p = Parsed::default;
 
         // numeric
         check("1987", &[num(Year)], p().set_year(1987));
@@ -849,7 +849,7 @@ mod tests {
         use crate::format::Fixed::*;
         use crate::format::Item::{Literal, Space};
 
-        let p = Parsed::new;
+        let p = Parsed::default;
 
         // fixed: month and weekday names
         check("apr", &[fixed(ShortMonthName)], p().set_month(4));
@@ -920,7 +920,7 @@ mod tests {
         use crate::format::Item::Literal;
         use crate::format::Numeric::Second;
 
-        let p = Parsed::new;
+        let p = Parsed::default;
 
         // fixed: dot plus nanoseconds
         check("", &[fixed(Nanosecond)], Ok(&mut p())); // no field set, but not an error
@@ -1020,7 +1020,7 @@ mod tests {
         use crate::format::InternalInternal::*;
         use crate::format::Item::Literal;
 
-        let p = Parsed::new;
+        let p = Parsed::default;
 
         // TimezoneOffset
         check("1", &[fixed(TimezoneOffset)], Err(INVALID));
@@ -1457,7 +1457,7 @@ mod tests {
         use crate::format::Item::{Literal, Space};
         use crate::format::Numeric::*;
 
-        let p = Parsed::new;
+        let p = Parsed::default;
 
         // some practical examples
         check(
@@ -1570,13 +1570,13 @@ mod tests {
 
     #[track_caller]
     fn parses(s: &str, items: &[Item]) {
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         assert!(parse(&mut parsed, s, items.iter()).is_ok());
     }
 
     #[track_caller]
     fn check(s: &str, items: &[Item], expected: ParseResult<&mut Parsed>) {
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         let result = parse(&mut parsed, s, items.iter());
         let parsed = result.map(|_| parsed);
         assert_eq!(parsed.as_ref(), expected.as_deref());
@@ -1657,7 +1657,7 @@ mod tests {
         ];
 
         fn rfc2822_to_datetime(date: &str) -> ParseResult<DateTime<FixedOffset>> {
-            let mut parsed = Parsed::new();
+            let mut parsed = Parsed::default();
             parse(&mut parsed, date, [Item::Fixed(Fixed::RFC2822)].iter())?;
             parsed.to_datetime()
         }

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -1368,37 +1368,18 @@ mod tests {
             Err(OUT_OF_RANGE)
         );
         assert_eq!(
-            parse!(year_div_100: 19, year_mod_100: 83, month: 13, day: 1),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
             parse!(year_div_100: 19, year_mod_100: 83, month: 12, day: 31),
             ymd(1983, 12, 31)
         );
-        assert_eq!(
-            parse!(year_div_100: 19, year_mod_100: 83, month: 12, day: 32),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
-            parse!(year_div_100: 19, year_mod_100: 83, month: 12, day: 0),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
-            parse!(year_div_100: 19, year_mod_100: 100, month: 1, day: 1),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(parse!(year_div_100: 19, year_mod_100: -1, month: 1, day: 1), Err(OUT_OF_RANGE));
         assert_eq!(parse!(year_div_100: 0, year_mod_100: 0, month: 1, day: 1), ymd(0, 1, 1));
-        assert_eq!(parse!(year_div_100: -1, year_mod_100: 42, month: 1, day: 1), Err(IMPOSSIBLE));
         let max_year = NaiveDate::MAX.year();
         assert_eq!(
-            parse!(year_div_100: max_year / 100,
-                          year_mod_100: max_year % 100, month: 1, day: 1),
+            parse!(year_div_100: max_year / 100, year_mod_100: max_year % 100, month: 1, day: 1),
             ymd(max_year, 1, 1)
         );
         assert_eq!(
             parse!(year_div_100: (max_year + 1) / 100,
-                          year_mod_100: (max_year + 1) % 100, month: 1, day: 1),
+                   year_mod_100: (max_year + 1) % 100, month: 1, day: 1),
             Err(OUT_OF_RANGE)
         );
 
@@ -1413,18 +1394,6 @@ mod tests {
         );
         assert_eq!(
             parse!(year: 1984, year_div_100: 18, year_mod_100: 94, month: 1, day: 1),
-            Err(IMPOSSIBLE)
-        );
-        assert_eq!(
-            parse!(year: 1984, year_div_100: 18, year_mod_100: 184, month: 1, day: 1),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
-            parse!(year: -1, year_div_100: 0, year_mod_100: -1, month: 1, day: 1),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
-            parse!(year: -1, year_div_100: -1, year_mod_100: 99, month: 1, day: 1),
             Err(IMPOSSIBLE)
         );
         assert_eq!(parse!(year: -1, year_div_100: 0, month: 1, day: 1), Err(IMPOSSIBLE));
@@ -1450,7 +1419,6 @@ mod tests {
         assert_eq!(parse!(year: 2000, week_from_sun: 52, weekday: Sat), ymd(2000, 12, 30));
         assert_eq!(parse!(year: 2000, week_from_sun: 53, weekday: Sun), ymd(2000, 12, 31));
         assert_eq!(parse!(year: 2000, week_from_sun: 53, weekday: Mon), Err(IMPOSSIBLE));
-        assert_eq!(parse!(year: 2000, week_from_sun: 0xffffffff, weekday: Mon), Err(OUT_OF_RANGE));
         assert_eq!(parse!(year: 2006, week_from_sun: 0, weekday: Sat), Err(IMPOSSIBLE));
         assert_eq!(parse!(year: 2006, week_from_sun: 1, weekday: Sun), ymd(2006, 1, 1));
 
@@ -1501,22 +1469,21 @@ mod tests {
         // more complex cases
         assert_eq!(
             parse!(year: 2014, month: 12, day: 31, ordinal: 365, isoyear: 2015, isoweek: 1,
-                          week_from_sun: 52, week_from_mon: 52, weekday: Wed),
+                   week_from_sun: 52, week_from_mon: 52, weekday: Wed),
             ymd(2014, 12, 31)
         );
         assert_eq!(
             parse!(year: 2014, month: 12, ordinal: 365, isoyear: 2015, isoweek: 1,
-                          week_from_sun: 52, week_from_mon: 52),
+                   week_from_sun: 52, week_from_mon: 52),
             ymd(2014, 12, 31)
         );
         assert_eq!(
             parse!(year: 2014, month: 12, day: 31, ordinal: 365, isoyear: 2014, isoweek: 53,
-                          week_from_sun: 52, week_from_mon: 52, weekday: Wed),
+                   week_from_sun: 52, week_from_mon: 52, weekday: Wed),
             Err(IMPOSSIBLE)
         ); // no ISO week date 2014-W53-3
         assert_eq!(
-            parse!(year: 2012, isoyear: 2015, isoweek: 1,
-                          week_from_sun: 52, week_from_mon: 52),
+            parse!(year: 2012, isoyear: 2015, isoweek: 1, week_from_sun: 52, week_from_mon: 52),
             Err(NOT_ENOUGH)
         ); // ambiguous (2014-12-29, 2014-12-30, 2014-12-31)
         assert_eq!(parse!(year_div_100: 20, isoyear_mod_100: 15, ordinal: 366), Err(NOT_ENOUGH));
@@ -1550,20 +1517,6 @@ mod tests {
         assert_eq!(
             parse!(hour_div_12: 0, hour_mod_12: 1, minute: 23, nanosecond: 456_789_012),
             Err(NOT_ENOUGH)
-        );
-
-        // out-of-range conditions
-        assert_eq!(parse!(hour_div_12: 2, hour_mod_12: 0, minute: 0), Err(OUT_OF_RANGE));
-        assert_eq!(parse!(hour_div_12: 1, hour_mod_12: 12, minute: 0), Err(OUT_OF_RANGE));
-        assert_eq!(parse!(hour_div_12: 0, hour_mod_12: 1, minute: 60), Err(OUT_OF_RANGE));
-        assert_eq!(
-            parse!(hour_div_12: 0, hour_mod_12: 1, minute: 23, second: 61),
-            Err(OUT_OF_RANGE)
-        );
-        assert_eq!(
-            parse!(hour_div_12: 0, hour_mod_12: 1, minute: 23, second: 34,
-                          nanosecond: 1_000_000_000),
-            Err(OUT_OF_RANGE)
         );
 
         // leap seconds
@@ -1684,51 +1637,44 @@ mod tests {
         // we need to have separate tests for them since it uses another control flow.
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 59, timestamp: 1_341_100_798),
+                   minute: 59, second: 59, timestamp: 1_341_100_798),
             Err(IMPOSSIBLE)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 59, timestamp: 1_341_100_799),
+                   minute: 59, second: 59, timestamp: 1_341_100_799),
             ymdhms(2012, 6, 30, 23, 59, 59)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 59, timestamp: 1_341_100_800),
+                   minute: 59, second: 59, timestamp: 1_341_100_800),
             Err(IMPOSSIBLE)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 60, timestamp: 1_341_100_799),
+                   minute: 59, second: 60, timestamp: 1_341_100_799),
             ymdhmsn(2012, 6, 30, 23, 59, 59, 1_000_000_000)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 60, timestamp: 1_341_100_800),
+                   minute: 59, second: 60, timestamp: 1_341_100_800),
             ymdhmsn(2012, 6, 30, 23, 59, 59, 1_000_000_000)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 183, hour_div_12: 0, hour_mod_12: 0,
-                          minute: 0, second: 0, timestamp: 1_341_100_800),
+                   minute: 0, second: 0, timestamp: 1_341_100_800),
             ymdhms(2012, 7, 1, 0, 0, 0)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 183, hour_div_12: 0, hour_mod_12: 0,
-                          minute: 0, second: 1, timestamp: 1_341_100_800),
+                   minute: 0, second: 1, timestamp: 1_341_100_800),
             Err(IMPOSSIBLE)
         );
         assert_eq!(
             parse!(year: 2012, ordinal: 182, hour_div_12: 1, hour_mod_12: 11,
-                          minute: 59, second: 60, timestamp: 1_341_100_801),
+                   minute: 59, second: 60, timestamp: 1_341_100_801),
             Err(IMPOSSIBLE)
         );
-
-        // error codes
-        assert_eq!(
-            parse!(year: 2015, month: 1, day: 20, weekday: Tue,
-                          hour_div_12: 2, hour_mod_12: 1, minute: 35, second: 20),
-            Err(OUT_OF_RANGE)
-        ); // `hour_div_12` is out of range
     }
 
     #[test]

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -1162,7 +1162,7 @@ fn resolve_week_date(
 
 #[cfg(test)]
 mod tests {
-    use super::super::{IMPOSSIBLE, NOT_ENOUGH, OUT_OF_RANGE};
+    use super::super::{ParseError, IMPOSSIBLE, NOT_ENOUGH, OUT_OF_RANGE};
     use super::Parsed;
     use crate::naive::{NaiveDate, NaiveTime};
     use crate::offset::{FixedOffset, TimeZone, Utc};
@@ -1793,16 +1793,24 @@ mod tests {
     }
 
     #[test]
-    fn issue_551() {
+    fn issue_551() -> Result<(), ParseError> {
         use crate::Weekday;
-        let mut parsed = Parsed::new();
-
-        parsed.year = Some(2002);
-        parsed.week_from_mon = Some(22);
-        parsed.weekday = Some(Weekday::Mon);
-        assert_eq!(NaiveDate::from_ymd(2002, 6, 3).unwrap(), parsed.to_naive_date().unwrap());
-
-        parsed.year = Some(2001);
-        assert_eq!(NaiveDate::from_ymd(2001, 5, 28).unwrap(), parsed.to_naive_date().unwrap());
+        assert_eq!(
+            NaiveDate::from_ymd(2002, 6, 3).unwrap(),
+            Parsed::new()
+                .set_year(2002)?
+                .set_week_from_mon(22)?
+                .set_weekday(Weekday::Mon)?
+                .to_naive_date()?
+        );
+        assert_eq!(
+            NaiveDate::from_ymd(2001, 5, 28).unwrap(),
+            Parsed::new()
+                .set_year(2001)?
+                .set_week_from_mon(22)?
+                .set_weekday(Weekday::Mon)?
+                .to_naive_date()?
+        );
+        Ok(())
     }
 }

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -63,26 +63,28 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 /// use chrono::Weekday;
 ///
 /// let mut parsed = Parsed::new();
-/// parsed.set_weekday(Weekday::Wed)?;
-/// parsed.set_day(31)?;
-/// parsed.set_month(12)?;
-/// parsed.set_year(2014)?;
-/// parsed.set_hour(4)?;
-/// parsed.set_minute(26)?;
-/// parsed.set_second(40)?;
-/// parsed.set_offset(0)?;
+/// parsed
+///     .set_weekday(Weekday::Wed)?
+///     .set_day(31)?
+///     .set_month(12)?
+///     .set_year(2014)?
+///     .set_hour(4)?
+///     .set_minute(26)?
+///     .set_second(40)?
+///     .set_offset(0)?;
 /// let dt = parsed.to_datetime()?;
 /// assert_eq!(dt.to_rfc2822(), "Wed, 31 Dec 2014 04:26:40 +0000");
 ///
 /// let mut parsed = Parsed::new();
-/// parsed.set_weekday(Weekday::Thu)?; // changed to the wrong day
-/// parsed.set_day(31)?;
-/// parsed.set_month(12)?;
-/// parsed.set_year(2014)?;
-/// parsed.set_hour(4)?;
-/// parsed.set_minute(26)?;
-/// parsed.set_second(40)?;
-/// parsed.set_offset(0)?;
+/// parsed
+///     .set_weekday(Weekday::Thu)? // changed to the wrong day
+///     .set_day(31)?
+///     .set_month(12)?
+///     .set_year(2014)?
+///     .set_hour(4)?
+///     .set_minute(26)?
+///     .set_second(40)?
+///     .set_offset(0)?;
 /// let result = parsed.to_datetime();
 ///
 /// assert!(result.is_err());
@@ -201,8 +203,9 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_year(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.year, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_year(&mut self, value: i64) -> ParseResult<&mut Self> {
+        set_if_consistent(&mut self.year, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Set the [`year_div_100`](Parsed::year_div_100) field to the given value.
@@ -213,11 +216,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_year_div_100(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_year_div_100(&mut self, value: i64) -> ParseResult<&mut Self> {
         if !(0..=i32::MAX as i64).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.year_div_100, value as i32)
+        set_if_consistent(&mut self.year_div_100, value as i32)?;
+        Ok(self)
     }
 
     /// Set the [`year_mod_100`](Parsed::year_mod_100) field to the given value.
@@ -235,11 +239,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_year_mod_100(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_year_mod_100(&mut self, value: i64) -> ParseResult<&mut Self> {
         if !(0..100).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.year_mod_100, value as i32)
+        set_if_consistent(&mut self.year_mod_100, value as i32)?;
+        Ok(self)
     }
 
     /// Set the [`isoyear`](Parsed::isoyear) field, that is part of an [ISO 8601 week date], to the
@@ -256,8 +261,9 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_isoyear(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.isoyear, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_isoyear(&mut self, value: i64) -> ParseResult<&mut Self> {
+        set_if_consistent(&mut self.isoyear, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Set the [`isoyear_div_100`](Parsed::isoyear_div_100) field, that is part of an
@@ -271,11 +277,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_isoyear_div_100(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_isoyear_div_100(&mut self, value: i64) -> ParseResult<&mut Self> {
         if !(0..=i32::MAX as i64).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.isoyear_div_100, value as i32)
+        set_if_consistent(&mut self.isoyear_div_100, value as i32)?;
+        Ok(self)
     }
 
     /// Set the [`isoyear_mod_100`](Parsed::isoyear_mod_100) field, that is part of an
@@ -296,11 +303,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_isoyear_mod_100(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_isoyear_mod_100(&mut self, value: i64) -> ParseResult<&mut Self> {
         if !(0..100).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.isoyear_mod_100, value as i32)
+        set_if_consistent(&mut self.isoyear_mod_100, value as i32)?;
+        Ok(self)
     }
 
     /// Set the [`month`](Parsed::month) field to the given value.
@@ -311,11 +319,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_month(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_month(&mut self, value: i64) -> ParseResult<&mut Self> {
         if !(1..=12).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.month, value as u32)
+        set_if_consistent(&mut self.month, value as u32)?;
+        Ok(self)
     }
 
     /// Set the [`week_from_sun`](Parsed::week_from_sun) week number field to the given value.
@@ -328,11 +337,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_week_from_sun(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_week_from_sun(&mut self, value: i64) -> ParseResult<&mut Self> {
         if !(0..=53).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.week_from_sun, value as u32)
+        set_if_consistent(&mut self.week_from_sun, value as u32)?;
+        Ok(self)
     }
 
     /// Set the [`week_from_mon`](Parsed::week_from_mon) week number field to the given value.
@@ -346,11 +356,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_week_from_mon(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_week_from_mon(&mut self, value: i64) -> ParseResult<&mut Self> {
         if !(0..=53).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.week_from_mon, value as u32)
+        set_if_consistent(&mut self.week_from_mon, value as u32)?;
+        Ok(self)
     }
 
     /// Set the [`isoweek`](Parsed::isoweek) field for an [ISO 8601 week date] to the given value.
@@ -363,11 +374,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_isoweek(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_isoweek(&mut self, value: i64) -> ParseResult<&mut Self> {
         if !(1..=53).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.isoweek, value as u32)
+        set_if_consistent(&mut self.isoweek, value as u32)?;
+        Ok(self)
     }
 
     /// Set the [`weekday`](Parsed::weekday) field to the given value.
@@ -376,8 +388,9 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_weekday(&mut self, value: Weekday) -> ParseResult<()> {
-        set_if_consistent(&mut self.weekday, value)
+    pub fn set_weekday(&mut self, value: Weekday) -> ParseResult<&mut Self> {
+        set_if_consistent(&mut self.weekday, value)?;
+        Ok(self)
     }
 
     /// Set the [`ordinal`](Parsed::ordinal) (day of the year) field to the given value.
@@ -388,11 +401,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_ordinal(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_ordinal(&mut self, value: i64) -> ParseResult<&mut Self> {
         if !(1..=366).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.ordinal, value as u32)
+        set_if_consistent(&mut self.ordinal, value as u32)?;
+        Ok(self)
     }
 
     /// Set the [`day`](Parsed::day) of the month field to the given value.
@@ -403,11 +417,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_day(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_day(&mut self, value: i64) -> ParseResult<&mut Self> {
         if !(1..=31).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.day, value as u32)
+        set_if_consistent(&mut self.day, value as u32)?;
+        Ok(self)
     }
 
     /// Set the [`hour_div_12`](Parsed::hour_div_12) am/pm field to the given value.
@@ -418,8 +433,9 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_ampm(&mut self, value: bool) -> ParseResult<()> {
-        set_if_consistent(&mut self.hour_div_12, value as u32)
+    pub fn set_ampm(&mut self, value: bool) -> ParseResult<&mut Self> {
+        set_if_consistent(&mut self.hour_div_12, value as u32)?;
+        Ok(self)
     }
 
     /// Set the [`hour_mod_12`](Parsed::hour_mod_12) field, for the hour number in 12-hour clocks,
@@ -434,14 +450,15 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_hour12(&mut self, mut value: i64) -> ParseResult<()> {
+    pub fn set_hour12(&mut self, mut value: i64) -> ParseResult<&mut Self> {
         if !(1..=12).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
         if value == 12 {
             value = 0
         }
-        set_if_consistent(&mut self.hour_mod_12, value as u32)
+        set_if_consistent(&mut self.hour_mod_12, value as u32)?;
+        Ok(self)
     }
 
     /// Set the [`hour_div_12`](Parsed::hour_div_12) and [`hour_mod_12`](Parsed::hour_mod_12)
@@ -454,14 +471,15 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` one of the fields was already set to a different value.
     #[inline]
-    pub fn set_hour(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_hour(&mut self, value: i64) -> ParseResult<&mut Self> {
         let (hour_div_12, hour_mod_12) = match value {
             hour @ 0..=11 => (0, hour as u32),
             hour @ 12..=23 => (1, hour as u32 - 12),
             _ => return Err(OUT_OF_RANGE),
         };
         set_if_consistent(&mut self.hour_div_12, hour_div_12)?;
-        set_if_consistent(&mut self.hour_mod_12, hour_mod_12)
+        set_if_consistent(&mut self.hour_mod_12, hour_mod_12)?;
+        Ok(self)
     }
 
     /// Set the [`minute`](Parsed::minute) field to the given value.
@@ -472,11 +490,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_minute(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_minute(&mut self, value: i64) -> ParseResult<&mut Self> {
         if !(0..=59).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.minute, value as u32)
+        set_if_consistent(&mut self.minute, value as u32)?;
+        Ok(self)
     }
 
     /// Set the [`second`](Parsed::second) field to the given value.
@@ -489,11 +508,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_second(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_second(&mut self, value: i64) -> ParseResult<&mut Self> {
         if !(0..=60).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.second, value as u32)
+        set_if_consistent(&mut self.second, value as u32)?;
+        Ok(self)
     }
 
     /// Set the [`nanosecond`](Parsed::nanosecond) field to the given value.
@@ -506,11 +526,12 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_nanosecond(&mut self, value: i64) -> ParseResult<()> {
+    pub fn set_nanosecond(&mut self, value: i64) -> ParseResult<&mut Self> {
         if !(0..=999_999_999).contains(&value) {
             return Err(OUT_OF_RANGE);
         }
-        set_if_consistent(&mut self.nanosecond, value as u32)
+        set_if_consistent(&mut self.nanosecond, value as u32)?;
+        Ok(self)
     }
 
     /// Set the [`timestamp`](Parsed::timestamp) field to the given value.
@@ -522,8 +543,9 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_timestamp(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.timestamp, value)
+    pub fn set_timestamp(&mut self, value: i64) -> ParseResult<&mut Self> {
+        set_if_consistent(&mut self.timestamp, value)?;
+        Ok(self)
     }
 
     /// Set the [`offset`](Parsed::offset) field to the given value.
@@ -536,8 +558,9 @@ impl Parsed {
     ///
     /// Returns `IMPOSSIBLE` if this field was already set to a different value.
     #[inline]
-    pub fn set_offset(&mut self, value: i64) -> ParseResult<()> {
-        set_if_consistent(&mut self.offset, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)
+    pub fn set_offset(&mut self, value: i64) -> ParseResult<&mut Self> {
+        set_if_consistent(&mut self.offset, i32::try_from(value).map_err(|_| OUT_OF_RANGE)?)?;
+        Ok(self)
     }
 
     /// Returns a parsed naive date out of given fields.
@@ -1171,69 +1194,69 @@ mod tests {
     fn test_parsed_set_fields() {
         // year*, isoyear*
         let mut p = Parsed::new();
-        assert_eq!(p.set_year(1987), Ok(()));
+        assert!(p.set_year(1987).is_ok());
         assert_eq!(p.set_year(1986), Err(IMPOSSIBLE));
         assert_eq!(p.set_year(1988), Err(IMPOSSIBLE));
-        assert_eq!(p.set_year(1987), Ok(()));
-        assert_eq!(p.set_year_div_100(20), Ok(())); // independent to `year`
+        assert!(p.set_year(1987).is_ok());
+        assert!(p.set_year_div_100(20).is_ok()); // independent to `year`
         assert_eq!(p.set_year_div_100(21), Err(IMPOSSIBLE));
         assert_eq!(p.set_year_div_100(19), Err(IMPOSSIBLE));
-        assert_eq!(p.set_year_mod_100(37), Ok(())); // ditto
+        assert!(p.set_year_mod_100(37).is_ok()); // ditto
         assert_eq!(p.set_year_mod_100(38), Err(IMPOSSIBLE));
         assert_eq!(p.set_year_mod_100(36), Err(IMPOSSIBLE));
 
         let mut p = Parsed::new();
-        assert_eq!(p.set_year(0), Ok(()));
-        assert_eq!(p.set_year_div_100(0), Ok(()));
-        assert_eq!(p.set_year_mod_100(0), Ok(()));
+        assert!(p.set_year(0).is_ok());
+        assert!(p.set_year_div_100(0).is_ok());
+        assert!(p.set_year_mod_100(0).is_ok());
 
         let mut p = Parsed::new();
         assert_eq!(p.set_year_div_100(-1), Err(OUT_OF_RANGE));
         assert_eq!(p.set_year_mod_100(-1), Err(OUT_OF_RANGE));
-        assert_eq!(p.set_year(-1), Ok(()));
+        assert!(p.set_year(-1).is_ok());
         assert_eq!(p.set_year(-2), Err(IMPOSSIBLE));
         assert_eq!(p.set_year(0), Err(IMPOSSIBLE));
 
         let mut p = Parsed::new();
         assert_eq!(p.set_year_div_100(0x1_0000_0008), Err(OUT_OF_RANGE));
-        assert_eq!(p.set_year_div_100(8), Ok(()));
+        assert!(p.set_year_div_100(8).is_ok());
         assert_eq!(p.set_year_div_100(0x1_0000_0008), Err(OUT_OF_RANGE));
 
         // month, week*, isoweek, ordinal, day, minute, second, nanosecond, offset
         let mut p = Parsed::new();
-        assert_eq!(p.set_month(7), Ok(()));
+        assert!(p.set_month(7).is_ok());
         assert_eq!(p.set_month(1), Err(IMPOSSIBLE));
         assert_eq!(p.set_month(6), Err(IMPOSSIBLE));
         assert_eq!(p.set_month(8), Err(IMPOSSIBLE));
         assert_eq!(p.set_month(12), Err(IMPOSSIBLE));
 
         let mut p = Parsed::new();
-        assert_eq!(p.set_month(8), Ok(()));
+        assert!(p.set_month(8).is_ok());
         assert_eq!(p.set_month(0x1_0000_0008), Err(OUT_OF_RANGE));
 
         // hour
         let mut p = Parsed::new();
-        assert_eq!(p.set_hour(12), Ok(()));
+        assert!(p.set_hour(12).is_ok());
         assert_eq!(p.set_hour(11), Err(IMPOSSIBLE));
         assert_eq!(p.set_hour(13), Err(IMPOSSIBLE));
-        assert_eq!(p.set_hour(12), Ok(()));
+        assert!(p.set_hour(12).is_ok());
         assert_eq!(p.set_ampm(false), Err(IMPOSSIBLE));
-        assert_eq!(p.set_ampm(true), Ok(()));
-        assert_eq!(p.set_hour12(12), Ok(()));
+        assert!(p.set_ampm(true).is_ok());
+        assert!(p.set_hour12(12).is_ok());
         assert_eq!(p.set_hour12(0), Err(OUT_OF_RANGE)); // requires canonical representation
         assert_eq!(p.set_hour12(1), Err(IMPOSSIBLE));
         assert_eq!(p.set_hour12(11), Err(IMPOSSIBLE));
 
         let mut p = Parsed::new();
-        assert_eq!(p.set_ampm(true), Ok(()));
-        assert_eq!(p.set_hour12(7), Ok(()));
+        assert!(p.set_ampm(true).is_ok());
+        assert!(p.set_hour12(7).is_ok());
         assert_eq!(p.set_hour(7), Err(IMPOSSIBLE));
         assert_eq!(p.set_hour(18), Err(IMPOSSIBLE));
-        assert_eq!(p.set_hour(19), Ok(()));
+        assert!(p.set_hour(19).is_ok());
 
         // timestamp
         let mut p = Parsed::new();
-        assert_eq!(p.set_timestamp(1_234_567_890), Ok(()));
+        assert!(p.set_timestamp(1_234_567_890).is_ok());
         assert_eq!(p.set_timestamp(1_234_567_889), Err(IMPOSSIBLE));
         assert_eq!(p.set_timestamp(1_234_567_891), Err(IMPOSSIBLE));
     }

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -124,49 +124,28 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 /// }
 /// # Ok::<(), chrono::ParseError>(())
 /// ```
-#[non_exhaustive]
 #[derive(Clone, PartialEq, Eq, Debug, Default, Hash)]
 pub struct Parsed {
-    #[doc(hidden)]
-    pub year: Option<i32>,
-    #[doc(hidden)]
-    pub year_div_100: Option<i32>,
-    #[doc(hidden)]
-    pub year_mod_100: Option<i32>,
-    #[doc(hidden)]
-    pub isoyear: Option<i32>,
-    #[doc(hidden)]
-    pub isoyear_div_100: Option<i32>,
-    #[doc(hidden)]
-    pub isoyear_mod_100: Option<i32>,
-    #[doc(hidden)]
-    pub month: Option<u32>,
-    #[doc(hidden)]
-    pub week_from_sun: Option<u32>,
-    #[doc(hidden)]
-    pub week_from_mon: Option<u32>,
-    #[doc(hidden)]
-    pub isoweek: Option<u32>,
-    #[doc(hidden)]
-    pub weekday: Option<Weekday>,
-    #[doc(hidden)]
-    pub ordinal: Option<u32>,
-    #[doc(hidden)]
-    pub day: Option<u32>,
-    #[doc(hidden)]
-    pub hour_div_12: Option<u32>,
-    #[doc(hidden)]
-    pub hour_mod_12: Option<u32>,
-    #[doc(hidden)]
-    pub minute: Option<u32>,
-    #[doc(hidden)]
-    pub second: Option<u32>,
-    #[doc(hidden)]
-    pub nanosecond: Option<u32>,
-    #[doc(hidden)]
-    pub timestamp: Option<i64>,
-    #[doc(hidden)]
-    pub offset: Option<i32>,
+    year: Option<i32>,
+    year_div_100: Option<i32>, // 0..=i32::MAX
+    year_mod_100: Option<i32>, // 0..=99
+    isoyear: Option<i32>,
+    isoyear_div_100: Option<i32>, // 0..=i32::MAX
+    isoyear_mod_100: Option<i32>, // 0..=99
+    month: Option<u32>,           // 1..=12
+    week_from_sun: Option<u32>,   // 0..=53
+    week_from_mon: Option<u32>,   // 0..=53
+    isoweek: Option<u32>,         // 1..=53
+    weekday: Option<Weekday>,
+    ordinal: Option<u32>,     // 1..=366
+    day: Option<u32>,         // 1..=31
+    hour_div_12: Option<u32>, // 0 = AM, 1 = PM
+    hour_mod_12: Option<u32>, // 0..=11
+    minute: Option<u32>,      // 0..=59
+    second: Option<u32>,      // 0..=60
+    nanosecond: Option<u32>,  // 0..=999_999_999
+    timestamp: Option<i64>,
+    offset: Option<i32>,
 }
 
 /// Checks if `old` is either empty or has the same value as `new` (i.e. "consistent"),

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -62,7 +62,7 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 /// use chrono::format::{ParseErrorKind, Parsed};
 /// use chrono::Weekday;
 ///
-/// let mut parsed = Parsed::new();
+/// let mut parsed = Parsed::default();
 /// parsed
 ///     .set_weekday(Weekday::Wed)?
 ///     .set_day(31)?
@@ -75,7 +75,7 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 /// let dt = parsed.to_datetime()?;
 /// assert_eq!(dt.to_rfc2822(), "Wed, 31 Dec 2014 04:26:40 +0000");
 ///
-/// let mut parsed = Parsed::new();
+/// let mut parsed = Parsed::default();
 /// parsed
 ///     .set_weekday(Weekday::Thu)? // changed to the wrong day
 ///     .set_day(31)?
@@ -107,13 +107,13 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 ///
 /// let rfc_2822 = [Item::Fixed(Fixed::RFC2822)];
 ///
-/// let mut parsed = Parsed::new();
+/// let mut parsed = Parsed::default();
 /// parse(&mut parsed, "Wed, 31 Dec 2014 04:26:40 +0000", rfc_2822.iter())?;
 /// let dt = parsed.to_datetime()?;
 ///
 /// assert_eq!(dt.to_rfc2822(), "Wed, 31 Dec 2014 04:26:40 +0000");
 ///
-/// let mut parsed = Parsed::new();
+/// let mut parsed = Parsed::default();
 /// parse(&mut parsed, "Thu, 31 Dec 2014 04:26:40 +0000", rfc_2822.iter())?;
 /// let result = parsed.to_datetime();
 ///
@@ -165,12 +165,6 @@ fn set_if_consistent<T: PartialEq>(old: &mut Option<T>, new: T) -> ParseResult<(
 }
 
 impl Parsed {
-    /// Returns the initial value of parsed parts.
-    #[must_use]
-    pub fn new() -> Parsed {
-        Parsed::default()
-    }
-
     /// Set the [`year`](Parsed::year) field to the given value.
     ///
     /// The value can be negative, unlike the [`year_div_100`](Parsed::year_div_100) and
@@ -1143,7 +1137,7 @@ mod tests {
     #[test]
     fn test_parsed_set_fields() {
         // year*, isoyear*
-        let mut p = Parsed::new();
+        let mut p = Parsed::default();
         assert!(p.set_year(1987).is_ok());
         assert_eq!(p.set_year(1986), Err(IMPOSSIBLE));
         assert_eq!(p.set_year(1988), Err(IMPOSSIBLE));
@@ -1155,37 +1149,37 @@ mod tests {
         assert_eq!(p.set_year_mod_100(38), Err(IMPOSSIBLE));
         assert_eq!(p.set_year_mod_100(36), Err(IMPOSSIBLE));
 
-        let mut p = Parsed::new();
+        let mut p = Parsed::default();
         assert!(p.set_year(0).is_ok());
         assert!(p.set_year_div_100(0).is_ok());
         assert!(p.set_year_mod_100(0).is_ok());
 
-        let mut p = Parsed::new();
+        let mut p = Parsed::default();
         assert_eq!(p.set_year_div_100(-1), Err(OUT_OF_RANGE));
         assert_eq!(p.set_year_mod_100(-1), Err(OUT_OF_RANGE));
         assert!(p.set_year(-1).is_ok());
         assert_eq!(p.set_year(-2), Err(IMPOSSIBLE));
         assert_eq!(p.set_year(0), Err(IMPOSSIBLE));
 
-        let mut p = Parsed::new();
+        let mut p = Parsed::default();
         assert_eq!(p.set_year_div_100(0x1_0000_0008), Err(OUT_OF_RANGE));
         assert!(p.set_year_div_100(8).is_ok());
         assert_eq!(p.set_year_div_100(0x1_0000_0008), Err(OUT_OF_RANGE));
 
         // month, week*, isoweek, ordinal, day, minute, second, nanosecond, offset
-        let mut p = Parsed::new();
+        let mut p = Parsed::default();
         assert!(p.set_month(7).is_ok());
         assert_eq!(p.set_month(1), Err(IMPOSSIBLE));
         assert_eq!(p.set_month(6), Err(IMPOSSIBLE));
         assert_eq!(p.set_month(8), Err(IMPOSSIBLE));
         assert_eq!(p.set_month(12), Err(IMPOSSIBLE));
 
-        let mut p = Parsed::new();
+        let mut p = Parsed::default();
         assert!(p.set_month(8).is_ok());
         assert_eq!(p.set_month(0x1_0000_0008), Err(OUT_OF_RANGE));
 
         // hour
-        let mut p = Parsed::new();
+        let mut p = Parsed::default();
         assert!(p.set_hour(12).is_ok());
         assert_eq!(p.set_hour(11), Err(IMPOSSIBLE));
         assert_eq!(p.set_hour(13), Err(IMPOSSIBLE));
@@ -1197,7 +1191,7 @@ mod tests {
         assert_eq!(p.set_hour12(1), Err(IMPOSSIBLE));
         assert_eq!(p.set_hour12(11), Err(IMPOSSIBLE));
 
-        let mut p = Parsed::new();
+        let mut p = Parsed::default();
         assert!(p.set_ampm(true).is_ok());
         assert!(p.set_hour12(7).is_ok());
         assert_eq!(p.set_hour(7), Err(IMPOSSIBLE));
@@ -1205,7 +1199,7 @@ mod tests {
         assert!(p.set_hour(19).is_ok());
 
         // timestamp
-        let mut p = Parsed::new();
+        let mut p = Parsed::default();
         assert!(p.set_timestamp(1_234_567_890).is_ok());
         assert_eq!(p.set_timestamp(1_234_567_889), Err(IMPOSSIBLE));
         assert_eq!(p.set_timestamp(1_234_567_891), Err(IMPOSSIBLE));
@@ -1213,105 +1207,105 @@ mod tests {
 
     #[test]
     fn test_parsed_set_range() {
-        assert_eq!(Parsed::new().set_year(i32::MIN as i64 - 1), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_year(i32::MIN as i64).is_ok());
-        assert!(Parsed::new().set_year(i32::MAX as i64).is_ok());
-        assert_eq!(Parsed::new().set_year(i32::MAX as i64 + 1), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_year(i32::MIN as i64 - 1), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_year(i32::MIN as i64).is_ok());
+        assert!(Parsed::default().set_year(i32::MAX as i64).is_ok());
+        assert_eq!(Parsed::default().set_year(i32::MAX as i64 + 1), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_year_div_100(-1), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_year_div_100(0).is_ok());
-        assert!(Parsed::new().set_year_div_100(i32::MAX as i64).is_ok());
-        assert_eq!(Parsed::new().set_year_div_100(i32::MAX as i64 + 1), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_year_div_100(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_year_div_100(0).is_ok());
+        assert!(Parsed::default().set_year_div_100(i32::MAX as i64).is_ok());
+        assert_eq!(Parsed::default().set_year_div_100(i32::MAX as i64 + 1), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_year_mod_100(-1), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_year_mod_100(0).is_ok());
-        assert!(Parsed::new().set_year_mod_100(99).is_ok());
-        assert_eq!(Parsed::new().set_year_mod_100(100), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_year_mod_100(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_year_mod_100(0).is_ok());
+        assert!(Parsed::default().set_year_mod_100(99).is_ok());
+        assert_eq!(Parsed::default().set_year_mod_100(100), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_isoyear(i32::MIN as i64 - 1), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_isoyear(i32::MIN as i64).is_ok());
-        assert!(Parsed::new().set_isoyear(i32::MAX as i64).is_ok());
-        assert_eq!(Parsed::new().set_isoyear(i32::MAX as i64 + 1), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_isoyear(i32::MIN as i64 - 1), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_isoyear(i32::MIN as i64).is_ok());
+        assert!(Parsed::default().set_isoyear(i32::MAX as i64).is_ok());
+        assert_eq!(Parsed::default().set_isoyear(i32::MAX as i64 + 1), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_isoyear_div_100(-1), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_isoyear_div_100(0).is_ok());
-        assert!(Parsed::new().set_isoyear_div_100(99).is_ok());
-        assert_eq!(Parsed::new().set_isoyear_div_100(i32::MAX as i64 + 1), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_isoyear_div_100(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_isoyear_div_100(0).is_ok());
+        assert!(Parsed::default().set_isoyear_div_100(99).is_ok());
+        assert_eq!(Parsed::default().set_isoyear_div_100(i32::MAX as i64 + 1), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_isoyear_mod_100(-1), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_isoyear_mod_100(0).is_ok());
-        assert!(Parsed::new().set_isoyear_mod_100(99).is_ok());
-        assert_eq!(Parsed::new().set_isoyear_mod_100(100), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_isoyear_mod_100(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_isoyear_mod_100(0).is_ok());
+        assert!(Parsed::default().set_isoyear_mod_100(99).is_ok());
+        assert_eq!(Parsed::default().set_isoyear_mod_100(100), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_month(0), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_month(1).is_ok());
-        assert!(Parsed::new().set_month(12).is_ok());
-        assert_eq!(Parsed::new().set_month(13), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_month(0), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_month(1).is_ok());
+        assert!(Parsed::default().set_month(12).is_ok());
+        assert_eq!(Parsed::default().set_month(13), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_week_from_sun(-1), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_week_from_sun(0).is_ok());
-        assert!(Parsed::new().set_week_from_sun(53).is_ok());
-        assert_eq!(Parsed::new().set_week_from_sun(54), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_week_from_sun(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_week_from_sun(0).is_ok());
+        assert!(Parsed::default().set_week_from_sun(53).is_ok());
+        assert_eq!(Parsed::default().set_week_from_sun(54), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_week_from_mon(-1), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_week_from_mon(0).is_ok());
-        assert!(Parsed::new().set_week_from_mon(53).is_ok());
-        assert_eq!(Parsed::new().set_week_from_mon(54), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_week_from_mon(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_week_from_mon(0).is_ok());
+        assert!(Parsed::default().set_week_from_mon(53).is_ok());
+        assert_eq!(Parsed::default().set_week_from_mon(54), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_isoweek(0), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_isoweek(1).is_ok());
-        assert!(Parsed::new().set_isoweek(53).is_ok());
-        assert_eq!(Parsed::new().set_isoweek(54), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_isoweek(0), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_isoweek(1).is_ok());
+        assert!(Parsed::default().set_isoweek(53).is_ok());
+        assert_eq!(Parsed::default().set_isoweek(54), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_ordinal(0), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_ordinal(1).is_ok());
-        assert!(Parsed::new().set_ordinal(366).is_ok());
-        assert_eq!(Parsed::new().set_ordinal(367), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_ordinal(0), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_ordinal(1).is_ok());
+        assert!(Parsed::default().set_ordinal(366).is_ok());
+        assert_eq!(Parsed::default().set_ordinal(367), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_day(0), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_day(1).is_ok());
-        assert!(Parsed::new().set_day(31).is_ok());
-        assert_eq!(Parsed::new().set_day(32), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_day(0), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_day(1).is_ok());
+        assert!(Parsed::default().set_day(31).is_ok());
+        assert_eq!(Parsed::default().set_day(32), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_hour12(0), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_hour12(1).is_ok());
-        assert!(Parsed::new().set_hour12(12).is_ok());
-        assert_eq!(Parsed::new().set_hour12(13), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_hour12(0), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_hour12(1).is_ok());
+        assert!(Parsed::default().set_hour12(12).is_ok());
+        assert_eq!(Parsed::default().set_hour12(13), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_hour(-1), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_hour(0).is_ok());
-        assert!(Parsed::new().set_hour(23).is_ok());
-        assert_eq!(Parsed::new().set_hour(24), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_hour(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_hour(0).is_ok());
+        assert!(Parsed::default().set_hour(23).is_ok());
+        assert_eq!(Parsed::default().set_hour(24), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_minute(-1), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_minute(0).is_ok());
-        assert!(Parsed::new().set_minute(59).is_ok());
-        assert_eq!(Parsed::new().set_minute(60), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_minute(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_minute(0).is_ok());
+        assert!(Parsed::default().set_minute(59).is_ok());
+        assert_eq!(Parsed::default().set_minute(60), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_second(-1), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_second(0).is_ok());
-        assert!(Parsed::new().set_second(60).is_ok());
-        assert_eq!(Parsed::new().set_second(61), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_second(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_second(0).is_ok());
+        assert!(Parsed::default().set_second(60).is_ok());
+        assert_eq!(Parsed::default().set_second(61), Err(OUT_OF_RANGE));
 
-        assert_eq!(Parsed::new().set_nanosecond(-1), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_nanosecond(0).is_ok());
-        assert!(Parsed::new().set_nanosecond(999_999_999).is_ok());
-        assert_eq!(Parsed::new().set_nanosecond(1_000_000_000), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_nanosecond(-1), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_nanosecond(0).is_ok());
+        assert!(Parsed::default().set_nanosecond(999_999_999).is_ok());
+        assert_eq!(Parsed::default().set_nanosecond(1_000_000_000), Err(OUT_OF_RANGE));
 
-        assert!(Parsed::new().set_timestamp(i64::MIN).is_ok());
-        assert!(Parsed::new().set_timestamp(i64::MAX).is_ok());
+        assert!(Parsed::default().set_timestamp(i64::MIN).is_ok());
+        assert!(Parsed::default().set_timestamp(i64::MAX).is_ok());
 
-        assert_eq!(Parsed::new().set_offset(i32::MIN as i64 - 1), Err(OUT_OF_RANGE));
-        assert!(Parsed::new().set_offset(i32::MIN as i64).is_ok());
-        assert!(Parsed::new().set_offset(i32::MAX as i64).is_ok());
-        assert_eq!(Parsed::new().set_offset(i32::MAX as i64 + 1), Err(OUT_OF_RANGE));
+        assert_eq!(Parsed::default().set_offset(i32::MIN as i64 - 1), Err(OUT_OF_RANGE));
+        assert!(Parsed::default().set_offset(i32::MIN as i64).is_ok());
+        assert!(Parsed::default().set_offset(i32::MAX as i64).is_ok());
+        assert_eq!(Parsed::default().set_offset(i32::MAX as i64 + 1), Err(OUT_OF_RANGE));
     }
 
     #[test]
     fn test_parsed_to_naive_date() {
         macro_rules! parse {
             ($($k:ident: $v:expr),*) => (
-                Parsed { $($k: Some($v),)* ..Parsed::new() }.to_naive_date()
+                Parsed { $($k: Some($v),)* ..Parsed::default() }.to_naive_date()
             )
         }
 
@@ -1465,7 +1459,7 @@ mod tests {
     fn test_parsed_to_naive_time() {
         macro_rules! parse {
             ($($k:ident: $v:expr),*) => (
-                Parsed { $($k: Some($v),)* ..Parsed::new() }.to_naive_time()
+                Parsed { $($k: Some($v),)* ..Parsed::default() }.to_naive_time()
             )
         }
 
@@ -1506,7 +1500,7 @@ mod tests {
     fn test_parsed_to_naive_datetime_with_offset() {
         macro_rules! parse {
             (offset = $offset:expr; $($k:ident: $v:expr),*) => (
-                Parsed { $($k: Some($v),)* ..Parsed::new() }.to_naive_datetime_with_offset($offset)
+                Parsed { $($k: Some($v),)* ..Parsed::default() }.to_naive_datetime_with_offset($offset)
             );
             ($($k:ident: $v:expr),*) => (parse!(offset = 0; $($k: $v),*))
         }
@@ -1652,7 +1646,7 @@ mod tests {
     fn test_parsed_to_datetime() {
         macro_rules! parse {
             ($($k:ident: $v:expr),*) => (
-                Parsed { $($k: Some($v),)* ..Parsed::new() }.to_datetime()
+                Parsed { $($k: Some($v),)* ..Parsed::default() }.to_datetime()
             )
         }
 
@@ -1697,7 +1691,7 @@ mod tests {
     fn test_parsed_to_datetime_with_timezone() {
         macro_rules! parse {
             ($tz:expr; $($k:ident: $v:expr),*) => (
-                Parsed { $($k: Some($v),)* ..Parsed::new() }.to_datetime_with_timezone(&$tz)
+                Parsed { $($k: Some($v),)* ..Parsed::default() }.to_datetime_with_timezone(&$tz)
             )
         }
 
@@ -1768,7 +1762,7 @@ mod tests {
         use crate::Weekday;
         assert_eq!(
             NaiveDate::from_ymd(2002, 6, 3).unwrap(),
-            Parsed::new()
+            Parsed::default()
                 .set_year(2002)?
                 .set_week_from_mon(22)?
                 .set_weekday(Weekday::Mon)?
@@ -1776,7 +1770,7 @@ mod tests {
         );
         assert_eq!(
             NaiveDate::from_ymd(2001, 5, 28).unwrap(),
-            Parsed::new()
+            Parsed::default()
                 .set_year(2001)?
                 .set_week_from_mon(22)?
                 .set_weekday(Weekday::Mon)?

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -323,7 +323,7 @@ impl<'a> StrftimeItems<'a> {
     /// );
     ///
     /// // Parsing
-    /// let mut parsed = Parsed::new();
+    /// let mut parsed = Parsed::default();
     /// parse(&mut parsed, "11 Jul 2023 9.00", fmt_items.as_slice().iter())?;
     /// let parsed_dt = parsed.to_naive_datetime_with_offset(0)?;
     /// assert_eq!(parsed_dt, datetime);

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -410,7 +410,7 @@ impl NaiveDate {
     /// assert!(parse_from_str("Sat, 09 Aug 2013", "%a, %d %b %Y").is_err());
     /// ```
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<NaiveDate> {
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         parse(&mut parsed, s, StrftimeItems::new(fmt))?;
         parsed.to_naive_date()
     }
@@ -432,7 +432,7 @@ impl NaiveDate {
     /// assert_eq!(remainder, " trailing text");
     /// ```
     pub fn parse_and_remainder<'a>(s: &'a str, fmt: &str) -> ParseResult<(NaiveDate, &'a str)> {
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         let remainder = parse_and_remainder(&mut parsed, s, StrftimeItems::new(fmt))?;
         parsed.to_naive_date().map(|d| (d, remainder))
     }
@@ -2147,7 +2147,7 @@ impl str::FromStr for NaiveDate {
             Item::Space(""),
         ];
 
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         parse(&mut parsed, s, ITEMS.iter())?;
         parsed.to_naive_date()
     }

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -244,7 +244,7 @@ impl NaiveDateTime {
     /// assert!(parse_from_str("+10000-09-09 01:46:39", fmt).is_ok());
     /// ```
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<NaiveDateTime> {
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         parse(&mut parsed, s, StrftimeItems::new(fmt))?;
         parsed.to_naive_datetime_with_offset(0) // no offset adjustment
     }
@@ -269,7 +269,7 @@ impl NaiveDateTime {
     /// assert_eq!(remainder, " trailing text");
     /// ```
     pub fn parse_and_remainder<'a>(s: &'a str, fmt: &str) -> ParseResult<(NaiveDateTime, &'a str)> {
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         let remainder = parse_and_remainder(&mut parsed, s, StrftimeItems::new(fmt))?;
         parsed.to_naive_datetime_with_offset(0).map(|d| (d, remainder)) // no offset adjustment
     }
@@ -2029,7 +2029,7 @@ impl str::FromStr for NaiveDateTime {
             Item::Space(""),
         ];
 
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         parse(&mut parsed, s, ITEMS.iter())?;
         parsed.to_naive_datetime_with_offset(0)
     }

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -493,7 +493,7 @@ impl NaiveTime {
     /// assert!(parse_from_str("13:07 AM", "%H:%M %p").is_err());
     /// ```
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<NaiveTime> {
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         parse(&mut parsed, s, StrftimeItems::new(fmt))?;
         parsed.to_naive_time()
     }
@@ -515,7 +515,7 @@ impl NaiveTime {
     /// assert_eq!(remainder, " trailing text");
     /// ```
     pub fn parse_and_remainder<'a>(s: &'a str, fmt: &str) -> ParseResult<(NaiveTime, &'a str)> {
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         let remainder = parse_and_remainder(&mut parsed, s, StrftimeItems::new(fmt))?;
         parsed.to_naive_time().map(|t| (t, remainder))
     }
@@ -1539,7 +1539,7 @@ impl str::FromStr for NaiveTime {
         ];
         const TRAILING_WHITESPACE: [Item<'static>; 1] = [Item::Space("")];
 
-        let mut parsed = Parsed::new();
+        let mut parsed = Parsed::default();
         let s = parse_and_remainder(&mut parsed, s, HOUR_AND_MINUTE.iter())?;
         // Seconds are optional, don't fail if parsing them doesn't succeed.
         let s = parse_and_remainder(&mut parsed, s, SECOND_AND_NANOS.iter()).unwrap_or(s);


### PR DESCRIPTION
The first commit changes the signature of the `Parsed::set_*` methods to be usable in a builder pattern, returning `ParseResult<&mut Parsed>`.

Now that they can be used in a builder pattern, the second commit replaces the `parsed!` macro in `format::parse`. That accounts for 250 of the changed lines in this PR.

Then we can change the fields of `Parsed` to private, and update the tests to no longer set them to invalid values.

The final commit removes some range checks from `Parsed::_to` that have now become unnecessary.