### PR TITLE
Convert `NaiveDate::from_weekday_of_month` to return `Result`

### DIFF
--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -302,19 +302,21 @@ fn test_date_from_num_days_from_ce() {
 #[test]
 fn test_date_from_weekday_of_month() {
     let ymwd = NaiveDate::from_weekday_of_month;
-    assert_eq!(ymwd(2018, 8, Weekday::Tue, 0), None);
-    assert_eq!(ymwd(2018, 8, Weekday::Wed, 1), Some(NaiveDate::from_ymd(2018, 8, 1).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Thu, 1), Some(NaiveDate::from_ymd(2018, 8, 2).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Sun, 1), Some(NaiveDate::from_ymd(2018, 8, 5).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Mon, 1), Some(NaiveDate::from_ymd(2018, 8, 6).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Tue, 1), Some(NaiveDate::from_ymd(2018, 8, 7).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Wed, 2), Some(NaiveDate::from_ymd(2018, 8, 8).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Sun, 2), Some(NaiveDate::from_ymd(2018, 8, 12).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Thu, 3), Some(NaiveDate::from_ymd(2018, 8, 16).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Thu, 4), Some(NaiveDate::from_ymd(2018, 8, 23).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Thu, 5), Some(NaiveDate::from_ymd(2018, 8, 30).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Fri, 5), Some(NaiveDate::from_ymd(2018, 8, 31).unwrap()));
-    assert_eq!(ymwd(2018, 8, Weekday::Sat, 5), None);
+    assert_eq!(ymwd(2018, 8, Weekday::Tue, 0), Err(Error::InvalidArgument));
+    assert_eq!(ymwd(2018, 8, Weekday::Wed, 1), Ok(NaiveDate::from_ymd(2018, 8, 1).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Thu, 1), Ok(NaiveDate::from_ymd(2018, 8, 2).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Sun, 1), Ok(NaiveDate::from_ymd(2018, 8, 5).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Mon, 1), Ok(NaiveDate::from_ymd(2018, 8, 6).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Tue, 1), Ok(NaiveDate::from_ymd(2018, 8, 7).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Wed, 2), Ok(NaiveDate::from_ymd(2018, 8, 8).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Sun, 2), Ok(NaiveDate::from_ymd(2018, 8, 12).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Thu, 3), Ok(NaiveDate::from_ymd(2018, 8, 16).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Thu, 4), Ok(NaiveDate::from_ymd(2018, 8, 23).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Thu, 5), Ok(NaiveDate::from_ymd(2018, 8, 30).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Fri, 5), Ok(NaiveDate::from_ymd(2018, 8, 31).unwrap()));
+    assert_eq!(ymwd(2018, 8, Weekday::Sat, 5), Err(Error::DoesNotExist));
+    assert_eq!(ymwd(2018, 8, Weekday::Sat, 6), Err(Error::InvalidArgument));
+    assert_eq!(ymwd(2018, 13, Weekday::Sat, 1), Err(Error::InvalidArgument));
 }
 
 #[test]


### PR DESCRIPTION
A small PR converting just a single method.

In my personal use I found the way the method currently works inconvenient.

It is not uncommon for scheduling applications to equal some recurring thing on the 5th `Weekday` of the month with the *last* `Weekday` of the month. No matter if that turns out to be the 4th or the 5th `Weekday`.

Is that practise something we want to support? And if so do we want to adjust this method or add another one?