### PR TITLE
`TimeZone` trait: take `NaiveDateTime` by value

### DIFF
--- a/bench/benches/chrono.rs
+++ b/bench/benches/chrono.rs
@@ -50,7 +50,7 @@ fn bench_datetime_to_rfc2822(c: &mut Criterion) {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            &NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
+            NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
         )
         .unwrap();
     c.bench_function("bench_datetime_to_rfc2822", |b| b.iter(|| black_box(dt).to_rfc2822()));
@@ -60,7 +60,7 @@ fn bench_datetime_to_rfc3339(c: &mut Criterion) {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            &NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
+            NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
         )
         .unwrap();
     c.bench_function("bench_datetime_to_rfc3339", |b| b.iter(|| black_box(dt).to_rfc3339()));
@@ -70,7 +70,7 @@ fn bench_datetime_to_rfc3339_opts(c: &mut Criterion) {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            &NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
+            NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
         )
         .unwrap();
     c.bench_function("bench_datetime_to_rfc3339_opts", |b| {

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -285,7 +285,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     #[inline]
     #[must_use]
     pub fn with_timezone<Tz2: TimeZone>(&self, tz: &Tz2) -> DateTime<Tz2> {
-        tz.from_utc_datetime(&self.datetime)
+        tz.from_utc_datetime(self.datetime)
     }
 
     /// Fix the offset from UTC to its current value, dropping the associated timezone information.
@@ -314,7 +314,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     pub fn checked_add_signed(self, rhs: TimeDelta) -> Option<DateTime<Tz>> {
         let datetime = self.datetime.checked_add_signed(rhs).ok()?;
         let tz = self.timezone();
-        Some(tz.from_utc_datetime(&datetime))
+        Some(tz.from_utc_datetime(datetime))
     }
 
     /// Adds given `Months` to the current date and time.
@@ -351,7 +351,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     pub fn checked_sub_signed(self, rhs: TimeDelta) -> Option<DateTime<Tz>> {
         let datetime = self.datetime.checked_sub_signed(rhs).ok()?;
         let tz = self.timezone();
-        Some(tz.from_utc_datetime(&datetime))
+        Some(tz.from_utc_datetime(datetime))
     }
 
     /// Subtracts given `Months` from the current date and time.
@@ -397,7 +397,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
         // range local datetime when adding `Days(0)`.
         let naive = self.overflowing_naive_local().checked_add_days(days).ok()?;
         self.timezone()
-            .from_local_datetime(&naive)
+            .from_local_datetime(naive)
             .single()
             .filter(|dt| dt <= &DateTime::<Utc>::MAX_UTC)
     }
@@ -418,7 +418,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
         // range local datetime when adding `Days(0)`.
         let naive = self.overflowing_naive_local().checked_sub_days(days).ok()?;
         self.timezone()
-            .from_local_datetime(&naive)
+            .from_local_datetime(naive)
             .single()
             .filter(|dt| dt >= &DateTime::<Utc>::MIN_UTC)
     }
@@ -541,7 +541,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     /// let dt = pst
     ///     .from_local_datetime(
-    ///         &NaiveDate::from_ymd(2018, 1, 26).unwrap().and_hms_micro(10, 30, 9, 453_829).unwrap(),
+    ///         NaiveDate::from_ymd(2018, 1, 26).unwrap().and_hms_micro(10, 30, 9, 453_829).unwrap(),
     ///     )
     ///     .unwrap();
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Secs, true), "2018-01-26T10:30:09+08:00");
@@ -696,7 +696,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     #[must_use]
     pub fn with_time(&self, time: NaiveTime) -> MappedLocalTime<Self> {
-        self.timezone().from_local_datetime(&self.overflowing_naive_local().date().and_time(time))
+        self.timezone().from_local_datetime(self.overflowing_naive_local().date().and_time(time))
     }
 
     /// Makes a new `DateTime` with the hour number changed.
