### PR TITLE
Convert `with_month` and `with_day` to return `Result`

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -589,7 +589,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///   daylight saving time transition.
     #[inline]
     pub fn with_month(&self, month: u32) -> Option<DateTime<Tz>> {
-        map_local(self, |datetime| datetime.with_month(month))
+        map_local(self, |datetime| datetime.with_month(month).ok())
     }
 
     /// Makes a new `DateTime` with the month number (starting from 0) changed.
@@ -605,7 +605,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///   daylight saving time transition.
     #[inline]
     pub fn with_month0(&self, month0: u32) -> Option<DateTime<Tz>> {
-        map_local(self, |datetime| datetime.with_month0(month0))
+        map_local(self, |datetime| datetime.with_month0(month0).ok())
     }
 
     /// Makes a new `DateTime` with the day of month (starting from 1) changed.

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -621,7 +621,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///   daylight saving time transition.
     #[inline]
     pub fn with_day(&self, day: u32) -> Option<DateTime<Tz>> {
-        map_local(self, |datetime| datetime.with_day(day))
+        map_local(self, |datetime| datetime.with_day(day).ok())
     }
 
     /// Makes a new `DateTime` with the day of month (starting from 0) changed.
@@ -637,7 +637,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///   daylight saving time transition.
     #[inline]
     pub fn with_day0(&self, day0: u32) -> Option<DateTime<Tz>> {
-        map_local(self, |datetime| datetime.with_day0(day0))
+        map_local(self, |datetime| datetime.with_day0(day0).ok())
     }
 
     /// Makes a new `DateTime` with the day of year (starting from 1) changed.

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -807,16 +807,16 @@ impl NaiveDate {
 
     /// Makes a new `NaiveDate` with the packed month-day-flags changed.
     ///
-    /// Returns `None` when the resulting `NaiveDate` would be invalid.
+    /// # Errors
+    ///
+    /// This method returns:
+    /// - [`Error::InvalidArgument`] if the `mdf` was created with `month == 0` or `day == 0`.
+    /// - [`Error::DoesNotExist`] if the given day does not exist in the given month.
     #[inline]
-    const fn with_mdf(&self, mdf: Mdf) -> Option<NaiveDate> {
+    const fn with_mdf(&self, mdf: Mdf) -> Result<NaiveDate, Error> {
         debug_assert!(self.year_flags().0 == mdf.year_flags().0);
-        match mdf.ordinal() {
-            Ok(ordinal) => {
-                Some(NaiveDate::from_yof((self.yof() & !ORDINAL_MASK) | (ordinal << 4) as i32))
-            }
-            Err(_) => None, // Non-existing date
-        }
+        let ordinal = try_err!(mdf.ordinal());
+        Ok(NaiveDate::from_yof((self.yof() & !ORDINAL_MASK) | (ordinal << 4) as i32))
     }
 
     /// Makes a new `NaiveDate` for the next calendar date.
@@ -1285,7 +1285,7 @@ impl NaiveDate {
     /// ```
     #[inline]
     pub const fn with_month(&self, month: u32) -> Option<NaiveDate> {
-        self.with_mdf(try_opt!(ok!(self.mdf().with_month(month))))
+        ok!(self.with_mdf(try_opt!(ok!(self.mdf().with_month(month)))))
     }
 
     /// Makes a new `NaiveDate` with the month number (starting from 0) changed.
@@ -1311,7 +1311,7 @@ impl NaiveDate {
     #[inline]
     pub const fn with_month0(&self, month0: u32) -> Option<NaiveDate> {
         let month = try_opt!(month0.checked_add(1));
-        self.with_mdf(try_opt!(ok!(self.mdf().with_month(month))))
+        ok!(self.with_mdf(try_opt!(ok!(self.mdf().with_month(month)))))
     }
 
     /// Makes a new `NaiveDate` with the day of month (starting from 1) changed.
@@ -1335,7 +1335,7 @@ impl NaiveDate {
     /// ```
     #[inline]
     pub const fn with_day(&self, day: u32) -> Option<NaiveDate> {
-        self.with_mdf(try_opt!(ok!(self.mdf().with_day(day))))
+        ok!(self.with_mdf(try_opt!(ok!(self.mdf().with_day(day)))))
     }
 
     /// Makes a new `NaiveDate` with the day of month (starting from 0) changed.
@@ -1360,7 +1360,7 @@ impl NaiveDate {
     #[inline]
     pub const fn with_day0(&self, day0: u32) -> Option<NaiveDate> {
         let day = try_opt!(day0.checked_add(1));
-        self.with_mdf(try_opt!(ok!(self.mdf().with_day(day))))
+        ok!(self.with_mdf(try_opt!(ok!(self.mdf().with_day(day)))))
     }
 
     /// Makes a new `NaiveDate` with the day of year (starting from 1) changed.

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -1319,49 +1319,49 @@ impl NaiveDate {
     ///
     /// # Errors
     ///
-    /// Returns `None` if:
-    /// - The resulting date does not exist (for example `day(31)` in April).
-    /// - The value for `day` is invalid.
+    /// This method returns:
+    /// - [`Error::DoesNotExist`] if the resulting date does not exist (for example `day(31)` in
+    ///   April).
+    /// - [`Error::InvalidArgument`] if the value for `day` is invalid.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::NaiveDate;
+    /// use chrono::{Error, NaiveDate};
     ///
-    /// assert_eq!(
-    ///     NaiveDate::from_ymd(2015, 9, 8).unwrap().with_day(30),
-    ///     Some(NaiveDate::from_ymd(2015, 9, 30).unwrap())
-    /// );
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().with_day(31), None); // no September 31
+    /// let date = NaiveDate::from_ymd(2015, 9, 8)?;
+    /// assert_eq!(date.with_day(30), NaiveDate::from_ymd(2015, 9, 30));
+    /// assert_eq!(date.with_day(31), Err(Error::DoesNotExist)); // No September 31
+    /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn with_day(&self, day: u32) -> Option<NaiveDate> {
-        ok!(self.with_mdf(try_opt!(ok!(self.mdf().with_day(day)))))
+    pub const fn with_day(&self, day: u32) -> Result<NaiveDate, Error> {
+        self.with_mdf(try_err!(self.mdf().with_day(day)))
     }
 
     /// Makes a new `NaiveDate` with the day of month (starting from 0) changed.
     ///
     /// # Errors
     ///
-    /// Returns `None` if:
-    /// - The resulting date does not exist (for example `day(30)` in April).
-    /// - The value for `day0` is invalid.
+    /// This method returns:
+    /// - [`Error::DoesNotExist`] if the resulting date does not exist (for example `day0(30)` in
+    ///   April).
+    /// - [`Error::InvalidArgument`] if the value for `day0` is invalid.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::NaiveDate;
+    /// use chrono::{Error, NaiveDate};
     ///
-    /// assert_eq!(
-    ///     NaiveDate::from_ymd(2015, 9, 8).unwrap().with_day0(29),
-    ///     Some(NaiveDate::from_ymd(2015, 9, 30).unwrap())
-    /// );
-    /// assert_eq!(NaiveDate::from_ymd(2015, 9, 8).unwrap().with_day0(30), None); // no September 31
+    /// let date = NaiveDate::from_ymd(2015, 9, 8)?;
+    /// assert_eq!(date.with_day0(29), NaiveDate::from_ymd(2015, 9, 30));
+    /// assert_eq!(date.with_day0(30), Err(Error::DoesNotExist)); // No September 31
+    /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn with_day0(&self, day0: u32) -> Option<NaiveDate> {
-        let day = try_opt!(day0.checked_add(1));
-        ok!(self.with_mdf(try_opt!(ok!(self.mdf().with_day(day)))))
+    pub const fn with_day0(&self, day0: u32) -> Result<NaiveDate, Error> {
+        let day = try_ok_or!(day0.checked_add(1), Error::InvalidArgument);
+        self.with_mdf(try_err!(self.mdf().with_day(day)))
     }
 
     /// Makes a new `NaiveDate` with the day of year (starting from 1) changed.

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -377,14 +377,14 @@ fn test_date_with_fields() {
     assert_eq!(d.with_year(i32::MAX), Err(Error::OutOfRange));
 
     let d = NaiveDate::from_ymd(2000, 4, 30).unwrap();
-    assert_eq!(d.with_month(0), None);
-    assert_eq!(d.with_month(1), Some(NaiveDate::from_ymd(2000, 1, 30).unwrap()));
-    assert_eq!(d.with_month(2), None);
-    assert_eq!(d.with_month(3), Some(NaiveDate::from_ymd(2000, 3, 30).unwrap()));
-    assert_eq!(d.with_month(4), Some(NaiveDate::from_ymd(2000, 4, 30).unwrap()));
-    assert_eq!(d.with_month(12), Some(NaiveDate::from_ymd(2000, 12, 30).unwrap()));
-    assert_eq!(d.with_month(13), None);
-    assert_eq!(d.with_month(u32::MAX), None);
+    assert_eq!(d.with_month(0), Err(Error::InvalidArgument));
+    assert_eq!(d.with_month(1), NaiveDate::from_ymd(2000, 1, 30));
+    assert_eq!(d.with_month(2), Err(Error::DoesNotExist));
+    assert_eq!(d.with_month(3), NaiveDate::from_ymd(2000, 3, 30));
+    assert_eq!(d.with_month(4), NaiveDate::from_ymd(2000, 4, 30));
+    assert_eq!(d.with_month(12), NaiveDate::from_ymd(2000, 12, 30));
+    assert_eq!(d.with_month(13), Err(Error::InvalidArgument));
+    assert_eq!(d.with_month(u32::MAX), Err(Error::InvalidArgument));
 
     let d = NaiveDate::from_ymd(2000, 2, 8).unwrap();
     assert_eq!(d.with_day(0), None);
@@ -750,7 +750,7 @@ fn test_weeks_from() {
 #[test]
 fn test_with_0_overflow() {
     let dt = NaiveDate::from_ymd(2023, 4, 18).unwrap();
-    assert!(dt.with_month0(4294967295).is_none());
+    assert_eq!(dt.with_month0(u32::MAX), Err(Error::InvalidArgument));
     assert!(dt.with_day0(4294967295).is_none());
     assert!(dt.with_ordinal0(4294967295).is_none());
 }

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -387,11 +387,11 @@ fn test_date_with_fields() {
     assert_eq!(d.with_month(u32::MAX), Err(Error::InvalidArgument));
 
     let d = NaiveDate::from_ymd(2000, 2, 8).unwrap();
-    assert_eq!(d.with_day(0), None);
-    assert_eq!(d.with_day(1), Some(NaiveDate::from_ymd(2000, 2, 1).unwrap()));
-    assert_eq!(d.with_day(29), Some(NaiveDate::from_ymd(2000, 2, 29).unwrap()));
-    assert_eq!(d.with_day(30), None);
-    assert_eq!(d.with_day(u32::MAX), None);
+    assert_eq!(d.with_day(0), Err(Error::InvalidArgument));
+    assert_eq!(d.with_day(1), NaiveDate::from_ymd(2000, 2, 1));
+    assert_eq!(d.with_day(29), NaiveDate::from_ymd(2000, 2, 29));
+    assert_eq!(d.with_day(30), Err(Error::DoesNotExist));
+    assert_eq!(d.with_day(u32::MAX), Err(Error::InvalidArgument));
 }
 
 #[test]
@@ -751,7 +751,7 @@ fn test_weeks_from() {
 fn test_with_0_overflow() {
     let dt = NaiveDate::from_ymd(2023, 4, 18).unwrap();
     assert_eq!(dt.with_month0(u32::MAX), Err(Error::InvalidArgument));
-    assert!(dt.with_day0(4294967295).is_none());
+    assert_eq!(dt.with_day0(u32::MAX), Err(Error::InvalidArgument));
     assert!(dt.with_ordinal0(4294967295).is_none());
 }
 

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -773,7 +773,7 @@ impl NaiveDateTime {
     /// ```
     #[inline]
     pub const fn with_month(&self, month: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { date: try_opt!(self.date.with_month(month)), ..*self })
+        Some(NaiveDateTime { date: try_opt!(ok!(self.date.with_month(month))), ..*self })
     }
 
     /// Makes a new `NaiveDateTime` with the month number (starting from 0) changed.
@@ -801,7 +801,7 @@ impl NaiveDateTime {
     /// ```
     #[inline]
     pub const fn with_month0(&self, month0: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { date: try_opt!(self.date.with_month0(month0)), ..*self })
+        Some(NaiveDateTime { date: try_opt!(ok!(self.date.with_month0(month0))), ..*self })
     }
 
     /// Makes a new `NaiveDateTime` with the day of month (starting from 1) changed.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -754,26 +754,25 @@ impl NaiveDateTime {
     ///
     /// # Errors
     ///
-    /// Returns `None` if:
-    /// - The resulting date does not exist (for example `month(4)` when day of the month is 31).
-    /// - The value for `month` is invalid.
+    /// This method returns:
+    /// - [`Error::DoesNotExist`] if the resulting date does not exist (for example `month(4)` when
+    ///   day of the month is 31).
+    /// - [`Error::InvalidArgument`] if the value for `month` is invalid.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::{NaiveDate, NaiveDateTime};
+    /// use chrono::{Error, NaiveDate, NaiveDateTime};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms(12, 34, 56).unwrap();
-    /// assert_eq!(
-    ///     dt.with_month(10),
-    ///     Some(NaiveDate::from_ymd(2015, 10, 30).unwrap().and_hms(12, 34, 56).unwrap())
-    /// );
-    /// assert_eq!(dt.with_month(13), None); // No month 13
-    /// assert_eq!(dt.with_month(2), None); // No February 30
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 30)?.and_hms(12, 34, 56)?;
+    /// assert_eq!(dt.with_month(10), NaiveDate::from_ymd(2015, 10, 30)?.and_hms(12, 34, 56));
+    /// assert_eq!(dt.with_month(13), Err(Error::InvalidArgument));
+    /// assert_eq!(dt.with_month(2), Err(Error::DoesNotExist)); // No February 30
+    /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn with_month(&self, month: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { date: try_opt!(ok!(self.date.with_month(month))), ..*self })
+    pub const fn with_month(&self, month: u32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { date: try_err!(self.date.with_month(month)), ..*self })
     }
 
     /// Makes a new `NaiveDateTime` with the month number (starting from 0) changed.
@@ -782,26 +781,25 @@ impl NaiveDateTime {
     ///
     /// # Errors
     ///
-    /// Returns `None` if:
-    /// - The resulting date does not exist (for example `month0(3)` when day of the month is 31).
-    /// - The value for `month0` is invalid.
+    /// This method returns:
+    /// - [`Error::DoesNotExist`] if the resulting date does not exist (for example `month0(3)` when
+    ///   day of the month is 31).
+    /// - [`Error::InvalidArgument`] if the value for `month0` is invalid.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::{NaiveDate, NaiveDateTime};
+    /// use chrono::{Error, NaiveDate, NaiveDateTime};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms(12, 34, 56).unwrap();
-    /// assert_eq!(
-    ///     dt.with_month0(9),
-    ///     Some(NaiveDate::from_ymd(2015, 10, 30).unwrap().and_hms(12, 34, 56).unwrap())
-    /// );
-    /// assert_eq!(dt.with_month0(12), None); // No month 13
-    /// assert_eq!(dt.with_month0(1), None); // No February 30
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 30)?.and_hms(12, 34, 56)?;
+    /// assert_eq!(dt.with_month0(9), NaiveDate::from_ymd(2015, 10, 30)?.and_hms(12, 34, 56));
+    /// assert_eq!(dt.with_month0(12), Err(Error::InvalidArgument));
+    /// assert_eq!(dt.with_month0(1), Err(Error::DoesNotExist)); // No February 30
+    /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn with_month0(&self, month0: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { date: try_opt!(ok!(self.date.with_month0(month0))), ..*self })
+    pub const fn with_month0(&self, month0: u32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { date: try_err!(self.date.with_month0(month0)), ..*self })
     }
 
     /// Makes a new `NaiveDateTime` with the day of month (starting from 1) changed.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -826,7 +826,7 @@ impl NaiveDateTime {
     /// ```
     #[inline]
     pub const fn with_day(&self, day: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { date: try_opt!(self.date.with_day(day)), ..*self })
+        Some(NaiveDateTime { date: try_opt!(ok!(self.date.with_day(day))), ..*self })
     }
 
     /// Makes a new `NaiveDateTime` with the day of month (starting from 0) changed.
@@ -853,7 +853,7 @@ impl NaiveDateTime {
     /// ```
     #[inline]
     pub const fn with_day0(&self, day0: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { date: try_opt!(self.date.with_day0(day0)), ..*self })
+        Some(NaiveDateTime { date: try_opt!(ok!(self.date.with_day0(day0))), ..*self })
     }
 
     /// Makes a new `NaiveDateTime` with the day of year (starting from 1) changed.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -808,25 +808,24 @@ impl NaiveDateTime {
     ///
     /// # Errors
     ///
-    /// Returns `None` if:
-    /// - The resulting date does not exist (for example `day(31)` in April).
-    /// - The value for `day` is invalid.
+    /// This method returns:
+    /// - [`Error::DoesNotExist`] if the resulting date does not exist (for example `day(31)` in
+    ///   April).
+    /// - [`Error::InvalidArgument`] if the value for `day` is invalid.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::{NaiveDate, NaiveDateTime};
+    /// use chrono::{Error, NaiveDate, NaiveDateTime};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms(12, 34, 56).unwrap();
-    /// assert_eq!(
-    ///     dt.with_day(30),
-    ///     Some(NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms(12, 34, 56).unwrap())
-    /// );
-    /// assert_eq!(dt.with_day(31), None); // no September 31
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8)?.and_hms(12, 34, 56)?;
+    /// assert_eq!(dt.with_day(30), NaiveDate::from_ymd(2015, 9, 30)?.and_hms(12, 34, 56));
+    /// assert_eq!(dt.with_day(31), Err(Error::DoesNotExist)); // No September 31
+    /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn with_day(&self, day: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { date: try_opt!(ok!(self.date.with_day(day))), ..*self })
+    pub const fn with_day(&self, day: u32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { date: try_err!(self.date.with_day(day)), ..*self })
     }
 
     /// Makes a new `NaiveDateTime` with the day of month (starting from 0) changed.
@@ -835,25 +834,24 @@ impl NaiveDateTime {
     ///
     /// # Errors
     ///
-    /// Returns `None` if:
-    /// - The resulting date does not exist (for example `day(30)` in April).
-    /// - The value for `day0` is invalid.
+    /// This method returns:
+    /// - [`Error::DoesNotExist`] if the resulting date does not exist (for example `day0(30)` in
+    ///   April).
+    /// - [`Error::InvalidArgument`] if the value for `day0` is invalid.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::{NaiveDate, NaiveDateTime};
+    /// use chrono::{Error, NaiveDate, NaiveDateTime};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms(12, 34, 56).unwrap();
-    /// assert_eq!(
-    ///     dt.with_day0(29),
-    ///     Some(NaiveDate::from_ymd(2015, 9, 30).unwrap().and_hms(12, 34, 56).unwrap())
-    /// );
-    /// assert_eq!(dt.with_day0(30), None); // no September 31
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8)?.and_hms(12, 34, 56)?;
+    /// assert_eq!(dt.with_day0(29), NaiveDate::from_ymd(2015, 9, 30)?.and_hms(12, 34, 56));
+    /// assert_eq!(dt.with_day0(30), Err(Error::DoesNotExist)); // No September 31
+    /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn with_day0(&self, day0: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { date: try_opt!(ok!(self.date.with_day0(day0))), ..*self })
+    pub const fn with_day0(&self, day0: u32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { date: try_err!(self.date.with_day0(day0)), ..*self })
     }
 
     /// Makes a new `NaiveDateTime` with the day of year (starting from 1) changed.


### PR DESCRIPTION
Convert `NaiveDate::{with_month, with_month0, with_day, with_day0}` and `NaiveDateTime::{with_month, with_month0, with_day, with_day0}`.
All make use of `NaiveDate::with_mdf` internally.

Based on #1466, I'll rebase once that is merged.

cc @Zomtir