### PR TITLE
Rename `LocalResult` to `TzResolution`, add alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Chrono aims to provide all functionality needed to do correct operations on date
 * The [`DateTime`](https://docs.rs/chrono/latest/chrono/struct.DateTime.html) type is timezone-aware
   by default, with separate timezone-naive types.
 * Operations that may produce an invalid or ambiguous date and time return `Option` or
-  [`LocalResult`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html).
+  [`MappedLocalTime`](https://docs.rs/chrono/latest/chrono/offset/enum.MappedLocalTime.html).
 * Configurable parsing and formatting with an `strftime` inspired date and time formatting syntax.
 * The [`Local`](https://docs.rs/chrono/latest/chrono/offset/struct.Local.html) timezone works with
   the current timezone of the OS.

--- a/src/datetime/rustc_serialize.rs
+++ b/src/datetime/rustc_serialize.rs
@@ -2,7 +2,7 @@ use super::DateTime;
 use crate::format::SecondsFormat;
 #[cfg(feature = "clock")]
 use crate::offset::Local;
-use crate::offset::{FixedOffset, LocalResult, TimeZone, Utc};
+use crate::offset::{FixedOffset, MappedLocalTime, TimeZone, Utc};
 use core::fmt;
 use core::ops::Deref;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
@@ -13,16 +13,16 @@ impl<Tz: TimeZone> Encodable for DateTime<Tz> {
     }
 }
 
-// lik? function to convert a LocalResult into a serde-ish Result
-fn from<T, D>(me: LocalResult<T>, d: &mut D) -> Result<T, D::Error>
+// Function to convert a MappedLocalTime into a serde-ish Result
+fn from<T, D>(me: MappedLocalTime<T>, d: &mut D) -> Result<T, D::Error>
 where
     D: Decoder,
     T: fmt::Display,
 {
     match me {
-        LocalResult::None => Err(d.error("value is not a legal timestamp")),
-        LocalResult::Ambiguous(..) => Err(d.error("value is an ambiguous timestamp")),
-        LocalResult::Single(val) => Ok(val),
+        MappedLocalTime::None => Err(d.error("value is not a legal timestamp")),
+        MappedLocalTime::Ambiguous(..) => Err(d.error("value is an ambiguous timestamp")),
+        MappedLocalTime::Single(val) => Ok(val),
     }
 }
 

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -1251,7 +1251,7 @@ mod tests {
 
     #[test]
     fn test_serde_no_offset_debug() {
-        use crate::{LocalResult, NaiveDate, NaiveDateTime, Offset};
+        use crate::{MappedLocalTime, NaiveDate, NaiveDateTime, Offset};
         use core::fmt::Debug;
 
         #[derive(Clone)]
@@ -1266,14 +1266,14 @@ mod tests {
             fn from_offset(_state: &TestTimeZone) -> TestTimeZone {
                 TestTimeZone
             }
-            fn offset_from_local_date(&self, _local: &NaiveDate) -> LocalResult<TestTimeZone> {
-                LocalResult::Single(TestTimeZone)
+            fn offset_from_local_date(&self, _local: &NaiveDate) -> MappedLocalTime<TestTimeZone> {
+                MappedLocalTime::Single(TestTimeZone)
             }
             fn offset_from_local_datetime(
                 &self,
                 _local: &NaiveDateTime,
-            ) -> LocalResult<TestTimeZone> {
-                LocalResult::Single(TestTimeZone)
+            ) -> MappedLocalTime<TestTimeZone> {
+                MappedLocalTime::Single(TestTimeZone)
             }
             fn offset_from_utc_date(&self, _utc: &NaiveDate) -> TestTimeZone {
                 TestTimeZone

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -3,7 +3,7 @@ use crate::naive::{NaiveDate, NaiveTime};
 use crate::offset::{FixedOffset, TimeZone, Utc};
 #[cfg(feature = "clock")]
 use crate::offset::{Local, Offset};
-use crate::{Datelike, Days, LocalResult, Months, NaiveDateTime, TimeDelta, Timelike, Weekday};
+use crate::{Datelike, Days, MappedLocalTime, Months, NaiveDateTime, TimeDelta, Timelike, Weekday};
 
 #[derive(Clone)]
 struct DstTester;
@@ -31,14 +31,14 @@ impl TimeZone for DstTester {
         DstTester
     }
 
-    fn offset_from_local_date(&self, _: &NaiveDate) -> crate::LocalResult<Self::Offset> {
+    fn offset_from_local_date(&self, _: &NaiveDate) -> crate::MappedLocalTime<Self::Offset> {
         unimplemented!()
     }
 
     fn offset_from_local_datetime(
         &self,
         local: &NaiveDateTime,
-    ) -> crate::LocalResult<Self::Offset> {
+    ) -> crate::MappedLocalTime<Self::Offset> {
         let local_to_winter_transition_start = NaiveDate::from_ymd_opt(
             local.year(),
             DstTester::TO_WINTER_MONTH_DAY.0,
@@ -72,19 +72,19 @@ impl TimeZone for DstTester {
         .and_time(DstTester::transition_start_local() + TimeDelta::try_hours(1).unwrap());
 
         if *local < local_to_winter_transition_end || *local >= local_to_summer_transition_end {
-            LocalResult::Single(DstTester::summer_offset())
+            MappedLocalTime::Single(DstTester::summer_offset())
         } else if *local >= local_to_winter_transition_start
             && *local < local_to_summer_transition_start
         {
-            LocalResult::Single(DstTester::winter_offset())
+            MappedLocalTime::Single(DstTester::winter_offset())
         } else if *local >= local_to_winter_transition_end
             && *local < local_to_winter_transition_start
         {
-            LocalResult::Ambiguous(DstTester::winter_offset(), DstTester::summer_offset())
+            MappedLocalTime::Ambiguous(DstTester::winter_offset(), DstTester::summer_offset())
         } else if *local >= local_to_summer_transition_start
             && *local < local_to_summer_transition_end
         {
-            LocalResult::None
+            MappedLocalTime::None
         } else {
             panic!("Unexpected local time {}", local)
         }

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -6,7 +6,7 @@
 
 use super::{ParseResult, IMPOSSIBLE, NOT_ENOUGH, OUT_OF_RANGE};
 use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
-use crate::offset::{FixedOffset, LocalResult, Offset, TimeZone};
+use crate::offset::{FixedOffset, MappedLocalTime, Offset, TimeZone};
 use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 
 /// A type to hold parsed fields of date and time that can check all fields are consistent.
@@ -888,9 +888,9 @@ impl Parsed {
         let offset = FixedOffset::east_opt(offset).ok_or(OUT_OF_RANGE)?;
 
         match offset.from_local_datetime(&datetime) {
-            LocalResult::None => Err(IMPOSSIBLE),
-            LocalResult::Single(t) => Ok(t),
-            LocalResult::Ambiguous(..) => Err(NOT_ENOUGH),
+            MappedLocalTime::None => Err(IMPOSSIBLE),
+            MappedLocalTime::Single(t) => Ok(t),
+            MappedLocalTime::Ambiguous(..) => Err(NOT_ENOUGH),
         }
     }
 
@@ -944,15 +944,15 @@ impl Parsed {
         // it will be 0 otherwise, but this is fine as the algorithm ignores offset for that case.
         let datetime = self.to_naive_datetime_with_offset(guessed_offset)?;
         match tz.from_local_datetime(&datetime) {
-            LocalResult::None => Err(IMPOSSIBLE),
-            LocalResult::Single(t) => {
+            MappedLocalTime::None => Err(IMPOSSIBLE),
+            MappedLocalTime::Single(t) => {
                 if check_offset(&t) {
                     Ok(t)
                 } else {
                     Err(IMPOSSIBLE)
                 }
             }
-            LocalResult::Ambiguous(min, max) => {
+            MappedLocalTime::Ambiguous(min, max) => {
                 // try to disambiguate two possible local dates by offset.
                 match (check_offset(&min), check_offset(&max)) {
                     (false, false) => Err(IMPOSSIBLE),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! * The [`DateTime`](https://docs.rs/chrono/latest/chrono/struct.DateTime.html) type is timezone-aware
 //!   by default, with separate timezone-naive types.
 //! * Operations that may produce an invalid or ambiguous date and time return `Option` or
-//!   [`LocalResult`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html).
+//!   [`MappedLocalTime`](https://docs.rs/chrono/latest/chrono/offset/enum.MappedLocalTime.html).
 //! * Configurable parsing and formatting with a `strftime` inspired date and time formatting syntax.
 //! * The [`Local`](https://docs.rs/chrono/latest/chrono/offset/struct.Local.html) timezone works with
 //!   the current timezone of the OS.
@@ -130,7 +130,7 @@
 //!
 #![cfg_attr(not(feature = "now"), doc = "```ignore")]
 #![cfg_attr(feature = "now", doc = "```rust")]
-//! use chrono::offset::LocalResult;
+//! use chrono::offset::MappedLocalTime;
 //! use chrono::prelude::*;
 //!
 //! # fn doctest() -> Option<()> {
@@ -174,12 +174,12 @@
 //! // dynamic verification
 //! assert_eq!(
 //!     Utc.with_ymd_and_hms(2014, 7, 8, 21, 15, 33),
-//!     LocalResult::Single(
+//!     MappedLocalTime::Single(
 //!         NaiveDate::from_ymd_opt(2014, 7, 8)?.and_hms_opt(21, 15, 33)?.and_utc()
 //!     )
 //! );
-//! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 80, 15, 33), LocalResult::None);
-//! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 38, 21, 15, 33), LocalResult::None);
+//! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 80, 15, 33), MappedLocalTime::None);
+//! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 38, 21, 15, 33), MappedLocalTime::None);
 //!
 //! # #[cfg(feature = "clock")] {
 //! // other time zone objects can be used to construct a local datetime.
@@ -590,9 +590,9 @@ pub mod offset;
 #[cfg(feature = "clock")]
 #[doc(inline)]
 pub use offset::Local;
-pub use offset::LocalResult;
 #[doc(inline)]
 pub use offset::{FixedOffset, Offset, TimeZone, Utc};
+pub use offset::{LocalResult, MappedLocalTime};
 
 pub mod round;
 pub use round::{DurationRound, RoundingError, SubsecRound};

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -21,7 +21,7 @@ use crate::naive::{Days, IsoWeek, NaiveDate, NaiveTime};
 use crate::offset::Utc;
 use crate::time_delta::NANOS_PER_SEC;
 use crate::{
-    expect, try_opt, DateTime, Datelike, FixedOffset, LocalResult, Months, TimeDelta, TimeZone,
+    expect, try_opt, DateTime, Datelike, FixedOffset, MappedLocalTime, Months, TimeDelta, TimeZone,
     Timelike, Weekday,
 };
 #[cfg(feature = "rustc-serialize")]
@@ -929,7 +929,7 @@ impl NaiveDateTime {
     /// assert_eq!(dt.timezone(), tz);
     /// ```
     #[must_use]
-    pub fn and_local_timezone<Tz: TimeZone>(&self, tz: Tz) -> LocalResult<DateTime<Tz>> {
+    pub fn and_local_timezone<Tz: TimeZone>(&self, tz: Tz) -> MappedLocalTime<DateTime<Tz>> {
         tz.from_local_datetime(self)
     }
 

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -1,5 +1,5 @@
 use super::NaiveDateTime;
-use crate::{Datelike, FixedOffset, LocalResult, NaiveDate, TimeDelta, Utc};
+use crate::{Datelike, FixedOffset, MappedLocalTime, NaiveDate, TimeDelta, Utc};
 
 #[test]
 fn test_datetime_add() {
@@ -385,13 +385,13 @@ fn test_and_timezone_min_max_dates() {
         if offset_hour >= 0 {
             assert_eq!(local_max.unwrap().naive_local(), NaiveDateTime::MAX);
         } else {
-            assert_eq!(local_max, LocalResult::None);
+            assert_eq!(local_max, MappedLocalTime::None);
         }
         let local_min = NaiveDateTime::MIN.and_local_timezone(offset);
         if offset_hour <= 0 {
             assert_eq!(local_min.unwrap().naive_local(), NaiveDateTime::MIN);
         } else {
-            assert_eq!(local_min, LocalResult::None);
+            assert_eq!(local_min, MappedLocalTime::None);
         }
     }
 }

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -9,7 +9,7 @@ use core::str::FromStr;
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
-use super::{LocalResult, Offset, TimeZone};
+use super::{MappedLocalTime, Offset, TimeZone};
 use crate::format::{scan, ParseError, OUT_OF_RANGE};
 use crate::naive::{NaiveDate, NaiveDateTime};
 
@@ -129,11 +129,11 @@ impl TimeZone for FixedOffset {
         *offset
     }
 
-    fn offset_from_local_date(&self, _local: &NaiveDate) -> LocalResult<FixedOffset> {
-        LocalResult::Single(*self)
+    fn offset_from_local_date(&self, _local: &NaiveDate) -> MappedLocalTime<FixedOffset> {
+        MappedLocalTime::Single(*self)
     }
-    fn offset_from_local_datetime(&self, _local: &NaiveDateTime) -> LocalResult<FixedOffset> {
-        LocalResult::Single(*self)
+    fn offset_from_local_datetime(&self, _local: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
+        MappedLocalTime::Single(*self)
     }
 
     fn offset_from_utc_date(&self, _utc: &NaiveDate) -> FixedOffset {

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -10,7 +10,7 @@ use std::cmp::Ordering;
 use rkyv::{Archive, Deserialize, Serialize};
 
 use super::fixed::FixedOffset;
-use super::{LocalResult, TimeZone};
+use super::{MappedLocalTime, TimeZone};
 use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
 #[allow(deprecated)]
 use crate::Date;
@@ -38,16 +38,18 @@ mod win_bindings;
     ))
 ))]
 mod inner {
-    use crate::{FixedOffset, LocalResult, NaiveDateTime};
+    use crate::{FixedOffset, MappedLocalTime, NaiveDateTime};
 
-    pub(super) fn offset_from_utc_datetime(_utc_time: &NaiveDateTime) -> LocalResult<FixedOffset> {
-        LocalResult::Single(FixedOffset::east_opt(0).unwrap())
+    pub(super) fn offset_from_utc_datetime(
+        _utc_time: &NaiveDateTime,
+    ) -> MappedLocalTime<FixedOffset> {
+        MappedLocalTime::Single(FixedOffset::east_opt(0).unwrap())
     }
 
     pub(super) fn offset_from_local_datetime(
         _local_time: &NaiveDateTime,
-    ) -> LocalResult<FixedOffset> {
-        LocalResult::Single(FixedOffset::east_opt(0).unwrap())
+    ) -> MappedLocalTime<FixedOffset> {
+        MappedLocalTime::Single(FixedOffset::east_opt(0).unwrap())
     }
 }
 
@@ -57,14 +59,16 @@ mod inner {
     not(any(target_os = "emscripten", target_os = "wasi"))
 ))]
 mod inner {
-    use crate::{Datelike, FixedOffset, LocalResult, NaiveDateTime, Timelike};
+    use crate::{Datelike, FixedOffset, MappedLocalTime, NaiveDateTime, Timelike};
 
-    pub(super) fn offset_from_utc_datetime(utc: &NaiveDateTime) -> LocalResult<FixedOffset> {
+    pub(super) fn offset_from_utc_datetime(utc: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
         let offset = js_sys::Date::from(utc.and_utc()).get_timezone_offset();
-        LocalResult::Single(FixedOffset::west_opt((offset as i32) * 60).unwrap())
+        MappedLocalTime::Single(FixedOffset::west_opt((offset as i32) * 60).unwrap())
     }
 
-    pub(super) fn offset_from_local_datetime(local: &NaiveDateTime) -> LocalResult<FixedOffset> {
+    pub(super) fn offset_from_local_datetime(
+        local: &NaiveDateTime,
+    ) -> MappedLocalTime<FixedOffset> {
         let mut year = local.year();
         if year < 100 {
             // The API in `js_sys` does not let us create a `Date` with negative years.
@@ -84,7 +88,7 @@ mod inner {
         );
         let offset = js_date.get_timezone_offset();
         // We always get a result, even if this time does not exist or is ambiguous.
-        LocalResult::Single(FixedOffset::west_opt((offset as i32) * 60).unwrap())
+        MappedLocalTime::Single(FixedOffset::west_opt((offset as i32) * 60).unwrap())
     }
 }
 
@@ -166,12 +170,12 @@ impl TimeZone for Local {
     }
 
     #[allow(deprecated)]
-    fn offset_from_local_date(&self, local: &NaiveDate) -> LocalResult<FixedOffset> {
+    fn offset_from_local_date(&self, local: &NaiveDate) -> MappedLocalTime<FixedOffset> {
         // Get the offset at local midnight.
         self.offset_from_local_datetime(&local.and_time(NaiveTime::MIN))
     }
 
-    fn offset_from_local_datetime(&self, local: &NaiveDateTime) -> LocalResult<FixedOffset> {
+    fn offset_from_local_datetime(&self, local: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
         inner::offset_from_local_datetime(local)
     }
 
@@ -229,7 +233,7 @@ impl Ord for Transition {
 fn lookup_with_dst_transitions(
     transitions: &[Transition],
     dt: NaiveDateTime,
-) -> LocalResult<FixedOffset> {
+) -> MappedLocalTime<FixedOffset> {
     for t in transitions.iter() {
         // A transition can result in the wall clock time going forward (creating a gap) or going
         // backward (creating a fold). We are interested in the earliest and latest wall time of the
@@ -247,24 +251,24 @@ fn lookup_with_dst_transitions(
         let wall_latest = t.transition_utc.overflowing_add_offset(offset_max);
 
         if dt < wall_earliest {
-            return LocalResult::Single(t.offset_before);
+            return MappedLocalTime::Single(t.offset_before);
         } else if dt <= wall_latest {
             return match t.offset_after.local_minus_utc().cmp(&t.offset_before.local_minus_utc()) {
-                Ordering::Equal => LocalResult::Single(t.offset_before),
-                Ordering::Less => LocalResult::Ambiguous(t.offset_before, t.offset_after),
+                Ordering::Equal => MappedLocalTime::Single(t.offset_before),
+                Ordering::Less => MappedLocalTime::Ambiguous(t.offset_before, t.offset_after),
                 Ordering::Greater => {
                     if dt == wall_earliest {
-                        LocalResult::Single(t.offset_before)
+                        MappedLocalTime::Single(t.offset_before)
                     } else if dt == wall_latest {
-                        LocalResult::Single(t.offset_after)
+                        MappedLocalTime::Single(t.offset_after)
                     } else {
-                        LocalResult::None
+                        MappedLocalTime::None
                     }
                 }
             };
         }
     }
-    LocalResult::Single(transitions.last().unwrap().offset_after)
+    MappedLocalTime::Single(transitions.last().unwrap().offset_after)
 }
 
 #[cfg(test)]
@@ -275,7 +279,7 @@ mod tests {
     use crate::offset::TimeZone;
     use crate::{Datelike, Days, Utc};
     #[cfg(windows)]
-    use crate::{FixedOffset, LocalResult, NaiveDate, NaiveDateTime};
+    use crate::{FixedOffset, MappedLocalTime, NaiveDate, NaiveDateTime};
 
     #[test]
     fn verify_correct_offsets() {
@@ -368,7 +372,7 @@ mod tests {
             h: u32,
             n: u32,
             s: u32,
-            result: LocalResult<FixedOffset>,
+            result: MappedLocalTime<FixedOffset>,
         ) {
             let dt = NaiveDate::from_ymd_opt(y, m, d).unwrap().and_hms_opt(h, n, s).unwrap();
             assert_eq!(lookup_with_dst_transitions(transitions, dt), result);
@@ -382,17 +386,17 @@ mod tests {
             Transition::new(ymdhms(2023, 3, 26, 2, 0, 0), std, dst),
             Transition::new(ymdhms(2023, 10, 29, 3, 0, 0), dst, std),
         ];
-        compare_lookup(&transitions, 2023, 3, 26, 1, 0, 0, LocalResult::Single(std));
-        compare_lookup(&transitions, 2023, 3, 26, 2, 0, 0, LocalResult::Single(std));
-        compare_lookup(&transitions, 2023, 3, 26, 2, 30, 0, LocalResult::None);
-        compare_lookup(&transitions, 2023, 3, 26, 3, 0, 0, LocalResult::Single(dst));
-        compare_lookup(&transitions, 2023, 3, 26, 4, 0, 0, LocalResult::Single(dst));
+        compare_lookup(&transitions, 2023, 3, 26, 1, 0, 0, MappedLocalTime::Single(std));
+        compare_lookup(&transitions, 2023, 3, 26, 2, 0, 0, MappedLocalTime::Single(std));
+        compare_lookup(&transitions, 2023, 3, 26, 2, 30, 0, MappedLocalTime::None);
+        compare_lookup(&transitions, 2023, 3, 26, 3, 0, 0, MappedLocalTime::Single(dst));
+        compare_lookup(&transitions, 2023, 3, 26, 4, 0, 0, MappedLocalTime::Single(dst));
 
-        compare_lookup(&transitions, 2023, 10, 29, 1, 0, 0, LocalResult::Single(dst));
-        compare_lookup(&transitions, 2023, 10, 29, 2, 0, 0, LocalResult::Ambiguous(dst, std));
-        compare_lookup(&transitions, 2023, 10, 29, 2, 30, 0, LocalResult::Ambiguous(dst, std));
-        compare_lookup(&transitions, 2023, 10, 29, 3, 0, 0, LocalResult::Ambiguous(dst, std));
-        compare_lookup(&transitions, 2023, 10, 29, 4, 0, 0, LocalResult::Single(std));
+        compare_lookup(&transitions, 2023, 10, 29, 1, 0, 0, MappedLocalTime::Single(dst));
+        compare_lookup(&transitions, 2023, 10, 29, 2, 0, 0, MappedLocalTime::Ambiguous(dst, std));
+        compare_lookup(&transitions, 2023, 10, 29, 2, 30, 0, MappedLocalTime::Ambiguous(dst, std));
+        compare_lookup(&transitions, 2023, 10, 29, 3, 0, 0, MappedLocalTime::Ambiguous(dst, std));
+        compare_lookup(&transitions, 2023, 10, 29, 4, 0, 0, MappedLocalTime::Single(std));
 
         // std transition before dst transition
         // dst offset > std offset
@@ -402,17 +406,17 @@ mod tests {
             Transition::new(ymdhms(2023, 3, 24, 3, 0, 0), dst, std),
             Transition::new(ymdhms(2023, 10, 27, 2, 0, 0), std, dst),
         ];
-        compare_lookup(&transitions, 2023, 3, 24, 1, 0, 0, LocalResult::Single(dst));
-        compare_lookup(&transitions, 2023, 3, 24, 2, 0, 0, LocalResult::Ambiguous(dst, std));
-        compare_lookup(&transitions, 2023, 3, 24, 2, 30, 0, LocalResult::Ambiguous(dst, std));
-        compare_lookup(&transitions, 2023, 3, 24, 3, 0, 0, LocalResult::Ambiguous(dst, std));
-        compare_lookup(&transitions, 2023, 3, 24, 4, 0, 0, LocalResult::Single(std));
+        compare_lookup(&transitions, 2023, 3, 24, 1, 0, 0, MappedLocalTime::Single(dst));
+        compare_lookup(&transitions, 2023, 3, 24, 2, 0, 0, MappedLocalTime::Ambiguous(dst, std));
+        compare_lookup(&transitions, 2023, 3, 24, 2, 30, 0, MappedLocalTime::Ambiguous(dst, std));
+        compare_lookup(&transitions, 2023, 3, 24, 3, 0, 0, MappedLocalTime::Ambiguous(dst, std));
+        compare_lookup(&transitions, 2023, 3, 24, 4, 0, 0, MappedLocalTime::Single(std));
 
-        compare_lookup(&transitions, 2023, 10, 27, 1, 0, 0, LocalResult::Single(std));
-        compare_lookup(&transitions, 2023, 10, 27, 2, 0, 0, LocalResult::Single(std));
-        compare_lookup(&transitions, 2023, 10, 27, 2, 30, 0, LocalResult::None);
-        compare_lookup(&transitions, 2023, 10, 27, 3, 0, 0, LocalResult::Single(dst));
-        compare_lookup(&transitions, 2023, 10, 27, 4, 0, 0, LocalResult::Single(dst));
+        compare_lookup(&transitions, 2023, 10, 27, 1, 0, 0, MappedLocalTime::Single(std));
+        compare_lookup(&transitions, 2023, 10, 27, 2, 0, 0, MappedLocalTime::Single(std));
+        compare_lookup(&transitions, 2023, 10, 27, 2, 30, 0, MappedLocalTime::None);
+        compare_lookup(&transitions, 2023, 10, 27, 3, 0, 0, MappedLocalTime::Single(dst));
+        compare_lookup(&transitions, 2023, 10, 27, 4, 0, 0, MappedLocalTime::Single(dst));
 
         // dst transition before std transition
         // dst offset < std offset
@@ -422,17 +426,17 @@ mod tests {
             Transition::new(ymdhms(2023, 3, 26, 2, 30, 0), std, dst),
             Transition::new(ymdhms(2023, 10, 29, 2, 0, 0), dst, std),
         ];
-        compare_lookup(&transitions, 2023, 3, 26, 1, 0, 0, LocalResult::Single(std));
-        compare_lookup(&transitions, 2023, 3, 26, 2, 0, 0, LocalResult::Ambiguous(std, dst));
-        compare_lookup(&transitions, 2023, 3, 26, 2, 15, 0, LocalResult::Ambiguous(std, dst));
-        compare_lookup(&transitions, 2023, 3, 26, 2, 30, 0, LocalResult::Ambiguous(std, dst));
-        compare_lookup(&transitions, 2023, 3, 26, 3, 0, 0, LocalResult::Single(dst));
+        compare_lookup(&transitions, 2023, 3, 26, 1, 0, 0, MappedLocalTime::Single(std));
+        compare_lookup(&transitions, 2023, 3, 26, 2, 0, 0, MappedLocalTime::Ambiguous(std, dst));
+        compare_lookup(&transitions, 2023, 3, 26, 2, 15, 0, MappedLocalTime::Ambiguous(std, dst));
+        compare_lookup(&transitions, 2023, 3, 26, 2, 30, 0, MappedLocalTime::Ambiguous(std, dst));
+        compare_lookup(&transitions, 2023, 3, 26, 3, 0, 0, MappedLocalTime::Single(dst));
 
-        compare_lookup(&transitions, 2023, 10, 29, 1, 0, 0, LocalResult::Single(dst));
-        compare_lookup(&transitions, 2023, 10, 29, 2, 0, 0, LocalResult::Single(dst));
-        compare_lookup(&transitions, 2023, 10, 29, 2, 15, 0, LocalResult::None);
-        compare_lookup(&transitions, 2023, 10, 29, 2, 30, 0, LocalResult::Single(std));
-        compare_lookup(&transitions, 2023, 10, 29, 3, 0, 0, LocalResult::Single(std));
+        compare_lookup(&transitions, 2023, 10, 29, 1, 0, 0, MappedLocalTime::Single(dst));
+        compare_lookup(&transitions, 2023, 10, 29, 2, 0, 0, MappedLocalTime::Single(dst));
+        compare_lookup(&transitions, 2023, 10, 29, 2, 15, 0, MappedLocalTime::None);
+        compare_lookup(&transitions, 2023, 10, 29, 2, 30, 0, MappedLocalTime::Single(std));
+        compare_lookup(&transitions, 2023, 10, 29, 3, 0, 0, MappedLocalTime::Single(std));
 
         // std transition before dst transition
         // dst offset < std offset
@@ -442,17 +446,17 @@ mod tests {
             Transition::new(ymdhms(2023, 3, 24, 2, 0, 0), dst, std),
             Transition::new(ymdhms(2023, 10, 27, 2, 30, 0), std, dst),
         ];
-        compare_lookup(&transitions, 2023, 3, 24, 1, 0, 0, LocalResult::Single(dst));
-        compare_lookup(&transitions, 2023, 3, 24, 2, 0, 0, LocalResult::Single(dst));
-        compare_lookup(&transitions, 2023, 3, 24, 2, 15, 0, LocalResult::None);
-        compare_lookup(&transitions, 2023, 3, 24, 2, 30, 0, LocalResult::Single(std));
-        compare_lookup(&transitions, 2023, 3, 24, 3, 0, 0, LocalResult::Single(std));
+        compare_lookup(&transitions, 2023, 3, 24, 1, 0, 0, MappedLocalTime::Single(dst));
+        compare_lookup(&transitions, 2023, 3, 24, 2, 0, 0, MappedLocalTime::Single(dst));
+        compare_lookup(&transitions, 2023, 3, 24, 2, 15, 0, MappedLocalTime::None);
+        compare_lookup(&transitions, 2023, 3, 24, 2, 30, 0, MappedLocalTime::Single(std));
+        compare_lookup(&transitions, 2023, 3, 24, 3, 0, 0, MappedLocalTime::Single(std));
 
-        compare_lookup(&transitions, 2023, 10, 27, 1, 0, 0, LocalResult::Single(std));
-        compare_lookup(&transitions, 2023, 10, 27, 2, 0, 0, LocalResult::Ambiguous(std, dst));
-        compare_lookup(&transitions, 2023, 10, 27, 2, 15, 0, LocalResult::Ambiguous(std, dst));
-        compare_lookup(&transitions, 2023, 10, 27, 2, 30, 0, LocalResult::Ambiguous(std, dst));
-        compare_lookup(&transitions, 2023, 10, 27, 3, 0, 0, LocalResult::Single(dst));
+        compare_lookup(&transitions, 2023, 10, 27, 1, 0, 0, MappedLocalTime::Single(std));
+        compare_lookup(&transitions, 2023, 10, 27, 2, 0, 0, MappedLocalTime::Ambiguous(std, dst));
+        compare_lookup(&transitions, 2023, 10, 27, 2, 15, 0, MappedLocalTime::Ambiguous(std, dst));
+        compare_lookup(&transitions, 2023, 10, 27, 2, 30, 0, MappedLocalTime::Ambiguous(std, dst));
+        compare_lookup(&transitions, 2023, 10, 27, 3, 0, 0, MappedLocalTime::Single(dst));
 
         // offset stays the same
         let std = FixedOffset::east_opt(3 * 60 * 60).unwrap();
@@ -460,18 +464,18 @@ mod tests {
             Transition::new(ymdhms(2023, 3, 26, 2, 0, 0), std, std),
             Transition::new(ymdhms(2023, 10, 29, 3, 0, 0), std, std),
         ];
-        compare_lookup(&transitions, 2023, 3, 26, 2, 0, 0, LocalResult::Single(std));
-        compare_lookup(&transitions, 2023, 10, 29, 3, 0, 0, LocalResult::Single(std));
+        compare_lookup(&transitions, 2023, 3, 26, 2, 0, 0, MappedLocalTime::Single(std));
+        compare_lookup(&transitions, 2023, 10, 29, 3, 0, 0, MappedLocalTime::Single(std));
 
         // single transition
         let std = FixedOffset::east_opt(3 * 60 * 60).unwrap();
         let dst = FixedOffset::east_opt(4 * 60 * 60).unwrap();
         let transitions = [Transition::new(ymdhms(2023, 3, 26, 2, 0, 0), std, dst)];
-        compare_lookup(&transitions, 2023, 3, 26, 1, 0, 0, LocalResult::Single(std));
-        compare_lookup(&transitions, 2023, 3, 26, 2, 0, 0, LocalResult::Single(std));
-        compare_lookup(&transitions, 2023, 3, 26, 2, 30, 0, LocalResult::None);
-        compare_lookup(&transitions, 2023, 3, 26, 3, 0, 0, LocalResult::Single(dst));
-        compare_lookup(&transitions, 2023, 3, 26, 4, 0, 0, LocalResult::Single(dst));
+        compare_lookup(&transitions, 2023, 3, 26, 1, 0, 0, MappedLocalTime::Single(std));
+        compare_lookup(&transitions, 2023, 3, 26, 2, 0, 0, MappedLocalTime::Single(std));
+        compare_lookup(&transitions, 2023, 3, 26, 2, 30, 0, MappedLocalTime::None);
+        compare_lookup(&transitions, 2023, 3, 26, 3, 0, 0, MappedLocalTime::Single(dst));
+        compare_lookup(&transitions, 2023, 3, 26, 4, 0, 0, MappedLocalTime::Single(dst));
     }
 
     #[test]
@@ -486,17 +490,17 @@ mod tests {
         ];
         assert_eq!(
             lookup_with_dst_transitions(&transitions, NaiveDateTime::MAX.with_month(3).unwrap()),
-            LocalResult::Single(std)
+            MappedLocalTime::Single(std)
         );
         assert_eq!(
             lookup_with_dst_transitions(&transitions, NaiveDateTime::MAX.with_month(8).unwrap()),
-            LocalResult::Single(dst)
+            MappedLocalTime::Single(dst)
         );
         // Doesn't panic with `NaiveDateTime::MAX` as argument (which would be out of range when
         // converted to UTC).
         assert_eq!(
             lookup_with_dst_transitions(&transitions, NaiveDateTime::MAX),
-            LocalResult::Ambiguous(dst, std)
+            MappedLocalTime::Ambiguous(dst, std)
         );
 
         // Transition before UTC year end doesn't panic in year of `NaiveDate::MIN`
@@ -508,17 +512,17 @@ mod tests {
         ];
         assert_eq!(
             lookup_with_dst_transitions(&transitions, NaiveDateTime::MIN.with_month(3).unwrap()),
-            LocalResult::Single(dst)
+            MappedLocalTime::Single(dst)
         );
         assert_eq!(
             lookup_with_dst_transitions(&transitions, NaiveDateTime::MIN.with_month(8).unwrap()),
-            LocalResult::Single(std)
+            MappedLocalTime::Single(std)
         );
         // Doesn't panic with `NaiveDateTime::MIN` as argument (which would be out of range when
         // converted to UTC).
         assert_eq!(
             lookup_with_dst_transitions(&transitions, NaiveDateTime::MIN),
-            LocalResult::Ambiguous(std, dst)
+            MappedLocalTime::Ambiguous(std, dst)
         );
     }
 

--- a/src/offset/local/tz_info/rule.rs
+++ b/src/offset/local/tz_info/rule.rs
@@ -83,10 +83,10 @@ impl TransitionRule {
         &self,
         local_time: i64,
         year: i32,
-    ) -> Result<crate::LocalResult<LocalTimeType>, Error> {
+    ) -> Result<crate::MappedLocalTime<LocalTimeType>, Error> {
         match self {
             TransitionRule::Fixed(local_time_type) => {
-                Ok(crate::LocalResult::Single(*local_time_type))
+                Ok(crate::MappedLocalTime::Single(*local_time_type))
             }
             TransitionRule::Alternate(alternate_time) => {
                 alternate_time.find_local_time_type_from_local(local_time, year)
@@ -231,7 +231,7 @@ impl AlternateTime {
         &self,
         local_time: i64,
         current_year: i32,
-    ) -> Result<crate::LocalResult<LocalTimeType>, Error> {
+    ) -> Result<crate::MappedLocalTime<LocalTimeType>, Error> {
         // Check if the current year is valid for the following computations
         if !(i32::min_value() + 2 <= current_year && current_year <= i32::max_value() - 2) {
             return Err(Error::OutOfRange("out of range date time"));
@@ -252,7 +252,7 @@ impl AlternateTime {
             - i64::from(self.dst.ut_offset);
 
         match self.std.ut_offset.cmp(&self.dst.ut_offset) {
-            Ordering::Equal => Ok(crate::LocalResult::Single(self.std)),
+            Ordering::Equal => Ok(crate::MappedLocalTime::Single(self.std)),
             Ordering::Less => {
                 if self.dst_start.transition_date(current_year).0
                     < self.dst_end.transition_date(current_year).0
@@ -260,41 +260,41 @@ impl AlternateTime {
                     // northern hemisphere
                     // For the DST END transition, the `start` happens at a later timestamp than the `end`.
                     if local_time <= dst_start_transition_start {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(crate::MappedLocalTime::Single(self.std))
                     } else if local_time > dst_start_transition_start
                         && local_time < dst_start_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(crate::MappedLocalTime::None)
                     } else if local_time >= dst_start_transition_end
                         && local_time < dst_end_transition_end
                     {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(crate::MappedLocalTime::Single(self.dst))
                     } else if local_time >= dst_end_transition_end
                         && local_time <= dst_end_transition_start
                     {
-                        Ok(crate::LocalResult::Ambiguous(self.std, self.dst))
+                        Ok(crate::MappedLocalTime::Ambiguous(self.std, self.dst))
                     } else {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(crate::MappedLocalTime::Single(self.std))
                     }
                 } else {
                     // southern hemisphere regular DST
                     // For the DST END transition, the `start` happens at a later timestamp than the `end`.
                     if local_time < dst_end_transition_end {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(crate::MappedLocalTime::Single(self.dst))
                     } else if local_time >= dst_end_transition_end
                         && local_time <= dst_end_transition_start
                     {
-                        Ok(crate::LocalResult::Ambiguous(self.std, self.dst))
+                        Ok(crate::MappedLocalTime::Ambiguous(self.std, self.dst))
                     } else if local_time > dst_end_transition_end
                         && local_time < dst_start_transition_start
                     {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(crate::MappedLocalTime::Single(self.std))
                     } else if local_time >= dst_start_transition_start
                         && local_time < dst_start_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(crate::MappedLocalTime::None)
                     } else {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(crate::MappedLocalTime::Single(self.dst))
                     }
                 }
             }
@@ -305,41 +305,41 @@ impl AlternateTime {
                     // southern hemisphere reverse DST
                     // For the DST END transition, the `start` happens at a later timestamp than the `end`.
                     if local_time < dst_start_transition_end {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(crate::MappedLocalTime::Single(self.std))
                     } else if local_time >= dst_start_transition_end
                         && local_time <= dst_start_transition_start
                     {
-                        Ok(crate::LocalResult::Ambiguous(self.dst, self.std))
+                        Ok(crate::MappedLocalTime::Ambiguous(self.dst, self.std))
                     } else if local_time > dst_start_transition_start
                         && local_time < dst_end_transition_start
                     {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(crate::MappedLocalTime::Single(self.dst))
                     } else if local_time >= dst_end_transition_start
                         && local_time < dst_end_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(crate::MappedLocalTime::None)
                     } else {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(crate::MappedLocalTime::Single(self.std))
                     }
                 } else {
                     // northern hemisphere reverse DST
                     // For the DST END transition, the `start` happens at a later timestamp than the `end`.
                     if local_time <= dst_end_transition_start {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(crate::MappedLocalTime::Single(self.dst))
                     } else if local_time > dst_end_transition_start
                         && local_time < dst_end_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(crate::MappedLocalTime::None)
                     } else if local_time >= dst_end_transition_end
                         && local_time < dst_start_transition_end
                     {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(crate::MappedLocalTime::Single(self.std))
                     } else if local_time >= dst_start_transition_end
                         && local_time <= dst_start_transition_start
                     {
-                        Ok(crate::LocalResult::Ambiguous(self.dst, self.std))
+                        Ok(crate::MappedLocalTime::Ambiguous(self.dst, self.std))
                     } else {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(crate::MappedLocalTime::Single(self.dst))
                     }
                 }
             }

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -12,17 +12,17 @@ use std::{cell::RefCell, collections::hash_map, env, fs, hash::Hasher, time::Sys
 
 use super::tz_info::TimeZone;
 use super::{FixedOffset, NaiveDateTime};
-use crate::{Datelike, LocalResult};
+use crate::{Datelike, MappedLocalTime};
 
-pub(super) fn offset_from_utc_datetime(utc: &NaiveDateTime) -> LocalResult<FixedOffset> {
+pub(super) fn offset_from_utc_datetime(utc: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
     offset(utc, false)
 }
 
-pub(super) fn offset_from_local_datetime(local: &NaiveDateTime) -> LocalResult<FixedOffset> {
+pub(super) fn offset_from_local_datetime(local: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
     offset(local, true)
 }
 
-fn offset(d: &NaiveDateTime, local: bool) -> LocalResult<FixedOffset> {
+fn offset(d: &NaiveDateTime, local: bool) -> MappedLocalTime<FixedOffset> {
     TZ_INFO.with(|maybe_cache| {
         maybe_cache.borrow_mut().get_or_insert_with(Cache::default).offset(*d, local)
     })
@@ -104,7 +104,7 @@ fn current_zone(var: Option<&str>) -> TimeZone {
 }
 
 impl Cache {
-    fn offset(&mut self, d: NaiveDateTime, local: bool) -> LocalResult<FixedOffset> {
+    fn offset(&mut self, d: NaiveDateTime, local: bool) -> MappedLocalTime<FixedOffset> {
         let now = SystemTime::now();
 
         match now.duration_since(self.last_checked) {
@@ -156,13 +156,13 @@ impl Cache {
                 .offset();
 
             return match FixedOffset::east_opt(offset) {
-                Some(offset) => LocalResult::Single(offset),
-                None => LocalResult::None,
+                Some(offset) => MappedLocalTime::Single(offset),
+                None => MappedLocalTime::None,
             };
         }
 
         // we pass through the year as the year of a local point in time must either be valid in that locale, or
-        // the entire time was skipped in which case we will return LocalResult::None anyway.
+        // the entire time was skipped in which case we will return MappedLocalTime::None anyway.
         self.zone
             .find_local_time_type_from_local(d.and_utc().timestamp(), d.year())
             .expect("unable to select local time type")

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -17,7 +17,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
-use super::{FixedOffset, LocalResult, Offset, TimeZone};
+use super::{FixedOffset, MappedLocalTime, Offset, TimeZone};
 use crate::naive::{NaiveDate, NaiveDateTime};
 #[cfg(feature = "now")]
 #[allow(deprecated)]
@@ -118,11 +118,11 @@ impl TimeZone for Utc {
         Utc
     }
 
-    fn offset_from_local_date(&self, _local: &NaiveDate) -> LocalResult<Utc> {
-        LocalResult::Single(Utc)
+    fn offset_from_local_date(&self, _local: &NaiveDate) -> MappedLocalTime<Utc> {
+        MappedLocalTime::Single(Utc)
     }
-    fn offset_from_local_datetime(&self, _local: &NaiveDateTime) -> LocalResult<Utc> {
-        LocalResult::Single(Utc)
+    fn offset_from_local_datetime(&self, _local: &NaiveDateTime) -> MappedLocalTime<Utc> {
+        MappedLocalTime::Single(Utc)
     }
 
     fn offset_from_utc_date(&self, _utc: &NaiveDate) -> Utc {

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -29,18 +29,18 @@ fn verify_against_date_command_local(path: &'static str, dt: NaiveDateTime) {
     // }
 
     // This is used while a decision is made whether the `date` output needs to
-    // be exactly matched, or whether LocalResult::Ambiguous should be handled
+    // be exactly matched, or whether MappedLocalTime::Ambiguous should be handled
     // differently
 
     let date = NaiveDate::from_ymd_opt(dt.year(), dt.month(), dt.day()).unwrap();
     match Local.from_local_datetime(&date.and_hms_opt(dt.hour(), 5, 1).unwrap()) {
-        chrono::LocalResult::Ambiguous(a, b) => assert!(
+        chrono::MappedLocalTime::Ambiguous(a, b) => assert!(
             format!("{}\n", a) == date_command_str || format!("{}\n", b) == date_command_str
         ),
-        chrono::LocalResult::Single(a) => {
+        chrono::MappedLocalTime::Single(a) => {
             assert_eq!(format!("{}\n", a), date_command_str);
         }
-        chrono::LocalResult::None => {
+        chrono::MappedLocalTime::None => {
             assert_eq!("", date_command_str);
         }
     }


### PR DESCRIPTION
The name `LocalResult` is unfortunate because in Rust types called `*Result` are used as return values for error cases.
However in our case it is not an error (at least not usually) but a choice of how to deal with time zone transitions due to for example DST.

We can do the rename on the 0.5.x branch or on main. If we think `TzResolution` is a better name that helps in understanding the use we may as well start using it on 0.4.x. With a type alias with the old name that is easy.

Doing the rename on main also has the advantage of keeping the branches a bit more similar. But if 0.5.x is a better target I'll rebase of course.

The first commit is a simple find-replace-rustfmt.
The second commit extends the documentation.