### PR TITLE
Convert time-related `with_*` methods to return `Result`

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -730,7 +730,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///   daylight saving time transition.
     #[inline]
     pub fn with_hour(&self, hour: u32) -> Option<DateTime<Tz>> {
-        map_local(self, |datetime| datetime.with_hour(hour))
+        map_local(self, |datetime| datetime.with_hour(hour).ok())
     }
 
     /// Makes a new `DateTime` with the minute number changed.

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -744,7 +744,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///   daylight saving time transition.
     #[inline]
     pub fn with_minute(&self, min: u32) -> Option<DateTime<Tz>> {
-        map_local(self, |datetime| datetime.with_minute(min))
+        map_local(self, |datetime| datetime.with_minute(min).ok())
     }
 
     /// Makes a new `DateTime` with the second number changed.

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -762,7 +762,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///   daylight saving time transition.
     #[inline]
     pub fn with_second(&self, sec: u32) -> Option<DateTime<Tz>> {
-        map_local(self, |datetime| datetime.with_second(sec))
+        map_local(self, |datetime| datetime.with_second(sec).ok())
     }
 
     /// Makes a new `DateTime` with nanoseconds since the whole non-leap second changed.

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -778,7 +778,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// Returns `None` if `nanosecond >= 2,000,000,000`.
     #[inline]
     pub fn with_nanosecond(&self, nano: u32) -> Option<DateTime<Tz>> {
-        map_local(self, |datetime| datetime.with_nanosecond(nano))
+        map_local(self, |datetime| datetime.with_nanosecond(nano).ok())
     }
 }
 

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -1016,7 +1016,7 @@ impl NaiveDateTime {
     /// ```
     #[inline]
     pub const fn with_second(&self, sec: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { time: try_opt!(self.time.with_second(sec)), ..*self })
+        Some(NaiveDateTime { time: try_opt!(ok!(self.time.with_second(sec))), ..*self })
     }
 
     /// Makes a new `NaiveDateTime` with nanoseconds since the whole non-leap second changed.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -987,7 +987,7 @@ impl NaiveDateTime {
     /// ```
     #[inline]
     pub const fn with_minute(&self, min: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { time: try_opt!(self.time.with_minute(min)), ..*self })
+        Some(NaiveDateTime { time: try_opt!(ok!(self.time.with_minute(min))), ..*self })
     }
 
     /// Makes a new `NaiveDateTime` with the second number changed.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -20,8 +20,8 @@ use crate::format::{Fixed, Item, Numeric, Pad};
 use crate::naive::{Days, IsoWeek, NaiveDate, NaiveTime};
 use crate::offset::Utc;
 use crate::{
-    expect, ok, try_opt, DateTime, Datelike, FixedOffset, LocalResult, Months, TimeDelta, TimeZone,
-    Timelike, Weekday,
+    expect, ok, try_err, try_opt, DateTime, Datelike, Error, FixedOffset, LocalResult, Months,
+    TimeDelta, TimeZone, Timelike, Weekday,
 };
 
 /// Tools to help serializing/deserializing `NaiveDateTime`s
@@ -944,24 +944,21 @@ impl NaiveDateTime {
     ///
     /// # Errors
     ///
-    /// Returns `None` if the value for `hour` is invalid.
+    /// Returns [`Error::InvalidArgument`] if the value for `hour` is invalid.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::{NaiveDate, NaiveDateTime};
+    /// use chrono::{Error, NaiveDate};
     ///
-    /// let dt: NaiveDateTime =
-    ///     NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 56, 789).unwrap();
-    /// assert_eq!(
-    ///     dt.with_hour(7),
-    ///     Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(7, 34, 56, 789).unwrap())
-    /// );
-    /// assert_eq!(dt.with_hour(24), None);
+    /// let dt = NaiveDate::from_ymd(2015, 9, 8)?.and_hms_milli(12, 34, 56, 789)?;
+    /// assert_eq!(dt.with_hour(7), NaiveDate::from_ymd(2015, 9, 8)?.and_hms_milli(7, 34, 56, 789));
+    /// assert_eq!(dt.with_hour(24), Err(Error::InvalidArgument));
+    /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_hour(&self, hour: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { time: try_opt!(ok!(self.time.with_hour(hour))), ..*self })
+    pub const fn with_hour(&self, hour: u32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { time: try_err!(self.time.with_hour(hour)), ..*self })
     }
 
     /// Makes a new `NaiveDateTime` with the minute number changed.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -1057,7 +1057,7 @@ impl NaiveDateTime {
     /// ```
     #[inline]
     pub const fn with_nanosecond(&self, nano: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { time: try_opt!(self.time.with_nanosecond(nano)), ..*self })
