### PR TITLE
0.5: Revise prelude

### DIFF
--- a/bench/benches/chrono.rs
+++ b/bench/benches/chrono.rs
@@ -6,7 +6,7 @@ use chrono::format::StrftimeItems;
 use chrono::prelude::*;
 #[cfg(feature = "unstable-locales")]
 use chrono::Locale;
-use chrono::{DateTime, FixedOffset, Local, TimeDelta, Utc, __BenchYearFlags};
+use chrono::{DateTime, FixedOffset, Local, SecondsFormat, TimeDelta, Utc, __BenchYearFlags};
 
 fn bench_date_from_ymd(c: &mut Criterion) {
     c.bench_function("bench_date_from_ymd", |b| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,6 @@
 //!
 //! ```rust
 //! use chrono::prelude::*;
-//! use chrono::TimeDelta;
 //!
 //! // assume this returned `2014-11-28T21:45:59.324310806+09:00`:
 //! let dt = FixedOffset::east(9*3600).unwrap().from_local_datetime(&NaiveDate::from_ymd(2014, 11, 28).unwrap().and_hms_nano(21, 45, 59, 324310806).unwrap()).unwrap();
@@ -234,9 +233,10 @@
 //! ```rust
 //! # #[allow(unused_imports)]
 //! use chrono::prelude::*;
-//!
 //! # #[cfg(all(feature = "unstable-locales", feature = "alloc"))]
 //! # fn test() {
+//! use chrono::Locale;
+//!
 //! let dt = Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap();
 //! assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2014-11-28 12:00:09");
 //! assert_eq!(dt.format("%a %b %e %T %Y").to_string(), "Fri Nov 28 12:00:09 2014");
@@ -478,15 +478,16 @@ use core::fmt;
 
 /// A convenience module appropriate for glob imports (`use chrono::prelude::*;`).
 pub mod prelude {
+    // Common date/time types
+    pub use crate::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeDelta, Weekday};
+
+    // Offset types
     #[cfg(feature = "clock")]
     pub use crate::Local;
-    #[cfg(all(feature = "unstable-locales", feature = "alloc"))]
-    pub use crate::Locale;
-    pub use crate::SubsecRound;
-    pub use crate::{DateTime, SecondsFormat};
-    pub use crate::{Datelike, Month, Timelike, Weekday};
     pub use crate::{FixedOffset, Utc};
-    pub use crate::{NaiveDate, NaiveDateTime, NaiveTime};
+
+    // Bring trait methods in scope
+    pub use crate::{Datelike, Timelike};
     pub use crate::{Offset, TimeZone};
 }
 

--- a/src/month.rs
+++ b/src/month.rs
@@ -13,6 +13,8 @@ use crate::OutOfRange;
 /// It is possible to convert from a date to a month independently
 /// ```
 /// use chrono::prelude::*;
+/// use chrono::Month;
+///
 /// let date = Utc.with_ymd_and_hms(2019, 10, 28, 9, 10, 11).unwrap();
 /// // `2019-10-28T09:10:11Z`
 /// let month = Month::try_from(u8::try_from(date.month()).unwrap()).ok();
@@ -21,6 +23,7 @@ use crate::OutOfRange;
 /// Or from a Month to an integer usable by dates
 /// ```
 /// # use chrono::prelude::*;
+/// # use chrono::Month;
 /// let month = Month::January;
 /// let dt = Utc.with_ymd_and_hms(2019, month.number_from_month(), 28, 9, 10, 11).unwrap();
 /// assert_eq!((dt.year(), dt.month(), dt.day()), (2019, 1, 28));


### PR DESCRIPTION
As I see it not everything that is currently in the prelude deserves to be there. This limits the prelude to just our date/time and offset types, and the traits.

Compared to 0.4.x the following is changed:
- Removed `SubsecRound`, still the worst part of chrono in my opinion.
- Removed `SecondsFormat`, only used by `DateTime::to_rfc_3339_opts`.
- Removed `Month`, not used anywhere in the API of chrono.
- Removed `Locale`, only relevant in the `unstable_locales` feature.
- Added `TimeDelta`, since it no longer shadows `std::Duration`.