@@ -919,20 +919,20 @@ impl DateTime<Utc> {
 
 impl Default for DateTime<Utc> {
     fn default() -> Self {
-        Utc.from_utc_datetime(&NaiveDateTime::default())
+        Utc.from_utc_datetime(NaiveDateTime::default())
     }
 }
 
 #[cfg(feature = "clock")]
 impl Default for DateTime<Local> {
     fn default() -> Self {
-        Local.from_utc_datetime(&NaiveDateTime::default())
+        Local.from_utc_datetime(NaiveDateTime::default())
     }
 }
 
 impl Default for DateTime<FixedOffset> {
     fn default() -> Self {
-        FixedOffset::west(0).unwrap().from_utc_datetime(&NaiveDateTime::default())
+        FixedOffset::west(0).unwrap().from_utc_datetime(NaiveDateTime::default())
     }
 }
 
@@ -1010,7 +1010,7 @@ where
     F: FnMut(NaiveDateTime) -> Option<NaiveDateTime>,
 {
     f(dt.overflowing_naive_local())
-        .and_then(|datetime| dt.timezone().from_local_datetime(&datetime).single())
+        .and_then(|datetime| dt.timezone().from_local_datetime(datetime).single())
         .filter(|dt| dt >= &DateTime::<Utc>::MIN_UTC && dt <= &DateTime::<Utc>::MAX_UTC)
 }
 
@@ -1097,7 +1097,7 @@ impl DateTime<FixedOffset> {
     ///     Ok(FixedOffset::east(0)
     ///         .unwrap()
     ///         .from_local_datetime(
-    ///             &NaiveDate::from_ymd(1983, 4, 13).unwrap().and_hms_milli(12, 9, 14, 274).unwrap()
+    ///             NaiveDate::from_ymd(1983, 4, 13).unwrap().and_hms_milli(12, 9, 14, 274).unwrap()
     ///         )
     ///         .unwrap())
     /// );
@@ -1390,7 +1390,7 @@ impl<Tz: TimeZone> AddAssign<TimeDelta> for DateTime<Tz> {
         let datetime =
             self.datetime.checked_add_signed(rhs).expect("`DateTime + TimeDelta` overflowed");
         let tz = self.timezone();
-        *self = tz.from_utc_datetime(&datetime);
+        *self = tz.from_utc_datetime(datetime);
     }
 }
 
@@ -1510,7 +1510,7 @@ impl<Tz: TimeZone> SubAssign<TimeDelta> for DateTime<Tz> {
         let datetime =
             self.datetime.checked_sub_signed(rhs).expect("`DateTime - TimeDelta` overflowed");
         let tz = self.timezone();
-        *self = tz.from_utc_datetime(&datetime)
+        *self = tz.from_utc_datetime(datetime)
     }
 }
 

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -1252,11 +1252,11 @@ mod tests {
             }
             fn offset_from_local_datetime(
                 &self,
-                _local: &NaiveDateTime,
+                _local: NaiveDateTime,
             ) -> MappedLocalTime<TestTimeZone> {
                 MappedLocalTime::Single(TestTimeZone)
             }
