### PR TITLE
Deprecate `Parsed::to_naive_datetime_with_offset`, simplify logic

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1027,6 +1027,16 @@ impl DateTime<FixedOffset> {
     ///         .unwrap())
     /// );
     /// ```
+    ///
+    /// All parsed fields should be consistent to each other, otherwise it's an error.
+    ///
+    /// ```
+    /// # use chrono::DateTime;
+    /// # let parse_from_str = DateTime::parse_from_str;
+    /// let fmt = "%Y-%m-%d %H:%M:%S %z = timestamp %s";
+    /// assert!(parse_from_str("2001-09-09 01:46:39 +00:00 = timestamp 999999999", fmt).is_ok());
+    /// assert!(parse_from_str("1970-01-01 00:00:00 +00:00 = timestamp 1", fmt).is_err());
+    /// ```
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<DateTime<FixedOffset>> {
         let mut parsed = Parsed::new();
         parse(&mut parsed, s, StrftimeItems::new(fmt))?;

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -970,8 +970,10 @@ impl Parsed {
 
     /// Returns a parsed naive date and time out of given fields.
     ///
-    /// The offset field will be ignored. If there is a timestamp field set, all other date and time
-    /// fields must be in UTC.
+    /// If there are not enough date and time fields set for a complete `NaiveDateTime`, the date
+    /// and time are derived from the timestamp if present:
+    /// - If the offset field is set the local date and time will be calculated.
+    /// - Otherwise the offset is assumed to be `0`, returning a `NaiveDateTime` in UTC.
     ///
     /// # Errors
     ///
@@ -985,7 +987,7 @@ impl Parsed {
     ///   - if the value would be outside the range of a [`NaiveDateTime`].
     ///   - if the date does not exist.
     pub fn to_naive_datetime(&self) -> ParseResult<NaiveDateTime> {
-        self.to_naive_datetime_with_offset(0)
+        self.to_datetime_or_utc().map(|dt| dt.naive_local())
     }
 
     /// Returns a parsed timezone-aware date and time out of given fields.

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -886,6 +886,10 @@ impl Parsed {
     ///     range.
     ///   - if the value would be outside the range of a [`NaiveDateTime`].
     ///   - if the date does not exist.
+    #[deprecated(
+        since = "0.4.36",
+        note = "Use `to_datetime_or_utc`, `to_naive_datetime()` or `to_datetime()` instead"
+    )]
     pub fn to_naive_datetime_with_offset(&self, offset: i32) -> ParseResult<NaiveDateTime> {
         let date = self.to_naive_date();
         let time = self.to_naive_time();

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -859,6 +859,26 @@ impl Parsed {
         FixedOffset::east_opt(self.offset.ok_or(NOT_ENOUGH)?).ok_or(OUT_OF_RANGE)
     }
 
+    /// Returns a parsed naive date and time out of given fields.
+    ///
+    /// The offset field will be ignored. If there is a timestamp field set, all other date and time
+    /// fields must be in UTC.
+    ///
+    /// # Errors
+    ///
+    /// This method returns:
+    /// - `IMPOSSIBLE` if any of the date fields conflict, or if a timestamp conflicts with any of
+    ///   the other fields.
+    /// - `NOT_ENOUGH` if there are not enough fields set in `Parsed` for a complete datetime.
+    /// - `OUT_OF_RANGE`
+    ///   - if any of the date or time fields of `Parsed` are set to a value beyond their acceptable
+    ///     range.
+    ///   - if the value would be outside the range of a [`NaiveDateTime`].
+    ///   - if the date does not exist.
+    pub fn to_naive_datetime(&self) -> ParseResult<NaiveDateTime> {
+        self.to_naive_datetime_with_offset(0)
+    }
+
     /// Returns a parsed timezone-aware date and time out of given fields.
     ///
     /// This method is able to determine the combined date and time from date, time and offset

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -325,7 +325,7 @@ impl<'a> StrftimeItems<'a> {
     /// // Parsing
     /// let mut parsed = Parsed::new();
     /// parse(&mut parsed, "11 Jul 2023  9.00", fmt_items.as_slice().iter())?;
-    /// let parsed_dt = parsed.to_naive_datetime_with_offset(0)?;
+    /// let parsed_dt = parsed.to_naive_datetime()?;
     /// assert_eq!(parsed_dt, datetime);
     /// # Ok::<(), chrono::ParseError>(())
     /// ```

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -287,7 +287,7 @@ impl NaiveDateTime {
     pub fn parse_from_str(s: &str, fmt: &str) -> ParseResult<NaiveDateTime> {
         let mut parsed = Parsed::new();
         parse(&mut parsed, s, StrftimeItems::new(fmt))?;
-        parsed.to_naive_datetime_with_offset(0) // no offset adjustment
+        parsed.to_naive_datetime()
     }
 
     /// Parses a string with the specified format string and returns a new `NaiveDateTime`, and a
@@ -315,7 +315,7 @@ impl NaiveDateTime {
     pub fn parse_and_remainder<'a>(s: &'a str, fmt: &str) -> ParseResult<(NaiveDateTime, &'a str)> {
         let mut parsed = Parsed::new();
         let remainder = parse_and_remainder(&mut parsed, s, StrftimeItems::new(fmt))?;
-        parsed.to_naive_datetime_with_offset(0).map(|d| (d, remainder)) // no offset adjustment
+        parsed.to_naive_datetime().map(|d| (d, remainder))
     }
 
     /// Retrieves a date component.
@@ -2140,7 +2140,7 @@ impl str::FromStr for NaiveDateTime {
 
         let mut parsed = Parsed::new();
         parse(&mut parsed, s, ITEMS.iter())?;
-        parsed.to_naive_datetime_with_offset(0)
+        parsed.to_naive_datetime()
     }
 }
 

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -265,16 +265,6 @@ impl NaiveDateTime {
     /// assert!(parse_from_str("94/9/4 24:00:00", "%y/%m/%d %H:%M:%S").is_err());
     /// ```
     ///
-    /// All parsed fields should be consistent to each other, otherwise it's an error.
-    ///
-    /// ```
-    /// # use chrono::NaiveDateTime;
-    /// # let parse_from_str = NaiveDateTime::parse_from_str;
-    /// let fmt = "%Y-%m-%d %H:%M:%S = UNIX timestamp %s";
-    /// assert!(parse_from_str("2001-09-09 01:46:39 = UNIX timestamp 999999999", fmt).is_ok());
-    /// assert!(parse_from_str("1970-01-01 00:00:00 = UNIX timestamp 1", fmt).is_err());
-    /// ```
-    ///
     /// Years before 1 BCE or after 9999 CE, require an initial sign
     ///
     ///```


### PR DESCRIPTION
I would like to deprecate `Parsed::to_naive_datetime_with_offset` and replace it with `Parsed::to_datetime_or_utc` and `Parsed::to_naive_datetime`.

The reason is that in my opinion any use of `Parsed::to_naive_datetime_with_offset` had its logic inside out. Because why would you need to supply an offset in order to parse something as `NaiveDateTime`? It needed it just in case `Parsed` contained a UTC timestamp and also local date and time fields, that have to be checked against each other.

What makes the code much more natural is to parse into a `DateTime<FixedOffset>` first, and discard the offset if all you need is a `NaiveDateTime`.

With this changes we can add two pieces of functionality:
- Allow creating a `NaiveDateTime` from only a timestamp with offset.
- Fix roundtripping values near `DateTime::{MIN, MAX}` where the offset pushes the local value out of range, where we were limited by the API of `Parsed` before (not implemented here yet).

We do now also accept something like:
```rust
let fmt = "%Y-%m-%d %H:%M:%S = timestamp %s";
assert!(NaiveDateTime::parse_from_str("1970-01-01 01:00:00 = timestamp 0", fmt).is_err());
```

It will assume the date and time are not in UTC but have an offset of one hour.

--------

We unfortunately can't reuse the new logic in `Parsed::to_datetime_or_utc` in the old `Parsed::to_naive_datetime_with_offset`. The old method does not check the offset field for consistency, which it left up to the callers.