+        Some(NaiveDateTime { time: try_opt!(ok!(self.time.with_nanosecond(nano))), ..*self })
     }
 
     /// The minimum possible `NaiveDateTime`.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -1026,35 +1026,28 @@ impl NaiveDateTime {
     ///
     /// # Errors
     ///
-    /// Returns `None` if `nanosecond >= 2,000,000,000`.
+    /// Returns [`Error::InvalidArgument`] if `nanosecond >= 2,000,000,000`.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::{NaiveDate, NaiveDateTime};
+    /// use chrono::{Error, NaiveDate};
     ///
-    /// let dt: NaiveDateTime =
-    ///     NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 59, 789).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 9, 8)?.and_hms_milli(12, 34, 59, 789)?;
     /// assert_eq!(
     ///     dt.with_nanosecond(333_333_333),
-    ///     Some(
-    ///         NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_nano(12, 34, 59, 333_333_333).unwrap()
-    ///     )
+    ///     NaiveDate::from_ymd(2015, 9, 8)?.and_hms_nano(12, 34, 59, 333_333_333)
     /// );
     /// assert_eq!(
     ///     dt.with_nanosecond(1_333_333_333), // leap second
-    ///     Some(
-    ///         NaiveDate::from_ymd(2015, 9, 8)
-    ///             .unwrap()
-    ///             .and_hms_nano(12, 34, 59, 1_333_333_333)
-    ///             .unwrap()
-    ///     )
+    ///     NaiveDate::from_ymd(2015, 9, 8)?.and_hms_nano(12, 34, 59, 1_333_333_333)
     /// );
-    /// assert_eq!(dt.with_nanosecond(2_000_000_000), None);
+    /// assert_eq!(dt.with_nanosecond(2_000_000_000), Err(Error::InvalidArgument));
+    /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_nanosecond(&self, nano: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { time: try_opt!(ok!(self.time.with_nanosecond(nano))), ..*self })
+    pub const fn with_nanosecond(&self, nano: u32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { time: try_err!(self.time.with_nanosecond(nano)), ..*self })
     }
 
     /// The minimum possible `NaiveDateTime`.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -961,7 +961,7 @@ impl NaiveDateTime {
     /// ```
     #[inline]
     pub const fn with_hour(&self, hour: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { time: try_opt!(self.time.with_hour(hour)), ..*self })
+        Some(NaiveDateTime { time: try_opt!(ok!(self.time.with_hour(hour))), ..*self })
     }
 
     /// Makes a new `NaiveDateTime` with the minute number changed.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -967,24 +967,24 @@ impl NaiveDateTime {
     ///
     /// # Errors
     ///
-    /// Returns `None` if the value for `minute` is invalid.
+    /// Returns [`Error::InvalidArgument`] if the value for `minute` is invalid.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::{NaiveDate, NaiveDateTime};
+    /// use chrono::{Error, NaiveDate};
     ///
-    /// let dt: NaiveDateTime =
-    ///     NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 56, 789).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 9, 8)?.and_hms_milli(12, 34, 56, 789)?;
     /// assert_eq!(
     ///     dt.with_minute(45),
-    ///     Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 45, 56, 789).unwrap())
+    ///     NaiveDate::from_ymd(2015, 9, 8)?.and_hms_milli(12, 45, 56, 789)
     /// );
-    /// assert_eq!(dt.with_minute(60), None);
+    /// assert_eq!(dt.with_minute(60), Err(Error::InvalidArgument));
+    /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_minute(&self, min: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { time: try_opt!(ok!(self.time.with_minute(min))), ..*self })
+    pub const fn with_minute(&self, min: u32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { time: try_err!(self.time.with_minute(min)), ..*self })
     }
 
     /// Makes a new `NaiveDateTime` with the second number changed.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -996,24 +996,24 @@ impl NaiveDateTime {
     ///
     /// # Errors
     ///
-    /// Returns `None` if the value for `second` is invalid.
+    /// Returns [`Error::InvalidArgument`] if the value for `second` is invalid.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::{NaiveDate, NaiveDateTime};
+    /// use chrono::{Error, NaiveDate};
     ///
-    /// let dt: NaiveDateTime =
-    ///     NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 56, 789).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 9, 8)?.and_hms_milli(12, 34, 56, 789)?;
     /// assert_eq!(
     ///     dt.with_second(17),
-    ///     Some(NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 17, 789).unwrap())
+    ///     NaiveDate::from_ymd(2015, 9, 8)?.and_hms_milli(12, 34, 17, 789)
     /// );
