### PR TITLE
Merge 0.4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Chrono aims to provide all functionality needed to do correct operations on date
 * The [`DateTime`](https://docs.rs/chrono/latest/chrono/struct.DateTime.html) type is timezone-aware
   by default, with separate timezone-naive types.
 * Operations that may produce an invalid or ambiguous date and time return `Option` or
-  [`LocalResult`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html).
+  [`MappedLocalTime`](https://docs.rs/chrono/latest/chrono/offset/enum.MappedLocalTime.html).
 * Configurable parsing and formatting with an `strftime` inspired date and time formatting syntax.
 * The [`Local`](https://docs.rs/chrono/latest/chrono/offset/struct.Local.html) timezone works with
   the current timezone of the OS.

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -25,7 +25,7 @@ use crate::format::{write_rfc2822, write_rfc3339, DelayedFormat, SecondsFormat};
 use crate::naive::{Days, IsoWeek, NaiveDate, NaiveDateTime, NaiveTime};
 #[cfg(feature = "clock")]
 use crate::offset::Local;
-use crate::offset::{FixedOffset, Offset, TimeZone, Utc};
+use crate::offset::{FixedOffset, MappedLocalTime, Offset, TimeZone, Utc};
 #[cfg(any(feature = "clock", feature = "std"))]
 use crate::OutOfRange;
 use crate::{try_err, try_ok_or, Datelike, Error, Months, TimeDelta, Timelike, Weekday};
@@ -671,6 +671,32 @@ impl<Tz: TimeZone> DateTime<Tz> {
     #[inline]
     pub fn with_ordinal0(&self, ordinal0: u32) -> Option<DateTime<Tz>> {
         map_local(self, |datetime| datetime.with_ordinal0(ordinal0))
+    }
+
+    /// Set the time to a new fixed time on the existing date.
+    ///
+    /// # Errors
+    ///
+    /// Returns `MappedLocalTime::None` if the datetime is at the edge of the representable range
+    /// for a `DateTime`, and `with_time` would push the value in UTC out of range.
+    ///
+    /// # Example
+    ///
+    #[cfg_attr(not(feature = "clock"), doc = "```ignore")]
+    #[cfg_attr(feature = "clock", doc = "```rust")]
+    /// use chrono::{Local, NaiveTime};
+    ///
+    /// let noon = NaiveTime::from_hms(12, 0, 0)?;
+    /// let today_noon = Local::now().with_time(noon);
+    /// let today_midnight = Local::now().with_time(NaiveTime::MIN);
+    ///
+    /// assert_eq!(today_noon.single().unwrap().time(), noon);
+    /// assert_eq!(today_midnight.single().unwrap().time(), NaiveTime::MIN);
+    /// # Ok::<(), chrono::Error>(())
+    /// ```
+    #[must_use]
+    pub fn with_time(&self, time: NaiveTime) -> MappedLocalTime<Self> {
+        self.timezone().from_local_datetime(&self.overflowing_naive_local().date().and_time(time))
     }
 
     /// Makes a new `DateTime` with the hour number changed.

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -1235,7 +1235,7 @@ mod tests {
 
     #[test]
     fn test_serde_no_offset_debug() {
-        use crate::{LocalResult, NaiveDateTime, Offset};
+        use crate::{MappedLocalTime, NaiveDateTime, Offset};
         use core::fmt::Debug;
 
         #[derive(Clone)]
@@ -1253,8 +1253,8 @@ mod tests {
             fn offset_from_local_datetime(
                 &self,
                 _local: &NaiveDateTime,
-            ) -> LocalResult<TestTimeZone> {
-                LocalResult::Single(TestTimeZone)
+            ) -> MappedLocalTime<TestTimeZone> {
+                MappedLocalTime::Single(TestTimeZone)
             }
             fn offset_from_utc_datetime(&self, _utc: &NaiveDateTime) -> TestTimeZone {
                 TestTimeZone

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -4,7 +4,7 @@ use crate::offset::{FixedOffset, TimeZone, Utc};
 #[cfg(feature = "clock")]
 use crate::offset::{Local, Offset};
 use crate::{
-    Datelike, Days, Error, LocalResult, Months, NaiveDateTime, TimeDelta, Timelike, Weekday,
+    Datelike, Days, Error, MappedLocalTime, Months, NaiveDateTime, TimeDelta, Timelike, Weekday,
 };
 
 #[derive(Clone)]
@@ -36,7 +36,7 @@ impl TimeZone for DstTester {
     fn offset_from_local_datetime(
         &self,
         local: &NaiveDateTime,
-    ) -> crate::LocalResult<Self::Offset> {
+    ) -> crate::MappedLocalTime<Self::Offset> {
         let local_to_winter_transition_start = NaiveDate::from_ymd(
             local.year(),
             DstTester::TO_WINTER_MONTH_DAY.0,
@@ -70,19 +70,19 @@ impl TimeZone for DstTester {
         .and_time(DstTester::transition_start_local() + TimeDelta::hours(1));
 
         if *local < local_to_winter_transition_end || *local >= local_to_summer_transition_end {
-            LocalResult::Single(DstTester::summer_offset())
+            MappedLocalTime::Single(DstTester::summer_offset())
         } else if *local >= local_to_winter_transition_start
             && *local < local_to_summer_transition_start
         {
-            LocalResult::Single(DstTester::winter_offset())
+            MappedLocalTime::Single(DstTester::winter_offset())
         } else if *local >= local_to_winter_transition_end
             && *local < local_to_winter_transition_start
         {
-            LocalResult::Ambiguous(DstTester::winter_offset(), DstTester::summer_offset())
+            MappedLocalTime::Ambiguous(DstTester::winter_offset(), DstTester::summer_offset())
         } else if *local >= local_to_summer_transition_start
             && *local < local_to_summer_transition_end
         {
-            LocalResult::None
+            MappedLocalTime::None
         } else {
             panic!("Unexpected local time {}", local)
         }
@@ -592,7 +592,7 @@ fn signed_duration_since_autoref() {
     let diff2 = dt2.signed_duration_since(&dt1); // Take by reference
     assert_eq!(diff1, -diff2);
 
-    let diff1 = dt1 - &dt2; // We can choose to substract rhs by reference
+    let diff1 = dt1 - &dt2; // We can choose to subtract rhs by reference
     let diff2 = dt2 - dt1; // Or consume rhs
     assert_eq!(diff1, -diff2);
 }

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -6,7 +6,7 @@
 
 use super::{ParseResult, IMPOSSIBLE, NOT_ENOUGH, OUT_OF_RANGE};
 use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
-use crate::offset::{FixedOffset, LocalResult, Offset, TimeZone};
+use crate::offset::{FixedOffset, MappedLocalTime, Offset, TimeZone};
 use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 
 /// A type to hold parsed fields of date and time that can check all fields are consistent.
@@ -859,9 +859,9 @@ impl Parsed {
         let offset = FixedOffset::east(offset).map_err(|_| OUT_OF_RANGE)?;
 
         match offset.from_local_datetime(&datetime) {
-            LocalResult::None => Err(IMPOSSIBLE),
-            LocalResult::Single(t) => Ok(t),
-            LocalResult::Ambiguous(..) => Err(NOT_ENOUGH),
+            MappedLocalTime::None => Err(IMPOSSIBLE),
+            MappedLocalTime::Single(t) => Ok(t),
+            MappedLocalTime::Ambiguous(..) => Err(NOT_ENOUGH),
         }
     }
 
@@ -915,15 +915,15 @@ impl Parsed {
         // it will be 0 otherwise, but this is fine as the algorithm ignores offset for that case.
         let datetime = self.to_naive_datetime_with_offset(guessed_offset)?;
         match tz.from_local_datetime(&datetime) {
-            LocalResult::None => Err(IMPOSSIBLE),
-            LocalResult::Single(t) => {
+            MappedLocalTime::None => Err(IMPOSSIBLE),
+            MappedLocalTime::Single(t) => {
                 if check_offset(&t) {
                     Ok(t)
                 } else {
                     Err(IMPOSSIBLE)
                 }
             }
-            LocalResult::Ambiguous(min, max) => {
+            MappedLocalTime::Ambiguous(min, max) => {
                 // try to disambiguate two possible local dates by offset.
                 match (check_offset(&min), check_offset(&max)) {
                     (false, false) => Err(IMPOSSIBLE),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! * The [`DateTime`](https://docs.rs/chrono/latest/chrono/struct.DateTime.html) type is timezone-aware
 //!   by default, with separate timezone-naive types.
 //! * Operations that may produce an invalid or ambiguous date and time return `Option` or
-//!   [`LocalResult`](https://docs.rs/chrono/latest/chrono/offset/enum.LocalResult.html).
+//!   [`MappedLocalTime`](https://docs.rs/chrono/latest/chrono/offset/enum.MappedLocalTime.html).
 //! * Configurable parsing and formatting with a `strftime` inspired date and time formatting syntax.
 //! * The [`Local`](https://docs.rs/chrono/latest/chrono/offset/struct.Local.html) timezone works with
 //!   the current timezone of the OS.
@@ -129,7 +129,7 @@
 //!
 #![cfg_attr(not(feature = "now"), doc = "```ignore")]
 #![cfg_attr(feature = "now", doc = "```rust")]
-//! use chrono::offset::LocalResult;
+//! use chrono::offset::MappedLocalTime;
 //! use chrono::prelude::*;
 //!
 //! # fn doctest() -> Option<()> {
@@ -147,10 +147,14 @@
 //! assert_eq!(dt, NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_nano(9, 10, 11, 12_000_000).unwrap().and_local_timezone(Utc).unwrap());
 //!
 //! // dynamic verification
-//! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 21, 15, 33),
-//!            LocalResult::Single(NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms(21, 15, 33).unwrap().and_utc()));
-//! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 80, 15, 33), LocalResult::None);
-//! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 38, 21, 15, 33), LocalResult::None);
+//! assert_eq!(
+//!     Utc.with_ymd_and_hms(2014, 7, 8, 21, 15, 33),
+//!     MappedLocalTime::Single(
+//!         NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms(21, 15, 33).unwrap().and_utc()
+//!     )
+//! );
+//! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 80, 15, 33), MappedLocalTime::None);
+//! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 38, 21, 15, 33), MappedLocalTime::None);
 //!
 //! # #[cfg(feature = "clock")] {
 //! // other time zone objects can be used to construct a local datetime.
@@ -512,7 +516,7 @@ pub mod offset;
 #[cfg(feature = "clock")]
 #[doc(inline)]
 pub use offset::Local;
-pub use offset::LocalResult;
+pub use offset::MappedLocalTime;
 #[doc(inline)]
 pub use offset::{FixedOffset, Offset, TimeZone, Utc};
 

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -20,8 +20,8 @@ use crate::format::{Fixed, Item, Numeric, Pad};
 use crate::naive::{Days, IsoWeek, NaiveDate, NaiveTime};
 use crate::offset::Utc;
 use crate::{
-    expect, ok, try_err, try_ok_or, try_opt, DateTime, Datelike, Error, FixedOffset, LocalResult,
-    Months, TimeDelta, TimeZone, Timelike, Weekday,
+    expect, ok, try_err, try_ok_or, try_opt, DateTime, Datelike, Error, FixedOffset,
+    MappedLocalTime, Months, TimeDelta, TimeZone, Timelike, Weekday,
 };
 
 /// Tools to help serializing/deserializing `NaiveDateTime`s
@@ -686,7 +686,7 @@ impl NaiveDateTime {
     /// This can fail in cases where the local time represented by the `NaiveDateTime`
     /// is not a valid local timestamp in the target timezone due to an offset transition
     /// for example if the target timezone had a change from +00:00 to +01:00
-    /// occuring at 2015-09-05 22:59:59, then a local time of 2015-09-05 23:56:04
+    /// occurring at 2015-09-05 22:59:59, then a local time of 2015-09-05 23:56:04
     /// could never occur. Similarly, if the offset transitioned in the opposite direction
     /// then there would be two local times of 2015-09-05 23:56:04, one at +00:00 and one
     /// at +01:00.
@@ -706,7 +706,7 @@ impl NaiveDateTime {
     /// assert_eq!(dt.timezone(), tz);
     /// ```
     #[must_use]
-    pub fn and_local_timezone<Tz: TimeZone>(&self, tz: Tz) -> LocalResult<DateTime<Tz>> {
+    pub fn and_local_timezone<Tz: TimeZone>(&self, tz: Tz) -> MappedLocalTime<DateTime<Tz>> {
         tz.from_local_datetime(self)
     }
 

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -1,5 +1,5 @@
 use super::NaiveDateTime;
-use crate::{Datelike, Error, FixedOffset, LocalResult, NaiveDate, TimeDelta, Utc};
+use crate::{Datelike, Error, FixedOffset, MappedLocalTime, NaiveDate, TimeDelta, Utc};
 
 #[test]
 fn test_datetime_add() -> Result<(), Error> {
@@ -385,13 +385,13 @@ fn test_and_timezone_min_max_dates() {
         if offset_hour >= 0 {
             assert_eq!(local_max.unwrap().naive_local(), NaiveDateTime::MAX);
         } else {
-            assert_eq!(local_max, LocalResult::None);
+            assert_eq!(local_max, MappedLocalTime::None);
         }
         let local_min = NaiveDateTime::MIN.and_local_timezone(offset);
         if offset_hour <= 0 {
             assert_eq!(local_min.unwrap().naive_local(), NaiveDateTime::MIN);
         } else {
-            assert_eq!(local_min, LocalResult::None);
+            assert_eq!(local_min, MappedLocalTime::None);
         }
     }
 }

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -9,7 +9,7 @@ use core::str::FromStr;
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
-use super::{LocalResult, Offset, TimeZone};
+use super::{MappedLocalTime, Offset, TimeZone};
 use crate::format::{scan, OUT_OF_RANGE};
 use crate::{Error, NaiveDateTime, ParseError};
 
@@ -113,8 +113,8 @@ impl TimeZone for FixedOffset {
         *offset
     }
 
-    fn offset_from_local_datetime(&self, _local: &NaiveDateTime) -> LocalResult<FixedOffset> {
-        LocalResult::Single(*self)
+    fn offset_from_local_datetime(&self, _local: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
+        MappedLocalTime::Single(*self)
     }
 
     fn offset_from_utc_datetime(&self, _utc: &NaiveDateTime) -> FixedOffset {

--- a/src/offset/local/tz_info/rule.rs
+++ b/src/offset/local/tz_info/rule.rs
@@ -83,10 +83,10 @@ impl TransitionRule {
         &self,
         local_time: i64,
         year: i32,
-    ) -> Result<crate::LocalResult<LocalTimeType>, Error> {
+    ) -> Result<crate::MappedLocalTime<LocalTimeType>, Error> {
         match self {
             TransitionRule::Fixed(local_time_type) => {
-                Ok(crate::LocalResult::Single(*local_time_type))
+                Ok(crate::MappedLocalTime::Single(*local_time_type))
             }
             TransitionRule::Alternate(alternate_time) => {
                 alternate_time.find_local_time_type_from_local(local_time, year)
@@ -231,7 +231,7 @@ impl AlternateTime {
         &self,
         local_time: i64,
         current_year: i32,
-    ) -> Result<crate::LocalResult<LocalTimeType>, Error> {
+    ) -> Result<crate::MappedLocalTime<LocalTimeType>, Error> {
         // Check if the current year is valid for the following computations
         if !(i32::min_value() + 2 <= current_year && current_year <= i32::max_value() - 2) {
             return Err(Error::OutOfRange("out of range date time"));
@@ -252,7 +252,7 @@ impl AlternateTime {
             - i64::from(self.dst.ut_offset);
 
         match self.std.ut_offset.cmp(&self.dst.ut_offset) {
-            Ordering::Equal => Ok(crate::LocalResult::Single(self.std)),
+            Ordering::Equal => Ok(crate::MappedLocalTime::Single(self.std)),
             Ordering::Less => {
                 if self.dst_start.transition_date(current_year).0
                     < self.dst_end.transition_date(current_year).0
@@ -260,41 +260,41 @@ impl AlternateTime {
                     // northern hemisphere
                     // For the DST END transition, the `start` happens at a later timestamp than the `end`.
                     if local_time <= dst_start_transition_start {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(crate::MappedLocalTime::Single(self.std))
                     } else if local_time > dst_start_transition_start
                         && local_time < dst_start_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(crate::MappedLocalTime::None)
                     } else if local_time >= dst_start_transition_end
                         && local_time < dst_end_transition_end
                     {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(crate::MappedLocalTime::Single(self.dst))
                     } else if local_time >= dst_end_transition_end
                         && local_time <= dst_end_transition_start
                     {
-                        Ok(crate::LocalResult::Ambiguous(self.std, self.dst))
+                        Ok(crate::MappedLocalTime::Ambiguous(self.std, self.dst))
                     } else {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(crate::MappedLocalTime::Single(self.std))
                     }
                 } else {
                     // southern hemisphere regular DST
                     // For the DST END transition, the `start` happens at a later timestamp than the `end`.
                     if local_time < dst_end_transition_end {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(crate::MappedLocalTime::Single(self.dst))
                     } else if local_time >= dst_end_transition_end
                         && local_time <= dst_end_transition_start
                     {
-                        Ok(crate::LocalResult::Ambiguous(self.std, self.dst))
+                        Ok(crate::MappedLocalTime::Ambiguous(self.std, self.dst))
                     } else if local_time > dst_end_transition_end
                         && local_time < dst_start_transition_start
                     {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(crate::MappedLocalTime::Single(self.std))
                     } else if local_time >= dst_start_transition_start
                         && local_time < dst_start_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(crate::MappedLocalTime::None)
                     } else {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(crate::MappedLocalTime::Single(self.dst))
                     }
                 }
             }
@@ -305,41 +305,41 @@ impl AlternateTime {
                     // southern hemisphere reverse DST
                     // For the DST END transition, the `start` happens at a later timestamp than the `end`.
                     if local_time < dst_start_transition_end {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(crate::MappedLocalTime::Single(self.std))
                     } else if local_time >= dst_start_transition_end
                         && local_time <= dst_start_transition_start
                     {
-                        Ok(crate::LocalResult::Ambiguous(self.dst, self.std))
+                        Ok(crate::MappedLocalTime::Ambiguous(self.dst, self.std))
                     } else if local_time > dst_start_transition_start
                         && local_time < dst_end_transition_start
                     {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(crate::MappedLocalTime::Single(self.dst))
                     } else if local_time >= dst_end_transition_start
                         && local_time < dst_end_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(crate::MappedLocalTime::None)
                     } else {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(crate::MappedLocalTime::Single(self.std))
                     }
                 } else {
                     // northern hemisphere reverse DST
                     // For the DST END transition, the `start` happens at a later timestamp than the `end`.
                     if local_time <= dst_end_transition_start {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(crate::MappedLocalTime::Single(self.dst))
                     } else if local_time > dst_end_transition_start
                         && local_time < dst_end_transition_end
                     {
-                        Ok(crate::LocalResult::None)
+                        Ok(crate::MappedLocalTime::None)
                     } else if local_time >= dst_end_transition_end
                         && local_time < dst_start_transition_end
                     {
-                        Ok(crate::LocalResult::Single(self.std))
+                        Ok(crate::MappedLocalTime::Single(self.std))
                     } else if local_time >= dst_start_transition_end
                         && local_time <= dst_start_transition_start
                     {
-                        Ok(crate::LocalResult::Ambiguous(self.dst, self.std))
+                        Ok(crate::MappedLocalTime::Ambiguous(self.dst, self.std))
                     } else {
-                        Ok(crate::LocalResult::Single(self.dst))
+                        Ok(crate::MappedLocalTime::Single(self.dst))
                     }
                 }
             }

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -17,7 +17,7 @@ use std::time::SystemTime;
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
-use super::{FixedOffset, LocalResult, Offset, TimeZone};
+use super::{FixedOffset, MappedLocalTime, Offset, TimeZone};
 use crate::naive::NaiveDateTime;
 #[cfg(feature = "now")]
 use crate::DateTime;
@@ -114,8 +114,8 @@ impl TimeZone for Utc {
         Utc
     }
 
-    fn offset_from_local_datetime(&self, _local: &NaiveDateTime) -> LocalResult<Utc> {
-        LocalResult::Single(Utc)
+    fn offset_from_local_datetime(&self, _local: &NaiveDateTime) -> MappedLocalTime<Utc> {
+        MappedLocalTime::Single(Utc)
     }
 
     fn offset_from_utc_datetime(&self, _utc: &NaiveDateTime) -> Utc {

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -28,19 +28,19 @@ fn verify_against_date_command_local(path: &'static str, dt: NaiveDateTime) {
     //     assert_eq!("", date_command_str);
     // }
 
-    // This is used while a decision is made wheter the `date` output needs to
-    // be exactly matched, or whether LocalResult::Ambigious should be handled
+    // This is used while a decision is made whether the `date` output needs to
+    // be exactly matched, or whether MappedLocalTime::Ambiguous should be handled
     // differently
 
     let date = NaiveDate::from_ymd(dt.year(), dt.month(), dt.day()).unwrap();
     match Local.from_local_datetime(&date.and_hms(dt.hour(), 5, 1).unwrap()) {
-        chrono::LocalResult::Ambiguous(a, b) => assert!(
+        chrono::MappedLocalTime::Ambiguous(a, b) => assert!(
             format!("{}\n", a) == date_command_str || format!("{}\n", b) == date_command_str
         ),
-        chrono::LocalResult::Single(a) => {
+        chrono::MappedLocalTime::Single(a) => {
             assert_eq!(format!("{}\n", a), date_command_str);
         }
-        chrono::LocalResult::None => {
+        chrono::MappedLocalTime::None => {
             assert_eq!("", date_command_str);
         }
     }


### PR DESCRIPTION
The rename from `LocalResult` to `MappedLocalTime` caused a lot of merge conflicts.