### PR TITLE
Fallible variants for `TimeZone::from_utc_*`

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -416,6 +416,21 @@ impl<Tz: TimeZone> DateTime<Tz> {
         tz.from_utc_datetime(&self.datetime)
     }
 
+    /// Changes the associated time zone.
+    ///
+    /// The returned `DateTime` references the same instant of time from the perspective of the
+    /// provided time zone.
+    ///
+    /// # Errors
+    ///
+    /// In theory every instant of time should exist in every time zone. Still errors may originate
+    /// from for example an OS API, in which case this method returns `None`.
+    #[inline]
+    #[must_use]
+    pub fn with_timezone_opt<Tz2: TimeZone>(&self, tz: &Tz2) -> Option<DateTime<Tz2>> {
+        tz.from_utc_datetime_opt(&self.datetime)
+    }
+
     /// Fix the offset from UTC to its current value, dropping the associated timezone information.
     /// This it useful for converting a generic `DateTime<Tz: Timezone>` to `DateTime<FixedOffset>`.
     #[inline]

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1418,11 +1418,13 @@ impl<Tz: TimeZone, Tz2: TimeZone> PartialOrd<DateTime<Tz2>> for DateTime<Tz> {
     /// let earlier = Utc
     ///     .with_ymd_and_hms(2015, 5, 15, 2, 0, 0)
     ///     .unwrap()
-    ///     .with_timezone(&FixedOffset::west_opt(1 * 3600).unwrap());
+    ///     .with_timezone_opt(&FixedOffset::west_opt(1 * 3600).unwrap())
+    ///     .unwrap();
     /// let later = Utc
     ///     .with_ymd_and_hms(2015, 5, 15, 3, 0, 0)
     ///     .unwrap()
-    ///     .with_timezone(&FixedOffset::west_opt(5 * 3600).unwrap());
+    ///     .with_timezone_opt(&FixedOffset::west_opt(5 * 3600).unwrap())
+    ///     .unwrap();
     ///
     /// assert_eq!(earlier.to_string(), "2015-05-15 01:00:00 -01:00");
     /// assert_eq!(later.to_string(), "2015-05-14 22:00:00 -05:00");

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -457,7 +457,7 @@ impl Error for ParseError {
 
 // to be used in this module and submodules
 pub(crate) const OUT_OF_RANGE: ParseError = ParseError(ParseErrorKind::OutOfRange);
-const IMPOSSIBLE: ParseError = ParseError(ParseErrorKind::Impossible);
+pub(crate) const IMPOSSIBLE: ParseError = ParseError(ParseErrorKind::Impossible);
 const NOT_ENOUGH: ParseError = ParseError(ParseErrorKind::NotEnough);
 const INVALID: ParseError = ParseError(ParseErrorKind::Invalid);
 const TOO_SHORT: ParseError = ParseError(ParseErrorKind::TooShort);

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -928,7 +928,8 @@ impl Parsed {
             let nanosecond = self.nanosecond.unwrap_or(0);
             let dt =
                 DateTime::from_timestamp(timestamp, nanosecond).ok_or(OUT_OF_RANGE)?.naive_utc();
-            guessed_offset = tz.offset_from_utc_datetime(&dt).fix().local_minus_utc();
+            guessed_offset =
+                tz.offset_from_utc_datetime_opt(&dt).ok_or(IMPOSSIBLE)?.fix().local_minus_utc();
         }
 
         // checks if the given `DateTime` has a consistent `Offset` with given `self.offset`.

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -922,20 +922,17 @@ mod tests {
         assert_eq!(dt.format("%c").to_string(), "Sun Jul  8 00:34:60 2001");
         assert_eq!(dt.format("%+").to_string(), "2001-07-08T00:34:60.026490708+09:30");
 
+        assert_eq!(dt.to_utc().format("%+").to_string(), "2001-07-07T15:04:60.026490708+00:00");
         assert_eq!(
-            dt.with_timezone(&Utc).format("%+").to_string(),
-            "2001-07-07T15:04:60.026490708+00:00"
-        );
-        assert_eq!(
-            dt.with_timezone(&Utc),
+            dt.to_utc(),
             DateTime::parse_from_str("2001-07-07T15:04:60.026490708Z", "%+").unwrap()
         );
         assert_eq!(
-            dt.with_timezone(&Utc),
+            dt.to_utc(),
             DateTime::parse_from_str("2001-07-07T15:04:60.026490708UTC", "%+").unwrap()
         );
         assert_eq!(
-            dt.with_timezone(&Utc),
+            dt.to_utc(),
             DateTime::parse_from_str("2001-07-07t15:04:60.026490708utc", "%+").unwrap()
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@
 //!
 //! `DateTime`s with different `TimeZone` types are distinct and do not mix,
 //! but can be converted to each other using
-//! the [`DateTime::with_timezone`](./struct.DateTime.html#method.with_timezone) method.
+//! the [`DateTime::with_timezone_opt`](DateTime::with_timezone_opt) method.
 //!
 //! You can get the current date and time in the UTC time zone
 //! ([`Utc::now()`](./offset/struct.Utc.html#method.now))
@@ -240,7 +240,7 @@
 //! assert_eq!(dt.offset().fix().local_minus_utc(), 9 * 3600);
 //! assert_eq!(dt.timezone(), FixedOffset::east_opt(9 * 3600).unwrap());
 //! assert_eq!(
-//!     dt.with_timezone(&Utc),
+//!     dt.with_timezone_opt(&Utc).unwrap(),
 //!     NaiveDate::from_ymd_opt(2014, 11, 28)
 //!         .unwrap()
 //!         .and_hms_nano_opt(12, 45, 59, 324310806)
@@ -349,7 +349,7 @@
 //! use chrono::prelude::*;
 //!
 //! let dt = Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap();
-//! let fixed_dt = dt.with_timezone(&FixedOffset::east_opt(9 * 3600).unwrap());
+//! let fixed_dt = dt.with_timezone_opt(&FixedOffset::east_opt(9 * 3600).unwrap()).unwrap();
 //!
 //! // method 1
 //! assert_eq!("2014-11-28T12:00:09Z".parse::<DateTime<Utc>>(), Ok(dt.clone()));

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -199,12 +199,12 @@ mod tests;
 /// let paramaribo_pre1945 = FixedOffset::east_opt(-13236).unwrap(); // -03:40:36
 /// let leap_sec_2015 =
 ///     NaiveDate::from_ymd_opt(2015, 6, 30).unwrap().and_hms_milli_opt(23, 59, 59, 1_000).unwrap();
-/// let dt1 = paramaribo_pre1945.from_utc_datetime(&leap_sec_2015);
+/// let dt1 = paramaribo_pre1945.from_utc_datetime_opt(&leap_sec_2015).unwrap();
 /// assert_eq!(format!("{:?}", dt1), "2015-06-30T20:19:24-03:40:36");
 /// assert_eq!(format!("{:?}", dt1.time()), "20:19:24");
 ///
 /// let next_sec = NaiveDate::from_ymd_opt(2015, 7, 1).unwrap().and_hms_opt(0, 0, 0).unwrap();
-/// let dt2 = paramaribo_pre1945.from_utc_datetime(&next_sec);
+/// let dt2 = paramaribo_pre1945.from_utc_datetime_opt(&next_sec).unwrap();
 /// assert_eq!(format!("{:?}", dt2), "2015-06-30T20:19:24-03:40:36");
 /// assert_eq!(format!("{:?}", dt2.time()), "20:19:24");
 ///

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -156,7 +156,7 @@ impl Local {
     /// let now_with_offset = Local::now().with_timezone(&offset);
     /// ```
     pub fn now() -> DateTime<Local> {
-        Utc::now().with_timezone(&Local)
+        Utc::now().with_timezone_opt(&Local).expect("unable to get the system time zone offset")
     }
 }
 
@@ -184,7 +184,11 @@ impl TimeZone for Local {
     }
 
     fn offset_from_utc_datetime(&self, utc: &NaiveDateTime) -> FixedOffset {
-        inner::offset_from_utc_datetime(utc).unwrap()
+        self.offset_from_utc_datetime_opt(utc).expect("time zone lookup for UTC value failed")
+    }
+
+    fn offset_from_utc_datetime_opt(&self, utc: &NaiveDateTime) -> Option<FixedOffset> {
+        inner::offset_from_utc_datetime(utc)
     }
 }
 

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -40,10 +40,8 @@ mod win_bindings;
 mod inner {
     use crate::{FixedOffset, MappedLocalTime, NaiveDateTime};
 
-    pub(super) fn offset_from_utc_datetime(
-        _utc_time: &NaiveDateTime,
-    ) -> MappedLocalTime<FixedOffset> {
-        MappedLocalTime::Single(FixedOffset::east_opt(0).unwrap())
+    pub(super) fn offset_from_utc_datetime(_utc_time: &NaiveDateTime) -> Option<FixedOffset> {
+        Some(FixedOffset::east_opt(0).unwrap())
     }
 
     pub(super) fn offset_from_local_datetime(
@@ -61,9 +59,9 @@ mod inner {
 mod inner {
     use crate::{Datelike, FixedOffset, MappedLocalTime, NaiveDateTime, Timelike};
 
-    pub(super) fn offset_from_utc_datetime(utc: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
+    pub(super) fn offset_from_utc_datetime(utc: &NaiveDateTime) -> Option<FixedOffset> {
         let offset = js_sys::Date::from(utc.and_utc()).get_timezone_offset();
-        MappedLocalTime::Single(FixedOffset::west_opt((offset as i32) * 60).unwrap())
+        Some(FixedOffset::west_opt((offset as i32) * 60).unwrap())
     }
 
     pub(super) fn offset_from_local_datetime(

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -153,7 +153,7 @@ impl Local {
     /// // Current time in some timezone (let's use +05:00)
     /// // Note that it is usually more efficient to use `Utc::now` for this use case.
     /// let offset = FixedOffset::east_opt(5 * 60 * 60).unwrap();
-    /// let now_with_offset = Local::now().with_timezone(&offset);
+    /// let now_with_offset = Local::now().with_timezone_opt(&offset).unwrap();
     /// ```
     pub fn now() -> DateTime<Local> {
         Utc::now().with_timezone_opt(&Local).expect("unable to get the system time zone offset")
@@ -287,7 +287,7 @@ mod tests {
     fn verify_correct_offsets() {
         let now = Local::now();
         let from_local = Local.from_local_datetime(&now.naive_local()).unwrap();
-        let from_utc = Local.from_utc_datetime(&now.naive_utc());
+        let from_utc = Local.from_utc_datetime_opt(&now.naive_utc()).unwrap();
 
         assert_eq!(now.offset().local_minus_utc(), from_local.offset().local_minus_utc());
         assert_eq!(now.offset().local_minus_utc(), from_utc.offset().local_minus_utc());
@@ -300,7 +300,7 @@ mod tests {
     fn verify_correct_offsets_distant_past() {
         let distant_past = Local::now() - Days::new(365 * 500);
         let from_local = Local.from_local_datetime(&distant_past.naive_local()).unwrap();
-        let from_utc = Local.from_utc_datetime(&distant_past.naive_utc());
+        let from_utc = Local.from_utc_datetime_opt(&distant_past.naive_utc()).unwrap();
 
         assert_eq!(distant_past.offset().local_minus_utc(), from_local.offset().local_minus_utc());
         assert_eq!(distant_past.offset().local_minus_utc(), from_utc.offset().local_minus_utc());
@@ -313,7 +313,7 @@ mod tests {
     fn verify_correct_offsets_distant_future() {
         let distant_future = Local::now() + Days::new(365 * 35000);
         let from_local = Local.from_local_datetime(&distant_future.naive_local()).unwrap();
-        let from_utc = Local.from_utc_datetime(&distant_future.naive_utc());
+        let from_utc = Local.from_utc_datetime_opt(&distant_future.naive_utc()).unwrap();
 
         assert_eq!(
             distant_future.offset().local_minus_utc(),

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -14,8 +14,8 @@ use super::tz_info::TimeZone;
 use super::{FixedOffset, NaiveDateTime};
 use crate::{Datelike, MappedLocalTime};
 
-pub(super) fn offset_from_utc_datetime(utc: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
-    offset(utc, false)
+pub(super) fn offset_from_utc_datetime(utc: &NaiveDateTime) -> Option<FixedOffset> {
+    offset(utc, false).single()
 }
 
 pub(super) fn offset_from_local_datetime(local: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -572,8 +572,25 @@ pub trait TimeZone: Sized + Clone {
     /// Creates the offset for given UTC `NaiveDate`. This cannot fail.
     fn offset_from_utc_date(&self, utc: &NaiveDate) -> Self::Offset;
 
-    /// Creates the offset for given UTC `NaiveDateTime`. This cannot fail.
+    /// Creates the offset for given UTC `NaiveDateTime`.
+    ///
+    /// # Panics
+    ///
+    /// In theory UTC is continuous and every instant of time should map to one local date and time.
+    /// Still errors may originate from for example an OS API, in which case this method may panic
+    /// or return invalid results.
     fn offset_from_utc_datetime(&self, utc: &NaiveDateTime) -> Self::Offset;
+
+    /// Creates the offset for given UTC `NaiveDateTime`.
+    ///
+    /// # Errors
+    ///
+    /// In theory UTC is continuous and every instant of time should map to one local date and time.
+    /// Still errors may originate from for example an OS API, in which case this method returns
+    /// `None`.
+    fn offset_from_utc_datetime_opt(&self, utc: &NaiveDateTime) -> Option<Self::Offset> {
+        Some(self.offset_from_utc_datetime(utc))
+    }
 
     /// Converts the UTC `NaiveDate` to the local time.
     /// The UTC is continuous and thus this cannot fail (but can give the duplicate local time).
@@ -585,10 +602,26 @@ pub trait TimeZone: Sized + Clone {
     }
 
     /// Converts the UTC `NaiveDateTime` to the local time.
-    /// The UTC is continuous and thus this cannot fail (but can give the duplicate local time).
+    ///
+    /// # Panics
+    ///
+    /// In theory UTC is continuous and every instant of time should exist in every time zone. Still
+    /// errors may originate from for example an OS API, in which case this method may panic
+    /// or return invalid results.
     #[allow(clippy::wrong_self_convention)]
     fn from_utc_datetime(&self, utc: &NaiveDateTime) -> DateTime<Self> {
         DateTime::from_naive_utc_and_offset(*utc, self.offset_from_utc_datetime(utc))
+    }
+
+    /// Converts the UTC `NaiveDateTime` to the local time.
+    ///
+    /// # Errors
+    ///
+    /// In theory UTC is continuous and every instant of time should exist in every time zone. Still
+    /// errors may originate from for example an OS API, in which case this method returns `None`.
+    #[allow(clippy::wrong_self_convention)]
+    fn from_utc_datetime_opt(&self, utc: &NaiveDateTime) -> Option<DateTime<Self>> {
+        Some(DateTime::from_naive_utc_and_offset(*utc, self.offset_from_utc_datetime_opt(utc)?))
     }
 }
 

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -642,9 +642,9 @@ mod tests {
             dbg!(offset_hour);
             let offset = FixedOffset::east_opt(offset_hour * 60 * 60).unwrap();
 
-            let local_max = offset.from_utc_datetime(&NaiveDateTime::MAX);
+            let local_max = offset.from_utc_datetime_opt(&NaiveDateTime::MAX).unwrap();
             assert_eq!(local_max.naive_utc(), NaiveDateTime::MAX);
-            let local_min = offset.from_utc_datetime(&NaiveDateTime::MIN);
+            let local_min = offset.from_utc_datetime_opt(&NaiveDateTime::MIN).unwrap();
             assert_eq!(local_min.naive_utc(), NaiveDateTime::MIN);
 
             let local_max = offset.from_local_datetime(&NaiveDateTime::MAX);

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -426,8 +426,10 @@ pub trait TimeZone: Sized + Clone {
     /// assert_eq!(Utc.timestamp_opt(1431648000, 0).unwrap().to_string(), "2015-05-15 00:00:00 UTC");
     /// ```
     fn timestamp_opt(&self, secs: i64, nsecs: u32) -> MappedLocalTime<DateTime<Self>> {
-        match DateTime::from_timestamp(secs, nsecs) {
-            Some(dt) => MappedLocalTime::Single(self.from_utc_datetime(&dt.naive_utc())),
+        match DateTime::from_timestamp(secs, nsecs)
+            .and_then(|dt| self.from_utc_datetime_opt(&dt.naive_utc()))
+        {
+            Some(dt) => MappedLocalTime::Single(dt),
             None => MappedLocalTime::None,
         }
     }
@@ -460,8 +462,10 @@ pub trait TimeZone: Sized + Clone {
     /// };
     /// ```
     fn timestamp_millis_opt(&self, millis: i64) -> MappedLocalTime<DateTime<Self>> {
-        match DateTime::from_timestamp_millis(millis) {
-            Some(dt) => MappedLocalTime::Single(self.from_utc_datetime(&dt.naive_utc())),
+        match DateTime::from_timestamp_millis(millis)
+            .and_then(|dt| self.from_utc_datetime_opt(&dt.naive_utc()))
+        {
+            Some(dt) => MappedLocalTime::Single(dt),
             None => MappedLocalTime::None,
         }
     }
@@ -479,7 +483,8 @@ pub trait TimeZone: Sized + Clone {
     /// assert_eq!(Utc.timestamp_nanos(1431648000000000).timestamp(), 1431648);
     /// ```
     fn timestamp_nanos(&self, nanos: i64) -> DateTime<Self> {
-        self.from_utc_datetime(&DateTime::from_timestamp_nanos(nanos).naive_utc())
+        self.from_utc_datetime_opt(&DateTime::from_timestamp_nanos(nanos).naive_utc())
+            .expect("time zone lookup for UTC value failed")
     }
 
     /// Makes a new `DateTime` from the number of non-leap microseconds
@@ -493,8 +498,10 @@ pub trait TimeZone: Sized + Clone {
     /// assert_eq!(Utc.timestamp_micros(1431648000000).unwrap().timestamp(), 1431648);
     /// ```
     fn timestamp_micros(&self, micros: i64) -> MappedLocalTime<DateTime<Self>> {
-        match DateTime::from_timestamp_micros(micros) {
-            Some(dt) => MappedLocalTime::Single(self.from_utc_datetime(&dt.naive_utc())),
+        match DateTime::from_timestamp_micros(micros)
+            .and_then(|dt| self.from_utc_datetime_opt(&dt.naive_utc()))
+        {
+            Some(dt) => MappedLocalTime::Single(dt),
             None => MappedLocalTime::None,
         }
     }

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -84,7 +84,7 @@ impl Utc {
     ///
     /// // Current time in some timezone (let's use +05:00)
     /// let offset = FixedOffset::east_opt(5 * 60 * 60).unwrap();
-    /// let now_with_offset = Utc::now().with_timezone(&offset);
+    /// let now_with_offset = Utc::now().with_timezone_opt(&offset).unwrap();
     /// ```
     #[cfg(not(all(
         target_arch = "wasm32",


### PR DESCRIPTION
As discussed in https://github.com/chronotope/chrono/issues/1448#issuecomment-1972580791:
> What would we need to change to propagate the error instead of unwrapping on [this line](https://github.com/chronotope/chrono/blob/v0.4.34/src/offset/local/mod.rs#L185) in `Local::offset_from_utc_datetime`?
> 
> Three methods:
> * `TimeZone::offset_from_utc_datetime`
> * `Timezone::from_utc_datetime`
> * `DateTime::with_timezone`
> 
> Those methods currently come with the assumption that finding the offset of a UTC datetime in some time zone will never fail. This is reasonable in a mathematical sense, but ignores that a `TimeZone` implementation can run into errors, such as our `Local` type or a more flexible type that uses the OS time zone information.
> 
> Within chrono it turns out these methods are used almost always in methods that are already fallible. Or, for `DateTime::with_timezone`, there are the infallible `DateTime::to_utc` and `DateTime::fixed_offset` methods which cover many uses.

The first commit adds `TimeZone::offset_from_utc_datetime_opt`, `Timezone::from_utc_datetime_opt` and `DateTime::with_timezone_opt`.
The second makes our platform implementations for `Local` return an `Option` (instead of going through `LocalResult`).

The third commit goes through all uses of the existing three methods and changes them to propagate the error, or switch to the infallible `DateTime::to_utc` and `DateTime::fixed_offset`. In cases where we still need to panic I used `expect` instead of hiding the panic case behind another layer.

For the rest I adjusted the tests to make it easy to switch to fallible methods on the 0.5 branch.