-    /// assert_eq!(dt.with_second(60), None);
+    /// assert_eq!(dt.with_second(60), Err(Error::InvalidArgument));
+    /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_second(&self, sec: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { time: try_opt!(ok!(self.time.with_second(sec))), ..*self })
+    pub const fn with_second(&self, sec: u32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { time: try_err!(self.time.with_second(sec)), ..*self })
     }
 
     /// Makes a new `NaiveDateTime` with nanoseconds since the whole non-leap second changed.

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -816,24 +816,25 @@ impl NaiveTime {
     ///
     /// # Errors
     ///
-    /// Returns `None` if the value for `hour` is invalid.
+    /// Returns [`Error::InvalidArgument`] if the value for `hour` is invalid.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::NaiveTime;
+    /// use chrono::{Error, NaiveTime};
     ///
-    /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap();
-    /// assert_eq!(dt.with_hour(7), Some(NaiveTime::from_hms_nano(7, 56, 4, 12_345_678).unwrap()));
-    /// assert_eq!(dt.with_hour(24), None);
+    /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678)?;
+    /// assert_eq!(dt.with_hour(7), NaiveTime::from_hms_nano(7, 56, 4, 12_345_678));
+    /// assert_eq!(dt.with_hour(24), Err(Error::InvalidArgument));
+    /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_hour(&self, hour: u32) -> Option<NaiveTime> {
+    pub const fn with_hour(&self, hour: u32) -> Result<NaiveTime, Error> {
         if hour >= 24 {
-            return None;
+            return Err(Error::InvalidArgument);
         }
         let secs = hour * 3600 + self.secs % 3600;
-        Some(NaiveTime { secs, ..*self })
+        Ok(NaiveTime { secs, ..*self })
     }
 
     /// Makes a new `NaiveTime` with the minute number changed.

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -869,24 +869,25 @@ impl NaiveTime {
     ///
     /// # Errors
     ///
-    /// Returns `None` if the value for `second` is invalid.
+    /// Returns [`Error::InvalidArgument`] if the value for `second` is invalid.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::NaiveTime;
+    /// use chrono::{Error, NaiveTime};
     ///
-    /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap();
-    /// assert_eq!(dt.with_second(17), Some(NaiveTime::from_hms_nano(23, 56, 17, 12_345_678).unwrap()));
-    /// assert_eq!(dt.with_second(60), None);
+    /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678)?;
+    /// assert_eq!(dt.with_second(17), NaiveTime::from_hms_nano(23, 56, 17, 12_345_678));
+    /// assert_eq!(dt.with_second(60), Err(Error::InvalidArgument));
+    /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_second(&self, sec: u32) -> Option<NaiveTime> {
+    pub const fn with_second(&self, sec: u32) -> Result<NaiveTime, Error> {
         if sec >= 60 {
-            return None;
+            return Err(Error::InvalidArgument);
         }
         let secs = self.secs / 60 * 60 + sec;
-        Some(NaiveTime { secs, ..*self })
+        Ok(NaiveTime { secs, ..*self })
     }
 
     /// Makes a new `NaiveTime` with nanoseconds since the whole non-leap second changed.

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -897,19 +897,20 @@ impl NaiveTime {
     ///
     /// # Errors
     ///
-    /// Returns `None` if `nanosecond >= 2,000,000,000`.
+    /// Returns [`Error::InvalidArgument`] if `nanosecond >= 2,000,000,000`.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::NaiveTime;
+    /// use chrono::{Error, NaiveTime};
     ///
-    /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap();
+    /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678)?;
     /// assert_eq!(
     ///     dt.with_nanosecond(333_333_333),
-    ///     Some(NaiveTime::from_hms_nano(23, 56, 4, 333_333_333).unwrap())
+    ///     NaiveTime::from_hms_nano(23, 56, 4, 333_333_333)
     /// );
-    /// assert_eq!(dt.with_nanosecond(2_000_000_000), None);
+    /// assert_eq!(dt.with_nanosecond(2_000_000_000), Err(Error::InvalidArgument));
+    /// # Ok::<(), chrono::Error>(())
     /// ```
     ///
     /// Leap seconds can theoretically follow *any* whole second.
@@ -919,16 +920,17 @@ impl NaiveTime {
     ///
     /// ```
     /// # use chrono::{NaiveTime, Timelike};
-    /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap();
-    /// let strange_leap_second = dt.with_nanosecond(1_333_333_333).unwrap();
+    /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678)?;
+    /// let strange_leap_second = dt.with_nanosecond(1_333_333_333)?;
     /// assert_eq!(strange_leap_second.nanosecond(), 1_333_333_333);
+    /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_nanosecond(&self, nano: u32) -> Option<NaiveTime> {
+    pub const fn with_nanosecond(&self, nano: u32) -> Result<NaiveTime, Error> {
         if nano >= 2_000_000_000 {
-            return None;
+            return Err(Error::InvalidArgument);
         }
-        Some(NaiveTime { frac: nano, ..*self })
+        Ok(NaiveTime { frac: nano, ..*self })
     }
 
     /// Returns a triple of the hour, minute and second numbers.

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -841,24 +841,25 @@ impl NaiveTime {
     ///
     /// # Errors
     ///
-    /// Returns `None` if the value for `minute` is invalid.
+    /// Returns [`Error::InvalidArgument`] if the value for `minute` is invalid.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::NaiveTime;
+    /// use chrono::{Error, NaiveTime};
     ///
-    /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678).unwrap();
-    /// assert_eq!(dt.with_minute(45), Some(NaiveTime::from_hms_nano(23, 45, 4, 12_345_678).unwrap()));
-    /// assert_eq!(dt.with_minute(60), None);
+    /// let dt = NaiveTime::from_hms_nano(23, 56, 4, 12_345_678)?;
+    /// assert_eq!(dt.with_minute(45), NaiveTime::from_hms_nano(23, 45, 4, 12_345_678));
+    /// assert_eq!(dt.with_minute(60), Err(Error::InvalidArgument));
+    /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_minute(&self, min: u32) -> Option<NaiveTime> {
+    pub const fn with_minute(&self, min: u32) -> Result<NaiveTime, Error> {
         if min >= 60 {
-            return None;
+            return Err(Error::InvalidArgument);
         }
         let secs = self.secs / 3600 * 3600 + min * 60 + self.secs % 60;
-        Some(NaiveTime { secs, ..*self })
+        Ok(NaiveTime { secs, ..*self })
     }
 
     /// Makes a new `NaiveTime` with the second number changed.

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -78,14 +78,17 @@ fn test_time_hms() {
     assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().second(), 7);
     assert_eq!(
         NaiveTime::from_hms(3, 5, 7).unwrap().with_second(0),
-        Some(NaiveTime::from_hms(3, 5, 0).unwrap())
+        Ok(NaiveTime::from_hms(3, 5, 0).unwrap())
     );
     assert_eq!(
         NaiveTime::from_hms(3, 5, 7).unwrap().with_second(59),
-        Some(NaiveTime::from_hms(3, 5, 59).unwrap())
+        Ok(NaiveTime::from_hms(3, 5, 59).unwrap())
     );
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().with_second(60), None);
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().with_second(u32::MAX), None);
+    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().with_second(60), Err(Error::InvalidArgument));
+    assert_eq!(
+        NaiveTime::from_hms(3, 5, 7).unwrap().with_second(u32::MAX),
+        Err(Error::InvalidArgument)
+    );
 }
 
 #[test]

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -63,14 +63,17 @@ fn test_time_hms() {
     assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().minute(), 5);
     assert_eq!(
         NaiveTime::from_hms(3, 5, 7).unwrap().with_minute(0),
-        Some(NaiveTime::from_hms(3, 0, 7).unwrap())
+        Ok(NaiveTime::from_hms(3, 0, 7).unwrap())
     );
     assert_eq!(
         NaiveTime::from_hms(3, 5, 7).unwrap().with_minute(59),
-        Some(NaiveTime::from_hms(3, 59, 7).unwrap())
+        Ok(NaiveTime::from_hms(3, 59, 7).unwrap())
     );
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().with_minute(60), None);
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().with_minute(u32::MAX), None);
+    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().with_minute(60), Err(Error::InvalidArgument));
+    assert_eq!(
+        NaiveTime::from_hms(3, 5, 7).unwrap().with_minute(u32::MAX),
+        Err(Error::InvalidArgument)
+    );
 
     assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().second(), 7);
     assert_eq!(

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -48,14 +48,17 @@ fn test_time_hms() {
     assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().hour(), 3);
     assert_eq!(
         NaiveTime::from_hms(3, 5, 7).unwrap().with_hour(0),
-        Some(NaiveTime::from_hms(0, 5, 7).unwrap())
+        Ok(NaiveTime::from_hms(0, 5, 7).unwrap())
     );
     assert_eq!(
         NaiveTime::from_hms(3, 5, 7).unwrap().with_hour(23),
-        Some(NaiveTime::from_hms(23, 5, 7).unwrap())
+        Ok(NaiveTime::from_hms(23, 5, 7).unwrap())
     );
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().with_hour(24), None);
-    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().with_hour(u32::MAX), None);
+    assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().with_hour(24), Err(Error::InvalidArgument));
+    assert_eq!(
+        NaiveTime::from_hms(3, 5, 7).unwrap().with_hour(u32::MAX),
+        Err(Error::InvalidArgument)
+    );
 
     assert_eq!(NaiveTime::from_hms(3, 5, 7).unwrap().minute(), 5);
     assert_eq!(


### PR DESCRIPTION
Convert `NaiveTime::{with_hour, with_minute, with_second, with_nanosecond}` and `NaiveDateTime::{with_hour, with_minute, with_second, with_nanosecond}` to return `Result`.
This turned out to be a refreshingly mechanical change.

I took the opportunity to use `?` in the doctests of the relevant methods.
At some point when we are a bit further along we should convert more doctests and regular tests to use `?`.

cc @Zomtir