-            fn offset_from_utc_datetime(&self, _utc: &NaiveDateTime) -> TestTimeZone {
+            fn offset_from_utc_datetime(&self, _utc: NaiveDateTime) -> TestTimeZone {
                 TestTimeZone
             }
         }

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -35,7 +35,7 @@ impl TimeZone for DstTester {
 
     fn offset_from_local_datetime(
         &self,
-        local: &NaiveDateTime,
+        local: NaiveDateTime,
     ) -> crate::MappedLocalTime<Self::Offset> {
         let local_to_winter_transition_start = NaiveDate::from_ymd(
             local.year(),
@@ -69,18 +69,18 @@ impl TimeZone for DstTester {
         .unwrap()
         .and_time(DstTester::transition_start_local() + TimeDelta::hours(1));
 
-        if *local < local_to_winter_transition_end || *local >= local_to_summer_transition_end {
+        if local < local_to_winter_transition_end || local >= local_to_summer_transition_end {
             MappedLocalTime::Single(DstTester::summer_offset())
-        } else if *local >= local_to_winter_transition_start
-            && *local < local_to_summer_transition_start
+        } else if local >= local_to_winter_transition_start
+            && local < local_to_summer_transition_start
         {
             MappedLocalTime::Single(DstTester::winter_offset())
-        } else if *local >= local_to_winter_transition_end
-            && *local < local_to_winter_transition_start
+        } else if local >= local_to_winter_transition_end
+            && local < local_to_winter_transition_start
         {
             MappedLocalTime::Ambiguous(DstTester::winter_offset(), DstTester::summer_offset())
-        } else if *local >= local_to_summer_transition_start
-            && *local < local_to_summer_transition_end
+        } else if local >= local_to_summer_transition_start
+            && local < local_to_summer_transition_end
         {
             MappedLocalTime::None
         } else {
@@ -88,7 +88,7 @@ impl TimeZone for DstTester {
         }
     }
 
-    fn offset_from_utc_datetime(&self, utc: &NaiveDateTime) -> Self::Offset {
+    fn offset_from_utc_datetime(&self, utc: NaiveDateTime) -> Self::Offset {
         let utc_to_winter_transition = NaiveDate::from_ymd(
             utc.year(),
             DstTester::TO_WINTER_MONTH_DAY.0,
@@ -107,9 +107,9 @@ impl TimeZone for DstTester {
         .and_time(DstTester::transition_start_local())
             - DstTester::winter_offset();
 
-        if *utc < utc_to_winter_transition || *utc >= utc_to_summer_transition {
+        if utc < utc_to_winter_transition || utc >= utc_to_summer_transition {
             DstTester::summer_offset()
-        } else if *utc >= utc_to_winter_transition && *utc < utc_to_summer_transition {
+        } else if utc >= utc_to_winter_transition && utc < utc_to_summer_transition {
             DstTester::winter_offset()
         } else {
             panic!("Unexpected utc time {}", utc)
@@ -644,7 +644,7 @@ fn test_datetime_rfc2822() {
     // timezone +05
     assert_eq!(
         edt.from_local_datetime(
-            &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+            NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
         )
         .unwrap()
         .to_rfc2822(),
@@ -654,10 +654,7 @@ fn test_datetime_rfc2822() {
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:60 +0500"),
         Ok(edt
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18)
-                    .unwrap()
-                    .and_hms_milli(23, 59, 59, 1_000)
-                    .unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 59, 59, 1_000).unwrap()
             )
             .unwrap())
     );
@@ -666,7 +663,7 @@ fn test_datetime_rfc2822() {
         DateTime::parse_from_rfc3339("2015-02-18T23:59:60.234567+05:00"),
         Ok(edt
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18)
+                NaiveDate::from_ymd(2015, 2, 18)
                     .unwrap()
                     .and_hms_micro(23, 59, 59, 1_234_567)
                     .unwrap()
@@ -676,10 +673,7 @@ fn test_datetime_rfc2822() {
     // seconds 60
     assert_eq!(
         edt.from_local_datetime(
-            &NaiveDate::from_ymd(2015, 2, 18)
-                .unwrap()
-                .and_hms_micro(23, 59, 59, 1_234_567)
-                .unwrap()
+            NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_micro(23, 59, 59, 1_234_567).unwrap()
         )
         .unwrap()
         .to_rfc2822(),
@@ -762,7 +756,7 @@ fn test_datetime_rfc3339() {
     // timezone +05
     assert_eq!(
         edt5.from_local_datetime(
-            &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+            NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
         )
         .unwrap()
         .to_rfc3339(),
@@ -838,7 +832,7 @@ fn test_rfc3339_opts() {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            &NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
+            NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
         )
         .unwrap();
     assert_eq!(dt.to_rfc3339_opts(Secs, false), "2018-01-11T10:05:13+08:00");
@@ -865,7 +859,7 @@ fn test_datetime_from_str() {
         Ok(FixedOffset::east(0)
             .unwrap()
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -873,7 +867,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -881,7 +875,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15 UTC".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -889,7 +883,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15UTC".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -897,7 +891,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15Utc".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -907,7 +901,7 @@ fn test_datetime_from_str() {
         Ok(FixedOffset::east(0)
             .unwrap()
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -916,7 +910,7 @@ fn test_datetime_from_str() {
         Ok(FixedOffset::west(10 * 3600)
             .unwrap()
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(13, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(13, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -926,7 +920,7 @@ fn test_datetime_from_str() {
         "2015-2-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -934,7 +928,7 @@ fn test_datetime_from_str() {
         "2015-2-18T13:16:9.15-10:00".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -1269,7 +1263,7 @@ fn test_datetime_is_send_and_copy() {
 fn test_subsecond_part() {
     let datetime = Utc
         .from_local_datetime(
-            &NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_nano(9, 10, 11, 1234567).unwrap(),
+            NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_nano(9, 10, 11, 1234567).unwrap(),
         )
         .unwrap();
 
@@ -1295,21 +1289,21 @@ fn test_from_system_time() {
     assert_eq!(
         DateTime::<Utc>::try_from(UNIX_EPOCH + Duration::new(999_999_999, nanos)).unwrap(),
         Utc.from_local_datetime(
-            &NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano(1, 46, 39, nanos).unwrap()
+            NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano(1, 46, 39, nanos).unwrap()
         )
         .unwrap()
     );
     assert_eq!(
         DateTime::<Utc>::try_from(UNIX_EPOCH - Duration::new(999_999_999, nanos)).unwrap(),
         Utc.from_local_datetime(
-            &NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 20, 1_000).unwrap()
+            NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 20, 1_000).unwrap()
         )
         .unwrap()
     );
     assert_eq!(
         DateTime::<Utc>::try_from(UNIX_EPOCH - Duration::new(999_999_999, 0)).unwrap(),
         Utc.from_local_datetime(
-            &NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 21, 0).unwrap()
+            NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 21, 0).unwrap()
         )
         .unwrap()
     );
@@ -1319,7 +1313,7 @@ fn test_from_system_time() {
     assert_eq!(
         SystemTime::try_from(
             Utc.from_local_datetime(
-                &NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano(1, 46, 39, nanos).unwrap()
+                NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano(1, 46, 39, nanos).unwrap()
             )
             .unwrap()
         )
@@ -1329,7 +1323,7 @@ fn test_from_system_time() {
     assert_eq!(
         SystemTime::try_from(
             Utc.from_local_datetime(
-                &NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 20, 1_000).unwrap()
+                NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 20, 1_000).unwrap()
             )
             .unwrap()
         )
@@ -1363,7 +1357,7 @@ fn test_datetime_before_windows_api_limits() {
     // This used to fail on Windows for timezones with an offset of -5:00 or greater.
     // The API limits years to 1601..=30827.
     let dt = NaiveDate::from_ymd(1601, 1, 1).unwrap().and_hms_milli(4, 5, 22, 122).unwrap();
-    let local_dt = Local.from_utc_datetime(&dt);
+    let local_dt = Local.from_utc_datetime(dt);
     dbg!(local_dt);
 }
 
@@ -1410,8 +1404,8 @@ fn test_datetime_add_assign() {
 fn test_datetime_add_assign_local() {
     let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
 
-    let datetime = Local.from_utc_datetime(&naivedatetime);
-    let mut datetime_add = Local.from_utc_datetime(&naivedatetime);
+    let datetime = Local.from_utc_datetime(naivedatetime);
+    let mut datetime_add = Local.from_utc_datetime(naivedatetime);
 
     // ensure we cross a DST transition
     for i in 1..=365 {
@@ -1445,9 +1439,9 @@ fn test_datetime_sub_assign() {
 #[test]
 fn test_min_max_getters() {
     let offset_min = FixedOffset::west(2 * 60 * 60).unwrap();
-    let beyond_min = offset_min.from_utc_datetime(&NaiveDateTime::MIN);
+    let beyond_min = offset_min.from_utc_datetime(NaiveDateTime::MIN);
     let offset_max = FixedOffset::east(2 * 60 * 60).unwrap();
-    let beyond_max = offset_max.from_utc_datetime(&NaiveDateTime::MAX);
+    let beyond_max = offset_max.from_utc_datetime(NaiveDateTime::MAX);
 
     assert_eq!(format!("{:?}", beyond_min), "-262144-12-31T22:00:00-02:00");
     // RFC 2822 doesn't support years with more than 4 digits.
@@ -1503,9 +1497,9 @@ fn test_min_max_getters() {
 #[test]
 fn test_min_max_setters() {
     let offset_min = FixedOffset::west(2 * 60 * 60).unwrap();
-    let beyond_min = offset_min.from_utc_datetime(&NaiveDateTime::MIN);
+    let beyond_min = offset_min.from_utc_datetime(NaiveDateTime::MIN);
     let offset_max = FixedOffset::east(2 * 60 * 60).unwrap();
-    let beyond_max = offset_max.from_utc_datetime(&NaiveDateTime::MAX);
+    let beyond_max = offset_max.from_utc_datetime(NaiveDateTime::MAX);
 
     assert_eq!(beyond_min.with_year(2020).unwrap().year(), 2020);
     assert_eq!(beyond_min.with_year(beyond_min.year()), Some(beyond_min));
@@ -1553,15 +1547,15 @@ fn test_min_max_setters() {
 #[test]
 fn test_min_max_add_days() {
     let offset_min = FixedOffset::west(2 * 60 * 60).unwrap();
-    let beyond_min = offset_min.from_utc_datetime(&NaiveDateTime::MIN);
+    let beyond_min = offset_min.from_utc_datetime(NaiveDateTime::MIN);
     let offset_max = FixedOffset::east(2 * 60 * 60).unwrap();
-    let beyond_max = offset_max.from_utc_datetime(&NaiveDateTime::MAX);
+    let beyond_max = offset_max.from_utc_datetime(NaiveDateTime::MAX);
     let max_time = NaiveTime::from_hms_nano(23, 59, 59, 999_999_999).unwrap();
 
     assert_eq!(beyond_min.checked_add_days(Days::new(0)), Some(beyond_min));
     assert_eq!(
         beyond_min.checked_add_days(Days::new(1)),
-        Some(offset_min.from_utc_datetime(&(NaiveDate::MIN + Days(1)).and_time(NaiveTime::MIN)))
+        Some(offset_min.from_utc_datetime((NaiveDate::MIN + Days(1)).and_time(NaiveTime::MIN)))
     );
     assert_eq!(beyond_min.checked_sub_days(Days::new(0)), Some(beyond_min));
     assert_eq!(beyond_min.checked_sub_days(Days::new(1)), None);
@@ -1571,22 +1565,22 @@ fn test_min_max_add_days() {
     assert_eq!(beyond_max.checked_sub_days(Days::new(0)), Some(beyond_max));
     assert_eq!(
         beyond_max.checked_sub_days(Days::new(1)),
-        Some(offset_max.from_utc_datetime(&(NaiveDate::MAX - Days(1)).and_time(max_time)))
+        Some(offset_max.from_utc_datetime((NaiveDate::MAX - Days(1)).and_time(max_time)))
     );
 }
 
 #[test]
 fn test_min_max_add_months() {
     let offset_min = FixedOffset::west(2 * 60 * 60).unwrap();
-    let beyond_min = offset_min.from_utc_datetime(&NaiveDateTime::MIN);
+    let beyond_min = offset_min.from_utc_datetime(NaiveDateTime::MIN);
     let offset_max = FixedOffset::east(2 * 60 * 60).unwrap();
-    let beyond_max = offset_max.from_utc_datetime(&NaiveDateTime::MAX);
+    let beyond_max = offset_max.from_utc_datetime(NaiveDateTime::MAX);
     let max_time = NaiveTime::from_hms_nano(23, 59, 59, 999_999_999).unwrap();
 
     assert_eq!(beyond_min.checked_add_months(Months::new(0)), Some(beyond_min));
     assert_eq!(
         beyond_min.checked_add_months(Months::new(1)),
-        Some(offset_min.from_utc_datetime(&(NaiveDate::MIN + Months(1)).and_time(NaiveTime::MIN)))
+        Some(offset_min.from_utc_datetime((NaiveDate::MIN + Months(1)).and_time(NaiveTime::MIN)))
     );
     assert_eq!(beyond_min.checked_sub_months(Months::new(0)), Some(beyond_min));
     assert_eq!(beyond_min.checked_sub_months(Months::new(1)), None);
@@ -1596,21 +1590,21 @@ fn test_min_max_add_months() {
     assert_eq!(beyond_max.checked_sub_months(Months::new(0)), Some(beyond_max));
     assert_eq!(
         beyond_max.checked_sub_months(Months::new(1)),
-        Some(offset_max.from_utc_datetime(&(NaiveDate::MAX - Months(1)).and_time(max_time)))
+        Some(offset_max.from_utc_datetime((NaiveDate::MAX - Months(1)).and_time(max_time)))
     );
 }
 
 #[test]
 #[should_panic]
 fn test_local_beyond_min_datetime() {
-    let min = FixedOffset::west(2 * 60 * 60).unwrap().from_utc_datetime(&NaiveDateTime::MIN);
+    let min = FixedOffset::west(2 * 60 * 60).unwrap().from_utc_datetime(NaiveDateTime::MIN);
     let _ = min.naive_local();
 }
 
 #[test]
 #[should_panic]
 fn test_local_beyond_max_datetime() {
-    let max = FixedOffset::east(2 * 60 * 60).unwrap().from_utc_datetime(&NaiveDateTime::MAX);
+    let max = FixedOffset::east(2 * 60 * 60).unwrap().from_utc_datetime(NaiveDateTime::MAX);
     let _ = max.naive_local();
 }
 
@@ -1619,8 +1613,8 @@ fn test_local_beyond_max_datetime() {
 fn test_datetime_sub_assign_local() {
     let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
 
-    let datetime = Local.from_utc_datetime(&naivedatetime);
-    let mut datetime_sub = Local.from_utc_datetime(&naivedatetime);
+    let datetime = Local.from_utc_datetime(naivedatetime);
+    let mut datetime_sub = Local.from_utc_datetime(naivedatetime);
 
     // ensure we cross a DST transition
     for i in 1..=365 {
@@ -1655,7 +1649,7 @@ fn test_core_duration_max() {
 fn test_datetime_local_from_preserves_offset() {
     let naivedatetime = NaiveDate::from_ymd(2023, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
 
-    let datetime = Local.from_utc_datetime(&naivedatetime);
+    let datetime = Local.from_utc_datetime(naivedatetime);
     let offset = datetime.offset().fix();
 
     let datetime_fixed: DateTime<FixedOffset> = datetime.into();
@@ -1667,12 +1661,12 @@ fn test_datetime_local_from_preserves_offset() {
 fn test_datetime_fixed_offset() {
     let naivedatetime = NaiveDate::from_ymd(2023, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
 
-    let datetime = Utc.from_utc_datetime(&naivedatetime);
+    let datetime = Utc.from_utc_datetime(naivedatetime);
     let fixed_utc = FixedOffset::east(0).unwrap();
-    assert_eq!(datetime.fixed_offset(), fixed_utc.from_local_datetime(&naivedatetime).unwrap());
+    assert_eq!(datetime.fixed_offset(), fixed_utc.from_local_datetime(naivedatetime).unwrap());
 
     let fixed_offset = FixedOffset::east(3600).unwrap();
-    let datetime_fixed = fixed_offset.from_local_datetime(&naivedatetime).unwrap();
+    let datetime_fixed = fixed_offset.from_local_datetime(naivedatetime).unwrap();
     assert_eq!(datetime_fixed.fixed_offset(), datetime_fixed);
 }
 

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -858,7 +858,7 @@ impl Parsed {
         let datetime = self.to_naive_datetime_with_offset(offset)?;
         let offset = FixedOffset::east(offset).map_err(|_| OUT_OF_RANGE)?;
 
-        match offset.from_local_datetime(&datetime) {
+        match offset.from_local_datetime(datetime) {
             MappedLocalTime::None => Err(IMPOSSIBLE),
             MappedLocalTime::Single(t) => Ok(t),
             MappedLocalTime::Ambiguous(..) => Err(NOT_ENOUGH),
@@ -899,7 +899,7 @@ impl Parsed {
             let dt = DateTime::from_timestamp(timestamp, nanosecond)
                 .map_err(|_| OUT_OF_RANGE)?
                 .naive_utc();
-            guessed_offset = tz.offset_from_utc_datetime(&dt).fix().local_minus_utc();
+            guessed_offset = tz.offset_from_utc_datetime(dt).fix().local_minus_utc();
         }
 
         // checks if the given `DateTime` has a consistent `Offset` with given `self.offset`.
@@ -914,7 +914,7 @@ impl Parsed {
         // `guessed_offset` should be correct when `self.timestamp` is given.
         // it will be 0 otherwise, but this is fine as the algorithm ignores offset for that case.
         let datetime = self.to_naive_datetime_with_offset(guessed_offset)?;
-        match tz.from_local_datetime(&datetime) {
+        match tz.from_local_datetime(datetime) {
             MappedLocalTime::None => Err(IMPOSSIBLE),
             MappedLocalTime::Single(t) => {
                 if check_offset(&t) {
@@ -1656,7 +1656,7 @@ mod tests {
             Ok(FixedOffset::east(off)
                 .unwrap()
                 .from_local_datetime(
-                    &NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano(h, n, s, nano).unwrap(),
+                    NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano(h, n, s, nano).unwrap(),
                 )
                 .unwrap())
         };
@@ -1704,7 +1704,7 @@ mod tests {
                           minute: 26, second: 40, nanosecond: 12_345_678, offset: 0),
             Ok(Utc
                 .from_local_datetime(
-                    &NaiveDate::from_ymd(2014, 12, 31)
+                    NaiveDate::from_ymd(2014, 12, 31)
                         .unwrap()
                         .and_hms_nano(4, 26, 40, 12_345_678)
                         .unwrap()
@@ -1730,7 +1730,7 @@ mod tests {
             Ok(FixedOffset::east(32400)
                 .unwrap()
                 .from_local_datetime(
-                    &NaiveDate::from_ymd(2014, 12, 31)
+                    NaiveDate::from_ymd(2014, 12, 31)
                         .unwrap()
                         .and_hms_nano(13, 26, 40, 12_345_678)
                         .unwrap()

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -853,7 +853,7 @@ mod tests {
         let dt = FixedOffset::east(34200)
             .unwrap()
             .from_local_datetime(
-                &NaiveDate::from_ymd(2001, 7, 8)
+                NaiveDate::from_ymd(2001, 7, 8)
                     .unwrap()
                     .and_hms_nano(0, 34, 59, 1_026_490_708)
                     .unwrap(),
@@ -1021,7 +1021,7 @@ mod tests {
         let dt = FixedOffset::east(34200)
             .unwrap()
             .from_local_datetime(
-                &NaiveDate::from_ymd(2001, 7, 8)
+                NaiveDate::from_ymd(2001, 7, 8)
                     .unwrap()
                     .and_hms_nano(0, 34, 59, 1_026_490_708)
                     .unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,8 +159,8 @@
 //! # #[cfg(feature = "clock")] {
 //! // other time zone objects can be used to construct a local datetime.
 //! // obviously, `local_dt` is normally different from `dt`, but `fixed_dt` should be identical.
-//! let local_dt = Local.from_local_datetime(&NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_milli(9, 10, 11, 12).unwrap()).unwrap();
-//! let fixed_dt = FixedOffset::east(9 * 3600).unwrap().from_local_datetime(&NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_milli(18, 10, 11, 12).unwrap()).unwrap();
+//! let local_dt = Local.from_local_datetime(NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_milli(9, 10, 11, 12).unwrap()).unwrap();
+//! let fixed_dt = FixedOffset::east(9 * 3600).unwrap().from_local_datetime(NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_milli(18, 10, 11, 12).unwrap()).unwrap();
 //! assert_eq!(dt, fixed_dt);
 //! # let _ = local_dt;
 //! # }
@@ -179,7 +179,7 @@
 //! use chrono::prelude::*;
 //!
 //! // assume this returned `2014-11-28T21:45:59.324310806+09:00`:
-//! let dt = FixedOffset::east(9*3600).unwrap().from_local_datetime(&NaiveDate::from_ymd(2014, 11, 28).unwrap().and_hms_nano(21, 45, 59, 324310806).unwrap()).unwrap();
+//! let dt = FixedOffset::east(9*3600).unwrap().from_local_datetime(NaiveDate::from_ymd(2014, 11, 28).unwrap().and_hms_nano(21, 45, 59, 324310806).unwrap()).unwrap();
 //!
 //! // property accessors
 //! assert_eq!((dt.year(), dt.month(), dt.day()), (2014, 11, 28));

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -707,7 +707,7 @@ impl NaiveDateTime {
     /// ```
     #[must_use]
     pub fn and_local_timezone<Tz: TimeZone>(&self, tz: Tz) -> MappedLocalTime<DateTime<Tz>> {
-        tz.from_local_datetime(self)
+        tz.from_local_datetime(*self)
     }
 
     /// Converts the `NaiveDateTime` into the timezone-aware `DateTime<Utc>`.

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -193,12 +193,12 @@ mod tests;
 /// let paramaribo_pre1945 = FixedOffset::east(-13236).unwrap(); // -03:40:36
 /// let leap_sec_2015 =
 ///     NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli(23, 59, 59, 1_000).unwrap();
-/// let dt1 = paramaribo_pre1945.from_utc_datetime(&leap_sec_2015);
+/// let dt1 = paramaribo_pre1945.from_utc_datetime(leap_sec_2015);
 /// assert_eq!(format!("{:?}", dt1), "2015-06-30T20:19:24-03:40:36");
 /// assert_eq!(format!("{:?}", dt1.time()), "20:19:24");
 ///
 /// let next_sec = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms(0, 0, 0).unwrap();
-/// let dt2 = paramaribo_pre1945.from_utc_datetime(&next_sec);
+/// let dt2 = paramaribo_pre1945.from_utc_datetime(next_sec);
 /// assert_eq!(format!("{:?}", dt2), "2015-06-30T20:19:24-03:40:36");
 /// assert_eq!(format!("{:?}", dt2.time()), "20:19:24");
 ///

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -113,11 +113,11 @@ impl TimeZone for FixedOffset {
         *offset
     }
 
-    fn offset_from_local_datetime(&self, _local: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
+    fn offset_from_local_datetime(&self, _local: NaiveDateTime) -> MappedLocalTime<FixedOffset> {
         MappedLocalTime::Single(*self)
     }
 
-    fn offset_from_utc_datetime(&self, _utc: &NaiveDateTime) -> FixedOffset {
+    fn offset_from_utc_datetime(&self, _utc: NaiveDateTime) -> FixedOffset {
         *self
     }
 }

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -38,13 +38,13 @@ mod inner {
     use crate::{FixedOffset, MappedLocalTime, NaiveDateTime};
 
     pub(super) fn offset_from_utc_datetime(
-        _utc_time: &NaiveDateTime,
+        _utc_time: NaiveDateTime,
     ) -> MappedLocalTime<FixedOffset> {
         MappedLocalTime::Single(FixedOffset::east(0).unwrap())
     }
 
     pub(super) fn offset_from_local_datetime(
-        _local_time: &NaiveDateTime,
+        _local_time: NaiveDateTime,
     ) -> MappedLocalTime<FixedOffset> {
         MappedLocalTime::Single(FixedOffset::east(0).unwrap())
     }
@@ -58,14 +58,12 @@ mod inner {
 mod inner {
     use crate::{Datelike, FixedOffset, MappedLocalTime, NaiveDateTime, Timelike};
 
-    pub(super) fn offset_from_utc_datetime(utc: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
+    pub(super) fn offset_from_utc_datetime(utc: NaiveDateTime) -> MappedLocalTime<FixedOffset> {
         let offset = js_sys::Date::from(utc.and_utc()).get_timezone_offset();
         MappedLocalTime::Single(FixedOffset::west((offset as i32) * 60).unwrap())
     }
 
-    pub(super) fn offset_from_local_datetime(
-        local: &NaiveDateTime,
-    ) -> MappedLocalTime<FixedOffset> {
+    pub(super) fn offset_from_local_datetime(local: NaiveDateTime) -> MappedLocalTime<FixedOffset> {
         let mut year = local.year();
         if year < 100 {
             // The API in `js_sys` does not let us create a `Date` with negative years.
@@ -158,11 +156,11 @@ impl TimeZone for Local {
         Local
     }
 
-    fn offset_from_local_datetime(&self, local: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
+    fn offset_from_local_datetime(&self, local: NaiveDateTime) -> MappedLocalTime<FixedOffset> {
         inner::offset_from_local_datetime(local)
     }
 
-    fn offset_from_utc_datetime(&self, utc: &NaiveDateTime) -> FixedOffset {
+    fn offset_from_utc_datetime(&self, utc: NaiveDateTime) -> FixedOffset {
         inner::offset_from_utc_datetime(utc).unwrap()
     }
 }
@@ -261,8 +259,8 @@ mod tests {
     #[test]
     fn verify_correct_offsets() {
         let now = Local::now();
-        let from_local = Local.from_local_datetime(&now.naive_local()).unwrap();
-        let from_utc = Local.from_utc_datetime(&now.naive_utc());
+        let from_local = Local.from_local_datetime(now.naive_local()).unwrap();
+        let from_utc = Local.from_utc_datetime(now.naive_utc());
 
         assert_eq!(now.offset().local_minus_utc(), from_local.offset().local_minus_utc());
         assert_eq!(now.offset().local_minus_utc(), from_utc.offset().local_minus_utc());
@@ -274,8 +272,8 @@ mod tests {
     #[test]
     fn verify_correct_offsets_distant_past() {
         let distant_past = Local::now() - Days::new(365 * 500);
-        let from_local = Local.from_local_datetime(&distant_past.naive_local()).unwrap();
-        let from_utc = Local.from_utc_datetime(&distant_past.naive_utc());
+        let from_local = Local.from_local_datetime(distant_past.naive_local()).unwrap();
+        let from_utc = Local.from_utc_datetime(distant_past.naive_utc());
 
         assert_eq!(distant_past.offset().local_minus_utc(), from_local.offset().local_minus_utc());
         assert_eq!(distant_past.offset().local_minus_utc(), from_utc.offset().local_minus_utc());
@@ -287,8 +285,8 @@ mod tests {
     #[test]
     fn verify_correct_offsets_distant_future() {
         let distant_future = Local::now() + Days::new(365 * 35000);
-        let from_local = Local.from_local_datetime(&distant_future.naive_local()).unwrap();
-        let from_utc = Local.from_utc_datetime(&distant_future.naive_utc());
+        let from_local = Local.from_local_datetime(distant_future.naive_local()).unwrap();
+        let from_utc = Local.from_utc_datetime(distant_future.naive_utc());
 
         assert_eq!(
             distant_future.offset().local_minus_utc(),

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -14,17 +14,17 @@ use super::tz_info::TimeZone;
 use super::{FixedOffset, NaiveDateTime};
 use crate::{Datelike, MappedLocalTime};
 
-pub(super) fn offset_from_utc_datetime(utc: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
+pub(super) fn offset_from_utc_datetime(utc: NaiveDateTime) -> MappedLocalTime<FixedOffset> {
     offset(utc, false)
 }
 
-pub(super) fn offset_from_local_datetime(local: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
+pub(super) fn offset_from_local_datetime(local: NaiveDateTime) -> MappedLocalTime<FixedOffset> {
     offset(local, true)
 }
 
-fn offset(d: &NaiveDateTime, local: bool) -> MappedLocalTime<FixedOffset> {
+fn offset(d: NaiveDateTime, local: bool) -> MappedLocalTime<FixedOffset> {
     TZ_INFO.with(|maybe_cache| {
-        maybe_cache.borrow_mut().get_or_insert_with(Cache::default).offset(*d, local)
+        maybe_cache.borrow_mut().get_or_insert_with(Cache::default).offset(d, local)
     })
 }
 

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -114,11 +114,11 @@ impl TimeZone for Utc {
         Utc
     }
 
-    fn offset_from_local_datetime(&self, _local: &NaiveDateTime) -> MappedLocalTime<Utc> {
+    fn offset_from_local_datetime(&self, _local: NaiveDateTime) -> MappedLocalTime<Utc> {
         MappedLocalTime::Single(Utc)
     }
 
-    fn offset_from_utc_datetime(&self, _utc: &NaiveDateTime) -> Utc {
+    fn offset_from_utc_datetime(&self, _utc: NaiveDateTime) -> Utc {
         Utc
     }
 }

--- a/src/round.rs
+++ b/src/round.rs
@@ -320,7 +320,7 @@ mod tests {
         let pst = FixedOffset::east(8 * 60 * 60).unwrap();
         let dt = pst
             .from_local_datetime(
-                &NaiveDate::from_ymd(2018, 1, 11)
+                NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
                     .and_hms_nano(10, 5, 13, 84_660_684)
                     .unwrap(),
@@ -343,7 +343,7 @@ mod tests {
 
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2018, 1, 11)
+                NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
                     .and_hms_nano(10, 5, 27, 750_500_000)
                     .unwrap(),
@@ -363,7 +363,7 @@ mod tests {
     fn test_round_leap_nanos() {
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2016, 12, 31)
+                NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
                     .and_hms_nano(23, 59, 59, 1_750_500_000)
                     .unwrap(),
@@ -384,7 +384,7 @@ mod tests {
         let pst = FixedOffset::east(8 * 60 * 60).unwrap();
         let dt = pst
             .from_local_datetime(
-                &NaiveDate::from_ymd(2018, 1, 11)
+                NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
                     .and_hms_nano(10, 5, 13, 84_660_684)
                     .unwrap(),
@@ -407,7 +407,7 @@ mod tests {
 
         let dt = pst
             .from_local_datetime(
-                &NaiveDate::from_ymd(2018, 1, 11)
+                NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
                     .and_hms_nano(10, 5, 27, 750_500_000)
                     .unwrap(),
@@ -427,7 +427,7 @@ mod tests {
     fn test_trunc_leap_nanos() {
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2016, 12, 31)
+                NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
                     .and_hms_nano(23, 59, 59, 1_750_500_000)
                     .unwrap(),
@@ -447,7 +447,7 @@ mod tests {
     fn test_duration_round() {
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2016, 12, 31)
+                NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
                     .and_hms_nano(23, 59, 59, 175_500_000)
                     .unwrap(),
@@ -467,7 +467,7 @@ mod tests {
         // round up
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
             )
             .unwrap();
         assert_eq!(
@@ -477,7 +477,7 @@ mod tests {
         // round down
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
             )
             .unwrap();
         assert_eq!(
@@ -529,7 +529,7 @@ mod tests {
     fn test_duration_round_naive() {
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2016, 12, 31)
+                NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
                     .and_hms_nano(23, 59, 59, 175_500_000)
                     .unwrap(),
@@ -550,7 +550,7 @@ mod tests {
         // round up
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
             )
             .unwrap()
             .naive_utc();
@@ -561,7 +561,7 @@ mod tests {
         // round down
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
             )
             .unwrap()
             .naive_utc();
@@ -601,7 +601,7 @@ mod tests {
     fn test_duration_trunc() {
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2016, 12, 31)
+                NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
                     .and_hms_nano(23, 59, 59, 175_500_000)
                     .unwrap(),
@@ -616,7 +616,7 @@ mod tests {
         // would round up
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
             )
             .unwrap();
         assert_eq!(
@@ -626,7 +626,7 @@ mod tests {
         // would round down
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
             )
             .unwrap();
         assert_eq!(
@@ -677,7 +677,7 @@ mod tests {
     fn test_duration_trunc_naive() {
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2016, 12, 31)
+                NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
                     .and_hms_nano(23, 59, 59, 175_500_000)
                     .unwrap(),
@@ -693,7 +693,7 @@ mod tests {
         // would round up
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
             )
             .unwrap()
             .naive_utc();
@@ -704,7 +704,7 @@ mod tests {
         // would round down
         let dt = Utc
             .from_local_datetime(
-                &NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
             )
             .unwrap()
             .naive_utc();

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -33,7 +33,7 @@ fn verify_against_date_command_local(path: &'static str, dt: NaiveDateTime) {
     // differently
 
     let date = NaiveDate::from_ymd(dt.year(), dt.month(), dt.day()).unwrap();
-    match Local.from_local_datetime(&date.and_hms(dt.hour(), 5, 1).unwrap()) {
+    match Local.from_local_datetime(date.and_hms(dt.hour(), 5, 1).unwrap()) {
         chrono::MappedLocalTime::Ambiguous(a, b) => assert!(
             format!("{}\n", a) == date_command_str || format!("{}\n", b) == date_command_str
         ),
@@ -139,7 +139,7 @@ fn verify_against_date_command_format_local(path: &'static str, dt: NaiveDateTim
     let date_command_str = String::from_utf8(output.stdout).unwrap();
     let date = NaiveDate::from_ymd(dt.year(), dt.month(), dt.day()).unwrap();
     let ldt = Local
-        .from_local_datetime(&date.and_hms(dt.hour(), dt.minute(), dt.second()).unwrap())
+        .from_local_datetime(date.and_hms(dt.hour(), dt.minute(), dt.second()).unwrap())
         .unwrap();
     let formated_date = format!("{}\n", ldt.format(required_format));
     assert_eq!(date_command_str, formated_date);

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -67,7 +67,7 @@ fn from_is_exact() {
 fn local_from_local_datetime() {
     let now = Local::now();
     let ndt = now.naive_local();
-    let res = match Local.from_local_datetime(&ndt).single() {
+    let res = match Local.from_local_datetime(ndt).single() {
         Some(v) => v,
         None => panic! {"Required for test!"},
     };


### PR DESCRIPTION
Adjust `TimeZone::{offset_from_local_datetime, offset_from_utc_datetime, from_local_datetime, from_utc_datetime}` to take their `NaiveDateTime` argument by value.
Taking a small `Copy` value by reference was useless friction.