### PR TITLE
Convert `DateTime::with_nanosecond` to return `Result`

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -748,18 +748,21 @@ impl<Tz: TimeZone> DateTime<Tz> {
 
     /// Makes a new `DateTime` with nanoseconds since the whole non-leap second changed.
     ///
-    /// Returns `None` when the resulting `NaiveDateTime` would be invalid.
-    /// As with the [`NaiveDateTime::nanosecond`] method,
-    /// the input range can exceed 1,000,000,000 for leap seconds.
+    /// As with the [`DateTime::nanosecond`] method, the input range can exceed 1,000,000,000 for
+    /// leap seconds.
     ///
     /// See also the [`NaiveTime::with_nanosecond`] method.
     ///
     /// # Errors
     ///
-    /// Returns `None` if `nanosecond >= 2,000,000,000`.
+    /// Returns [`Error::InvalidArgument`] if `nanosecond >= 2,000,000,000`.
     #[inline]
-    pub fn with_nanosecond(&self, nano: u32) -> Option<DateTime<Tz>> {
-        map_local(self, |datetime| datetime.with_nanosecond(nano).ok())
+    pub fn with_nanosecond(&self, nano: u32) -> Result<DateTime<Tz>, Error> {
+        // `with_nanosecond` does not need to recalculate the offset like the other `with_` methods.
+        // Like the IANA time zone database and other libraries we assume in chrono that offsets
+        // have second granularity, and time zone transitions (such as DTS) happen on second
+        // boundaries.
+        Ok(Self { datetime: self.datetime.with_nanosecond(nano)?, offset: self.offset.clone() })
     }
 }
 

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1526,7 +1526,7 @@ fn test_min_max_setters() {
     assert_eq!(beyond_min.with_hour(5), None);
     assert_eq!(beyond_min.with_minute(0), Some(beyond_min));
     assert_eq!(beyond_min.with_second(0), Some(beyond_min));
-    assert_eq!(beyond_min.with_nanosecond(0), Some(beyond_min));
+    assert_eq!(beyond_min.with_nanosecond(0), Ok(beyond_min));
 
     assert_eq!(beyond_max.with_year(2020).unwrap().year(), 2020);
     assert_eq!(beyond_max.with_year(beyond_max.year()), Some(beyond_max));
@@ -1547,7 +1547,7 @@ fn test_min_max_setters() {
     assert_eq!(beyond_max.with_hour(5), None);
     assert_eq!(beyond_max.with_minute(beyond_max.minute()), Some(beyond_max));
     assert_eq!(beyond_max.with_second(beyond_max.second()), Some(beyond_max));
-    assert_eq!(beyond_max.with_nanosecond(beyond_max.nanosecond()), Some(beyond_max));
+    assert_eq!(beyond_max.with_nanosecond(beyond_max.nanosecond()), Ok(beyond_max));
 }
 
 #[test]

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -1005,9 +1005,8 @@ impl NaiveDateTime {
 
     /// Makes a new `NaiveDateTime` with nanoseconds since the whole non-leap second changed.
     ///
-    /// Returns `None` when the resulting `NaiveDateTime` would be invalid.
-    /// As with the [`NaiveDateTime::nanosecond`] method,
-    /// the input range can exceed 1,000,000,000 for leap seconds.
+    /// As with the [`NaiveDateTime::nanosecond`] method, the input range can exceed 1,000,000,000
+    /// for leap seconds.
     ///
     /// See also the [`NaiveTime::with_nanosecond`] method.
     ///


### PR DESCRIPTION
As I see it `DateTime::with_nanosecond` is one of the few methods on `DateTime` that does not need to return an error from the `TimeZone` trait and does not need to return a `MappedLocalTime`.

We assume in some places, like the platform code of `Local`, that time zone transitions happen on second boundaries. That seems entirely reasonable to me and fits with reality. There is also some similarity to how we assume offsets to be a round number of seconds from UTC.

In the IANA time zone database there are some time zone offsets from the 19th century that have an offset with fractional seconds. Those are based on the longitude of a city or mean of the country. The fractional part is included with a comment, and the shipped data uses round seconds. Necessarily if anyone takes those fractional offsets serious, they would need a transitions at a fractional second at some point when the country aligns from *local mean time* to round offsets from UTC.

If we assume there are no subsecond transitions `DateTime::with_nanosecond` can just assume the entire second has the same offset from UTC.