### PR TITLE
Rename `TimeZone::timestamp*` to `TimeZone::and_timestamp*`

### DIFF
--- a/bench/benches/chrono.rs
+++ b/bench/benches/chrono.rs
@@ -206,7 +206,7 @@ fn bench_naivedate_add_signed(c: &mut Criterion) {
 }
 
 fn bench_datetime_with(c: &mut Criterion) {
-    let dt = FixedOffset::east(3600).unwrap().with_ymd_and_hms(2023, 9, 23, 7, 36, 0).unwrap();
+    let dt = FixedOffset::east(3600).unwrap().at_ymd_and_hms(2023, 9, 23, 7, 36, 0).unwrap();
     c.bench_function("bench_datetime_with", |b| {
         b.iter(|| black_box(black_box(dt).with_hour(12)).unwrap())
     });

--- a/bench/benches/chrono.rs
+++ b/bench/benches/chrono.rs
@@ -50,7 +50,7 @@ fn bench_datetime_to_rfc2822(c: &mut Criterion) {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
+            NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_nano(10, 5, 13, 84_660_000).unwrap(),
         )
         .unwrap();
     c.bench_function("bench_datetime_to_rfc2822", |b| b.iter(|| black_box(dt).to_rfc2822()));
@@ -60,7 +60,7 @@ fn bench_datetime_to_rfc3339(c: &mut Criterion) {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
+            NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_nano(10, 5, 13, 84_660_000).unwrap(),
         )
         .unwrap();
     c.bench_function("bench_datetime_to_rfc3339", |b| b.iter(|| black_box(dt).to_rfc3339()));
@@ -70,7 +70,7 @@ fn bench_datetime_to_rfc3339_opts(c: &mut Criterion) {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
+            NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_nano(10, 5, 13, 84_660_000).unwrap(),
         )
         .unwrap();
     c.bench_function("bench_datetime_to_rfc3339_opts", |b| {

--- a/ci/core-test/src/lib.rs
+++ b/ci/core-test/src/lib.rs
@@ -3,5 +3,5 @@
 use chrono::{TimeZone, Utc};
 
 pub fn create_time() {
-    let _ = Utc.with_ymd_and_hms(2019, 1, 1, 0, 0, 0).unwrap();
+    let _ = Utc.at_ymd_and_hms(2019, 1, 1, 0, 0, 0).unwrap();
 }

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -64,7 +64,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// passing it through FFI.
     ///
     /// For regular use you will probably want to use a method such as
-    /// [`TimeZone::from_local_datetime`] or [`NaiveDateTime::and_local_timezone`] instead.
+    /// [`TimeZone::from_local_datetime`] or [`NaiveDateTime::in_timezone`] instead.
     ///
     /// # Example
     ///
@@ -337,7 +337,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
         // datetime.
         self.overflowing_naive_local()
             .checked_add_months(months)?
-            .and_local_timezone(Tz::from_offset(&self.offset))
+            .in_timezone(self.timezone())
             .single()
     }
 
@@ -374,7 +374,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
         // datetime.
         self.overflowing_naive_local()
             .checked_sub_months(months)?
-            .and_local_timezone(Tz::from_offset(&self.offset))
+            .in_timezone(self.timezone())
             .single()
     }
 

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -648,7 +648,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     #[must_use]
     pub fn with_time(&self, time: NaiveTime) -> MappedLocalTime<Self> {
-        self.timezone().from_local_datetime(self.overflowing_naive_local().date().and_time(time))
+        self.timezone().from_local_datetime(self.overflowing_naive_local().date().at(time))
     }
 
     /// Makes a new `DateTime` with the hour number changed.
@@ -761,7 +761,7 @@ impl DateTime<Utc> {
         }
         let date = try_err!(NaiveDate::from_num_days_from_ce(days as i32));
         let time = try_err!(NaiveTime::from_num_seconds_from_midnight(secs as u32, nsecs));
-        Ok(date.and_time(time).and_utc())
+        Ok(date.at(time).and_utc())
     }
 
     /// Makes a new `DateTime<Utc>` from the number of non-leap milliseconds

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -151,10 +151,10 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd(1970, 1, 1)?.at_hms_milli(0, 0, 1, 444)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1)?.at_hms_milli(0, 0, 1, 444)?.in_utc();
     /// assert_eq!(dt.timestamp_millis(), 1_444);
     ///
-    /// let dt = NaiveDate::from_ymd(2001, 9, 9)?.at_hms_milli(1, 46, 40, 555)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9)?.at_hms_milli(1, 46, 40, 555)?.in_utc();
     /// assert_eq!(dt.timestamp_millis(), 1_000_000_000_555);
     /// # Ok::<(), chrono::Error>(())
     /// ```
@@ -172,10 +172,10 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd(1970, 1, 1)?.at_hms_micro(0, 0, 1, 444)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1)?.at_hms_micro(0, 0, 1, 444)?.in_utc();
     /// assert_eq!(dt.timestamp_micros(), 1_000_444);
     ///
-    /// let dt = NaiveDate::from_ymd(2001, 9, 9)?.at_hms_micro(1, 46, 40, 555)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9)?.at_hms_micro(1, 46, 40, 555)?.in_utc();
     /// assert_eq!(dt.timestamp_micros(), 1_000_000_000_000_555);
     /// # Ok::<(), chrono::Error>(())
     /// ```
@@ -201,22 +201,22 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     /// use chrono::{Error, NaiveDate};
     ///
-    /// let dt = NaiveDate::from_ymd(1970, 1, 1)?.at_hms_nano(0, 0, 1, 444)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1)?.at_hms_nano(0, 0, 1, 444)?.in_utc();
     /// assert_eq!(dt.timestamp_nanos(), Ok(1_000_000_444));
     ///
-    /// let dt = NaiveDate::from_ymd(2001, 9, 9)?.at_hms_nano(1, 46, 40, 555)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9)?.at_hms_nano(1, 46, 40, 555)?.in_utc();
     /// assert_eq!(dt.timestamp_nanos(), Ok(1_000_000_000_000_000_555));
     ///
-    /// let dt = NaiveDate::from_ymd(1677, 9, 21)?.at_hms_nano(0, 12, 43, 145_224_192)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(1677, 9, 21)?.at_hms_nano(0, 12, 43, 145_224_192)?.in_utc();
     /// assert_eq!(dt.timestamp_nanos(), Ok(-9_223_372_036_854_775_808));
     ///
-    /// let dt = NaiveDate::from_ymd(2262, 4, 11)?.at_hms_nano(23, 47, 16, 854_775_807)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(2262, 4, 11)?.at_hms_nano(23, 47, 16, 854_775_807)?.in_utc();
     /// assert_eq!(dt.timestamp_nanos(), Ok(9_223_372_036_854_775_807));
     ///
-    /// let dt = NaiveDate::from_ymd(1677, 9, 21)?.at_hms_nano(0, 12, 43, 145_224_191)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(1677, 9, 21)?.at_hms_nano(0, 12, 43, 145_224_191)?.in_utc();
     /// assert_eq!(dt.timestamp_nanos(), Err(Error::OutOfRange));
     ///
-    /// let dt = NaiveDate::from_ymd(2262, 4, 11)?.at_hms_nano(23, 47, 16, 854_775_808)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(2262, 4, 11)?.at_hms_nano(23, 47, 16, 854_775_808)?.in_utc();
     /// assert_eq!(dt.timestamp_nanos(), Err(Error::OutOfRange));
     /// # Ok::<(), Error>(())
     /// ```
@@ -532,7 +532,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///     .unwrap()
     ///     .at_hms_micro(18, 30, 9, 453_829)
     ///     .unwrap()
-    ///     .and_utc();
+    ///     .in_utc();
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Millis, false), "2018-01-26T18:30:09.453+00:00");
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Millis, true), "2018-01-26T18:30:09.453Z");
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Secs, true), "2018-01-26T18:30:09Z");
@@ -761,7 +761,7 @@ impl DateTime<Utc> {
         }
         let date = try_err!(NaiveDate::from_num_days_from_ce(days as i32));
         let time = try_err!(NaiveTime::from_num_seconds_from_midnight(secs as u32, nsecs));
-        Ok(date.at(time).and_utc())
+        Ok(date.at(time).in_utc())
     }
 
     /// Makes a new `DateTime<Utc>` from the number of non-leap milliseconds

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -103,9 +103,9 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     /// use chrono::prelude::*;
     ///
-    /// let date: DateTime<Utc> = Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+    /// let date: DateTime<Utc> = Utc.at_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
     /// let other: DateTime<FixedOffset> =
-    ///     FixedOffset::east(23).unwrap().with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
+    ///     FixedOffset::east(23).unwrap().at_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap();
     /// assert_eq!(date.date_naive(), other.date_naive());
     /// ```
     #[inline]
@@ -130,7 +130,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     /// use chrono::{DateTime, TimeZone, Utc};
     ///
-    /// let dt: DateTime<Utc> = Utc.with_ymd_and_hms(2015, 5, 15, 0, 0, 0).unwrap();
+    /// let dt: DateTime<Utc> = Utc.at_ymd_and_hms(2015, 5, 15, 0, 0, 0).unwrap();
     /// assert_eq!(dt.timestamp(), 1431648000);
     ///
     /// assert_eq!(DateTime::from_timestamp(dt.timestamp(), dt.timestamp_subsec_nanos())?, dt);
@@ -999,7 +999,7 @@ impl DateTime<FixedOffset> {
     /// # use chrono::{DateTime, FixedOffset, TimeZone};
     /// assert_eq!(
     ///     DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 GMT").unwrap(),
-    ///     FixedOffset::east(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap()
+    ///     FixedOffset::east(0).unwrap().at_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap()
     /// );
     /// ```
     pub fn parse_from_rfc2822(s: &str) -> ParseResult<DateTime<FixedOffset>> {
@@ -1087,7 +1087,7 @@ impl DateTime<FixedOffset> {
     /// .unwrap();
     /// assert_eq!(
     ///     datetime,
-    ///     FixedOffset::east(2 * 3600).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap()
+    ///     FixedOffset::east(2 * 3600).unwrap().at_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap()
     /// );
     /// assert_eq!(remainder, " trailing text");
     /// ```
@@ -1133,7 +1133,7 @@ where
     /// ```rust
     /// use chrono::prelude::*;
     ///
-    /// let date_time: DateTime<Utc> = Utc.with_ymd_and_hms(2017, 04, 02, 12, 50, 32).unwrap();
+    /// let date_time: DateTime<Utc> = Utc.at_ymd_and_hms(2017, 04, 02, 12, 50, 32).unwrap();
     /// let formatted = format!("{}", date_time.format("%d/%m/%Y %H:%M"));
     /// assert_eq!(formatted, "02/04/2017 12:50");
     /// ```
@@ -1259,11 +1259,11 @@ impl<Tz: TimeZone, Tz2: TimeZone> PartialOrd<DateTime<Tz2>> for DateTime<Tz> {
     /// use chrono::prelude::*;
     ///
     /// let earlier = Utc
-    ///     .with_ymd_and_hms(2015, 5, 15, 2, 0, 0)
+    ///     .at_ymd_and_hms(2015, 5, 15, 2, 0, 0)
     ///     .unwrap()
     ///     .with_timezone(&FixedOffset::west(1 * 3600).unwrap());
     /// let later = Utc
-    ///     .with_ymd_and_hms(2015, 5, 15, 3, 0, 0)
+    ///     .at_ymd_and_hms(2015, 5, 15, 3, 0, 0)
     ///     .unwrap()
     ///     .with_timezone(&FixedOffset::west(5 * 3600).unwrap());
     ///
@@ -1807,20 +1807,20 @@ where
     E: ::core::fmt::Debug,
 {
     assert_eq!(
-        to_string_utc(&Utc.with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()).ok(),
+        to_string_utc(&Utc.at_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()).ok(),
         Some(r#""2014-07-24T12:34:06Z""#.into())
     );
 
     assert_eq!(
         to_string_fixed(
-            &FixedOffset::east(3660).unwrap().with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
+            &FixedOffset::east(3660).unwrap().at_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
         )
         .ok(),
         Some(r#""2014-07-24T12:34:06+01:01""#.into())
     );
     assert_eq!(
         to_string_fixed(
-            &FixedOffset::east(3650).unwrap().with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
+            &FixedOffset::east(3650).unwrap().at_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
         )
         .ok(),
         // An offset with seconds is not allowed by RFC 3339, so we round it to the nearest minute.
@@ -1847,25 +1847,23 @@ fn test_decodable_json<FUtc, FFixed, FLocal, E>(
 
     assert_eq!(
         norm(&utc_from_str(r#""2014-07-24T12:34:06Z""#).ok()),
-        norm(&Some(Utc.with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()))
+        norm(&Some(Utc.at_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()))
     );
     assert_eq!(
         norm(&utc_from_str(r#""2014-07-24T13:57:06+01:23""#).ok()),
-        norm(&Some(Utc.with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()))
+        norm(&Some(Utc.at_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()))
     );
 
     assert_eq!(
         norm(&fixed_from_str(r#""2014-07-24T12:34:06Z""#).ok()),
-        norm(&Some(
-            FixedOffset::east(0).unwrap().with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
-        ))
+        norm(&Some(FixedOffset::east(0).unwrap().at_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()))
     );
     assert_eq!(
         norm(&fixed_from_str(r#""2014-07-24T13:57:06+01:23""#).ok()),
         norm(&Some(
             FixedOffset::east(60 * 60 + 23 * 60)
                 .unwrap()
-                .with_ymd_and_hms(2014, 7, 24, 13, 57, 6)
+                .at_ymd_and_hms(2014, 7, 24, 13, 57, 6)
                 .unwrap()
         ))
     );
@@ -1874,11 +1872,11 @@ fn test_decodable_json<FUtc, FFixed, FLocal, E>(
     // the conversion didn't change the instant itself
     assert_eq!(
         local_from_str(r#""2014-07-24T12:34:06Z""#).expect("local should parse"),
-        Utc.with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
+        Utc.at_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
     );
     assert_eq!(
         local_from_str(r#""2014-07-24T13:57:06+01:23""#).expect("local should parse with offset"),
-        Utc.with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
+        Utc.at_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap()
     );
 
     assert!(utc_from_str(r#""2014-07-32T12:34:06Z""#).is_err());

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -151,10 +151,10 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd(1970, 1, 1)?.and_hms_milli(0, 0, 1, 444)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1)?.at_hms_milli(0, 0, 1, 444)?.and_utc();
     /// assert_eq!(dt.timestamp_millis(), 1_444);
     ///
-    /// let dt = NaiveDate::from_ymd(2001, 9, 9)?.and_hms_milli(1, 46, 40, 555)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9)?.at_hms_milli(1, 46, 40, 555)?.and_utc();
     /// assert_eq!(dt.timestamp_millis(), 1_000_000_000_555);
     /// # Ok::<(), chrono::Error>(())
     /// ```
@@ -172,10 +172,10 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd(1970, 1, 1)?.and_hms_micro(0, 0, 1, 444)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1)?.at_hms_micro(0, 0, 1, 444)?.and_utc();
     /// assert_eq!(dt.timestamp_micros(), 1_000_444);
     ///
-    /// let dt = NaiveDate::from_ymd(2001, 9, 9)?.and_hms_micro(1, 46, 40, 555)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9)?.at_hms_micro(1, 46, 40, 555)?.and_utc();
     /// assert_eq!(dt.timestamp_micros(), 1_000_000_000_000_555);
     /// # Ok::<(), chrono::Error>(())
     /// ```
@@ -201,22 +201,22 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// ```
     /// use chrono::{Error, NaiveDate};
     ///
-    /// let dt = NaiveDate::from_ymd(1970, 1, 1)?.and_hms_nano(0, 0, 1, 444)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(1970, 1, 1)?.at_hms_nano(0, 0, 1, 444)?.and_utc();
     /// assert_eq!(dt.timestamp_nanos(), Ok(1_000_000_444));
     ///
-    /// let dt = NaiveDate::from_ymd(2001, 9, 9)?.and_hms_nano(1, 46, 40, 555)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(2001, 9, 9)?.at_hms_nano(1, 46, 40, 555)?.and_utc();
     /// assert_eq!(dt.timestamp_nanos(), Ok(1_000_000_000_000_000_555));
     ///
-    /// let dt = NaiveDate::from_ymd(1677, 9, 21)?.and_hms_nano(0, 12, 43, 145_224_192)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(1677, 9, 21)?.at_hms_nano(0, 12, 43, 145_224_192)?.and_utc();
     /// assert_eq!(dt.timestamp_nanos(), Ok(-9_223_372_036_854_775_808));
     ///
-    /// let dt = NaiveDate::from_ymd(2262, 4, 11)?.and_hms_nano(23, 47, 16, 854_775_807)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(2262, 4, 11)?.at_hms_nano(23, 47, 16, 854_775_807)?.and_utc();
     /// assert_eq!(dt.timestamp_nanos(), Ok(9_223_372_036_854_775_807));
     ///
-    /// let dt = NaiveDate::from_ymd(1677, 9, 21)?.and_hms_nano(0, 12, 43, 145_224_191)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(1677, 9, 21)?.at_hms_nano(0, 12, 43, 145_224_191)?.and_utc();
     /// assert_eq!(dt.timestamp_nanos(), Err(Error::OutOfRange));
     ///
-    /// let dt = NaiveDate::from_ymd(2262, 4, 11)?.and_hms_nano(23, 47, 16, 854_775_808)?.and_utc();
+    /// let dt = NaiveDate::from_ymd(2262, 4, 11)?.at_hms_nano(23, 47, 16, 854_775_808)?.and_utc();
     /// assert_eq!(dt.timestamp_nanos(), Err(Error::OutOfRange));
     /// # Ok::<(), Error>(())
     /// ```
@@ -530,7 +530,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// # use chrono::{FixedOffset, SecondsFormat, TimeZone, NaiveDate};
     /// let dt = NaiveDate::from_ymd(2018, 1, 26)
     ///     .unwrap()
-    ///     .and_hms_micro(18, 30, 9, 453_829)
+    ///     .at_hms_micro(18, 30, 9, 453_829)
     ///     .unwrap()
     ///     .and_utc();
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Millis, false), "2018-01-26T18:30:09.453+00:00");
@@ -540,7 +540,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     /// let dt = pst
     ///     .from_local_datetime(
-    ///         NaiveDate::from_ymd(2018, 1, 26).unwrap().and_hms_micro(10, 30, 9, 453_829).unwrap(),
+    ///         NaiveDate::from_ymd(2018, 1, 26).unwrap().at_hms_micro(10, 30, 9, 453_829).unwrap(),
     ///     )
     ///     .unwrap();
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Secs, true), "2018-01-26T10:30:09+08:00");
@@ -1052,7 +1052,7 @@ impl DateTime<FixedOffset> {
     ///     Ok(FixedOffset::east(0)
     ///         .unwrap()
     ///         .from_local_datetime(
-    ///             NaiveDate::from_ymd(1983, 4, 13).unwrap().and_hms_milli(12, 9, 14, 274).unwrap()
+    ///             NaiveDate::from_ymd(1983, 4, 13).unwrap().at_hms_milli(12, 9, 14, 274).unwrap()
     ///         )
     ///         .unwrap())
     /// );

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -125,7 +125,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// (aka "UNIX timestamp").
     ///
     /// The reverse operation of creating a [`DateTime`] from a timestamp can be performed
-    /// using [`from_timestamp`](DateTime::from_timestamp) or [`TimeZone::timestamp`].
+    /// using [`from_timestamp`](DateTime::from_timestamp) or [`TimeZone::at_timestamp`].
     ///
     /// ```
     /// use chrono::{DateTime, TimeZone, Utc};
@@ -727,7 +727,7 @@ impl DateTime<Utc> {
     /// [`timestamp_subsec_nanos`](DateTime::timestamp_subsec_nanos).
     ///
     /// If you need to create a `DateTime` with a [`TimeZone`] different from [`Utc`], use
-    /// [`TimeZone::timestamp`] or [`DateTime::with_timezone`].
+    /// [`TimeZone::at_timestamp`] or [`DateTime::with_timezone`].
     ///
     /// The nanosecond part can exceed 1,000,000,000 in order to represent a
     /// [leap second](NaiveTime#leap-second-handling), but only when `secs % 60 == 59`.
@@ -770,7 +770,7 @@ impl DateTime<Utc> {
     /// This is guaranteed to round-trip with [`timestamp_millis`](DateTime::timestamp_millis).
     ///
     /// If you need to create a `DateTime` with a [`TimeZone`] different from [`Utc`], use
-    /// [`TimeZone::timestamp_millis`] or [`DateTime::with_timezone`].
+    /// [`TimeZone::at_timestamp_millis`] or [`DateTime::with_timezone`].
     ///
     /// # Errors
     ///
@@ -801,7 +801,7 @@ impl DateTime<Utc> {
     /// This is guaranteed to round-trip with [`timestamp_micros`](DateTime::timestamp_micros).
     ///
     /// If you need to create a `DateTime` with a [`TimeZone`] different from [`Utc`], use
-    /// [`TimeZone::timestamp_micros`] or [`DateTime::with_timezone`].
+    /// [`TimeZone::at_timestamp_micros`] or [`DateTime::with_timezone`].
     ///
     /// # Errors
     ///
@@ -836,7 +836,7 @@ impl DateTime<Utc> {
     /// This is guaranteed to round-trip with [`timestamp_nanos`](DateTime::timestamp_nanos).
     ///
     /// If you need to create a `DateTime` with a [`TimeZone`] different from [`Utc`], use
-    /// [`TimeZone::timestamp_nanos`] or [`DateTime::with_timezone`].
+    /// [`TimeZone::at_timestamp_nanos`] or [`DateTime::with_timezone`].
     ///
     /// The UNIX epoch starts on midnight, January 1, 1970, UTC.
     ///
@@ -1755,7 +1755,7 @@ impl From<js_sys::Date> for DateTime<Utc> {
 ))]
 impl From<&js_sys::Date> for DateTime<Utc> {
     fn from(date: &js_sys::Date) -> DateTime<Utc> {
-        Utc.timestamp_millis(date.get_time() as i64).unwrap()
+        Utc.at_timestamp_millis(date.get_time() as i64).unwrap()
     }
 }
 

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -122,7 +122,7 @@ impl<'de> de::Deserialize<'de> for DateTime<Local> {
 ///     .unwrap()
 ///     .at_hms_nano(02, 04, 59, 918355733)
 ///     .unwrap()
-///     .and_utc();
+///     .in_utc();
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -167,7 +167,7 @@ pub mod ts_nanoseconds {
     ///         .unwrap()
     ///         .at_hms_nano(02, 04, 59, 918355733)
     ///         .unwrap()
-    ///         .and_utc(),
+    ///         .in_utc(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
@@ -265,7 +265,7 @@ pub mod ts_nanoseconds {
 ///         .unwrap()
 ///         .at_hms_nano(02, 04, 59, 918355733)
 ///         .unwrap()
-///         .and_utc(),
+///         .in_utc(),
 /// );
 /// let my_s = S { time: time.clone() };
 ///
@@ -313,7 +313,7 @@ pub mod ts_nanoseconds_option {
     ///             .unwrap()
     ///             .at_hms_nano(02, 04, 59, 918355733)
     ///             .unwrap()
-    ///             .and_utc(),
+    ///             .in_utc(),
     ///     ),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
@@ -414,7 +414,7 @@ pub mod ts_nanoseconds_option {
 ///     .unwrap()
 ///     .at_hms_micro(02, 04, 59, 918355)
 ///     .unwrap()
-///     .and_utc();
+///     .in_utc();
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -451,7 +451,7 @@ pub mod ts_microseconds {
     ///         .unwrap()
     ///         .at_hms_micro(02, 04, 59, 918355)
     ///         .unwrap()
-    ///         .and_utc(),
+    ///         .in_utc(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
@@ -550,7 +550,7 @@ pub mod ts_microseconds {
 ///         .unwrap()
 ///         .at_hms_micro(02, 04, 59, 918355)
 ///         .unwrap()
-///         .and_utc(),
+///         .in_utc(),
 /// );
 /// let my_s = S { time: time.clone() };
 ///
@@ -589,7 +589,7 @@ pub mod ts_microseconds_option {
     ///             .unwrap()
     ///             .at_hms_micro(02, 04, 59, 918355)
     ///             .unwrap()
-    ///             .and_utc(),
+    ///             .in_utc(),
     ///     ),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
@@ -685,7 +685,7 @@ pub mod ts_microseconds_option {
 /// }
 ///
 /// let time =
-///     NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_milli(02, 04, 59, 918).unwrap().and_utc();
+///     NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_milli(02, 04, 59, 918).unwrap().in_utc();
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -722,7 +722,7 @@ pub mod ts_milliseconds {
     ///         .unwrap()
     ///         .at_hms_milli(02, 04, 59, 918)
     ///         .unwrap()
-    ///         .and_utc(),
+    ///         .in_utc(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
@@ -810,7 +810,7 @@ pub mod ts_milliseconds {
 /// }
 ///
 /// let time = Some(
-///     NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_milli(02, 04, 59, 918).unwrap().and_utc(),
+///     NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_milli(02, 04, 59, 918).unwrap().in_utc(),
 /// );
 /// let my_s = S { time: time.clone() };
 ///
@@ -849,7 +849,7 @@ pub mod ts_milliseconds_option {
     ///             .unwrap()
     ///             .at_hms_milli(02, 04, 59, 918)
     ///             .unwrap()
-    ///             .and_utc(),
+    ///             .in_utc(),
     ///     ),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -956,7 +956,7 @@ pub mod ts_milliseconds_option {
 ///     time: DateTime<Utc>,
 /// }
 ///
-/// let time = Utc.with_ymd_and_hms(2015, 5, 15, 10, 0, 0).unwrap();
+/// let time = Utc.at_ymd_and_hms(2015, 5, 15, 10, 0, 0).unwrap();
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -988,7 +988,7 @@ pub mod ts_seconds {
     ///     time: DateTime<Utc>,
     /// }
     ///
-    /// let my_s = S { time: Utc.with_ymd_and_hms(2015, 5, 15, 10, 0, 0).unwrap() };
+    /// let my_s = S { time: Utc.at_ymd_and_hms(2015, 5, 15, 10, 0, 0).unwrap() };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
     /// # Ok::<(), serde_json::Error>(())
@@ -1074,7 +1074,7 @@ pub mod ts_seconds {
 ///     time: Option<DateTime<Utc>>,
 /// }
 ///
-/// let time = Some(Utc.with_ymd_and_hms(2015, 5, 15, 10, 0, 0).unwrap());
+/// let time = Some(Utc.at_ymd_and_hms(2015, 5, 15, 10, 0, 0).unwrap());
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -1106,7 +1106,7 @@ pub mod ts_seconds_option {
     ///     time: Option<DateTime<Utc>>,
     /// }
     ///
-    /// let my_s = S { time: Some(Utc.with_ymd_and_hms(2015, 5, 15, 10, 0, 0).unwrap()) };
+    /// let my_s = S { time: Some(Utc.at_ymd_and_hms(2015, 5, 15, 10, 0, 0).unwrap()) };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
     /// # Ok::<(), serde_json::Error>(())
@@ -1212,7 +1212,7 @@ mod tests {
         // it is not self-describing.
         use bincode::{deserialize, serialize};
 
-        let dt = Utc.with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap();
+        let dt = Utc.at_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap();
         let encoded = serialize(&dt).unwrap();
         let decoded: DateTime<Utc> = deserialize(&encoded).unwrap();
         assert_eq!(dt, decoded);
@@ -1255,7 +1255,7 @@ mod tests {
         let tz = TestTimeZone;
         assert_eq!(format!("{:?}", &tz), "TEST");
 
-        let dt = tz.with_ymd_and_hms(2023, 4, 24, 21, 10, 33).unwrap();
+        let dt = tz.at_ymd_and_hms(2023, 4, 24, 21, 10, 33).unwrap();
         let encoded = serde_json::to_string(&dt).unwrap();
         dbg!(&encoded);
         let decoded: DateTime<FixedOffset> = serde_json::from_str(&encoded).unwrap();

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -199,10 +199,10 @@ pub mod ts_nanoseconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp(1526522699, 918355733).unwrap() });
+    /// assert_eq!(my_s, S { time: Utc.at_timestamp(1526522699, 918355733).unwrap() });
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp(-1, 999_999_999).unwrap() });
+    /// assert_eq!(my_s, S { time: Utc.at_timestamp(-1, 999_999_999).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
@@ -349,7 +349,7 @@ pub mod ts_nanoseconds_option {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355733 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp(1526522699, 918355733).single() });
+    /// assert_eq!(my_s, S { time: Utc.at_timestamp(1526522699, 918355733).single() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
@@ -481,10 +481,10 @@ pub mod ts_microseconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp(1526522699, 918355000).unwrap() });
+    /// assert_eq!(my_s, S { time: Utc.at_timestamp(1526522699, 918355000).unwrap() });
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp(-1, 999_999_000).unwrap() });
+    /// assert_eq!(my_s, S { time: Utc.at_timestamp(-1, 999_999_000).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
@@ -623,7 +623,7 @@ pub mod ts_microseconds_option {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918355 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp(1526522699, 918355000).single() });
+    /// assert_eq!(my_s, S { time: Utc.at_timestamp(1526522699, 918355000).single() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>
@@ -752,10 +752,10 @@ pub mod ts_milliseconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp(1526522699, 918000000).unwrap() });
+    /// assert_eq!(my_s, S { time: Utc.at_timestamp(1526522699, 918000000).unwrap() });
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": -1 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp(-1, 999_000_000).unwrap() });
+    /// assert_eq!(my_s, S { time: Utc.at_timestamp(-1, 999_000_000).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
@@ -890,7 +890,7 @@ pub mod ts_milliseconds_option {
     /// }
     ///
     /// let my_s: E<S> = serde_json::from_str(r#"{ "time": 1526522699918 }"#)?;
-    /// assert_eq!(my_s, E::V(S { time: Some(Utc.timestamp(1526522699, 918000000).unwrap()) }));
+    /// assert_eq!(my_s, E::V(S { time: Some(Utc.at_timestamp(1526522699, 918000000).unwrap()) }));
     /// let s: E<S> = serde_json::from_str(r#"{ "time": null }"#)?;
     /// assert_eq!(s, E::V(S { time: None }));
     /// let t: E<S> = serde_json::from_str(r#"{}"#)?;
@@ -1017,7 +1017,7 @@ pub mod ts_seconds {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp(1431684000, 0).unwrap() });
+    /// assert_eq!(my_s, S { time: Utc.at_timestamp(1431684000, 0).unwrap() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<DateTime<Utc>, D::Error>
@@ -1138,7 +1138,7 @@ pub mod ts_seconds_option {
     /// }
     ///
     /// let my_s: S = serde_json::from_str(r#"{ "time": 1431684000 }"#)?;
-    /// assert_eq!(my_s, S { time: Utc.timestamp(1431684000, 0).single() });
+    /// assert_eq!(my_s, S { time: Utc.at_timestamp(1431684000, 0).single() });
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub fn deserialize<'de, D>(d: D) -> Result<Option<DateTime<Utc>>, D::Error>

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -120,7 +120,7 @@ impl<'de> de::Deserialize<'de> for DateTime<Local> {
 ///
 /// let time = NaiveDate::from_ymd(2018, 5, 17)
 ///     .unwrap()
-///     .and_hms_nano(02, 04, 59, 918355733)
+///     .at_hms_nano(02, 04, 59, 918355733)
 ///     .unwrap()
 ///     .and_utc();
 /// let my_s = S { time: time.clone() };
@@ -165,7 +165,7 @@ pub mod ts_nanoseconds {
     /// let my_s = S {
     ///     time: NaiveDate::from_ymd(2018, 5, 17)
     ///         .unwrap()
-    ///         .and_hms_nano(02, 04, 59, 918355733)
+    ///         .at_hms_nano(02, 04, 59, 918355733)
     ///         .unwrap()
     ///         .and_utc(),
     /// };
@@ -263,7 +263,7 @@ pub mod ts_nanoseconds {
 /// let time = Some(
 ///     NaiveDate::from_ymd(2018, 5, 17)
 ///         .unwrap()
-///         .and_hms_nano(02, 04, 59, 918355733)
+///         .at_hms_nano(02, 04, 59, 918355733)
 ///         .unwrap()
 ///         .and_utc(),
 /// );
@@ -311,7 +311,7 @@ pub mod ts_nanoseconds_option {
     ///     time: Some(
     ///         NaiveDate::from_ymd(2018, 5, 17)
     ///             .unwrap()
-    ///             .and_hms_nano(02, 04, 59, 918355733)
+    ///             .at_hms_nano(02, 04, 59, 918355733)
     ///             .unwrap()
     ///             .and_utc(),
     ///     ),
@@ -412,7 +412,7 @@ pub mod ts_nanoseconds_option {
 ///
 /// let time = NaiveDate::from_ymd(2018, 5, 17)
 ///     .unwrap()
-///     .and_hms_micro(02, 04, 59, 918355)
+///     .at_hms_micro(02, 04, 59, 918355)
 ///     .unwrap()
 ///     .and_utc();
 /// let my_s = S { time: time.clone() };
@@ -449,7 +449,7 @@ pub mod ts_microseconds {
     /// let my_s = S {
     ///     time: NaiveDate::from_ymd(2018, 5, 17)
     ///         .unwrap()
-    ///         .and_hms_micro(02, 04, 59, 918355)
+    ///         .at_hms_micro(02, 04, 59, 918355)
     ///         .unwrap()
     ///         .and_utc(),
     /// };
@@ -548,7 +548,7 @@ pub mod ts_microseconds {
 /// let time = Some(
 ///     NaiveDate::from_ymd(2018, 5, 17)
 ///         .unwrap()
-///         .and_hms_micro(02, 04, 59, 918355)
+///         .at_hms_micro(02, 04, 59, 918355)
 ///         .unwrap()
 ///         .and_utc(),
 /// );
@@ -587,7 +587,7 @@ pub mod ts_microseconds_option {
     ///     time: Some(
     ///         NaiveDate::from_ymd(2018, 5, 17)
     ///             .unwrap()
-    ///             .and_hms_micro(02, 04, 59, 918355)
+    ///             .at_hms_micro(02, 04, 59, 918355)
     ///             .unwrap()
     ///             .and_utc(),
     ///     ),
@@ -685,7 +685,7 @@ pub mod ts_microseconds_option {
 /// }
 ///
 /// let time =
-///     NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli(02, 04, 59, 918).unwrap().and_utc();
+///     NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_milli(02, 04, 59, 918).unwrap().and_utc();
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -720,7 +720,7 @@ pub mod ts_milliseconds {
     /// let my_s = S {
     ///     time: NaiveDate::from_ymd(2018, 5, 17)
     ///         .unwrap()
-    ///         .and_hms_milli(02, 04, 59, 918)
+    ///         .at_hms_milli(02, 04, 59, 918)
     ///         .unwrap()
     ///         .and_utc(),
     /// };
@@ -810,7 +810,7 @@ pub mod ts_milliseconds {
 /// }
 ///
 /// let time = Some(
-///     NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli(02, 04, 59, 918).unwrap().and_utc(),
+///     NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_milli(02, 04, 59, 918).unwrap().and_utc(),
 /// );
 /// let my_s = S { time: time.clone() };
 ///
@@ -847,7 +847,7 @@ pub mod ts_milliseconds_option {
     ///     time: Some(
     ///         NaiveDate::from_ymd(2018, 5, 17)
     ///             .unwrap()
-    ///             .and_hms_milli(02, 04, 59, 918)
+    ///             .at_hms_milli(02, 04, 59, 918)
     ///             .unwrap()
     ///             .and_utc(),
     ///     ),

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -245,7 +245,7 @@ fn test_datetime_from_timestamp_nanos() {
 fn test_datetime_from_timestamp() {
     let from_timestamp = |secs| DateTime::from_timestamp(secs, 0);
     let ymdhms =
-        |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().at_hms(h, n, s).unwrap().and_utc();
+        |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().at_hms(h, n, s).unwrap().in_utc();
     assert_eq!(from_timestamp(-1), Ok(ymdhms(1969, 12, 31, 23, 59, 59)));
     assert_eq!(from_timestamp(0), Ok(ymdhms(1970, 1, 1, 0, 0, 0)));
     assert_eq!(from_timestamp(1), Ok(ymdhms(1970, 1, 1, 0, 0, 1)));
@@ -258,7 +258,7 @@ fn test_datetime_from_timestamp() {
 #[test]
 fn test_datetime_timestamp() {
     let to_timestamp = |y, m, d, h, n, s| {
-        NaiveDate::from_ymd(y, m, d).unwrap().at_hms(h, n, s).unwrap().and_utc().timestamp()
+        NaiveDate::from_ymd(y, m, d).unwrap().at_hms(h, n, s).unwrap().in_utc().timestamp()
     };
     assert_eq!(to_timestamp(1969, 12, 31, 23, 59, 59), -1);
     assert_eq!(to_timestamp(1970, 1, 1, 0, 0, 0), 0);
@@ -841,7 +841,7 @@ fn test_rfc3339_opts() {
     assert_eq!(dt.to_rfc3339_opts(Nanos, false), "2018-01-11T10:05:13.084660000+08:00");
     assert_eq!(dt.to_rfc3339_opts(AutoSi, false), "2018-01-11T10:05:13.084660+08:00");
 
-    let ut = dt.naive_utc().and_utc();
+    let ut = dt.naive_utc().in_utc();
     assert_eq!(ut.to_rfc3339_opts(Secs, false), "2018-01-11T02:05:13+00:00");
     assert_eq!(ut.to_rfc3339_opts(Secs, true), "2018-01-11T02:05:13Z");
     assert_eq!(ut.to_rfc3339_opts(Millis, false), "2018-01-11T02:05:13.084+00:00");
@@ -1379,7 +1379,7 @@ fn test_years_elapsed() {
 #[test]
 fn test_datetime_add_assign() {
     let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).unwrap().at_hms(0, 0, 0).unwrap();
-    let datetime = naivedatetime.and_utc();
+    let datetime = naivedatetime.in_utc();
     let mut datetime_add = datetime;
 
     datetime_add += TimeDelta::seconds(60);
@@ -1416,7 +1416,7 @@ fn test_datetime_add_assign_local() {
 #[test]
 fn test_datetime_sub_assign() {
     let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).unwrap().at_hms(12, 0, 0).unwrap();
-    let datetime = naivedatetime.and_utc();
+    let datetime = naivedatetime.in_utc();
     let mut datetime_sub = datetime;
 
     datetime_sub -= TimeDelta::minutes(90);

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -306,38 +306,38 @@ fn test_datetime_add_days() {
     let kst = FixedOffset::east(9 * 60 * 60).unwrap();
 
     assert_eq!(
-        format!("{}", est.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Days::new(5)),
+        format!("{}", est.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Days::new(5)),
         "2014-05-11 07:08:09 -05:00"
     );
     assert_eq!(
-        format!("{}", kst.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Days::new(5)),
+        format!("{}", kst.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Days::new(5)),
         "2014-05-11 07:08:09 +09:00"
     );
 
     assert_eq!(
-        format!("{}", est.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Days::new(35)),
+        format!("{}", est.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Days::new(35)),
         "2014-06-10 07:08:09 -05:00"
     );
     assert_eq!(
-        format!("{}", kst.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Days::new(35)),
+        format!("{}", kst.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Days::new(35)),
         "2014-06-10 07:08:09 +09:00"
     );
 
     assert_eq!(
-        format!("{}", DstTester.with_ymd_and_hms(2014, 4, 6, 7, 8, 9).unwrap() + Days::new(5)),
+        format!("{}", DstTester.at_ymd_and_hms(2014, 4, 6, 7, 8, 9).unwrap() + Days::new(5)),
         "2014-04-11 07:08:09 +09:00"
     );
     assert_eq!(
-        format!("{}", DstTester.with_ymd_and_hms(2014, 4, 6, 7, 8, 9).unwrap() + Days::new(10)),
+        format!("{}", DstTester.at_ymd_and_hms(2014, 4, 6, 7, 8, 9).unwrap() + Days::new(10)),
         "2014-04-16 07:08:09 +08:00"
     );
 
     assert_eq!(
-        format!("{}", DstTester.with_ymd_and_hms(2014, 9, 6, 7, 8, 9).unwrap() + Days::new(5)),
+        format!("{}", DstTester.at_ymd_and_hms(2014, 9, 6, 7, 8, 9).unwrap() + Days::new(5)),
         "2014-09-11 07:08:09 +08:00"
     );
     assert_eq!(
-        format!("{}", DstTester.with_ymd_and_hms(2014, 9, 6, 7, 8, 9).unwrap() + Days::new(10)),
+        format!("{}", DstTester.at_ymd_and_hms(2014, 9, 6, 7, 8, 9).unwrap() + Days::new(10)),
         "2014-09-16 07:08:09 +09:00"
     );
 }
@@ -348,20 +348,20 @@ fn test_datetime_sub_days() {
     let kst = FixedOffset::east(9 * 60 * 60).unwrap();
 
     assert_eq!(
-        format!("{}", est.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Days::new(5)),
+        format!("{}", est.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Days::new(5)),
         "2014-05-01 07:08:09 -05:00"
     );
     assert_eq!(
-        format!("{}", kst.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Days::new(5)),
+        format!("{}", kst.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Days::new(5)),
         "2014-05-01 07:08:09 +09:00"
     );
 
     assert_eq!(
-        format!("{}", est.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Days::new(35)),
+        format!("{}", est.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Days::new(35)),
         "2014-04-01 07:08:09 -05:00"
     );
     assert_eq!(
-        format!("{}", kst.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Days::new(35)),
+        format!("{}", kst.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Days::new(35)),
         "2014-04-01 07:08:09 +09:00"
     );
 }
@@ -372,20 +372,20 @@ fn test_datetime_add_months() {
     let kst = FixedOffset::east(9 * 60 * 60).unwrap();
 
     assert_eq!(
-        format!("{}", est.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Months::new(1)),
+        format!("{}", est.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Months::new(1)),
         "2014-06-06 07:08:09 -05:00"
     );
     assert_eq!(
-        format!("{}", kst.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Months::new(1)),
+        format!("{}", kst.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Months::new(1)),
         "2014-06-06 07:08:09 +09:00"
     );
 
     assert_eq!(
-        format!("{}", est.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Months::new(5)),
+        format!("{}", est.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Months::new(5)),
         "2014-10-06 07:08:09 -05:00"
     );
     assert_eq!(
-        format!("{}", kst.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Months::new(5)),
+        format!("{}", kst.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() + Months::new(5)),
         "2014-10-06 07:08:09 +09:00"
     );
 }
@@ -396,20 +396,20 @@ fn test_datetime_sub_months() {
     let kst = FixedOffset::east(9 * 60 * 60).unwrap();
 
     assert_eq!(
-        format!("{}", est.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Months::new(1)),
+        format!("{}", est.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Months::new(1)),
         "2014-04-06 07:08:09 -05:00"
     );
     assert_eq!(
-        format!("{}", kst.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Months::new(1)),
+        format!("{}", kst.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Months::new(1)),
         "2014-04-06 07:08:09 +09:00"
     );
 
     assert_eq!(
-        format!("{}", est.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Months::new(5)),
+        format!("{}", est.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Months::new(5)),
         "2013-12-06 07:08:09 -05:00"
     );
     assert_eq!(
-        format!("{}", kst.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Months::new(5)),
+        format!("{}", kst.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap() - Months::new(5)),
         "2013-12-06 07:08:09 +09:00"
     );
 }
@@ -425,7 +425,7 @@ fn ymdhms(
     min: u32,
     sec: u32,
 ) -> DateTime<FixedOffset> {
-    fixedoffset.with_ymd_and_hms(year, month, day, hour, min, sec).unwrap()
+    fixedoffset.at_ymd_and_hms(year, month, day, hour, min, sec).unwrap()
 }
 
 // local helper function to easily create a DateTime<FixedOffset>
@@ -441,7 +441,7 @@ fn ymdhms_milli(
     milli: u32,
 ) -> DateTime<FixedOffset> {
     fixedoffset
-        .with_ymd_and_hms(year, month, day, hour, min, sec)
+        .at_ymd_and_hms(year, month, day, hour, min, sec)
         .unwrap()
         .with_nanosecond(milli * 1_000_000)
         .unwrap()
@@ -461,7 +461,7 @@ fn ymdhms_micro(
     micro: u32,
 ) -> DateTime<FixedOffset> {
     fixedoffset
-        .with_ymd_and_hms(year, month, day, hour, min, sec)
+        .at_ymd_and_hms(year, month, day, hour, min, sec)
         .unwrap()
         .with_nanosecond(micro * 1000)
         .unwrap()
@@ -481,7 +481,7 @@ fn ymdhms_nano(
     nano: u32,
 ) -> DateTime<FixedOffset> {
     fixedoffset
-        .with_ymd_and_hms(year, month, day, hour, min, sec)
+        .at_ymd_and_hms(year, month, day, hour, min, sec)
         .unwrap()
         .with_nanosecond(nano)
         .unwrap()
@@ -490,7 +490,7 @@ fn ymdhms_nano(
 // local helper function to easily create a DateTime<Utc>
 #[cfg(feature = "alloc")]
 fn ymdhms_utc(year: i32, month: u32, day: u32, hour: u32, min: u32, sec: u32) -> DateTime<Utc> {
-    Utc.with_ymd_and_hms(year, month, day, hour, min, sec).unwrap()
+    Utc.at_ymd_and_hms(year, month, day, hour, min, sec).unwrap()
 }
 
 // local helper function to easily create a DateTime<Utc>
@@ -503,7 +503,7 @@ fn ymdhms_milli_utc(
     sec: u32,
     milli: u32,
 ) -> DateTime<Utc> {
-    Utc.with_ymd_and_hms(year, month, day, hour, min, sec)
+    Utc.at_ymd_and_hms(year, month, day, hour, min, sec)
         .unwrap()
         .with_nanosecond(milli * 1_000_000)
         .unwrap()
@@ -516,77 +516,77 @@ fn test_datetime_offset() {
     let kst = FixedOffset::east(9 * 60 * 60).unwrap();
 
     assert_eq!(
-        format!("{}", Utc.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap()),
+        format!("{}", Utc.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap()),
         "2014-05-06 07:08:09 UTC"
     );
     assert_eq!(
-        format!("{}", edt.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap()),
+        format!("{}", edt.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap()),
         "2014-05-06 07:08:09 -04:00"
     );
     assert_eq!(
-        format!("{}", kst.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap()),
+        format!("{}", kst.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap()),
         "2014-05-06 07:08:09 +09:00"
     );
     assert_eq!(
-        format!("{:?}", Utc.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap()),
+        format!("{:?}", Utc.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap()),
         "2014-05-06T07:08:09Z"
     );
     assert_eq!(
-        format!("{:?}", edt.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap()),
+        format!("{:?}", edt.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap()),
         "2014-05-06T07:08:09-04:00"
     );
     assert_eq!(
-        format!("{:?}", kst.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap()),
+        format!("{:?}", kst.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap()),
         "2014-05-06T07:08:09+09:00"
     );
 
     // edge cases
     assert_eq!(
-        format!("{:?}", Utc.with_ymd_and_hms(2014, 5, 6, 0, 0, 0).unwrap()),
+        format!("{:?}", Utc.at_ymd_and_hms(2014, 5, 6, 0, 0, 0).unwrap()),
         "2014-05-06T00:00:00Z"
     );
     assert_eq!(
-        format!("{:?}", edt.with_ymd_and_hms(2014, 5, 6, 0, 0, 0).unwrap()),
+        format!("{:?}", edt.at_ymd_and_hms(2014, 5, 6, 0, 0, 0).unwrap()),
         "2014-05-06T00:00:00-04:00"
     );
     assert_eq!(
-        format!("{:?}", kst.with_ymd_and_hms(2014, 5, 6, 0, 0, 0).unwrap()),
+        format!("{:?}", kst.at_ymd_and_hms(2014, 5, 6, 0, 0, 0).unwrap()),
         "2014-05-06T00:00:00+09:00"
     );
     assert_eq!(
-        format!("{:?}", Utc.with_ymd_and_hms(2014, 5, 6, 23, 59, 59).unwrap()),
+        format!("{:?}", Utc.at_ymd_and_hms(2014, 5, 6, 23, 59, 59).unwrap()),
         "2014-05-06T23:59:59Z"
     );
     assert_eq!(
-        format!("{:?}", edt.with_ymd_and_hms(2014, 5, 6, 23, 59, 59).unwrap()),
+        format!("{:?}", edt.at_ymd_and_hms(2014, 5, 6, 23, 59, 59).unwrap()),
         "2014-05-06T23:59:59-04:00"
     );
     assert_eq!(
-        format!("{:?}", kst.with_ymd_and_hms(2014, 5, 6, 23, 59, 59).unwrap()),
+        format!("{:?}", kst.at_ymd_and_hms(2014, 5, 6, 23, 59, 59).unwrap()),
         "2014-05-06T23:59:59+09:00"
     );
 
-    let dt = Utc.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap();
-    assert_eq!(dt, edt.with_ymd_and_hms(2014, 5, 6, 3, 8, 9).unwrap());
+    let dt = Utc.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap();
+    assert_eq!(dt, edt.at_ymd_and_hms(2014, 5, 6, 3, 8, 9).unwrap());
     assert_eq!(
         dt + TimeDelta::seconds(3600 + 60 + 1),
-        Utc.with_ymd_and_hms(2014, 5, 6, 8, 9, 10).unwrap()
+        Utc.at_ymd_and_hms(2014, 5, 6, 8, 9, 10).unwrap()
     );
     assert_eq!(
-        dt.signed_duration_since(edt.with_ymd_and_hms(2014, 5, 6, 10, 11, 12).unwrap()),
+        dt.signed_duration_since(edt.at_ymd_and_hms(2014, 5, 6, 10, 11, 12).unwrap()),
         TimeDelta::seconds(-7 * 3600 - 3 * 60 - 3)
     );
 
-    assert_eq!(*Utc.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap().offset(), Utc);
-    assert_eq!(*edt.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap().offset(), edt);
-    assert!(*edt.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap().offset() != est);
+    assert_eq!(*Utc.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap().offset(), Utc);
+    assert_eq!(*edt.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap().offset(), edt);
+    assert!(*edt.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap().offset() != est);
 }
 
 #[test]
 #[allow(clippy::needless_borrow, clippy::op_ref)]
 fn signed_duration_since_autoref() {
-    let dt1 = Utc.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap();
-    let dt2 = Utc.with_ymd_and_hms(2014, 3, 4, 5, 6, 7).unwrap();
+    let dt1 = Utc.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap();
+    let dt2 = Utc.at_ymd_and_hms(2014, 3, 4, 5, 6, 7).unwrap();
     let diff1 = dt1.signed_duration_since(dt2); // Copy/consume
     #[allow(clippy::needless_borrows_for_generic_args)]
     let diff2 = dt2.signed_duration_since(&dt1); // Take by reference
@@ -600,21 +600,21 @@ fn signed_duration_since_autoref() {
 #[test]
 fn test_datetime_date_and_time() {
     let tz = FixedOffset::east(5 * 60 * 60).unwrap();
-    let d = tz.with_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap();
+    let d = tz.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap();
     assert_eq!(d.time(), NaiveTime::from_hms(7, 8, 9).unwrap());
     assert_eq!(d.date_naive(), NaiveDate::from_ymd(2014, 5, 6).unwrap());
 
     let tz = FixedOffset::east(4 * 60 * 60).unwrap();
-    let d = tz.with_ymd_and_hms(2016, 5, 4, 3, 2, 1).unwrap();
+    let d = tz.at_ymd_and_hms(2016, 5, 4, 3, 2, 1).unwrap();
     assert_eq!(d.time(), NaiveTime::from_hms(3, 2, 1).unwrap());
     assert_eq!(d.date_naive(), NaiveDate::from_ymd(2016, 5, 4).unwrap());
 
     let tz = FixedOffset::west(13 * 60 * 60).unwrap();
-    let d = tz.with_ymd_and_hms(2017, 8, 9, 12, 34, 56).unwrap();
+    let d = tz.at_ymd_and_hms(2017, 8, 9, 12, 34, 56).unwrap();
     assert_eq!(d.time(), NaiveTime::from_hms(12, 34, 56).unwrap());
     assert_eq!(d.date_naive(), NaiveDate::from_ymd(2017, 8, 9).unwrap());
 
-    let utc_d = Utc.with_ymd_and_hms(2017, 8, 9, 12, 34, 56).unwrap();
+    let utc_d = Utc.at_ymd_and_hms(2017, 8, 9, 12, 34, 56).unwrap();
     assert!(utc_d < d);
 }
 
@@ -634,11 +634,11 @@ fn test_datetime_rfc2822() {
 
     // timezone 0
     assert_eq!(
-        Utc.with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap().to_rfc2822(),
+        Utc.at_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap().to_rfc2822(),
         "Wed, 18 Feb 2015 23:16:09 +0000"
     );
     assert_eq!(
-        Utc.with_ymd_and_hms(2015, 2, 1, 23, 16, 9).unwrap().to_rfc2822(),
+        Utc.at_ymd_and_hms(2015, 2, 1, 23, 16, 9).unwrap().to_rfc2822(),
         "Sun, 1 Feb 2015 23:16:09 +0000"
     );
     // timezone +05
@@ -682,11 +682,11 @@ fn test_datetime_rfc2822() {
 
     assert_eq!(
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 +0000"),
-        Ok(FixedOffset::east(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
+        Ok(FixedOffset::east(0).unwrap().at_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
     );
     assert_eq!(
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:16:09 -0000"),
-        Ok(FixedOffset::east(0).unwrap().with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
+        Ok(FixedOffset::east(0).unwrap().at_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
     );
     assert_eq!(
         ymdhms_micro(&edt, 2015, 2, 18, 23, 59, 59, 1_234_567).to_rfc2822(),
@@ -750,7 +750,7 @@ fn test_datetime_rfc3339() {
 
     // timezone 0
     assert_eq!(
-        Utc.with_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap().to_rfc3339(),
+        Utc.at_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap().to_rfc3339(),
         "2015-02-18T23:16:09+00:00"
     );
     // timezone +05
@@ -1227,7 +1227,7 @@ fn test_datetime_parse_from_str() {
 
 #[test]
 fn test_to_string_round_trip() {
-    let dt = Utc.with_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap();
+    let dt = Utc.at_ymd_and_hms(2000, 1, 1, 0, 0, 0).unwrap();
     let _dt: DateTime<Utc> = dt.to_string().parse().unwrap();
 
     let ndt_fixed = dt.with_timezone(&FixedOffset::east(3600).unwrap());
@@ -1282,7 +1282,7 @@ fn test_from_system_time() {
 
     let nanos = 999_999_000;
 
-    let epoch = Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap();
+    let epoch = Utc.at_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap();
 
     // SystemTime -> DateTime<Utc>
     assert_eq!(DateTime::<Utc>::try_from(UNIX_EPOCH).unwrap(), epoch);
@@ -1615,12 +1615,12 @@ fn test_datetime_sub_assign_local() {
 fn test_core_duration_ops() {
     use core::time::Duration;
 
-    let mut utc_dt = Utc.with_ymd_and_hms(2023, 8, 29, 11, 34, 12).unwrap();
+    let mut utc_dt = Utc.at_ymd_and_hms(2023, 8, 29, 11, 34, 12).unwrap();
     let same = utc_dt + Duration::ZERO;
     assert_eq!(utc_dt, same);
 
     utc_dt += Duration::new(3600, 0);
-    assert_eq!(utc_dt, Utc.with_ymd_and_hms(2023, 8, 29, 12, 34, 12).unwrap());
+    assert_eq!(utc_dt, Utc.at_ymd_and_hms(2023, 8, 29, 12, 34, 12).unwrap());
 }
 
 #[test]
@@ -1628,7 +1628,7 @@ fn test_core_duration_ops() {
 fn test_core_duration_max() {
     use core::time::Duration;
 
-    let mut utc_dt = Utc.with_ymd_and_hms(2023, 8, 29, 11, 34, 12).unwrap();
+    let mut utc_dt = Utc.at_ymd_and_hms(2023, 8, 29, 11, 34, 12).unwrap();
     utc_dt += Duration::MAX;
 }
 
@@ -1660,33 +1660,33 @@ fn test_datetime_fixed_offset() {
 
 #[test]
 fn test_datetime_to_utc() {
-    let dt = FixedOffset::east(3600).unwrap().with_ymd_and_hms(2020, 2, 22, 23, 24, 25).unwrap();
+    let dt = FixedOffset::east(3600).unwrap().at_ymd_and_hms(2020, 2, 22, 23, 24, 25).unwrap();
     let dt_utc: DateTime<Utc> = dt.to_utc();
     assert_eq!(dt, dt_utc);
 }
 
 #[test]
 fn test_add_sub_months() {
-    let utc_dt = Utc.with_ymd_and_hms(2018, 9, 5, 23, 58, 0).unwrap();
-    assert_eq!(utc_dt + Months::new(15), Utc.with_ymd_and_hms(2019, 12, 5, 23, 58, 0).unwrap());
+    let utc_dt = Utc.at_ymd_and_hms(2018, 9, 5, 23, 58, 0).unwrap();
+    assert_eq!(utc_dt + Months::new(15), Utc.at_ymd_and_hms(2019, 12, 5, 23, 58, 0).unwrap());
 
-    let utc_dt = Utc.with_ymd_and_hms(2020, 1, 31, 23, 58, 0).unwrap();
-    assert_eq!(utc_dt + Months::new(1), Utc.with_ymd_and_hms(2020, 2, 29, 23, 58, 0).unwrap());
-    assert_eq!(utc_dt + Months::new(2), Utc.with_ymd_and_hms(2020, 3, 31, 23, 58, 0).unwrap());
+    let utc_dt = Utc.at_ymd_and_hms(2020, 1, 31, 23, 58, 0).unwrap();
+    assert_eq!(utc_dt + Months::new(1), Utc.at_ymd_and_hms(2020, 2, 29, 23, 58, 0).unwrap());
+    assert_eq!(utc_dt + Months::new(2), Utc.at_ymd_and_hms(2020, 3, 31, 23, 58, 0).unwrap());
 
-    let utc_dt = Utc.with_ymd_and_hms(2018, 9, 5, 23, 58, 0).unwrap();
-    assert_eq!(utc_dt - Months::new(15), Utc.with_ymd_and_hms(2017, 6, 5, 23, 58, 0).unwrap());
+    let utc_dt = Utc.at_ymd_and_hms(2018, 9, 5, 23, 58, 0).unwrap();
+    assert_eq!(utc_dt - Months::new(15), Utc.at_ymd_and_hms(2017, 6, 5, 23, 58, 0).unwrap());
 
-    let utc_dt = Utc.with_ymd_and_hms(2020, 3, 31, 23, 58, 0).unwrap();
-    assert_eq!(utc_dt - Months::new(1), Utc.with_ymd_and_hms(2020, 2, 29, 23, 58, 0).unwrap());
-    assert_eq!(utc_dt - Months::new(2), Utc.with_ymd_and_hms(2020, 1, 31, 23, 58, 0).unwrap());
+    let utc_dt = Utc.at_ymd_and_hms(2020, 3, 31, 23, 58, 0).unwrap();
+    assert_eq!(utc_dt - Months::new(1), Utc.at_ymd_and_hms(2020, 2, 29, 23, 58, 0).unwrap());
+    assert_eq!(utc_dt - Months::new(2), Utc.at_ymd_and_hms(2020, 1, 31, 23, 58, 0).unwrap());
 }
 
 #[test]
 fn test_auto_conversion() {
-    let utc_dt = Utc.with_ymd_and_hms(2018, 9, 5, 23, 58, 0).unwrap();
+    let utc_dt = Utc.at_ymd_and_hms(2018, 9, 5, 23, 58, 0).unwrap();
     let cdt_dt =
-        FixedOffset::west(5 * 60 * 60).unwrap().with_ymd_and_hms(2018, 9, 5, 18, 58, 0).unwrap();
+        FixedOffset::west(5 * 60 * 60).unwrap().at_ymd_and_hms(2018, 9, 5, 18, 58, 0).unwrap();
     let utc_dt2: DateTime<Utc> = cdt_dt.into();
     assert_eq!(utc_dt, utc_dt2);
 }
@@ -1695,8 +1695,7 @@ fn test_auto_conversion() {
 #[cfg(all(feature = "unstable-locales", feature = "alloc"))]
 fn locale_decimal_point() {
     use crate::Locale::{ar_SY, nl_NL};
-    let dt =
-        Utc.with_ymd_and_hms(2018, 9, 5, 18, 58, 0).unwrap().with_nanosecond(123456780).unwrap();
+    let dt = Utc.at_ymd_and_hms(2018, 9, 5, 18, 58, 0).unwrap().with_nanosecond(123456780).unwrap();
 
     assert_eq!(dt.format_localized("%T%.f", nl_NL).to_string(), "18:58:00,123456780");
     assert_eq!(dt.format_localized("%T%.3f", nl_NL).to_string(), "18:58:00,123");

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -43,7 +43,7 @@ impl TimeZone for DstTester {
             DstTester::TO_WINTER_MONTH_DAY.1,
         )
         .unwrap()
-        .and_time(DstTester::transition_start_local());
+        .at(DstTester::transition_start_local());
 
         let local_to_winter_transition_end = NaiveDate::from_ymd(
             local.year(),
@@ -51,7 +51,7 @@ impl TimeZone for DstTester {
             DstTester::TO_WINTER_MONTH_DAY.1,
         )
         .unwrap()
-        .and_time(DstTester::transition_start_local() - TimeDelta::hours(1));
+        .at(DstTester::transition_start_local() - TimeDelta::hours(1));
 
         let local_to_summer_transition_start = NaiveDate::from_ymd(
             local.year(),
@@ -59,7 +59,7 @@ impl TimeZone for DstTester {
             DstTester::TO_SUMMER_MONTH_DAY.1,
         )
         .unwrap()
-        .and_time(DstTester::transition_start_local());
+        .at(DstTester::transition_start_local());
 
         let local_to_summer_transition_end = NaiveDate::from_ymd(
             local.year(),
@@ -67,7 +67,7 @@ impl TimeZone for DstTester {
             DstTester::TO_SUMMER_MONTH_DAY.1,
         )
         .unwrap()
-        .and_time(DstTester::transition_start_local() + TimeDelta::hours(1));
+        .at(DstTester::transition_start_local() + TimeDelta::hours(1));
 
         if local < local_to_winter_transition_end || local >= local_to_summer_transition_end {
             MappedLocalTime::Single(DstTester::summer_offset())
@@ -95,7 +95,7 @@ impl TimeZone for DstTester {
             DstTester::TO_WINTER_MONTH_DAY.1,
         )
         .unwrap()
-        .and_time(DstTester::transition_start_local())
+        .at(DstTester::transition_start_local())
             - DstTester::summer_offset();
 
         let utc_to_summer_transition = NaiveDate::from_ymd(
@@ -104,7 +104,7 @@ impl TimeZone for DstTester {
             DstTester::TO_SUMMER_MONTH_DAY.1,
         )
         .unwrap()
-        .and_time(DstTester::transition_start_local())
+        .at(DstTester::transition_start_local())
             - DstTester::winter_offset();
 
         if utc < utc_to_winter_transition || utc >= utc_to_summer_transition {
@@ -597,7 +597,7 @@ fn signed_duration_since_autoref() {
 }
 
 #[test]
-fn test_datetime_date_and_time() {
+fn test_datetime_date_at() {
     let tz = FixedOffset::east(5 * 60 * 60).unwrap();
     let d = tz.at_ymd_and_hms(2014, 5, 6, 7, 8, 9).unwrap();
     assert_eq!(d.time(), NaiveTime::from_hms(7, 8, 9).unwrap());
@@ -1542,7 +1542,7 @@ fn test_min_max_add_days() {
     assert_eq!(beyond_min.checked_add_days(Days::new(0)), Some(beyond_min));
     assert_eq!(
         beyond_min.checked_add_days(Days::new(1)),
-        Some(offset_min.from_utc_datetime((NaiveDate::MIN + Days(1)).and_time(NaiveTime::MIN)))
+        Some(offset_min.from_utc_datetime((NaiveDate::MIN + Days(1)).at(NaiveTime::MIN)))
     );
     assert_eq!(beyond_min.checked_sub_days(Days::new(0)), Some(beyond_min));
     assert_eq!(beyond_min.checked_sub_days(Days::new(1)), None);
@@ -1552,7 +1552,7 @@ fn test_min_max_add_days() {
     assert_eq!(beyond_max.checked_sub_days(Days::new(0)), Some(beyond_max));
     assert_eq!(
         beyond_max.checked_sub_days(Days::new(1)),
-        Some(offset_max.from_utc_datetime((NaiveDate::MAX - Days(1)).and_time(max_time)))
+        Some(offset_max.from_utc_datetime((NaiveDate::MAX - Days(1)).at(max_time)))
     );
 }
 
@@ -1567,7 +1567,7 @@ fn test_min_max_add_months() {
     assert_eq!(beyond_min.checked_add_months(Months::new(0)), Some(beyond_min));
     assert_eq!(
         beyond_min.checked_add_months(Months::new(1)),
-        Some(offset_min.from_utc_datetime((NaiveDate::MIN + Months(1)).and_time(NaiveTime::MIN)))
+        Some(offset_min.from_utc_datetime((NaiveDate::MIN + Months(1)).at(NaiveTime::MIN)))
     );
     assert_eq!(beyond_min.checked_sub_months(Months::new(0)), Some(beyond_min));
     assert_eq!(beyond_min.checked_sub_months(Months::new(1)), None);
@@ -1577,7 +1577,7 @@ fn test_min_max_add_months() {
     assert_eq!(beyond_max.checked_sub_months(Months::new(0)), Some(beyond_max));
     assert_eq!(
         beyond_max.checked_sub_months(Months::new(1)),
-        Some(offset_max.from_utc_datetime((NaiveDate::MAX - Months(1)).and_time(max_time)))
+        Some(offset_max.from_utc_datetime((NaiveDate::MAX - Months(1)).at(max_time)))
     );
 }
 

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1736,7 +1736,7 @@ fn nano_roundrip() {
         i64::MAX,
     ] {
         println!("nanos: {}", nanos);
-        let dt = Utc.timestamp_nanos(nanos);
+        let dt = Utc.at_timestamp_nanos(nanos);
         let nanos2 = dt.timestamp_nanos().expect("value roundtrips");
         assert_eq!(nanos, nanos2);
     }

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -244,9 +244,8 @@ fn test_datetime_from_timestamp_nanos() {
 #[test]
 fn test_datetime_from_timestamp() {
     let from_timestamp = |secs| DateTime::from_timestamp(secs, 0);
-    let ymdhms = |y, m, d, h, n, s| {
-        NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap().and_utc()
-    };
+    let ymdhms =
+        |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().at_hms(h, n, s).unwrap().and_utc();
     assert_eq!(from_timestamp(-1), Ok(ymdhms(1969, 12, 31, 23, 59, 59)));
     assert_eq!(from_timestamp(0), Ok(ymdhms(1970, 1, 1, 0, 0, 0)));
     assert_eq!(from_timestamp(1), Ok(ymdhms(1970, 1, 1, 0, 0, 1)));
@@ -259,7 +258,7 @@ fn test_datetime_from_timestamp() {
 #[test]
 fn test_datetime_timestamp() {
     let to_timestamp = |y, m, d, h, n, s| {
-        NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap().and_utc().timestamp()
+        NaiveDate::from_ymd(y, m, d).unwrap().at_hms(h, n, s).unwrap().and_utc().timestamp()
     };
     assert_eq!(to_timestamp(1969, 12, 31, 23, 59, 59), -1);
     assert_eq!(to_timestamp(1970, 1, 1, 0, 0, 0), 0);
@@ -644,7 +643,7 @@ fn test_datetime_rfc2822() {
     // timezone +05
     assert_eq!(
         edt.from_local_datetime(
-            NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+            NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms_milli(23, 16, 9, 150).unwrap()
         )
         .unwrap()
         .to_rfc2822(),
@@ -654,7 +653,7 @@ fn test_datetime_rfc2822() {
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:60 +0500"),
         Ok(edt
             .from_local_datetime(
-                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 59, 59, 1_000).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms_milli(23, 59, 59, 1_000).unwrap()
             )
             .unwrap())
     );
@@ -665,7 +664,7 @@ fn test_datetime_rfc2822() {
             .from_local_datetime(
                 NaiveDate::from_ymd(2015, 2, 18)
                     .unwrap()
-                    .and_hms_micro(23, 59, 59, 1_234_567)
+                    .at_hms_micro(23, 59, 59, 1_234_567)
                     .unwrap()
             )
             .unwrap())
@@ -673,7 +672,7 @@ fn test_datetime_rfc2822() {
     // seconds 60
     assert_eq!(
         edt.from_local_datetime(
-            NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_micro(23, 59, 59, 1_234_567).unwrap()
+            NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms_micro(23, 59, 59, 1_234_567).unwrap()
         )
         .unwrap()
         .to_rfc2822(),
@@ -756,7 +755,7 @@ fn test_datetime_rfc3339() {
     // timezone +05
     assert_eq!(
         edt5.from_local_datetime(
-            NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+            NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms_milli(23, 16, 9, 150).unwrap()
         )
         .unwrap()
         .to_rfc3339(),
@@ -832,7 +831,7 @@ fn test_rfc3339_opts() {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
-            NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_nano(10, 5, 13, 84_660_000).unwrap(),
+            NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_nano(10, 5, 13, 84_660_000).unwrap(),
         )
         .unwrap();
     assert_eq!(dt.to_rfc3339_opts(Secs, false), "2018-01-11T10:05:13+08:00");
@@ -859,7 +858,7 @@ fn test_datetime_from_str() {
         Ok(FixedOffset::east(0)
             .unwrap()
             .from_local_datetime(
-                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -867,7 +866,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -875,7 +874,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15 UTC".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -883,7 +882,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15UTC".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -891,7 +890,7 @@ fn test_datetime_from_str() {
         "2015-02-18T23:16:9.15Utc".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -901,7 +900,7 @@ fn test_datetime_from_str() {
         Ok(FixedOffset::east(0)
             .unwrap()
             .from_local_datetime(
-                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -910,7 +909,7 @@ fn test_datetime_from_str() {
         Ok(FixedOffset::west(10 * 3600)
             .unwrap()
             .from_local_datetime(
-                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(13, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms_milli(13, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -920,7 +919,7 @@ fn test_datetime_from_str() {
         "2015-2-18T23:16:9.15Z".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -928,7 +927,7 @@ fn test_datetime_from_str() {
         "2015-2-18T13:16:9.15-10:00".parse::<DateTime<Utc>>(),
         Ok(Utc
             .from_local_datetime(
-                NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms_milli(23, 16, 9, 150).unwrap()
+                NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms_milli(23, 16, 9, 150).unwrap()
             )
             .unwrap())
     );
@@ -1263,7 +1262,7 @@ fn test_datetime_is_send_and_copy() {
 fn test_subsecond_part() {
     let datetime = Utc
         .from_local_datetime(
-            NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_nano(9, 10, 11, 1234567).unwrap(),
+            NaiveDate::from_ymd(2014, 7, 8).unwrap().at_hms_nano(9, 10, 11, 1234567).unwrap(),
         )
         .unwrap();
 
@@ -1289,21 +1288,21 @@ fn test_from_system_time() {
     assert_eq!(
         DateTime::<Utc>::try_from(UNIX_EPOCH + Duration::new(999_999_999, nanos)).unwrap(),
         Utc.from_local_datetime(
-            NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano(1, 46, 39, nanos).unwrap()
+            NaiveDate::from_ymd(2001, 9, 9).unwrap().at_hms_nano(1, 46, 39, nanos).unwrap()
         )
         .unwrap()
     );
     assert_eq!(
         DateTime::<Utc>::try_from(UNIX_EPOCH - Duration::new(999_999_999, nanos)).unwrap(),
         Utc.from_local_datetime(
-            NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 20, 1_000).unwrap()
+            NaiveDate::from_ymd(1938, 4, 24).unwrap().at_hms_nano(22, 13, 20, 1_000).unwrap()
         )
         .unwrap()
     );
     assert_eq!(
         DateTime::<Utc>::try_from(UNIX_EPOCH - Duration::new(999_999_999, 0)).unwrap(),
         Utc.from_local_datetime(
-            NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 21, 0).unwrap()
+            NaiveDate::from_ymd(1938, 4, 24).unwrap().at_hms_nano(22, 13, 21, 0).unwrap()
         )
         .unwrap()
     );
@@ -1313,7 +1312,7 @@ fn test_from_system_time() {
     assert_eq!(
         SystemTime::try_from(
             Utc.from_local_datetime(
-                NaiveDate::from_ymd(2001, 9, 9).unwrap().and_hms_nano(1, 46, 39, nanos).unwrap()
+                NaiveDate::from_ymd(2001, 9, 9).unwrap().at_hms_nano(1, 46, 39, nanos).unwrap()
             )
             .unwrap()
         )
@@ -1323,7 +1322,7 @@ fn test_from_system_time() {
     assert_eq!(
         SystemTime::try_from(
             Utc.from_local_datetime(
-                NaiveDate::from_ymd(1938, 4, 24).unwrap().and_hms_nano(22, 13, 20, 1_000).unwrap()
+                NaiveDate::from_ymd(1938, 4, 24).unwrap().at_hms_nano(22, 13, 20, 1_000).unwrap()
             )
             .unwrap()
         )
@@ -1356,7 +1355,7 @@ fn test_datetime_before_windows_api_limits() {
     // (https://github.com/chronotope/chrono/issues/651)
     // This used to fail on Windows for timezones with an offset of -5:00 or greater.
     // The API limits years to 1601..=30827.
-    let dt = NaiveDate::from_ymd(1601, 1, 1).unwrap().and_hms_milli(4, 5, 22, 122).unwrap();
+    let dt = NaiveDate::from_ymd(1601, 1, 1).unwrap().at_hms_milli(4, 5, 22, 122).unwrap();
     let local_dt = Local.from_utc_datetime(dt);
     dbg!(local_dt);
 }
@@ -1379,7 +1378,7 @@ fn test_years_elapsed() {
 
 #[test]
 fn test_datetime_add_assign() {
-    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).unwrap().at_hms(0, 0, 0).unwrap();
     let datetime = naivedatetime.and_utc();
     let mut datetime_add = datetime;
 
@@ -1402,7 +1401,7 @@ fn test_datetime_add_assign() {
 #[test]
 #[cfg(feature = "clock")]
 fn test_datetime_add_assign_local() {
-    let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).unwrap().at_hms(0, 0, 0).unwrap();
 
     let datetime = Local.from_utc_datetime(naivedatetime);
     let mut datetime_add = Local.from_utc_datetime(naivedatetime);
@@ -1416,7 +1415,7 @@ fn test_datetime_add_assign_local() {
 
 #[test]
 fn test_datetime_sub_assign() {
-    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).unwrap().and_hms(12, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2000, 1, 1).unwrap().at_hms(12, 0, 0).unwrap();
     let datetime = naivedatetime.and_utc();
     let mut datetime_sub = datetime;
 
@@ -1599,7 +1598,7 @@ fn test_local_beyond_max_datetime() {
 #[test]
 #[cfg(feature = "clock")]
 fn test_datetime_sub_assign_local() {
-    let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2022, 1, 1).unwrap().at_hms(0, 0, 0).unwrap();
 
     let datetime = Local.from_utc_datetime(naivedatetime);
     let mut datetime_sub = Local.from_utc_datetime(naivedatetime);
@@ -1635,7 +1634,7 @@ fn test_core_duration_max() {
 #[test]
 #[cfg(feature = "clock")]
 fn test_datetime_local_from_preserves_offset() {
-    let naivedatetime = NaiveDate::from_ymd(2023, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2023, 1, 1).unwrap().at_hms(0, 0, 0).unwrap();
 
     let datetime = Local.from_utc_datetime(naivedatetime);
     let offset = datetime.offset().fix();
@@ -1647,7 +1646,7 @@ fn test_datetime_local_from_preserves_offset() {
 
 #[test]
 fn test_datetime_fixed_offset() {
-    let naivedatetime = NaiveDate::from_ymd(2023, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
+    let naivedatetime = NaiveDate::from_ymd(2023, 1, 1).unwrap().at_hms(0, 0, 0).unwrap();
 
     let datetime = Utc.from_utc_datetime(naivedatetime);
     let fixed_utc = FixedOffset::east(0).unwrap();

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -699,11 +699,8 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test_datetime_format_alignment() {
-        let datetime = Utc
-            .with_ymd_and_hms(2007, 1, 2, 12, 34, 56)
-            .unwrap()
-            .with_nanosecond(123456789)
-            .unwrap();
+        let datetime =
+            Utc.at_ymd_and_hms(2007, 1, 2, 12, 34, 56).unwrap().with_nanosecond(123456789).unwrap();
 
         // Item::Literal, odd number of padding bytes.
         let percent = datetime.format("%%");

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -182,10 +182,10 @@ fn format_inner(
                 Timestamp => (
                     1,
                     match (date, time, off) {
-                        (Some(d), Some(t), None) => Some(d.and_time(*t).and_utc().timestamp()),
-                        (Some(d), Some(t), Some(&(_, off))) => Some(
-                            d.and_time(*t).and_utc().timestamp() - i64::from(off.local_minus_utc()),
-                        ),
+                        (Some(d), Some(t), None) => Some(d.at(*t).and_utc().timestamp()),
+                        (Some(d), Some(t), Some(&(_, off))) => {
+                            Some(d.at(*t).and_utc().timestamp() - i64::from(off.local_minus_utc()))
+                        }
                         (_, _, _) => None,
                     },
                 ),

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -182,9 +182,9 @@ fn format_inner(
                 Timestamp => (
                     1,
                     match (date, time, off) {
-                        (Some(d), Some(t), None) => Some(d.at(*t).and_utc().timestamp()),
+                        (Some(d), Some(t), None) => Some(d.at(*t).in_utc().timestamp()),
                         (Some(d), Some(t), Some(&(_, off))) => {
-                            Some(d.at(*t).and_utc().timestamp() - i64::from(off.local_minus_utc()))
+                            Some(d.at(*t).in_utc().timestamp() - i64::from(off.local_minus_utc()))
                         }
                         (_, _, _) => None,
                     },

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -684,14 +684,13 @@ mod tests {
     #[test]
     #[cfg(feature = "alloc")]
     fn test_datetime_format() {
-        let dt = NaiveDate::from_ymd(2010, 9, 8).unwrap().and_hms_milli(7, 6, 54, 321).unwrap();
+        let dt = NaiveDate::from_ymd(2010, 9, 8).unwrap().at_hms_milli(7, 6, 54, 321).unwrap();
         assert_eq!(dt.format("%c").to_string(), "Wed Sep  8 07:06:54 2010");
         assert_eq!(dt.format("%s").to_string(), "1283929614");
         assert_eq!(dt.format("%t%n%%%n%t").to_string(), "\t\n%\n\t");
 
         // a horror of leap second: coming near to you.
-        let dt =
-            NaiveDate::from_ymd(2012, 6, 30).unwrap().and_hms_milli(23, 59, 59, 1_000).unwrap();
+        let dt = NaiveDate::from_ymd(2012, 6, 30).unwrap().at_hms_milli(23, 59, 59, 1_000).unwrap();
         assert_eq!(dt.format("%c").to_string(), "Sat Jun 30 23:59:60 2012");
         assert_eq!(dt.format("%s").to_string(), "1341100799"); // not 1341100800, it's intentional.
     }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -20,7 +20,7 @@
 //! # #[cfg(feature = "alloc")] {
 //! use chrono::{NaiveDateTime, TimeZone, Utc};
 //!
-//! let date_time = Utc.with_ymd_and_hms(2020, 11, 10, 0, 1, 32).unwrap();
+//! let date_time = Utc.at_ymd_and_hms(2020, 11, 10, 0, 1, 32).unwrap();
 //!
 //! let formatted = format!("{}", date_time.format("%Y-%m-%d %H:%M:%S"));
 //! assert_eq!(formatted, "2020-11-10 00:01:32");

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -25,7 +25,7 @@
 //! let formatted = format!("{}", date_time.format("%Y-%m-%d %H:%M:%S"));
 //! assert_eq!(formatted, "2020-11-10 00:01:32");
 //!
-//! let parsed = NaiveDateTime::parse_from_str(&formatted, "%Y-%m-%d %H:%M:%S")?.and_utc();
+//! let parsed = NaiveDateTime::parse_from_str(&formatted, "%Y-%m-%d %H:%M:%S")?.in_utc();
 //! assert_eq!(parsed, date_time);
 //! # }
 //! # Ok::<(), chrono::ParseError>(())

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -1587,7 +1587,7 @@ mod tests {
         let ymd_hmsn = |y, m, d, h, n, s, nano, off| {
             FixedOffset::east(off * 60 * 60)
                 .unwrap()
-                .with_ymd_and_hms(y, m, d, h, n, s)
+                .at_ymd_and_hms(y, m, d, h, n, s)
                 .unwrap()
                 .with_nanosecond(nano)
                 .unwrap()
@@ -1681,7 +1681,7 @@ mod tests {
     fn parse_rfc850() {
         static RFC850_FMT: &str = "%A, %d-%b-%y %T GMT";
 
-        let dt = Utc.with_ymd_and_hms(1994, 11, 6, 8, 49, 37).unwrap();
+        let dt = Utc.at_ymd_and_hms(1994, 11, 6, 8, 49, 37).unwrap();
 
         // Check that the format is what we expect
         #[cfg(feature = "alloc")]
@@ -1696,28 +1696,25 @@ mod tests {
         // Check that the rest of the weekdays parse correctly (this test originally failed because
         // Sunday parsed incorrectly).
         let testdates = [
+            (Utc.at_ymd_and_hms(1994, 11, 7, 8, 49, 37).unwrap(), "Monday, 07-Nov-94 08:49:37 GMT"),
             (
-                Utc.with_ymd_and_hms(1994, 11, 7, 8, 49, 37).unwrap(),
-                "Monday, 07-Nov-94 08:49:37 GMT",
-            ),
-            (
-                Utc.with_ymd_and_hms(1994, 11, 8, 8, 49, 37).unwrap(),
+                Utc.at_ymd_and_hms(1994, 11, 8, 8, 49, 37).unwrap(),
                 "Tuesday, 08-Nov-94 08:49:37 GMT",
             ),
             (
-                Utc.with_ymd_and_hms(1994, 11, 9, 8, 49, 37).unwrap(),
+                Utc.at_ymd_and_hms(1994, 11, 9, 8, 49, 37).unwrap(),
                 "Wednesday, 09-Nov-94 08:49:37 GMT",
             ),
             (
-                Utc.with_ymd_and_hms(1994, 11, 10, 8, 49, 37).unwrap(),
+                Utc.at_ymd_and_hms(1994, 11, 10, 8, 49, 37).unwrap(),
                 "Thursday, 10-Nov-94 08:49:37 GMT",
             ),
             (
-                Utc.with_ymd_and_hms(1994, 11, 11, 8, 49, 37).unwrap(),
+                Utc.at_ymd_and_hms(1994, 11, 11, 8, 49, 37).unwrap(),
                 "Friday, 11-Nov-94 08:49:37 GMT",
             ),
             (
-                Utc.with_ymd_and_hms(1994, 11, 12, 8, 49, 37).unwrap(),
+                Utc.at_ymd_and_hms(1994, 11, 12, 8, 49, 37).unwrap(),
                 "Saturday, 12-Nov-94 08:49:37 GMT",
             ),
         ];
@@ -1751,7 +1748,7 @@ mod tests {
         let ymd_hmsn = |y, m, d, h, n, s, nano, off| {
             FixedOffset::east(off * 60 * 60)
                 .unwrap()
-                .with_ymd_and_hms(y, m, d, h, n, s)
+                .at_ymd_and_hms(y, m, d, h, n, s)
                 .unwrap()
                 .with_nanosecond(nano)
                 .unwrap()

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -752,7 +752,7 @@ impl Parsed {
         let date = self.to_naive_date();
         let time = self.to_naive_time();
         if let (Ok(date), Ok(time)) = (date, time) {
-            let datetime = date.and_time(time);
+            let datetime = date.at(time);
 
             // verify the timestamp field if any
             // the following is safe, `timestamp` is very limited in range
@@ -814,7 +814,7 @@ impl Parsed {
             // validate other fields (e.g. week) and return
             let date = parsed.to_naive_date()?;
             let time = parsed.to_naive_time()?;
-            Ok(date.and_time(time))
+            Ok(date.at(time))
         } else {
             // reproduce the previous error(s)
             date?;

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -756,7 +756,7 @@ impl Parsed {
 
             // verify the timestamp field if any
             // the following is safe, `timestamp` is very limited in range
-            let timestamp = datetime.and_utc().timestamp() - i64::from(offset);
+            let timestamp = datetime.in_utc().timestamp() - i64::from(offset);
             if let Some(given_timestamp) = self.timestamp {
                 // if `datetime` represents a leap second, it might be off by one second.
                 if given_timestamp != timestamp

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -1510,9 +1510,9 @@ mod tests {
         }
 
         let ymdhms =
-            |y, m, d, h, n, s| Ok(NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap());
+            |y, m, d, h, n, s| Ok(NaiveDate::from_ymd(y, m, d).unwrap().at_hms(h, n, s).unwrap());
         let ymdhmsn = |y, m, d, h, n, s, nano| {
-            Ok(NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano(h, n, s, nano).unwrap())
+            Ok(NaiveDate::from_ymd(y, m, d).unwrap().at_hms_nano(h, n, s, nano).unwrap())
         };
 
         // omission of fields
@@ -1658,7 +1658,7 @@ mod tests {
             Ok(FixedOffset::east(off)
                 .unwrap()
                 .from_local_datetime(
-                    NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano(h, n, s, nano).unwrap(),
+                    NaiveDate::from_ymd(y, m, d).unwrap().at_hms_nano(h, n, s, nano).unwrap(),
                 )
                 .unwrap())
         };
@@ -1708,7 +1708,7 @@ mod tests {
                 .from_local_datetime(
                     NaiveDate::from_ymd(2014, 12, 31)
                         .unwrap()
-                        .and_hms_nano(4, 26, 40, 12_345_678)
+                        .at_hms_nano(4, 26, 40, 12_345_678)
                         .unwrap()
                 )
                 .unwrap())
@@ -1734,7 +1734,7 @@ mod tests {
                 .from_local_datetime(
                     NaiveDate::from_ymd(2014, 12, 31)
                         .unwrap()
-                        .and_hms_nano(13, 26, 40, 12_345_678)
+                        .at_hms_nano(13, 26, 40, 12_345_678)
                         .unwrap()
                 )
                 .unwrap())

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -1743,7 +1743,7 @@ mod tests {
         // single result from timestamp
         assert_eq!(
             parse!(Utc; timestamp: 1_420_000_000, offset: 0),
-            Ok(Utc.with_ymd_and_hms(2014, 12, 31, 4, 26, 40).unwrap())
+            Ok(Utc.at_ymd_and_hms(2014, 12, 31, 4, 26, 40).unwrap())
         );
         assert_eq!(parse!(Utc; timestamp: 1_420_000_000, offset: 32400), Err(IMPOSSIBLE));
         assert_eq!(
@@ -1752,10 +1752,7 @@ mod tests {
         );
         assert_eq!(
             parse!(FixedOffset::east(32400).unwrap(); timestamp: 1_420_000_000, offset: 32400),
-            Ok(FixedOffset::east(32400)
-                .unwrap()
-                .with_ymd_and_hms(2014, 12, 31, 13, 26, 40)
-                .unwrap())
+            Ok(FixedOffset::east(32400).unwrap().at_ymd_and_hms(2014, 12, 31, 13, 26, 40).unwrap())
         );
 
         // TODO test with a variable time zone (for None and Ambiguous cases)

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -312,7 +312,7 @@ impl<'a> StrftimeItems<'a> {
     /// use chrono::NaiveDate;
     ///
     /// let fmt_items = StrftimeItems::new("%e %b %Y %k.%M").parse()?;
-    /// let datetime = NaiveDate::from_ymd(2023, 7, 11).unwrap().and_hms(9, 0, 0).unwrap();
+    /// let datetime = NaiveDate::from_ymd(2023, 7, 11).unwrap().at_hms(9, 0, 0).unwrap();
     ///
     /// // Formatting
     /// assert_eq!(
@@ -362,7 +362,7 @@ impl<'a> StrftimeItems<'a> {
     /// }
     ///
     /// let fmt_items = format_items("%e %b %Y", "%k.%M")?;
-    /// let datetime = NaiveDate::from_ymd(2023, 7, 11).unwrap().and_hms(9, 0, 0).unwrap();
+    /// let datetime = NaiveDate::from_ymd(2023, 7, 11).unwrap().at_hms(9, 0, 0).unwrap();
     ///
     /// assert_eq!(
     ///     datetime.format_with_items(fmt_items.as_slice().iter()).to_string(),
@@ -853,7 +853,7 @@ mod tests {
             .from_local_datetime(
                 NaiveDate::from_ymd(2001, 7, 8)
                     .unwrap()
-                    .and_hms_nano(0, 34, 59, 1_026_490_708)
+                    .at_hms_nano(0, 34, 59, 1_026_490_708)
                     .unwrap(),
             )
             .unwrap();
@@ -1021,7 +1021,7 @@ mod tests {
             .from_local_datetime(
                 NaiveDate::from_ymd(2001, 7, 8)
                     .unwrap()
-                    .and_hms_nano(0, 34, 59, 1_026_490_708)
+                    .at_hms_nano(0, 34, 59, 1_026_490_708)
                     .unwrap(),
             )
             .unwrap();

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -264,7 +264,7 @@ impl<'a> StrftimeItems<'a> {
     /// use chrono::{FixedOffset, TimeZone};
     ///
     /// let dt =
-    ///     FixedOffset::east(9 * 60 * 60).unwrap().with_ymd_and_hms(2023, 7, 11, 0, 34, 59).unwrap();
+    ///     FixedOffset::east(9 * 60 * 60).unwrap().at_ymd_and_hms(2023, 7, 11, 0, 34, 59).unwrap();
     ///
     /// // Note: you usually want to combine `StrftimeItems::new_with_locale` with other
     /// // locale-aware methods such as `DateTime::format_localized_with_items`.
@@ -961,7 +961,7 @@ mod tests {
     fn test_strftime_docs_localized() {
         let dt = FixedOffset::east(34200)
             .unwrap()
-            .with_ymd_and_hms(2001, 7, 8, 0, 34, 59)
+            .at_ymd_and_hms(2001, 7, 8, 0, 34, 59)
             .unwrap()
             .with_nanosecond(1_026_490_708)
             .unwrap();
@@ -1035,7 +1035,7 @@ mod tests {
     fn test_strftime_localized_korean() {
         let dt = FixedOffset::east(34200)
             .unwrap()
-            .with_ymd_and_hms(2001, 7, 8, 0, 34, 59)
+            .at_ymd_and_hms(2001, 7, 8, 0, 34, 59)
             .unwrap()
             .with_nanosecond(1_026_490_708)
             .unwrap();
@@ -1064,7 +1064,7 @@ mod tests {
     fn test_strftime_localized_japanese() {
         let dt = FixedOffset::east(34200)
             .unwrap()
-            .with_ymd_and_hms(2001, 7, 8, 0, 34, 59)
+            .at_ymd_and_hms(2001, 7, 8, 0, 34, 59)
             .unwrap()
             .with_nanosecond(1_026_490_708)
             .unwrap();
@@ -1091,8 +1091,8 @@ mod tests {
     #[test]
     #[cfg(all(feature = "unstable-locales", feature = "alloc"))]
     fn test_strftime_localized_time() {
-        let dt1 = Utc.with_ymd_and_hms(2024, 2, 9, 6, 54, 32).unwrap();
-        let dt2 = Utc.with_ymd_and_hms(2024, 2, 9, 18, 54, 32).unwrap();
+        let dt1 = Utc.at_ymd_and_hms(2024, 2, 9, 6, 54, 32).unwrap();
+        let dt2 = Utc.at_ymd_and_hms(2024, 2, 9, 18, 54, 32).unwrap();
         // Some of these locales gave issues before pure-rust-locales 0.8.0 with chrono 0.4.27+
         assert_eq!(dt1.format_localized("%X", Locale::nl_NL).to_string(), "06:54:32");
         assert_eq!(dt2.format_localized("%X", Locale::nl_NL).to_string(), "18:54:32");
@@ -1127,7 +1127,7 @@ mod tests {
     fn test_strftime_parse() {
         let fmt_str = StrftimeItems::new("%Y-%m-%dT%H:%M:%S%z");
         let fmt_items = fmt_str.parse().unwrap();
-        let dt = Utc.with_ymd_and_hms(2014, 5, 7, 12, 34, 56).unwrap();
+        let dt = Utc.at_ymd_and_hms(2014, 5, 7, 12, 34, 56).unwrap();
         assert_eq!(&dt.format_with_items(fmt_items.iter()).to_string(), "2014-05-07T12:34:56+0000");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,35 +131,35 @@
 //!     dt,
 //!     NaiveDate::from_ymd(2014, 7, 8)?
 //!         .at_hms(9, 10, 11)?
-//!         .and_utc()
+//!         .in_utc()
 //! );
 //!
 //! // July 8 is 188th day of the year 2014 (`o` for "ordinal")
-//! assert_eq!(dt, NaiveDate::from_yo(2014, 189).unwrap().at_hms(9, 10, 11).unwrap().and_utc());
+//! assert_eq!(dt, NaiveDate::from_yo(2014, 189).unwrap().at_hms(9, 10, 11).unwrap().in_utc());
 //! // July 8 is Tuesday in ISO week 28 of the year 2014.
-//! assert_eq!(dt, NaiveDate::from_isoywd(2014, 28, Weekday::Tue).unwrap().at_hms(9, 10, 11).unwrap().and_utc());
+//! assert_eq!(dt, NaiveDate::from_isoywd(2014, 28, Weekday::Tue).unwrap().at_hms(9, 10, 11).unwrap().in_utc());
 //!
 //! let dt = NaiveDate::from_ymd(2014, 7, 8)?
 //!     .at_hms_milli(9, 10, 11, 12)?
-//!     .and_utc(); // `2014-07-08T09:10:11.012Z`
+//!     .in_utc(); // `2014-07-08T09:10:11.012Z`
 //! assert_eq!(
 //!     dt,
 //!     NaiveDate::from_ymd(2014, 7, 8)?
 //!         .at_hms_micro(9, 10, 11, 12_000)?
-//!         .and_utc()
+//!         .in_utc()
 //! );
 //! assert_eq!(
 //!     dt,
 //!     NaiveDate::from_ymd(2014, 7, 8)?
 //!         .at_hms_nano(9, 10, 11, 12_000_000)?
-//!         .and_utc()
+//!         .in_utc()
 //! );
 //!
 //! // dynamic verification
 //! assert_eq!(
 //!     Utc.at_ymd_and_hms(2014, 7, 8, 21, 15, 33),
 //!     MappedLocalTime::Single(
-//!         NaiveDate::from_ymd(2014, 7, 8)?.at_hms(21, 15, 33)?.and_utc()
+//!         NaiveDate::from_ymd(2014, 7, 8)?.at_hms(21, 15, 33)?.in_utc()
 //!     )
 //! );
 //! assert_eq!(Utc.at_ymd_and_hms(2014, 7, 8, 80, 15, 33), MappedLocalTime::None);
@@ -203,7 +203,7 @@
 //! assert_eq!(dt.timezone(), FixedOffset::east(9 * 3600)?);
 //! assert_eq!(
 //!     dt.with_timezone(&Utc),
-//!     NaiveDate::from_ymd(2014, 11, 28)?.at_hms_nano(12, 45, 59, 324310806)?.and_utc()
+//!     NaiveDate::from_ymd(2014, 11, 28)?.at_hms_nano(12, 45, 59, 324310806)?.in_utc()
 //! );
 //!
 //! // a sample of property manipulations (validates dynamically)
@@ -271,7 +271,7 @@
 //!
 //! // Note that milli/nanoseconds are only printed if they are non-zero
 //! let dt_nano =
-//!     NaiveDate::from_ymd(2014, 11, 28).unwrap().at_hms_nano(12, 0, 9, 1).unwrap().and_utc();
+//!     NaiveDate::from_ymd(2014, 11, 28).unwrap().at_hms_nano(12, 0, 9, 1).unwrap().in_utc();
 //! assert_eq!(format!("{:?}", dt_nano), "2014-11-28T12:00:09.000000001Z");
 //! # }
 //! # #[cfg(not(all(feature = "unstable-locales", feature = "alloc")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@
 //! use chrono::offset::MappedLocalTime;
 //! use chrono::prelude::*;
 //!
-//! let dt = Utc.with_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap(); // `2014-07-08T09:10:11Z`
+//! let dt = Utc.at_ymd_and_hms(2014, 7, 8, 9, 10, 11).unwrap(); // `2014-07-08T09:10:11Z`
 //! assert_eq!(
 //!     dt,
 //!     NaiveDate::from_ymd(2014, 7, 8)?
@@ -157,13 +157,13 @@
 //!
 //! // dynamic verification
 //! assert_eq!(
-//!     Utc.with_ymd_and_hms(2014, 7, 8, 21, 15, 33),
+//!     Utc.at_ymd_and_hms(2014, 7, 8, 21, 15, 33),
 //!     MappedLocalTime::Single(
 //!         NaiveDate::from_ymd(2014, 7, 8)?.and_hms(21, 15, 33)?.and_utc()
 //!     )
 //! );
-//! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 8, 80, 15, 33), MappedLocalTime::None);
-//! assert_eq!(Utc.with_ymd_and_hms(2014, 7, 38, 21, 15, 33), MappedLocalTime::None);
+//! assert_eq!(Utc.at_ymd_and_hms(2014, 7, 8, 80, 15, 33), MappedLocalTime::None);
+//! assert_eq!(Utc.at_ymd_and_hms(2014, 7, 38, 21, 15, 33), MappedLocalTime::None);
 //!
 //! # #[cfg(feature = "clock")] {
 //! // other time zone objects can be used to construct a local datetime.
@@ -214,17 +214,17 @@
 //! assert_eq!(dt.with_year(-300).unwrap().num_days_from_ce(), -109606); // November 29, 301 BCE
 //!
 //! // arithmetic operations
-//! let dt1 = Utc.with_ymd_and_hms(2014, 11, 14, 8, 9, 10).unwrap();
-//! let dt2 = Utc.with_ymd_and_hms(2014, 11, 14, 10, 9, 8).unwrap();
+//! let dt1 = Utc.at_ymd_and_hms(2014, 11, 14, 8, 9, 10).unwrap();
+//! let dt2 = Utc.at_ymd_and_hms(2014, 11, 14, 10, 9, 8).unwrap();
 //! assert_eq!(dt1.signed_duration_since(dt2), TimeDelta::seconds(-2 * 3600 + 2));
 //! assert_eq!(dt2.signed_duration_since(dt1), TimeDelta::seconds(2 * 3600 - 2));
 //! assert_eq!(
-//!     Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap() + TimeDelta::seconds(1_000_000_000),
-//!     Utc.with_ymd_and_hms(2001, 9, 9, 1, 46, 40).unwrap()
+//!     Utc.at_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap() + TimeDelta::seconds(1_000_000_000),
+//!     Utc.at_ymd_and_hms(2001, 9, 9, 1, 46, 40).unwrap()
 //! );
 //! assert_eq!(
-//!     Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap() - TimeDelta::seconds(1_000_000_000),
-//!     Utc.with_ymd_and_hms(1938, 4, 24, 22, 13, 20).unwrap()
+//!     Utc.at_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap() - TimeDelta::seconds(1_000_000_000),
+//!     Utc.at_ymd_and_hms(1938, 4, 24, 22, 13, 20).unwrap()
 //! );
 //! # Ok::<(), chrono::Error>(())
 //! ```
@@ -257,7 +257,7 @@
 //! # fn test() {
 //! use chrono::Locale;
 //!
-//! let dt = Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap();
+//! let dt = Utc.at_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap();
 //! assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2014-11-28 12:00:09");
 //! assert_eq!(dt.format("%a %b %e %T %Y").to_string(), "Fri Nov 28 12:00:09 2014");
 //! assert_eq!(
@@ -304,7 +304,7 @@
 //! ```rust
 //! use chrono::prelude::*;
 //!
-//! let dt = Utc.with_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap();
+//! let dt = Utc.at_ymd_and_hms(2014, 11, 28, 12, 0, 9).unwrap();
 //! let fixed_dt = dt.with_timezone(&FixedOffset::east(9 * 3600).unwrap());
 //!
 //! // method 1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,28 +130,28 @@
 //! assert_eq!(
 //!     dt,
 //!     NaiveDate::from_ymd(2014, 7, 8)?
-//!         .and_hms(9, 10, 11)?
+//!         .at_hms(9, 10, 11)?
 //!         .and_utc()
 //! );
 //!
 //! // July 8 is 188th day of the year 2014 (`o` for "ordinal")
-//! assert_eq!(dt, NaiveDate::from_yo(2014, 189).unwrap().and_hms(9, 10, 11).unwrap().and_utc());
+//! assert_eq!(dt, NaiveDate::from_yo(2014, 189).unwrap().at_hms(9, 10, 11).unwrap().and_utc());
 //! // July 8 is Tuesday in ISO week 28 of the year 2014.
-//! assert_eq!(dt, NaiveDate::from_isoywd(2014, 28, Weekday::Tue).unwrap().and_hms(9, 10, 11).unwrap().and_utc());
+//! assert_eq!(dt, NaiveDate::from_isoywd(2014, 28, Weekday::Tue).unwrap().at_hms(9, 10, 11).unwrap().and_utc());
 //!
 //! let dt = NaiveDate::from_ymd(2014, 7, 8)?
-//!     .and_hms_milli(9, 10, 11, 12)?
+//!     .at_hms_milli(9, 10, 11, 12)?
 //!     .and_utc(); // `2014-07-08T09:10:11.012Z`
 //! assert_eq!(
 //!     dt,
 //!     NaiveDate::from_ymd(2014, 7, 8)?
-//!         .and_hms_micro(9, 10, 11, 12_000)?
+//!         .at_hms_micro(9, 10, 11, 12_000)?
 //!         .and_utc()
 //! );
 //! assert_eq!(
 //!     dt,
 //!     NaiveDate::from_ymd(2014, 7, 8)?
-//!         .and_hms_nano(9, 10, 11, 12_000_000)?
+//!         .at_hms_nano(9, 10, 11, 12_000_000)?
 //!         .and_utc()
 //! );
 //!
@@ -159,7 +159,7 @@
 //! assert_eq!(
 //!     Utc.at_ymd_and_hms(2014, 7, 8, 21, 15, 33),
 //!     MappedLocalTime::Single(
-//!         NaiveDate::from_ymd(2014, 7, 8)?.and_hms(21, 15, 33)?.and_utc()
+//!         NaiveDate::from_ymd(2014, 7, 8)?.at_hms(21, 15, 33)?.and_utc()
 //!     )
 //! );
 //! assert_eq!(Utc.at_ymd_and_hms(2014, 7, 8, 80, 15, 33), MappedLocalTime::None);
@@ -168,8 +168,8 @@
 //! # #[cfg(feature = "clock")] {
 //! // other time zone objects can be used to construct a local datetime.
 //! // obviously, `local_dt` is normally different from `dt`, but `fixed_dt` should be identical.
-//! let local_dt = Local.from_local_datetime(NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_milli(9, 10, 11, 12).unwrap()).unwrap();
-//! let fixed_dt = FixedOffset::east(9 * 3600).unwrap().from_local_datetime(NaiveDate::from_ymd(2014, 7, 8).unwrap().and_hms_milli(18, 10, 11, 12).unwrap()).unwrap();
+//! let local_dt = Local.from_local_datetime(NaiveDate::from_ymd(2014, 7, 8).unwrap().at_hms_milli(9, 10, 11, 12).unwrap()).unwrap();
+//! let fixed_dt = FixedOffset::east(9 * 3600).unwrap().from_local_datetime(NaiveDate::from_ymd(2014, 7, 8).unwrap().at_hms_milli(18, 10, 11, 12).unwrap()).unwrap();
 //! assert_eq!(dt, fixed_dt);
 //! # let _ = local_dt;
 //! # }
@@ -186,9 +186,7 @@
 //!
 //! // assume this returned `2014-11-28T21:45:59.324310806+09:00`:
 //! let dt = FixedOffset::east(9 * 3600)?
-//!     .from_local_datetime(
-//!         NaiveDate::from_ymd(2014, 11, 28)?.and_hms_nano(21, 45, 59, 324310806)?,
-//!     )
+//!     .from_local_datetime(NaiveDate::from_ymd(2014, 11, 28)?.at_hms_nano(21, 45, 59, 324310806)?)
 //!     .unwrap();
 //!
 //! // property accessors
@@ -205,7 +203,7 @@
 //! assert_eq!(dt.timezone(), FixedOffset::east(9 * 3600)?);
 //! assert_eq!(
 //!     dt.with_timezone(&Utc),
-//!     NaiveDate::from_ymd(2014, 11, 28)?.and_hms_nano(12, 45, 59, 324310806)?.and_utc()
+//!     NaiveDate::from_ymd(2014, 11, 28)?.at_hms_nano(12, 45, 59, 324310806)?.and_utc()
 //! );
 //!
 //! // a sample of property manipulations (validates dynamically)
@@ -272,11 +270,8 @@
 //! assert_eq!(format!("{:?}", dt), "2014-11-28T12:00:09Z");
 //!
 //! // Note that milli/nanoseconds are only printed if they are non-zero
-//! let dt_nano = NaiveDate::from_ymd(2014, 11, 28)
-//!     .unwrap()
-//!     .and_hms_nano(12, 0, 9, 1)
-//!     .unwrap()
-//!     .and_utc();
+//! let dt_nano =
+//!     NaiveDate::from_ymd(2014, 11, 28).unwrap().at_hms_nano(12, 0, 9, 1).unwrap().and_utc();
 //! assert_eq!(format!("{:?}", dt_nano), "2014-11-28T12:00:09.000000001Z");
 //! # }
 //! # #[cfg(not(all(feature = "unstable-locales", feature = "alloc")))]

--- a/src/month.rs
+++ b/src/month.rs
@@ -15,7 +15,7 @@ use crate::OutOfRange;
 /// use chrono::prelude::*;
 /// use chrono::Month;
 ///
-/// let date = Utc.with_ymd_and_hms(2019, 10, 28, 9, 10, 11).unwrap();
+/// let date = Utc.at_ymd_and_hms(2019, 10, 28, 9, 10, 11).unwrap();
 /// // `2019-10-28T09:10:11Z`
 /// let month = Month::try_from(u8::try_from(date.month()).unwrap()).ok();
 /// assert_eq!(month, Some(Month::October))
@@ -25,7 +25,7 @@ use crate::OutOfRange;
 /// # use chrono::prelude::*;
 /// # use chrono::Month;
 /// let month = Month::January;
-/// let dt = Utc.with_ymd_and_hms(2019, month.number_from_month(), 28, 9, 10, 11).unwrap();
+/// let dt = Utc.at_ymd_and_hms(2019, month.number_from_month(), 28, 9, 10, 11).unwrap();
 /// assert_eq!((dt.year(), dt.month(), dt.day()), (2019, 1, 28));
 /// ```
 /// Allows mapping from and to month, from 1-January to 12-December.
@@ -282,11 +282,11 @@ mod tests {
         assert_eq!(Month::try_from(12), Ok(Month::December));
         assert_eq!(Month::try_from(13), Err(OutOfRange::new()));
 
-        let date = Utc.with_ymd_and_hms(2019, 10, 28, 9, 10, 11).unwrap();
+        let date = Utc.at_ymd_and_hms(2019, 10, 28, 9, 10, 11).unwrap();
         assert_eq!(Month::try_from(date.month() as u8), Ok(Month::October));
 
         let month = Month::January;
-        let dt = Utc.with_ymd_and_hms(2019, month.number_from_month(), 28, 9, 10, 11).unwrap();
+        let dt = Utc.at_ymd_and_hms(2019, month.number_from_month(), 28, 9, 10, 11).unwrap();
         assert_eq!((dt.year(), dt.month(), dt.day()), (2019, 1, 28));
     }
 

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -636,7 +636,7 @@ impl NaiveDate {
     /// Makes a new `NaiveDateTime` from the current date, hour, minute and second.
     ///
     /// No [leap second](./struct.NaiveTime.html#leap-second-handling) is allowed here;
-    /// use `NaiveDate::and_hms_*` methods with a subsecond parameter instead.
+    /// use `NaiveDate::at_hms_*` methods with a subsecond parameter instead.
     ///
     /// # Errors
     ///
@@ -648,13 +648,13 @@ impl NaiveDate {
     /// use chrono::{Error, NaiveDate};
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3).unwrap();
-    /// assert!(d.and_hms(12, 34, 56).is_ok());
-    /// assert_eq!(d.and_hms(12, 34, 60), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms(12, 60, 56), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms(24, 34, 56), Err(Error::InvalidArgument));
+    /// assert!(d.at_hms(12, 34, 56).is_ok());
+    /// assert_eq!(d.at_hms(12, 34, 60), Err(Error::InvalidArgument));
+    /// assert_eq!(d.at_hms(12, 60, 56), Err(Error::InvalidArgument));
+    /// assert_eq!(d.at_hms(24, 34, 56), Err(Error::InvalidArgument));
     /// ```
     #[inline]
-    pub const fn and_hms(self, hour: u32, min: u32, sec: u32) -> Result<NaiveDateTime, Error> {
+    pub const fn at_hms(self, hour: u32, min: u32, sec: u32) -> Result<NaiveDateTime, Error> {
         let time = try_err!(NaiveTime::from_hms(hour, min, sec));
         Ok(self.and_time(time))
     }
@@ -677,15 +677,15 @@ impl NaiveDate {
     /// use chrono::{Error, NaiveDate};
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3).unwrap();
-    /// assert!(d.and_hms_milli(12, 34, 56, 789).is_ok());
-    /// assert!(d.and_hms_milli(12, 34, 59, 1_789).is_ok()); // leap second
-    /// assert_eq!(d.and_hms_milli(12, 34, 59, 2_789), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_milli(12, 34, 60, 789), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_milli(12, 60, 56, 789), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_milli(24, 34, 56, 789), Err(Error::InvalidArgument));
+    /// assert!(d.at_hms_milli(12, 34, 56, 789).is_ok());
+    /// assert!(d.at_hms_milli(12, 34, 59, 1_789).is_ok()); // leap second
+    /// assert_eq!(d.at_hms_milli(12, 34, 59, 2_789), Err(Error::InvalidArgument));
+    /// assert_eq!(d.at_hms_milli(12, 34, 60, 789), Err(Error::InvalidArgument));
+    /// assert_eq!(d.at_hms_milli(12, 60, 56, 789), Err(Error::InvalidArgument));
+    /// assert_eq!(d.at_hms_milli(24, 34, 56, 789), Err(Error::InvalidArgument));
     /// ```
     #[inline]
-    pub const fn and_hms_milli(
+    pub const fn at_hms_milli(
         &self,
         hour: u32,
         min: u32,
@@ -714,15 +714,15 @@ impl NaiveDate {
     /// use chrono::{Error, NaiveDate};
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3).unwrap();
-    /// assert!(d.and_hms_micro(12, 34, 56, 789_012).is_ok());
-    /// assert!(d.and_hms_micro(12, 34, 59, 1_789_012).is_ok()); // leap second
-    /// assert_eq!(d.and_hms_micro(12, 34, 59, 2_789_012), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_micro(12, 34, 60, 789_012), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_micro(12, 60, 56, 789_012), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_micro(24, 34, 56, 789_012), Err(Error::InvalidArgument));
+    /// assert!(d.at_hms_micro(12, 34, 56, 789_012).is_ok());
+    /// assert!(d.at_hms_micro(12, 34, 59, 1_789_012).is_ok()); // leap second
+    /// assert_eq!(d.at_hms_micro(12, 34, 59, 2_789_012), Err(Error::InvalidArgument));
+    /// assert_eq!(d.at_hms_micro(12, 34, 60, 789_012), Err(Error::InvalidArgument));
+    /// assert_eq!(d.at_hms_micro(12, 60, 56, 789_012), Err(Error::InvalidArgument));
+    /// assert_eq!(d.at_hms_micro(24, 34, 56, 789_012), Err(Error::InvalidArgument));
     /// ```
     #[inline]
-    pub const fn and_hms_micro(
+    pub const fn at_hms_micro(
         &self,
         hour: u32,
         min: u32,
@@ -751,15 +751,15 @@ impl NaiveDate {
     /// use chrono::{Error, NaiveDate};
     ///
     /// let d = NaiveDate::from_ymd(2015, 6, 3).unwrap();
-    /// assert!(d.and_hms_nano(12, 34, 56, 789_012_345).is_ok());
-    /// assert!(d.and_hms_nano(12, 34, 59, 1_789_012_345).is_ok()); // leap second
-    /// assert_eq!(d.and_hms_nano(12, 34, 59, 2_789_012_345), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_nano(12, 34, 60, 789_012_345), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_nano(12, 60, 56, 789_012_345), Err(Error::InvalidArgument));
-    /// assert_eq!(d.and_hms_nano(24, 34, 56, 789_012_345), Err(Error::InvalidArgument));
+    /// assert!(d.at_hms_nano(12, 34, 56, 789_012_345).is_ok());
+    /// assert!(d.at_hms_nano(12, 34, 59, 1_789_012_345).is_ok()); // leap second
+    /// assert_eq!(d.at_hms_nano(12, 34, 59, 2_789_012_345), Err(Error::InvalidArgument));
+    /// assert_eq!(d.at_hms_nano(12, 34, 60, 789_012_345), Err(Error::InvalidArgument));
+    /// assert_eq!(d.at_hms_nano(12, 60, 56, 789_012_345), Err(Error::InvalidArgument));
+    /// assert_eq!(d.at_hms_nano(24, 34, 56, 789_012_345), Err(Error::InvalidArgument));
     /// ```
     #[inline]
-    pub const fn and_hms_nano(
+    pub const fn at_hms_nano(
         &self,
         hour: u32,
         min: u32,

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -623,13 +623,13 @@ impl NaiveDate {
     /// let d = NaiveDate::from_ymd(2015, 6, 3).unwrap();
     /// let t = NaiveTime::from_hms_milli(12, 34, 56, 789).unwrap();
     ///
-    /// let dt: NaiveDateTime = d.and_time(t);
+    /// let dt: NaiveDateTime = d.at(t);
     /// assert_eq!(dt.date(), d);
     /// assert_eq!(dt.time(), t);
     /// ```
     #[inline]
     #[must_use]
-    pub const fn and_time(self, time: NaiveTime) -> NaiveDateTime {
+    pub const fn at(self, time: NaiveTime) -> NaiveDateTime {
         NaiveDateTime::new(self, time)
     }
 
@@ -656,7 +656,7 @@ impl NaiveDate {
     #[inline]
     pub const fn at_hms(self, hour: u32, min: u32, sec: u32) -> Result<NaiveDateTime, Error> {
         let time = try_err!(NaiveTime::from_hms(hour, min, sec));
-        Ok(self.and_time(time))
+        Ok(self.at(time))
     }
 
     /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and millisecond.
@@ -693,7 +693,7 @@ impl NaiveDate {
         milli: u32,
     ) -> Result<NaiveDateTime, Error> {
         let time = try_err!(NaiveTime::from_hms_milli(hour, min, sec, milli));
-        Ok(self.and_time(time))
+        Ok(self.at(time))
     }
 
     /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and microsecond.
@@ -730,7 +730,7 @@ impl NaiveDate {
         micro: u32,
     ) -> Result<NaiveDateTime, Error> {
         let time = try_err!(NaiveTime::from_hms_micro(hour, min, sec, micro));
-        Ok(self.and_time(time))
+        Ok(self.at(time))
     }
 
     /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and nanosecond.
@@ -767,7 +767,7 @@ impl NaiveDate {
         nano: u32,
     ) -> Result<NaiveDateTime, Error> {
         let time = try_err!(NaiveTime::from_hms_nano(hour, min, sec, nano));
-        Ok(self.and_time(time))
+        Ok(self.at(time))
     }
 
     /// Returns the packed month-day-flags.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -71,7 +71,7 @@ pub struct NaiveDateTime {
 
 impl NaiveDateTime {
     /// Makes a new `NaiveDateTime` from date and time components.
-    /// Equivalent to [`date.and_time(time)`](./struct.NaiveDate.html#method.and_time)
+    /// Equivalent to [`date.at(time)`](./struct.NaiveDate.html#method.at)
     /// and many other helper constructors on `NaiveDate`.
     ///
     /// # Example
@@ -939,7 +939,7 @@ impl NaiveDateTime {
 
     /// The Unix Epoch, 1970-01-01 00:00:00.
     pub const UNIX_EPOCH: Self =
-        expect(ok!(NaiveDate::from_ymd(1970, 1, 1)), "").and_time(NaiveTime::MIN);
+        expect(ok!(NaiveDate::from_ymd(1970, 1, 1)), "").at(NaiveTime::MIN);
 }
 
 impl From<NaiveDate> for NaiveDateTime {

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -40,7 +40,7 @@ mod tests;
 /// ```
 /// use chrono::{NaiveDate, NaiveDateTime};
 ///
-/// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms(9, 10, 11).unwrap();
+/// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 7, 8).unwrap().at_hms(9, 10, 11).unwrap();
 /// # let _ = dt;
 /// ```
 ///
@@ -49,7 +49,7 @@ mod tests;
 ///
 /// ```
 /// # use chrono::{NaiveDate, NaiveDateTime};
-/// # let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms(9, 10, 11).unwrap();
+/// # let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 7, 8).unwrap().at_hms(9, 10, 11).unwrap();
 /// use chrono::{Datelike, Timelike, Weekday};
 ///
 /// assert_eq!(dt.weekday(), Weekday::Fri);
@@ -104,11 +104,11 @@ impl NaiveDateTime {
     ///
     /// assert_eq!(
     ///     parse_from_str("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S"),
-    ///     Ok(NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms(23, 56, 4).unwrap())
+    ///     Ok(NaiveDate::from_ymd(2015, 9, 5).unwrap().at_hms(23, 56, 4).unwrap())
     /// );
     /// assert_eq!(
     ///     parse_from_str("5sep2015pm012345.6789", "%d%b%Y%p%I%M%S%.f"),
-    ///     Ok(NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms_micro(13, 23, 45, 678_900).unwrap())
+    ///     Ok(NaiveDate::from_ymd(2015, 9, 5).unwrap().at_hms_micro(13, 23, 45, 678_900).unwrap())
     /// );
     /// ```
     ///
@@ -119,7 +119,7 @@ impl NaiveDateTime {
     /// # let parse_from_str = NaiveDateTime::parse_from_str;
     /// assert_eq!(
     ///     parse_from_str("2014-5-17T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
-    ///     Ok(NaiveDate::from_ymd(2014, 5, 17).unwrap().and_hms(12, 34, 56).unwrap())
+    ///     Ok(NaiveDate::from_ymd(2014, 5, 17).unwrap().at_hms(12, 34, 56).unwrap())
     /// );
     /// ```
     ///
@@ -132,7 +132,7 @@ impl NaiveDateTime {
     /// # let parse_from_str = NaiveDateTime::parse_from_str;
     /// assert_eq!(
     ///     parse_from_str("2015-07-01 08:59:60.123", "%Y-%m-%d %H:%M:%S%.f"),
-    ///     Ok(NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_milli(8, 59, 59, 1_123).unwrap())
+    ///     Ok(NaiveDate::from_ymd(2015, 7, 1).unwrap().at_hms_milli(8, 59, 59, 1_123).unwrap())
     /// );
     /// ```
     ///
@@ -144,7 +144,7 @@ impl NaiveDateTime {
     /// # let parse_from_str = NaiveDateTime::parse_from_str;
     /// assert_eq!(
     ///     parse_from_str("94/9/4 7:15", "%y/%m/%d %H:%M"),
-    ///     Ok(NaiveDate::from_ymd(1994, 9, 4).unwrap().and_hms(7, 15, 0).unwrap())
+    ///     Ok(NaiveDate::from_ymd(1994, 9, 4).unwrap().at_hms(7, 15, 0).unwrap())
     /// );
     ///
     /// assert!(parse_from_str("04m33s", "%Mm%Ss").is_err());
@@ -194,7 +194,7 @@ impl NaiveDateTime {
     ///     "%Y-%m-%d %H:%M:%S",
     /// )
     /// .unwrap();
-    /// assert_eq!(datetime, NaiveDate::from_ymd(2015, 2, 18).unwrap().and_hms(23, 16, 9).unwrap());
+    /// assert_eq!(datetime, NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms(23, 16, 9).unwrap());
     /// assert_eq!(remainder, " trailing text");
     /// ```
     pub fn parse_and_remainder<'a>(s: &'a str, fmt: &str) -> ParseResult<(NaiveDateTime, &'a str)> {
@@ -210,7 +210,7 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms(9, 10, 11).unwrap();
+    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().at_hms(9, 10, 11).unwrap();
     /// assert_eq!(dt.date(), NaiveDate::from_ymd(2016, 7, 8).unwrap());
     /// ```
     #[inline]
@@ -225,7 +225,7 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{NaiveDate, NaiveTime};
     ///
-    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms(9, 10, 11).unwrap();
+    /// let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().at_hms(9, 10, 11).unwrap();
     /// assert_eq!(dt.time(), NaiveTime::from_hms(9, 10, 11).unwrap());
     /// ```
     #[inline]
@@ -250,17 +250,17 @@ impl NaiveDateTime {
     /// use chrono::{NaiveDate, TimeDelta};
     ///
     /// let d = NaiveDate::from_ymd(2016, 7, 8)?;
-    /// let hms = |h, m, s| d.and_hms(h, m, s);
+    /// let hms = |h, m, s| d.at_hms(h, m, s);
     /// assert_eq!(hms(3, 5, 7)?.checked_add_signed(TimeDelta::zero()), hms(3, 5, 7));
     /// assert_eq!(hms(3, 5, 7)?.checked_add_signed(TimeDelta::seconds(1)), hms(3, 5, 8));
     /// assert_eq!(hms(3, 5, 7)?.checked_add_signed(TimeDelta::seconds(-1)), hms(3, 5, 6));
     /// assert_eq!(hms(3, 5, 7)?.checked_add_signed(TimeDelta::seconds(3600 + 60)), hms(4, 6, 7));
     /// assert_eq!(
     ///     hms(3, 5, 7)?.checked_add_signed(TimeDelta::seconds(86_400)),
-    ///     NaiveDate::from_ymd(2016, 7, 9)?.and_hms(3, 5, 7)
+    ///     NaiveDate::from_ymd(2016, 7, 9)?.at_hms(3, 5, 7)
     /// );
     ///
-    /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli);
+    /// let hmsm = |h, m, s, milli| d.at_hms_milli(h, m, s, milli);
     /// assert_eq!(
     ///     hmsm(3, 5, 7, 980)?.checked_add_signed(TimeDelta::milliseconds(450).unwrap()),
     ///     hmsm(3, 5, 8, 430)
@@ -273,7 +273,7 @@ impl NaiveDateTime {
     /// ```
     /// # use chrono::{Error, NaiveDate, TimeDelta};
     /// # let d = NaiveDate::from_ymd(2016, 7, 8)?;
-    /// # let hms = |h, m, s| d.and_hms(h, m, s);
+    /// # let hms = |h, m, s| d.at_hms(h, m, s);
     /// assert_eq!(
     ///     hms(3, 5, 7)?.checked_add_signed(TimeDelta::days(1_000_000_000)),
     ///     Err(Error::OutOfRange)
@@ -287,7 +287,7 @@ impl NaiveDateTime {
     /// ```
     /// # use chrono::{NaiveDate, TimeDelta};
     /// # let d = NaiveDate::from_ymd(2016, 7, 8)?;
-    /// # let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli);
+    /// # let hmsm = |h, m, s, milli| d.at_hms_milli(h, m, s, milli);
     /// let leap = hmsm(3, 5, 59, 1_300)?;
     /// assert_eq!(leap.checked_add_signed(TimeDelta::zero()), hmsm(3, 5, 59, 1_300));
     /// assert_eq!(
@@ -303,7 +303,7 @@ impl NaiveDateTime {
     /// assert_eq!(leap.checked_add_signed(TimeDelta::seconds(-10)), hmsm(3, 5, 50, 300));
     /// assert_eq!(
     ///     leap.checked_add_signed(TimeDelta::days(1)),
-    ///     NaiveDate::from_ymd(2016, 7, 9)?.and_hms_milli(3, 5, 59, 300)
+    ///     NaiveDate::from_ymd(2016, 7, 9)?.at_hms_milli(3, 5, 59, 300)
     /// );
     /// # Ok::<(), chrono::Error>(())
     /// ```
@@ -330,16 +330,16 @@ impl NaiveDateTime {
     /// assert_eq!(
     ///     NaiveDate::from_ymd(2014, 1, 1)
     ///         .unwrap()
-    ///         .and_hms(1, 0, 0)
+    ///         .at_hms(1, 0, 0)
     ///         .unwrap()
     ///         .checked_add_months(Months::new(1)),
-    ///     Some(NaiveDate::from_ymd(2014, 2, 1).unwrap().and_hms(1, 0, 0).unwrap())
+    ///     Some(NaiveDate::from_ymd(2014, 2, 1).unwrap().at_hms(1, 0, 0).unwrap())
     /// );
     ///
     /// assert_eq!(
     ///     NaiveDate::from_ymd(2014, 1, 1)
     ///         .unwrap()
-    ///         .and_hms(1, 0, 0)
+    ///         .at_hms(1, 0, 0)
     ///         .unwrap()
     ///         .checked_add_months(Months::new(core::i32::MAX as u32 + 1)),
     ///     None
@@ -438,17 +438,17 @@ impl NaiveDateTime {
     /// use chrono::{NaiveDate, TimeDelta};
     ///
     /// let d = NaiveDate::from_ymd(2016, 7, 8)?;
-    /// let hms = |h, m, s| d.and_hms(h, m, s);
+    /// let hms = |h, m, s| d.at_hms(h, m, s);
     /// assert_eq!(hms(3, 5, 7)?.checked_sub_signed(TimeDelta::zero()), hms(3, 5, 7));
     /// assert_eq!(hms(3, 5, 7)?.checked_sub_signed(TimeDelta::seconds(1)), hms(3, 5, 6));
     /// assert_eq!(hms(3, 5, 7)?.checked_sub_signed(TimeDelta::seconds(-1)), hms(3, 5, 8));
     /// assert_eq!(hms(3, 5, 7)?.checked_sub_signed(TimeDelta::seconds(3600 + 60)), hms(2, 4, 7));
     /// assert_eq!(
     ///     hms(3, 5, 7)?.checked_sub_signed(TimeDelta::seconds(86_400)),
-    ///     NaiveDate::from_ymd(2016, 7, 7)?.and_hms(3, 5, 7)
+    ///     NaiveDate::from_ymd(2016, 7, 7)?.at_hms(3, 5, 7)
     /// );
     ///
-    /// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli);
+    /// let hmsm = |h, m, s, milli| d.at_hms_milli(h, m, s, milli);
     /// assert_eq!(
     ///     hmsm(3, 5, 7, 450)?.checked_sub_signed(TimeDelta::milliseconds(670).unwrap()),
     ///     hmsm(3, 5, 6, 780)
@@ -461,7 +461,7 @@ impl NaiveDateTime {
     /// ```
     /// # use chrono::{Error, NaiveDate, TimeDelta};
     /// # let d = NaiveDate::from_ymd(2016, 7, 8)?;
-    /// # let hms = |h, m, s| d.and_hms(h, m, s);
+    /// # let hms = |h, m, s| d.at_hms(h, m, s);
     /// assert_eq!(
     ///     hms(3, 5, 7)?.checked_sub_signed(TimeDelta::days(1_000_000_000)),
     ///     Err(Error::OutOfRange)
@@ -475,7 +475,7 @@ impl NaiveDateTime {
     /// ```
     /// # use chrono::{NaiveDate, TimeDelta};
     /// # let d = NaiveDate::from_ymd(2016, 7, 8)?;
-    /// # let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli);
+    /// # let hmsm = |h, m, s, milli| d.at_hms_milli(h, m, s, milli);
     /// let leap = hmsm(3, 5, 59, 1_300)?;
     /// assert_eq!(leap.checked_sub_signed(TimeDelta::zero()), hmsm(3, 5, 59, 1_300));
     /// assert_eq!(
@@ -486,7 +486,7 @@ impl NaiveDateTime {
     /// assert_eq!(leap.checked_sub_signed(TimeDelta::seconds(60)), hmsm(3, 5, 0, 300));
     /// assert_eq!(
     ///     leap.checked_sub_signed(TimeDelta::days(1)),
-    ///     NaiveDate::from_ymd(2016, 7, 7)?.and_hms_milli(3, 6, 0, 300)
+    ///     NaiveDate::from_ymd(2016, 7, 7)?.at_hms_milli(3, 6, 0, 300)
     /// );
     /// # Ok::<(), chrono::Error>(())
     /// ```
@@ -513,16 +513,16 @@ impl NaiveDateTime {
     /// assert_eq!(
     ///     NaiveDate::from_ymd(2014, 1, 1)
     ///         .unwrap()
-    ///         .and_hms(1, 0, 0)
+    ///         .at_hms(1, 0, 0)
     ///         .unwrap()
     ///         .checked_sub_months(Months::new(1)),
-    ///     Some(NaiveDate::from_ymd(2013, 12, 1).unwrap().and_hms(1, 0, 0).unwrap())
+    ///     Some(NaiveDate::from_ymd(2013, 12, 1).unwrap().at_hms(1, 0, 0).unwrap())
     /// );
     ///
     /// assert_eq!(
     ///     NaiveDate::from_ymd(2014, 1, 1)
     ///         .unwrap()
-    ///         .and_hms(1, 0, 0)
+    ///         .at_hms(1, 0, 0)
     ///         .unwrap()
     ///         .checked_sub_months(Months::new(core::i32::MAX as u32 + 1)),
     ///     None
@@ -565,14 +565,14 @@ impl NaiveDateTime {
     ///
     /// let d = from_ymd(2016, 7, 8);
     /// assert_eq!(
-    ///     d.and_hms(3, 5, 7).unwrap().signed_duration_since(d.and_hms(2, 4, 6).unwrap()),
+    ///     d.at_hms(3, 5, 7).unwrap().signed_duration_since(d.at_hms(2, 4, 6).unwrap()),
     ///     TimeDelta::seconds(3600 + 60 + 1)
     /// );
     ///
     /// // July 8 is 190th day in the year 2016
     /// let d0 = from_ymd(2016, 1, 1);
     /// assert_eq!(
-    ///     d.and_hms_milli(0, 7, 6, 500).unwrap().signed_duration_since(d0.and_hms(0, 0, 0).unwrap()),
+    ///     d.at_hms_milli(0, 7, 6, 500).unwrap().signed_duration_since(d0.at_hms(0, 0, 0).unwrap()),
     ///     TimeDelta::seconds(189 * 86_400 + 7 * 60 + 6) + TimeDelta::milliseconds(500).unwrap()
     /// );
     /// ```
@@ -583,13 +583,13 @@ impl NaiveDateTime {
     /// ```
     /// # use chrono::{TimeDelta, NaiveDate};
     /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
-    /// let leap = from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500).unwrap();
+    /// let leap = from_ymd(2015, 6, 30).at_hms_milli(23, 59, 59, 1_500).unwrap();
     /// assert_eq!(
-    ///     leap.signed_duration_since(from_ymd(2015, 6, 30).and_hms(23, 0, 0).unwrap()),
+    ///     leap.signed_duration_since(from_ymd(2015, 6, 30).at_hms(23, 0, 0).unwrap()),
     ///     TimeDelta::seconds(3600) + TimeDelta::milliseconds(500).unwrap()
     /// );
     /// assert_eq!(
-    ///     from_ymd(2015, 7, 1).and_hms(1, 0, 0).unwrap().signed_duration_since(leap),
+    ///     from_ymd(2015, 7, 1).at_hms(1, 0, 0).unwrap().signed_duration_since(leap),
     ///     TimeDelta::seconds(3600) - TimeDelta::milliseconds(500).unwrap()
     /// );
     /// ```
@@ -616,7 +616,7 @@ impl NaiveDateTime {
     /// use chrono::NaiveDate;
     ///
     /// let fmt = StrftimeItems::new("%Y-%m-%d %H:%M:%S");
-    /// let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms(23, 56, 4).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().at_hms(23, 56, 4).unwrap();
     /// assert_eq!(dt.format_with_items(fmt.clone()).to_string(), "2015-09-05 23:56:04");
     /// assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2015-09-05 23:56:04");
     /// ```
@@ -627,7 +627,7 @@ impl NaiveDateTime {
     /// # use chrono::NaiveDate;
     /// # use chrono::format::strftime::StrftimeItems;
     /// # let fmt = StrftimeItems::new("%Y-%m-%d %H:%M:%S").clone();
-    /// # let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms(23, 56, 4).unwrap();
+    /// # let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().at_hms(23, 56, 4).unwrap();
     /// assert_eq!(format!("{}", dt.format_with_items(fmt)), "2015-09-05 23:56:04");
     /// ```
     #[cfg(feature = "alloc")]
@@ -660,7 +660,7 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::NaiveDate;
     ///
-    /// let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms(23, 56, 4).unwrap();
+    /// let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().at_hms(23, 56, 4).unwrap();
     /// assert_eq!(dt.format("%Y-%m-%d %H:%M:%S").to_string(), "2015-09-05 23:56:04");
     /// assert_eq!(dt.format("around %l %p on %b %-d").to_string(), "around 11 PM on Sep 5");
     /// ```
@@ -669,7 +669,7 @@ impl NaiveDateTime {
     ///
     /// ```
     /// # use chrono::NaiveDate;
-    /// # let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().and_hms(23, 56, 4).unwrap();
+    /// # let dt = NaiveDate::from_ymd(2015, 9, 5).unwrap().at_hms(23, 56, 4).unwrap();
     /// assert_eq!(format!("{}", dt.format("%Y-%m-%d %H:%M:%S")), "2015-09-05 23:56:04");
     /// assert_eq!(format!("{}", dt.format("around %l %p on %b %-d")), "around 11 PM on Sep 5");
     /// ```
@@ -691,7 +691,7 @@ impl NaiveDateTime {
     /// let tz = FixedOffset::east(5 * hour).unwrap();
     /// let dt = NaiveDate::from_ymd(2015, 9, 5)
     ///     .unwrap()
-    ///     .and_hms(23, 56, 4)
+    ///     .at_hms(23, 56, 4)
     ///     .unwrap()
     ///     .and_local_timezone(tz)
     ///     .unwrap();
@@ -708,7 +708,7 @@ impl NaiveDateTime {
     ///
     /// ```
     /// use chrono::{NaiveDate, Utc};
-    /// let dt = NaiveDate::from_ymd(2023, 1, 30).unwrap().and_hms(19, 32, 33).unwrap().and_utc();
+    /// let dt = NaiveDate::from_ymd(2023, 1, 30).unwrap().at_hms(19, 32, 33).unwrap().and_utc();
     /// assert_eq!(dt.timezone(), Utc);
     /// ```
     #[must_use]
@@ -731,9 +731,9 @@ impl NaiveDateTime {
     ///
     /// ```
     /// # use chrono::{NaiveDate, NaiveDateTime, Error};
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25)?.and_hms(12, 34, 56)?;
-    /// assert_eq!(dt.with_year(2016), NaiveDate::from_ymd(2016, 9, 25)?.and_hms(12, 34, 56));
-    /// assert_eq!(dt.with_year(-308), NaiveDate::from_ymd(-308, 9, 25)?.and_hms(12, 34, 56));
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25)?.at_hms(12, 34, 56)?;
+    /// assert_eq!(dt.with_year(2016), NaiveDate::from_ymd(2016, 9, 25)?.at_hms(12, 34, 56));
+    /// assert_eq!(dt.with_year(-308), NaiveDate::from_ymd(-308, 9, 25)?.at_hms(12, 34, 56));
     /// # Ok::<(), Error>(())
     /// ```
     #[inline]
@@ -759,8 +759,8 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{Error, NaiveDate, NaiveDateTime};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 30)?.and_hms(12, 34, 56)?;
-    /// assert_eq!(dt.with_month(10), NaiveDate::from_ymd(2015, 10, 30)?.and_hms(12, 34, 56));
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 30)?.at_hms(12, 34, 56)?;
+    /// assert_eq!(dt.with_month(10), NaiveDate::from_ymd(2015, 10, 30)?.at_hms(12, 34, 56));
     /// assert_eq!(dt.with_month(13), Err(Error::InvalidArgument));
     /// assert_eq!(dt.with_month(2), Err(Error::DoesNotExist)); // No February 30
     /// # Ok::<(), Error>(())
@@ -786,8 +786,8 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{Error, NaiveDate, NaiveDateTime};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8)?.and_hms(12, 34, 56)?;
-    /// assert_eq!(dt.with_day(30), NaiveDate::from_ymd(2015, 9, 30)?.and_hms(12, 34, 56));
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8)?.at_hms(12, 34, 56)?;
+    /// assert_eq!(dt.with_day(30), NaiveDate::from_ymd(2015, 9, 30)?.at_hms(12, 34, 56));
     /// assert_eq!(dt.with_day(31), Err(Error::DoesNotExist)); // No September 31
     /// # Ok::<(), Error>(())
     /// ```
@@ -812,13 +812,13 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{Error, NaiveDate, NaiveDateTime};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8)?.and_hms(12, 34, 56)?;
-    /// assert_eq!(dt.with_ordinal(60), NaiveDate::from_ymd(2015, 3, 1)?.and_hms(12, 34, 56));
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8)?.at_hms(12, 34, 56)?;
+    /// assert_eq!(dt.with_ordinal(60), NaiveDate::from_ymd(2015, 3, 1)?.at_hms(12, 34, 56));
     /// assert_eq!(dt.with_ordinal(366), Err(Error::DoesNotExist)); // 2015 had only 365 days
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 9, 8)?.and_hms(12, 34, 56)?;
-    /// assert_eq!(dt.with_ordinal(60), NaiveDate::from_ymd(2016, 2, 29)?.and_hms(12, 34, 56));
-    /// assert_eq!(dt.with_ordinal(366), NaiveDate::from_ymd(2016, 12, 31)?.and_hms(12, 34, 56));
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 9, 8)?.at_hms(12, 34, 56)?;
+    /// assert_eq!(dt.with_ordinal(60), NaiveDate::from_ymd(2016, 2, 29)?.at_hms(12, 34, 56));
+    /// assert_eq!(dt.with_ordinal(366), NaiveDate::from_ymd(2016, 12, 31)?.at_hms(12, 34, 56));
     /// # Ok::<(), Error>(())
     /// ```
     #[inline]
@@ -839,8 +839,8 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{Error, NaiveDate};
     ///
-    /// let dt = NaiveDate::from_ymd(2015, 9, 8)?.and_hms_milli(12, 34, 56, 789)?;
-    /// assert_eq!(dt.with_hour(7), NaiveDate::from_ymd(2015, 9, 8)?.and_hms_milli(7, 34, 56, 789));
+    /// let dt = NaiveDate::from_ymd(2015, 9, 8)?.at_hms_milli(12, 34, 56, 789)?;
+    /// assert_eq!(dt.with_hour(7), NaiveDate::from_ymd(2015, 9, 8)?.at_hms_milli(7, 34, 56, 789));
     /// assert_eq!(dt.with_hour(24), Err(Error::InvalidArgument));
     /// # Ok::<(), chrono::Error>(())
     /// ```
@@ -862,8 +862,8 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{Error, NaiveDate};
     ///
-    /// let dt = NaiveDate::from_ymd(2015, 9, 8)?.and_hms_milli(12, 34, 56, 789)?;
-    /// assert_eq!(dt.with_minute(45), NaiveDate::from_ymd(2015, 9, 8)?.and_hms_milli(12, 45, 56, 789));
+    /// let dt = NaiveDate::from_ymd(2015, 9, 8)?.at_hms_milli(12, 34, 56, 789)?;
+    /// assert_eq!(dt.with_minute(45), NaiveDate::from_ymd(2015, 9, 8)?.at_hms_milli(12, 45, 56, 789));
     /// assert_eq!(dt.with_minute(60), Err(Error::InvalidArgument));
     /// # Ok::<(), chrono::Error>(())
     /// ```
@@ -888,8 +888,8 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{Error, NaiveDate};
     ///
-    /// let dt = NaiveDate::from_ymd(2015, 9, 8)?.and_hms_milli(12, 34, 56, 789)?;
-    /// assert_eq!(dt.with_second(17), NaiveDate::from_ymd(2015, 9, 8)?.and_hms_milli(12, 34, 17, 789));
+    /// let dt = NaiveDate::from_ymd(2015, 9, 8)?.at_hms_milli(12, 34, 56, 789)?;
+    /// assert_eq!(dt.with_second(17), NaiveDate::from_ymd(2015, 9, 8)?.at_hms_milli(12, 34, 17, 789));
     /// assert_eq!(dt.with_second(60), Err(Error::InvalidArgument));
     /// # Ok::<(), chrono::Error>(())
     /// ```
@@ -914,14 +914,14 @@ impl NaiveDateTime {
     /// ```
     /// use chrono::{Error, NaiveDate};
     ///
-    /// let dt = NaiveDate::from_ymd(2015, 9, 8)?.and_hms_milli(12, 34, 59, 789)?;
+    /// let dt = NaiveDate::from_ymd(2015, 9, 8)?.at_hms_milli(12, 34, 59, 789)?;
     /// assert_eq!(
     ///     dt.with_nanosecond(333_333_333),
-    ///     NaiveDate::from_ymd(2015, 9, 8)?.and_hms_nano(12, 34, 59, 333_333_333)
+    ///     NaiveDate::from_ymd(2015, 9, 8)?.at_hms_nano(12, 34, 59, 333_333_333)
     /// );
     /// assert_eq!(
     ///     dt.with_nanosecond(1_333_333_333), // leap second
-    ///     NaiveDate::from_ymd(2015, 9, 8)?.and_hms_nano(12, 34, 59, 1_333_333_333)
+    ///     NaiveDate::from_ymd(2015, 9, 8)?.at_hms_nano(12, 34, 59, 1_333_333_333)
     /// );
     /// assert_eq!(dt.with_nanosecond(2_000_000_000), Err(Error::InvalidArgument));
     /// # Ok::<(), chrono::Error>(())
@@ -951,10 +951,10 @@ impl From<NaiveDate> for NaiveDateTime {
     /// use chrono::{NaiveDate, NaiveDateTime};
     ///
     /// let nd = NaiveDate::from_ymd(2016, 5, 28).unwrap();
-    /// let ndt = NaiveDate::from_ymd(2016, 5, 28).unwrap().and_hms(0, 0, 0).unwrap();
+    /// let ndt = NaiveDate::from_ymd(2016, 5, 28).unwrap().at_hms(0, 0, 0).unwrap();
     /// assert_eq!(ndt, NaiveDateTime::from(nd));
     fn from(date: NaiveDate) -> Self {
-        date.and_hms(0, 0, 0).unwrap()
+        date.at_hms(0, 0, 0).unwrap()
     }
 }
 
@@ -968,7 +968,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{Datelike, NaiveDate, NaiveDateTime};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().at_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.year(), 2015);
     /// ```
     #[inline]
@@ -987,7 +987,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{Datelike, NaiveDate, NaiveDateTime};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().at_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.month(), 9);
     /// ```
     #[inline]
@@ -1006,7 +1006,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{Datelike, NaiveDate, NaiveDateTime};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().at_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.month0(), 8);
     /// ```
     #[inline]
@@ -1025,7 +1025,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{Datelike, NaiveDate, NaiveDateTime};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().at_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.day(), 25);
     /// ```
     #[inline]
@@ -1044,7 +1044,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{Datelike, NaiveDate, NaiveDateTime};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().at_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.day0(), 24);
     /// ```
     #[inline]
@@ -1063,7 +1063,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{Datelike, NaiveDate, NaiveDateTime};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().at_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.ordinal(), 268);
     /// ```
     #[inline]
@@ -1082,7 +1082,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{Datelike, NaiveDate, NaiveDateTime};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().at_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.ordinal0(), 267);
     /// ```
     #[inline]
@@ -1099,7 +1099,7 @@ impl Datelike for NaiveDateTime {
     /// ```
     /// use chrono::{Datelike, NaiveDate, NaiveDateTime, Weekday};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().and_hms(12, 34, 56).unwrap();
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 25).unwrap().at_hms(12, 34, 56).unwrap();
     /// assert_eq!(dt.weekday(), Weekday::Fri);
     /// ```
     #[inline]
@@ -1124,7 +1124,7 @@ impl Timelike for NaiveDateTime {
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
     /// let dt: NaiveDateTime =
-    ///     NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 56, 789).unwrap();
+    ///     NaiveDate::from_ymd(2015, 9, 8).unwrap().at_hms_milli(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.hour(), 12);
     /// ```
     #[inline]
@@ -1142,7 +1142,7 @@ impl Timelike for NaiveDateTime {
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
     /// let dt: NaiveDateTime =
-    ///     NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 56, 789).unwrap();
+    ///     NaiveDate::from_ymd(2015, 9, 8).unwrap().at_hms_milli(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.minute(), 34);
     /// ```
     #[inline]
@@ -1160,7 +1160,7 @@ impl Timelike for NaiveDateTime {
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
     /// let dt: NaiveDateTime =
-    ///     NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 56, 789).unwrap();
+    ///     NaiveDate::from_ymd(2015, 9, 8).unwrap().at_hms_milli(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.second(), 56);
     /// ```
     #[inline]
@@ -1180,7 +1180,7 @@ impl Timelike for NaiveDateTime {
     /// use chrono::{NaiveDate, NaiveDateTime, Timelike};
     ///
     /// let dt: NaiveDateTime =
-    ///     NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms_milli(12, 34, 56, 789).unwrap();
+    ///     NaiveDate::from_ymd(2015, 9, 8).unwrap().at_hms_milli(12, 34, 56, 789).unwrap();
     /// assert_eq!(dt.nanosecond(), 789_000_000);
     /// ```
     #[inline]
@@ -1208,18 +1208,18 @@ impl Timelike for NaiveDateTime {
 /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// let d = from_ymd(2016, 7, 8);
-/// let hms = |h, m, s| d.and_hms(h, m, s).unwrap();
+/// let hms = |h, m, s| d.at_hms(h, m, s).unwrap();
 /// assert_eq!(hms(3, 5, 7) + TimeDelta::zero(), hms(3, 5, 7));
 /// assert_eq!(hms(3, 5, 7) + TimeDelta::seconds(1), hms(3, 5, 8));
 /// assert_eq!(hms(3, 5, 7) + TimeDelta::seconds(-1), hms(3, 5, 6));
 /// assert_eq!(hms(3, 5, 7) + TimeDelta::seconds(3600 + 60), hms(4, 6, 7));
 /// assert_eq!(
 ///     hms(3, 5, 7) + TimeDelta::seconds(86_400),
-///     from_ymd(2016, 7, 9).and_hms(3, 5, 7).unwrap()
+///     from_ymd(2016, 7, 9).at_hms(3, 5, 7).unwrap()
 /// );
-/// assert_eq!(hms(3, 5, 7) + TimeDelta::days(365), from_ymd(2017, 7, 8).and_hms(3, 5, 7).unwrap());
+/// assert_eq!(hms(3, 5, 7) + TimeDelta::days(365), from_ymd(2017, 7, 8).at_hms(3, 5, 7).unwrap());
 ///
-/// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli).unwrap();
+/// let hmsm = |h, m, s, milli| d.at_hms_milli(h, m, s, milli).unwrap();
 /// assert_eq!(hmsm(3, 5, 7, 980) + TimeDelta::milliseconds(450).unwrap(), hmsm(3, 5, 8, 430));
 /// ```
 ///
@@ -1229,7 +1229,7 @@ impl Timelike for NaiveDateTime {
 /// ```
 /// # use chrono::{TimeDelta, NaiveDate};
 /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
-/// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli).unwrap();
+/// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).at_hms_milli(h, m, s, milli).unwrap();
 /// let leap = hmsm(3, 5, 59, 1_300);
 /// assert_eq!(leap + TimeDelta::zero(), hmsm(3, 5, 59, 1_300));
 /// assert_eq!(leap + TimeDelta::milliseconds(-500).unwrap(), hmsm(3, 5, 59, 800));
@@ -1237,8 +1237,10 @@ impl Timelike for NaiveDateTime {
 /// assert_eq!(leap + TimeDelta::milliseconds(800).unwrap(), hmsm(3, 6, 0, 100));
 /// assert_eq!(leap + TimeDelta::seconds(10), hmsm(3, 6, 9, 300));
 /// assert_eq!(leap + TimeDelta::seconds(-10), hmsm(3, 5, 50, 300));
-/// assert_eq!(leap + TimeDelta::days(1),
-///            from_ymd(2016, 7, 9).and_hms_milli(3, 5, 59, 300).unwrap());
+/// assert_eq!(
+///     leap + TimeDelta::days(1),
+///     from_ymd(2016, 7, 9).at_hms_milli(3, 5, 59, 300).unwrap()
+/// );
 /// ```
 ///
 /// [leap second handling]: crate::NaiveTime#leap-second-handling
@@ -1337,28 +1339,28 @@ impl Add<FixedOffset> for NaiveDateTime {
 /// use chrono::{Months, NaiveDate};
 ///
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms(1, 0, 0).unwrap() + Months::new(1),
-///     NaiveDate::from_ymd(2014, 2, 1).unwrap().and_hms(1, 0, 0).unwrap()
+///     NaiveDate::from_ymd(2014, 1, 1).unwrap().at_hms(1, 0, 0).unwrap() + Months::new(1),
+///     NaiveDate::from_ymd(2014, 2, 1).unwrap().at_hms(1, 0, 0).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms(0, 2, 0).unwrap() + Months::new(11),
-///     NaiveDate::from_ymd(2014, 12, 1).unwrap().and_hms(0, 2, 0).unwrap()
+///     NaiveDate::from_ymd(2014, 1, 1).unwrap().at_hms(0, 2, 0).unwrap() + Months::new(11),
+///     NaiveDate::from_ymd(2014, 12, 1).unwrap().at_hms(0, 2, 0).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms(0, 0, 3).unwrap() + Months::new(12),
-///     NaiveDate::from_ymd(2015, 1, 1).unwrap().and_hms(0, 0, 3).unwrap()
+///     NaiveDate::from_ymd(2014, 1, 1).unwrap().at_hms(0, 0, 3).unwrap() + Months::new(12),
+///     NaiveDate::from_ymd(2015, 1, 1).unwrap().at_hms(0, 0, 3).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 1, 1).unwrap().and_hms(0, 0, 4).unwrap() + Months::new(13),
-///     NaiveDate::from_ymd(2015, 2, 1).unwrap().and_hms(0, 0, 4).unwrap()
+///     NaiveDate::from_ymd(2014, 1, 1).unwrap().at_hms(0, 0, 4).unwrap() + Months::new(13),
+///     NaiveDate::from_ymd(2015, 2, 1).unwrap().at_hms(0, 0, 4).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 1, 31).unwrap().and_hms(0, 5, 0).unwrap() + Months::new(1),
-///     NaiveDate::from_ymd(2014, 2, 28).unwrap().and_hms(0, 5, 0).unwrap()
+///     NaiveDate::from_ymd(2014, 1, 31).unwrap().at_hms(0, 5, 0).unwrap() + Months::new(1),
+///     NaiveDate::from_ymd(2014, 2, 28).unwrap().at_hms(0, 5, 0).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd(2020, 1, 31).unwrap().and_hms(6, 0, 0).unwrap() + Months::new(1),
-///     NaiveDate::from_ymd(2020, 2, 29).unwrap().and_hms(6, 0, 0).unwrap()
+///     NaiveDate::from_ymd(2020, 1, 31).unwrap().at_hms(6, 0, 0).unwrap() + Months::new(1),
+///     NaiveDate::from_ymd(2020, 2, 29).unwrap().at_hms(6, 0, 0).unwrap()
 /// );
 /// ```
 impl Add<Months> for NaiveDateTime {
@@ -1390,18 +1392,18 @@ impl Add<Months> for NaiveDateTime {
 /// let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
 ///
 /// let d = from_ymd(2016, 7, 8);
-/// let hms = |h, m, s| d.and_hms(h, m, s).unwrap();
+/// let hms = |h, m, s| d.at_hms(h, m, s).unwrap();
 /// assert_eq!(hms(3, 5, 7) - TimeDelta::zero(), hms(3, 5, 7));
 /// assert_eq!(hms(3, 5, 7) - TimeDelta::seconds(1), hms(3, 5, 6));
 /// assert_eq!(hms(3, 5, 7) - TimeDelta::seconds(-1), hms(3, 5, 8));
 /// assert_eq!(hms(3, 5, 7) - TimeDelta::seconds(3600 + 60), hms(2, 4, 7));
 /// assert_eq!(
 ///     hms(3, 5, 7) - TimeDelta::seconds(86_400),
-///     from_ymd(2016, 7, 7).and_hms(3, 5, 7).unwrap()
+///     from_ymd(2016, 7, 7).at_hms(3, 5, 7).unwrap()
 /// );
-/// assert_eq!(hms(3, 5, 7) - TimeDelta::days(365), from_ymd(2015, 7, 9).and_hms(3, 5, 7).unwrap());
+/// assert_eq!(hms(3, 5, 7) - TimeDelta::days(365), from_ymd(2015, 7, 9).at_hms(3, 5, 7).unwrap());
 ///
-/// let hmsm = |h, m, s, milli| d.and_hms_milli(h, m, s, milli).unwrap();
+/// let hmsm = |h, m, s, milli| d.at_hms_milli(h, m, s, milli).unwrap();
 /// assert_eq!(hmsm(3, 5, 7, 450) - TimeDelta::milliseconds(670).unwrap(), hmsm(3, 5, 6, 780));
 /// ```
 ///
@@ -1411,14 +1413,13 @@ impl Add<Months> for NaiveDateTime {
 /// ```
 /// # use chrono::{TimeDelta, NaiveDate};
 /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
-/// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).and_hms_milli(h, m, s, milli).unwrap();
+/// # let hmsm = |h, m, s, milli| from_ymd(2016, 7, 8).at_hms_milli(h, m, s, milli).unwrap();
 /// let leap = hmsm(3, 5, 59, 1_300);
 /// assert_eq!(leap - TimeDelta::zero(), hmsm(3, 5, 59, 1_300));
 /// assert_eq!(leap - TimeDelta::milliseconds(200).unwrap(), hmsm(3, 5, 59, 1_100));
 /// assert_eq!(leap - TimeDelta::milliseconds(500).unwrap(), hmsm(3, 5, 59, 800));
 /// assert_eq!(leap - TimeDelta::seconds(60), hmsm(3, 5, 0, 300));
-/// assert_eq!(leap - TimeDelta::days(1),
-///            from_ymd(2016, 7, 7).and_hms_milli(3, 6, 0, 300).unwrap());
+/// assert_eq!(leap - TimeDelta::days(1), from_ymd(2016, 7, 7).at_hms_milli(3, 6, 0, 300).unwrap());
 /// ```
 ///
 /// [leap second handling]: crate::NaiveTime#leap-second-handling
@@ -1519,16 +1520,16 @@ impl Sub<FixedOffset> for NaiveDateTime {
 /// use chrono::{Months, NaiveDate};
 ///
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 01, 01).unwrap().and_hms(01, 00, 00).unwrap() - Months::new(11),
-///     NaiveDate::from_ymd(2013, 02, 01).unwrap().and_hms(01, 00, 00).unwrap()
+///     NaiveDate::from_ymd(2014, 01, 01).unwrap().at_hms(01, 00, 00).unwrap() - Months::new(11),
+///     NaiveDate::from_ymd(2013, 02, 01).unwrap().at_hms(01, 00, 00).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 01, 01).unwrap().and_hms(00, 02, 00).unwrap() - Months::new(12),
-///     NaiveDate::from_ymd(2013, 01, 01).unwrap().and_hms(00, 02, 00).unwrap()
+///     NaiveDate::from_ymd(2014, 01, 01).unwrap().at_hms(00, 02, 00).unwrap() - Months::new(12),
+///     NaiveDate::from_ymd(2013, 01, 01).unwrap().at_hms(00, 02, 00).unwrap()
 /// );
 /// assert_eq!(
-///     NaiveDate::from_ymd(2014, 01, 01).unwrap().and_hms(00, 00, 03).unwrap() - Months::new(13),
-///     NaiveDate::from_ymd(2012, 12, 01).unwrap().and_hms(00, 00, 03).unwrap()
+///     NaiveDate::from_ymd(2014, 01, 01).unwrap().at_hms(00, 00, 03).unwrap() - Months::new(13),
+///     NaiveDate::from_ymd(2012, 12, 01).unwrap().at_hms(00, 00, 03).unwrap()
 /// );
 /// ```
 impl Sub<Months> for NaiveDateTime {
@@ -1559,14 +1560,14 @@ impl Sub<Months> for NaiveDateTime {
 ///
 /// let d = from_ymd(2016, 7, 8);
 /// assert_eq!(
-///     d.and_hms(3, 5, 7).unwrap() - d.and_hms(2, 4, 6).unwrap(),
+///     d.at_hms(3, 5, 7).unwrap() - d.at_hms(2, 4, 6).unwrap(),
 ///     TimeDelta::seconds(3600 + 60 + 1)
 /// );
 ///
 /// // July 8 is 190th day in the year 2016
 /// let d0 = from_ymd(2016, 1, 1);
 /// assert_eq!(
-///     d.and_hms_milli(0, 7, 6, 500).unwrap() - d0.and_hms(0, 0, 0).unwrap(),
+///     d.at_hms_milli(0, 7, 6, 500).unwrap() - d0.at_hms(0, 0, 0).unwrap(),
 ///     TimeDelta::seconds(189 * 86_400 + 7 * 60 + 6) + TimeDelta::milliseconds(500).unwrap()
 /// );
 /// ```
@@ -1577,13 +1578,13 @@ impl Sub<Months> for NaiveDateTime {
 /// ```
 /// # use chrono::{TimeDelta, NaiveDate};
 /// # let from_ymd = |y, m, d| NaiveDate::from_ymd(y, m, d).unwrap();
-/// let leap = from_ymd(2015, 6, 30).and_hms_milli(23, 59, 59, 1_500).unwrap();
+/// let leap = from_ymd(2015, 6, 30).at_hms_milli(23, 59, 59, 1_500).unwrap();
 /// assert_eq!(
-///     leap - from_ymd(2015, 6, 30).and_hms(23, 0, 0).unwrap(),
+///     leap - from_ymd(2015, 6, 30).at_hms(23, 0, 0).unwrap(),
 ///     TimeDelta::seconds(3600) + TimeDelta::milliseconds(500).unwrap()
 /// );
 /// assert_eq!(
-///     from_ymd(2015, 7, 1).and_hms(1, 0, 0).unwrap() - leap,
+///     from_ymd(2015, 7, 1).at_hms(1, 0, 0).unwrap() - leap,
 ///     TimeDelta::seconds(3600) - TimeDelta::milliseconds(500).unwrap()
 /// );
 /// ```
@@ -1640,7 +1641,7 @@ impl Sub<Days> for NaiveDateTime {
 /// ```
 /// use chrono::NaiveDate;
 ///
-/// let dt = NaiveDate::from_ymd(2016, 11, 15).unwrap().and_hms(7, 39, 24).unwrap();
+/// let dt = NaiveDate::from_ymd(2016, 11, 15).unwrap().at_hms(7, 39, 24).unwrap();
 /// assert_eq!(format!("{:?}", dt), "2016-11-15T07:39:24");
 /// ```
 ///
@@ -1648,7 +1649,7 @@ impl Sub<Days> for NaiveDateTime {
 ///
 /// ```
 /// # use chrono::NaiveDate;
-/// let dt = NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli(23, 59, 59, 1_500).unwrap();
+/// let dt = NaiveDate::from_ymd(2015, 6, 30).unwrap().at_hms_milli(23, 59, 59, 1_500).unwrap();
 /// assert_eq!(format!("{:?}", dt), "2015-06-30T23:59:60.500");
 /// ```
 impl fmt::Debug for NaiveDateTime {
@@ -1673,7 +1674,7 @@ impl fmt::Debug for NaiveDateTime {
 /// ```
 /// use chrono::NaiveDate;
 ///
-/// let dt = NaiveDate::from_ymd(2016, 11, 15).unwrap().and_hms(7, 39, 24).unwrap();
+/// let dt = NaiveDate::from_ymd(2016, 11, 15).unwrap().at_hms(7, 39, 24).unwrap();
 /// assert_eq!(format!("{}", dt), "2016-11-15 07:39:24");
 /// ```
 ///
@@ -1681,7 +1682,7 @@ impl fmt::Debug for NaiveDateTime {
 ///
 /// ```
 /// # use chrono::NaiveDate;
-/// let dt = NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli(23, 59, 59, 1_500).unwrap();
+/// let dt = NaiveDate::from_ymd(2015, 6, 30).unwrap().at_hms_milli(23, 59, 59, 1_500).unwrap();
 /// assert_eq!(format!("{}", dt), "2015-06-30 23:59:60.500");
 /// ```
 impl fmt::Display for NaiveDateTime {
@@ -1700,10 +1701,10 @@ impl fmt::Display for NaiveDateTime {
 /// ```
 /// use chrono::{NaiveDateTime, NaiveDate};
 ///
-/// let dt = NaiveDate::from_ymd(2015, 9, 18).unwrap().and_hms(23, 56, 4).unwrap();
+/// let dt = NaiveDate::from_ymd(2015, 9, 18).unwrap().at_hms(23, 56, 4).unwrap();
 /// assert_eq!("2015-09-18T23:56:04".parse::<NaiveDateTime>(), Ok(dt));
 ///
-/// let dt = NaiveDate::from_ymd(12345, 6, 7).unwrap().and_hms_milli(7, 59, 59, 1_500).unwrap(); // leap second
+/// let dt = NaiveDate::from_ymd(12345, 6, 7).unwrap().at_hms_milli(7, 59, 59, 1_500).unwrap(); // leap second
 /// assert_eq!("+12345-6-7T7:59:60.5".parse::<NaiveDateTime>(), Ok(dt));
 ///
 /// assert!("foo".parse::<NaiveDateTime>().is_err());
@@ -1762,30 +1763,30 @@ where
     E: ::std::fmt::Debug,
 {
     assert_eq!(
-        to_string(&NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli(9, 10, 48, 90).unwrap())
+        to_string(&NaiveDate::from_ymd(2016, 7, 8).unwrap().at_hms_milli(9, 10, 48, 90).unwrap())
             .ok(),
         Some(r#""2016-07-08T09:10:48.090""#.into())
     );
     assert_eq!(
-        to_string(&NaiveDate::from_ymd(2014, 7, 24).unwrap().and_hms(12, 34, 6).unwrap()).ok(),
+        to_string(&NaiveDate::from_ymd(2014, 7, 24).unwrap().at_hms(12, 34, 6).unwrap()).ok(),
         Some(r#""2014-07-24T12:34:06""#.into())
     );
     assert_eq!(
-        to_string(&NaiveDate::from_ymd(0, 1, 1).unwrap().and_hms_milli(0, 0, 59, 1_000).unwrap())
+        to_string(&NaiveDate::from_ymd(0, 1, 1).unwrap().at_hms_milli(0, 0, 59, 1_000).unwrap())
             .ok(),
         Some(r#""0000-01-01T00:00:60""#.into())
     );
     assert_eq!(
-        to_string(&NaiveDate::from_ymd(-1, 12, 31).unwrap().and_hms_nano(23, 59, 59, 7).unwrap())
+        to_string(&NaiveDate::from_ymd(-1, 12, 31).unwrap().at_hms_nano(23, 59, 59, 7).unwrap())
             .ok(),
         Some(r#""-0001-12-31T23:59:59.000000007""#.into())
     );
     assert_eq!(
-        to_string(&NaiveDate::MIN.and_hms(0, 0, 0).unwrap()).ok(),
+        to_string(&NaiveDate::MIN.at_hms(0, 0, 0).unwrap()).ok(),
         Some(r#""-262143-01-01T00:00:00""#.into())
     );
     assert_eq!(
-        to_string(&NaiveDate::MAX.and_hms_nano(23, 59, 59, 1_999_999_999).unwrap()).ok(),
+        to_string(&NaiveDate::MAX.at_hms_nano(23, 59, 59, 1_999_999_999).unwrap()).ok(),
         Some(r#""+262142-12-31T23:59:60.999999999""#.into())
     );
 }
@@ -1798,39 +1799,39 @@ where
 {
     assert_eq!(
         from_str(r#""2016-07-08T09:10:48.090""#).ok(),
-        Some(NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli(9, 10, 48, 90).unwrap())
+        Some(NaiveDate::from_ymd(2016, 7, 8).unwrap().at_hms_milli(9, 10, 48, 90).unwrap())
     );
     assert_eq!(
         from_str(r#""2016-7-8T9:10:48.09""#).ok(),
-        Some(NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli(9, 10, 48, 90).unwrap())
+        Some(NaiveDate::from_ymd(2016, 7, 8).unwrap().at_hms_milli(9, 10, 48, 90).unwrap())
     );
     assert_eq!(
         from_str(r#""2014-07-24T12:34:06""#).ok(),
-        Some(NaiveDate::from_ymd(2014, 7, 24).unwrap().and_hms(12, 34, 6).unwrap())
+        Some(NaiveDate::from_ymd(2014, 7, 24).unwrap().at_hms(12, 34, 6).unwrap())
     );
     assert_eq!(
         from_str(r#""0000-01-01T00:00:60""#).ok(),
-        Some(NaiveDate::from_ymd(0, 1, 1).unwrap().and_hms_milli(0, 0, 59, 1_000).unwrap())
+        Some(NaiveDate::from_ymd(0, 1, 1).unwrap().at_hms_milli(0, 0, 59, 1_000).unwrap())
     );
     assert_eq!(
         from_str(r#""0-1-1T0:0:60""#).ok(),
-        Some(NaiveDate::from_ymd(0, 1, 1).unwrap().and_hms_milli(0, 0, 59, 1_000).unwrap())
+        Some(NaiveDate::from_ymd(0, 1, 1).unwrap().at_hms_milli(0, 0, 59, 1_000).unwrap())
     );
     assert_eq!(
         from_str(r#""-0001-12-31T23:59:59.000000007""#).ok(),
-        Some(NaiveDate::from_ymd(-1, 12, 31).unwrap().and_hms_nano(23, 59, 59, 7).unwrap())
+        Some(NaiveDate::from_ymd(-1, 12, 31).unwrap().at_hms_nano(23, 59, 59, 7).unwrap())
     );
     assert_eq!(
         from_str(r#""-262143-01-01T00:00:00""#).ok(),
-        Some(NaiveDate::MIN.and_hms(0, 0, 0).unwrap())
+        Some(NaiveDate::MIN.at_hms(0, 0, 0).unwrap())
     );
     assert_eq!(
         from_str(r#""+262142-12-31T23:59:60.999999999""#).ok(),
-        Some(NaiveDate::MAX.and_hms_nano(23, 59, 59, 1_999_999_999).unwrap())
+        Some(NaiveDate::MAX.at_hms_nano(23, 59, 59, 1_999_999_999).unwrap())
     );
     assert_eq!(
         from_str(r#""+262142-12-31T23:59:60.9999999999997""#).ok(), // excess digits are ignored
-        Some(NaiveDate::MAX.and_hms_nano(23, 59, 59, 1_999_999_999).unwrap())
+        Some(NaiveDate::MAX.at_hms_nano(23, 59, 59, 1_999_999_999).unwrap())
     );
 
     // bad formats

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -708,11 +708,11 @@ impl NaiveDateTime {
     ///
     /// ```
     /// use chrono::{NaiveDate, Utc};
-    /// let dt = NaiveDate::from_ymd(2023, 1, 30).unwrap().at_hms(19, 32, 33).unwrap().and_utc();
+    /// let dt = NaiveDate::from_ymd(2023, 1, 30).unwrap().at_hms(19, 32, 33).unwrap().in_utc();
     /// assert_eq!(dt.timezone(), Utc);
     /// ```
     #[must_use]
-    pub const fn and_utc(self) -> DateTime<Utc> {
+    pub const fn in_utc(self) -> DateTime<Utc> {
         DateTime::from_naive_utc_and_offset(self, Utc)
     }
 

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -693,12 +693,12 @@ impl NaiveDateTime {
     ///     .unwrap()
     ///     .at_hms(23, 56, 4)
     ///     .unwrap()
-    ///     .and_local_timezone(tz)
+    ///     .in_timezone(tz)
     ///     .unwrap();
     /// assert_eq!(dt.timezone(), tz);
     /// ```
     #[must_use]
-    pub fn and_local_timezone<Tz: TimeZone>(self, tz: Tz) -> MappedLocalTime<DateTime<Tz>> {
+    pub fn in_timezone<Tz: TimeZone>(self, tz: Tz) -> MappedLocalTime<DateTime<Tz>> {
         tz.from_local_datetime(self)
     }
 

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -117,7 +117,7 @@ pub mod ts_nanoseconds {
     where
         S: ser::Serializer,
     {
-        serializer.serialize_i64(dt.and_utc().timestamp_nanos().map_err(|_| {
+        serializer.serialize_i64(dt.in_utc().timestamp_nanos().map_err(|_| {
             ser::Error::custom("value out of range for a timestamp with nanosecond precision")
         })?)
     }
@@ -258,7 +258,7 @@ pub mod ts_nanoseconds_option {
     {
         match *opt {
             Some(ref dt) => {
-                serializer.serialize_some(&dt.and_utc().timestamp_nanos().map_err(|_| {
+                serializer.serialize_some(&dt.in_utc().timestamp_nanos().map_err(|_| {
                     ser::Error::custom(
                         "value out of range for a timestamp with nanosecond precision",
                     )
@@ -392,7 +392,7 @@ pub mod ts_microseconds {
     where
         S: ser::Serializer,
     {
-        serializer.serialize_i64(dt.and_utc().timestamp_micros())
+        serializer.serialize_i64(dt.in_utc().timestamp_micros())
     }
 
     /// Deserialize a `NaiveDateTime` from a microseconds timestamp
@@ -522,7 +522,7 @@ pub mod ts_microseconds_option {
         S: ser::Serializer,
     {
         match *opt {
-            Some(ref dt) => serializer.serialize_some(&dt.and_utc().timestamp_micros()),
+            Some(ref dt) => serializer.serialize_some(&dt.in_utc().timestamp_micros()),
             None => serializer.serialize_none(),
         }
     }
@@ -651,7 +651,7 @@ pub mod ts_milliseconds {
     where
         S: ser::Serializer,
     {
-        serializer.serialize_i64(dt.and_utc().timestamp_millis())
+        serializer.serialize_i64(dt.in_utc().timestamp_millis())
     }
 
     /// Deserialize a `NaiveDateTime` from a milliseconds timestamp
@@ -778,7 +778,7 @@ pub mod ts_milliseconds_option {
         S: ser::Serializer,
     {
         match *opt {
-            Some(ref dt) => serializer.serialize_some(&dt.and_utc().timestamp_millis()),
+            Some(ref dt) => serializer.serialize_some(&dt.in_utc().timestamp_millis()),
             None => serializer.serialize_none(),
         }
     }
@@ -905,7 +905,7 @@ pub mod ts_seconds {
     where
         S: ser::Serializer,
     {
-        serializer.serialize_i64(dt.and_utc().timestamp())
+        serializer.serialize_i64(dt.in_utc().timestamp())
     }
 
     /// Deserialize a `NaiveDateTime` from a seconds timestamp
@@ -1028,7 +1028,7 @@ pub mod ts_seconds_option {
         S: ser::Serializer,
     {
         match *opt {
-            Some(ref dt) => serializer.serialize_some(&dt.and_utc().timestamp()),
+            Some(ref dt) => serializer.serialize_some(&dt.in_utc().timestamp()),
             None => serializer.serialize_none(),
         }
     }

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -66,7 +66,7 @@ impl<'de> de::Deserialize<'de> for NaiveDateTime {
 /// }
 ///
 /// let time =
-///     NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano(02, 04, 59, 918355733).unwrap();
+///     NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_nano(02, 04, 59, 918355733).unwrap();
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -107,10 +107,7 @@ pub mod ts_nanoseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd(2018, 5, 17)
-    ///         .unwrap()
-    ///         .and_hms_nano(02, 04, 59, 918355733)
-    ///         .unwrap(),
+    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_nano(02, 04, 59, 918355733).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
@@ -205,9 +202,8 @@ pub mod ts_nanoseconds {
 ///     time: Option<NaiveDateTime>,
 /// }
 ///
-/// let time = Some(
-///     NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano(02, 04, 59, 918355733).unwrap(),
-/// );
+/// let time =
+///     Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_nano(02, 04, 59, 918355733).unwrap());
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -249,7 +245,7 @@ pub mod ts_nanoseconds_option {
     ///
     /// let my_s = S {
     ///     time: Some(
-    ///         NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_nano(02, 04, 59, 918355733).unwrap(),
+    ///         NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_nano(02, 04, 59, 918355733).unwrap(),
     ///     ),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
@@ -353,7 +349,7 @@ pub mod ts_nanoseconds_option {
 ///     time: NaiveDateTime,
 /// }
 ///
-/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro(02, 04, 59, 918355).unwrap();
+/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_micro(02, 04, 59, 918355).unwrap();
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -386,7 +382,7 @@ pub mod ts_microseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro(02, 04, 59, 918355).unwrap(),
+    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_micro(02, 04, 59, 918355).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
@@ -480,7 +476,7 @@ pub mod ts_microseconds {
 /// }
 ///
 /// let time =
-///     Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro(02, 04, 59, 918355).unwrap());
+///     Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_micro(02, 04, 59, 918355).unwrap());
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -514,7 +510,7 @@ pub mod ts_microseconds_option {
     ///
     /// let my_s = S {
     ///     time: Some(
-    ///         NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_micro(02, 04, 59, 918355).unwrap(),
+    ///         NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_micro(02, 04, 59, 918355).unwrap(),
     ///     ),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
@@ -612,7 +608,7 @@ pub mod ts_microseconds_option {
 ///     time: NaiveDateTime,
 /// }
 ///
-/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli(02, 04, 59, 918).unwrap();
+/// let time = NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_milli(02, 04, 59, 918).unwrap();
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -645,7 +641,7 @@ pub mod ts_milliseconds {
     /// }
     ///
     /// let my_s = S {
-    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli(02, 04, 59, 918).unwrap(),
+    ///     time: NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_milli(02, 04, 59, 918).unwrap(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
@@ -736,7 +732,7 @@ pub mod ts_milliseconds {
 /// }
 ///
 /// let time =
-///     Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli(02, 04, 59, 918).unwrap());
+///     Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_milli(02, 04, 59, 918).unwrap());
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -770,7 +766,7 @@ pub mod ts_milliseconds_option {
     ///
     /// let my_s = S {
     ///     time: Some(
-    ///         NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms_milli(02, 04, 59, 918).unwrap(),
+    ///         NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms_milli(02, 04, 59, 918).unwrap(),
     ///     ),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
@@ -868,7 +864,7 @@ pub mod ts_milliseconds_option {
 ///     time: NaiveDateTime,
 /// }
 ///
-/// let time = NaiveDate::from_ymd(2015, 5, 15).unwrap().and_hms(10, 0, 0).unwrap();
+/// let time = NaiveDate::from_ymd(2015, 5, 15).unwrap().at_hms(10, 0, 0).unwrap();
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -900,7 +896,7 @@ pub mod ts_seconds {
     ///     time: NaiveDateTime,
     /// }
     ///
-    /// let my_s = S { time: NaiveDate::from_ymd(2015, 5, 15).unwrap().and_hms(10, 0, 0).unwrap() };
+    /// let my_s = S { time: NaiveDate::from_ymd(2015, 5, 15).unwrap().at_hms(10, 0, 0).unwrap() };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1431684000}"#);
     /// # Ok::<(), serde_json::Error>(())
@@ -989,7 +985,7 @@ pub mod ts_seconds {
 ///     time: Option<NaiveDateTime>,
 /// }
 ///
-/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms(02, 04, 59).unwrap());
+/// let time = Some(NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms(02, 04, 59).unwrap());
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -1021,7 +1017,7 @@ pub mod ts_seconds_option {
     ///     time: Option<NaiveDateTime>,
     /// }
     ///
-    /// let expected = NaiveDate::from_ymd(2018, 5, 17).unwrap().and_hms(02, 04, 59).unwrap();
+    /// let expected = NaiveDate::from_ymd(2018, 5, 17).unwrap().at_hms(02, 04, 59).unwrap();
     /// let my_s = S { time: Some(expected) };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699}"#);
@@ -1123,7 +1119,7 @@ mod tests {
     // it is not self-describing.
     #[test]
     fn test_serde_bincode() {
-        let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().and_hms_milli(9, 10, 48, 90).unwrap();
+        let dt = NaiveDate::from_ymd(2016, 7, 8).unwrap().at_hms_milli(9, 10, 48, 90).unwrap();
         let encoded = serialize(&dt).unwrap();
         let decoded: NaiveDateTime = deserialize(&encoded).unwrap();
         assert_eq!(dt, decoded);

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -1139,7 +1139,7 @@ mod tests {
         }
 
         let expected =
-            Test { one: Some(1), two: Some(Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap()) };
+            Test { one: Some(1), two: Some(Utc.at_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap()) };
         let bytes: Vec<u8> = serialize(&expected).unwrap();
         let actual = deserialize::<Test>(&(bytes)).unwrap();
 

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -8,9 +8,9 @@ fn test_datetime_add() -> Result<(), Error> {
         rhs: TimeDelta,
         result: Result<(i32, u32, u32, u32, u32, u32), Error>,
     ) -> Result<(), Error> {
-        let lhs = NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s)?;
+        let lhs = NaiveDate::from_ymd(y, m, d)?.at_hms(h, n, s)?;
         let sum = match result {
-            Ok((y, m, d, h, n, s)) => NaiveDate::from_ymd(y, m, d)?.and_hms(h, n, s),
+            Ok((y, m, d, h, n, s)) => NaiveDate::from_ymd(y, m, d)?.at_hms(h, n, s),
             Err(e) => Err(e),
         };
         assert_eq!(lhs.checked_add_signed(rhs), sum);
@@ -49,7 +49,7 @@ fn test_datetime_add() -> Result<(), Error> {
 
 #[test]
 fn test_datetime_sub() {
-    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
+    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().at_hms(h, n, s).unwrap();
     let since = NaiveDateTime::signed_duration_since;
     assert_eq!(since(ymdhms(2014, 5, 6, 7, 8, 9), ymdhms(2014, 5, 6, 7, 8, 9)), TimeDelta::zero());
     assert_eq!(
@@ -72,7 +72,7 @@ fn test_datetime_sub() {
 
 #[test]
 fn test_datetime_addassignment() {
-    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
+    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().at_hms(h, n, s).unwrap();
     let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
     date += TimeDelta::minutes(10_000_000);
     assert_eq!(date, ymdhms(2035, 10, 6, 20, 50, 10));
@@ -82,7 +82,7 @@ fn test_datetime_addassignment() {
 
 #[test]
 fn test_datetime_subassignment() {
-    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
+    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().at_hms(h, n, s).unwrap();
     let mut date = ymdhms(2016, 10, 1, 10, 10, 10);
     date -= TimeDelta::minutes(10_000_000);
     assert_eq!(date, ymdhms(1997, 9, 26, 23, 30, 10));
@@ -94,12 +94,12 @@ fn test_datetime_subassignment() {
 fn test_core_duration_ops() {
     use core::time::Duration;
 
-    let mut dt = NaiveDate::from_ymd(2023, 8, 29).unwrap().and_hms(11, 34, 12).unwrap();
+    let mut dt = NaiveDate::from_ymd(2023, 8, 29).unwrap().at_hms(11, 34, 12).unwrap();
     let same = dt + Duration::ZERO;
     assert_eq!(dt, same);
 
     dt += Duration::new(3600, 0);
-    assert_eq!(dt, NaiveDate::from_ymd(2023, 8, 29).unwrap().and_hms(12, 34, 12).unwrap());
+    assert_eq!(dt, NaiveDate::from_ymd(2023, 8, 29).unwrap().at_hms(12, 34, 12).unwrap());
 }
 
 #[test]
@@ -107,7 +107,7 @@ fn test_core_duration_ops() {
 fn test_core_duration_max() {
     use core::time::Duration;
 
-    let mut utc_dt = NaiveDate::from_ymd(2023, 8, 29).unwrap().and_hms(11, 34, 12).unwrap();
+    let mut utc_dt = NaiveDate::from_ymd(2023, 8, 29).unwrap().at_hms(11, 34, 12).unwrap();
     utc_dt += Duration::MAX;
 }
 
@@ -180,9 +180,9 @@ fn test_datetime_from_str() {
 
 #[test]
 fn test_datetime_parse_from_str() {
-    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
+    let ymdhms = |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().at_hms(h, n, s).unwrap();
     let ymdhmsn = |y, m, d, h, n, s, nano| {
-        NaiveDate::from_ymd(y, m, d).unwrap().and_hms_nano(h, n, s, nano).unwrap()
+        NaiveDate::from_ymd(y, m, d).unwrap().at_hms_nano(h, n, s, nano).unwrap()
     };
     assert_eq!(
         NaiveDateTime::parse_from_str("2014-5-7T12:34:56+09:30", "%Y-%m-%dT%H:%M:%S%z"),
@@ -228,7 +228,7 @@ fn test_datetime_parse_from_str() {
 #[test]
 fn test_datetime_parse_from_str_with_spaces() {
     let parse_from_str = NaiveDateTime::parse_from_str;
-    let dt = NaiveDate::from_ymd(2013, 8, 9).unwrap().and_hms(23, 54, 35).unwrap();
+    let dt = NaiveDate::from_ymd(2013, 8, 9).unwrap().at_hms(23, 54, 35).unwrap();
     // with varying spaces - should succeed
     assert_eq!(parse_from_str(" Aug 09 2013 23:54:35", " %b %d %Y %H:%M:%S"), Ok(dt));
     assert_eq!(parse_from_str("Aug 09 2013 23:54:35 ", "%b %d %Y %H:%M:%S "), Ok(dt));
@@ -262,7 +262,7 @@ fn test_datetime_parse_from_str_with_spaces() {
 #[test]
 fn test_datetime_add_sub_invariant() {
     // issue #37
-    let base = NaiveDate::from_ymd(2000, 1, 1).unwrap().and_hms(0, 0, 0).unwrap();
+    let base = NaiveDate::from_ymd(2000, 1, 1).unwrap().at_hms(0, 0, 0).unwrap();
     let t = -946684799990000;
     let time = base + TimeDelta::microseconds(t);
     assert_eq!(t, time.signed_duration_since(base).num_microseconds().unwrap());
@@ -270,7 +270,7 @@ fn test_datetime_add_sub_invariant() {
 
 #[test]
 fn test_and_local_timezone() {
-    let ndt = NaiveDate::from_ymd(2022, 6, 15).unwrap().and_hms(18, 59, 36).unwrap();
+    let ndt = NaiveDate::from_ymd(2022, 6, 15).unwrap().at_hms(18, 59, 36).unwrap();
     let dt_utc = ndt.and_utc();
     assert_eq!(dt_utc.naive_local(), ndt);
     assert_eq!(dt_utc.timezone(), Utc);
@@ -283,7 +283,7 @@ fn test_and_local_timezone() {
 
 #[test]
 fn test_and_utc() {
-    let ndt = NaiveDate::from_ymd(2023, 1, 30).unwrap().and_hms(19, 32, 33).unwrap();
+    let ndt = NaiveDate::from_ymd(2023, 1, 30).unwrap().at_hms(19, 32, 33).unwrap();
     let dt_utc = ndt.and_utc();
     assert_eq!(dt_utc.naive_local(), ndt);
     assert_eq!(dt_utc.timezone(), Utc);
@@ -292,7 +292,7 @@ fn test_and_utc() {
 #[test]
 fn test_checked_add_offset() -> Result<(), Error> {
     let ymdhmsm = |y, m, d, h, mn, s, mi| {
-        NaiveDate::from_ymd(y, m, d).and_then(|d| d.and_hms_milli(h, mn, s, mi))
+        NaiveDate::from_ymd(y, m, d).and_then(|d| d.at_hms_milli(h, mn, s, mi))
     };
 
     let positive_offset = FixedOffset::east(2 * 60 * 60)?;
@@ -322,7 +322,7 @@ fn test_checked_add_offset() -> Result<(), Error> {
 #[test]
 fn test_checked_sub_offset() -> Result<(), Error> {
     let ymdhmsm = |y, m, d, h, mn, s, mi| {
-        NaiveDate::from_ymd(y, m, d).and_then(|d| d.and_hms_milli(h, mn, s, mi))
+        NaiveDate::from_ymd(y, m, d).and_then(|d| d.at_hms_milli(h, mn, s, mi))
     };
 
     let positive_offset = FixedOffset::east(2 * 60 * 60).unwrap();
@@ -352,7 +352,7 @@ fn test_checked_sub_offset() -> Result<(), Error> {
 #[test]
 fn test_overflowing_add_offset() {
     let ymdhmsm = |y, m, d, h, mn, s, mi| {
-        NaiveDate::from_ymd(y, m, d).unwrap().and_hms_milli(h, mn, s, mi).unwrap()
+        NaiveDate::from_ymd(y, m, d).unwrap().at_hms_milli(h, mn, s, mi).unwrap()
     };
     let positive_offset = FixedOffset::east(2 * 60 * 60).unwrap();
     // regular date

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -271,7 +271,7 @@ fn test_datetime_add_sub_invariant() {
 #[test]
 fn test_in_timezone() {
     let ndt = NaiveDate::from_ymd(2022, 6, 15).unwrap().at_hms(18, 59, 36).unwrap();
-    let dt_utc = ndt.and_utc();
+    let dt_utc = ndt.in_utc();
     assert_eq!(dt_utc.naive_local(), ndt);
     assert_eq!(dt_utc.timezone(), Utc);
 
@@ -282,9 +282,9 @@ fn test_in_timezone() {
 }
 
 #[test]
-fn test_and_utc() {
+fn test_in_utc() {
     let ndt = NaiveDate::from_ymd(2023, 1, 30).unwrap().at_hms(19, 32, 33).unwrap();
-    let dt_utc = ndt.and_utc();
+    let dt_utc = ndt.in_utc();
     assert_eq!(dt_utc.naive_local(), ndt);
     assert_eq!(dt_utc.timezone(), Utc);
 }

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -269,14 +269,14 @@ fn test_datetime_add_sub_invariant() {
 }
 
 #[test]
-fn test_and_local_timezone() {
+fn test_in_timezone() {
     let ndt = NaiveDate::from_ymd(2022, 6, 15).unwrap().at_hms(18, 59, 36).unwrap();
     let dt_utc = ndt.and_utc();
     assert_eq!(dt_utc.naive_local(), ndt);
     assert_eq!(dt_utc.timezone(), Utc);
 
     let offset_tz = FixedOffset::west(4 * 3600).unwrap();
-    let dt_offset = ndt.and_local_timezone(offset_tz).unwrap();
+    let dt_offset = ndt.in_timezone(offset_tz).unwrap();
     assert_eq!(dt_offset.naive_local(), ndt);
     assert_eq!(dt_offset.timezone(), offset_tz);
 }
@@ -381,13 +381,13 @@ fn test_and_timezone_min_max_dates() {
         dbg!(offset_hour);
         let offset = FixedOffset::east(offset_hour * 60 * 60).unwrap();
 
-        let local_max = NaiveDateTime::MAX.and_local_timezone(offset);
+        let local_max = NaiveDateTime::MAX.in_timezone(offset);
         if offset_hour >= 0 {
             assert_eq!(local_max.unwrap().naive_local(), NaiveDateTime::MAX);
         } else {
             assert_eq!(local_max, MappedLocalTime::None);
         }
-        let local_min = NaiveDateTime::MIN.and_local_timezone(offset);
+        let local_min = NaiveDateTime::MIN.in_timezone(offset);
         if offset_hour <= 0 {
             assert_eq!(local_min.unwrap().naive_local(), NaiveDateTime::MIN);
         } else {

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -83,7 +83,7 @@ mod tests;
 ///     .unwrap()
 ///     .at_hms_nano(23, 59, 59, 1_000_000_000)
 ///     .unwrap()
-///     .and_utc();
+///     .in_utc();
 /// # let _ = (t, dt1, dt2);
 /// ```
 ///
@@ -167,11 +167,8 @@ mod tests;
 /// ```
 /// use chrono::NaiveDate;
 ///
-/// let dt = NaiveDate::from_ymd(2015, 6, 30)
-///     .unwrap()
-///     .at_hms_milli(23, 59, 59, 1_000)
-///     .unwrap()
-///     .and_utc();
+/// let dt =
+///     NaiveDate::from_ymd(2015, 6, 30).unwrap().at_hms_milli(23, 59, 59, 1_000).unwrap().in_utc();
 /// assert_eq!(format!("{:?}", dt), "2015-06-30T23:59:60Z");
 /// ```
 ///

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -77,11 +77,11 @@ mod tests;
 ///
 /// let t = NaiveTime::from_hms_milli(8, 59, 59, 1_000).unwrap();
 ///
-/// let dt1 = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms_micro(8, 59, 59, 1_000_000).unwrap();
+/// let dt1 = NaiveDate::from_ymd(2015, 7, 1).unwrap().at_hms_micro(8, 59, 59, 1_000_000).unwrap();
 ///
 /// let dt2 = NaiveDate::from_ymd(2015, 6, 30)
 ///     .unwrap()
-///     .and_hms_nano(23, 59, 59, 1_000_000_000)
+///     .at_hms_nano(23, 59, 59, 1_000_000_000)
 ///     .unwrap()
 ///     .and_utc();
 /// # let _ = (t, dt1, dt2);
@@ -169,7 +169,7 @@ mod tests;
 ///
 /// let dt = NaiveDate::from_ymd(2015, 6, 30)
 ///     .unwrap()
-///     .and_hms_milli(23, 59, 59, 1_000)
+///     .at_hms_milli(23, 59, 59, 1_000)
 ///     .unwrap()
 ///     .and_utc();
 /// assert_eq!(format!("{:?}", dt), "2015-06-30T23:59:60Z");
@@ -190,12 +190,12 @@ mod tests;
 ///
 /// let paramaribo_pre1945 = FixedOffset::east(-13236).unwrap(); // -03:40:36
 /// let leap_sec_2015 =
-///     NaiveDate::from_ymd(2015, 6, 30).unwrap().and_hms_milli(23, 59, 59, 1_000).unwrap();
+///     NaiveDate::from_ymd(2015, 6, 30).unwrap().at_hms_milli(23, 59, 59, 1_000).unwrap();
 /// let dt1 = paramaribo_pre1945.from_utc_datetime(leap_sec_2015);
 /// assert_eq!(format!("{:?}", dt1), "2015-06-30T20:19:24-03:40:36");
 /// assert_eq!(format!("{:?}", dt1.time()), "20:19:24");
 ///
-/// let next_sec = NaiveDate::from_ymd(2015, 7, 1).unwrap().and_hms(0, 0, 0).unwrap();
+/// let next_sec = NaiveDate::from_ymd(2015, 7, 1).unwrap().at_hms(0, 0, 0).unwrap();
 /// let dt2 = paramaribo_pre1945.from_utc_datetime(next_sec);
 /// assert_eq!(format!("{:?}", dt2), "2015-06-30T20:19:24-03:40:36");
 /// assert_eq!(format!("{:?}", dt2.time()), "20:19:24");

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -46,7 +46,7 @@ impl FixedOffset {
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
     /// let datetime =
-    ///     FixedOffset::east(5 * hour).unwrap().with_ymd_and_hms(2016, 11, 08, 0, 0, 0).unwrap();
+    ///     FixedOffset::east(5 * hour).unwrap().at_ymd_and_hms(2016, 11, 08, 0, 0, 0).unwrap();
     /// assert_eq!(&datetime.to_rfc3339(), "2016-11-08T00:00:00+05:00")
     /// # }
     /// ```
@@ -71,7 +71,7 @@ impl FixedOffset {
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
     /// let datetime =
-    ///     FixedOffset::west(5 * hour).unwrap().with_ymd_and_hms(2016, 11, 08, 0, 0, 0).unwrap();
+    ///     FixedOffset::west(5 * hour).unwrap().at_ymd_and_hms(2016, 11, 08, 0, 0, 0).unwrap();
     /// assert_eq!(&datetime.to_rfc3339(), "2016-11-08T00:00:00-05:00")
     /// # }
     /// ```
@@ -168,22 +168,22 @@ mod tests {
         // this makes everything easier!
         let offset = FixedOffset::east(86399).unwrap();
         assert_eq!(
-            format!("{:?}", offset.with_ymd_and_hms(2012, 2, 29, 5, 6, 7).unwrap()),
+            format!("{:?}", offset.at_ymd_and_hms(2012, 2, 29, 5, 6, 7).unwrap()),
             "2012-02-29T05:06:07+23:59:59"
         );
         let offset = FixedOffset::east(-86399).unwrap();
         assert_eq!(
-            format!("{:?}", offset.with_ymd_and_hms(2012, 2, 29, 5, 6, 7).unwrap()),
+            format!("{:?}", offset.at_ymd_and_hms(2012, 2, 29, 5, 6, 7).unwrap()),
             "2012-02-29T05:06:07-23:59:59"
         );
         let offset = FixedOffset::west(86399).unwrap();
         assert_eq!(
-            format!("{:?}", offset.with_ymd_and_hms(2012, 3, 4, 5, 6, 7).unwrap()),
+            format!("{:?}", offset.at_ymd_and_hms(2012, 3, 4, 5, 6, 7).unwrap()),
             "2012-03-04T05:06:07-23:59:59"
         );
         let offset = FixedOffset::west(-86399).unwrap();
         assert_eq!(
-            format!("{:?}", offset.with_ymd_and_hms(2012, 3, 4, 5, 6, 7).unwrap()),
+            format!("{:?}", offset.at_ymd_and_hms(2012, 3, 4, 5, 6, 7).unwrap()),
             "2012-03-04T05:06:07+23:59:59"
         );
     }

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -301,7 +301,7 @@ mod tests {
     #[test]
     fn test_local_date_sanity_check() {
         // issue #27
-        assert_eq!(Local.with_ymd_and_hms(2999, 12, 28, 0, 0, 0).unwrap().day(), 28);
+        assert_eq!(Local.at_ymd_and_hms(2999, 12, 28, 0, 0, 0).unwrap().day(), 28);
     }
 
     #[test]

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -59,7 +59,7 @@ mod inner {
     use crate::{Datelike, FixedOffset, MappedLocalTime, NaiveDateTime, Timelike};
 
     pub(super) fn offset_from_utc_datetime(utc: NaiveDateTime) -> MappedLocalTime<FixedOffset> {
-        let offset = js_sys::Date::from(utc.and_utc()).get_timezone_offset();
+        let offset = js_sys::Date::from(utc.in_utc()).get_timezone_offset();
         MappedLocalTime::Single(FixedOffset::west((offset as i32) * 60).unwrap())
     }
 

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -309,7 +309,7 @@ mod tests {
         // issue #123
         let today = Utc::now().date_naive();
 
-        if let Ok(dt) = today.and_hms_milli(15, 2, 59, 1000) {
+        if let Ok(dt) = today.at_hms_milli(15, 2, 59, 1000) {
             let timestr = dt.time().to_string();
             // the OS API may or may not support the leap second,
             // but there are only two sensible options.
@@ -320,7 +320,7 @@ mod tests {
             );
         }
 
-        if let Ok(dt) = today.and_hms_milli(15, 2, 3, 1234) {
+        if let Ok(dt) = today.at_hms_milli(15, 2, 3, 1234) {
             let timestr = dt.time().to_string();
             assert!(
                 timestr == "15:02:03.234" || timestr == "15:02:04.234",
@@ -334,7 +334,7 @@ mod tests {
     #[cfg(windows)]
     fn test_lookup_with_dst_transitions() {
         let ymdhms =
-            |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
+            |y, m, d, h, n, s| NaiveDate::from_ymd(y, m, d).unwrap().at_hms(h, n, s).unwrap();
 
         #[track_caller]
         #[allow(clippy::too_many_arguments)]
@@ -348,7 +348,7 @@ mod tests {
             s: u32,
             result: MappedLocalTime<FixedOffset>,
         ) {
-            let dt = NaiveDate::from_ymd(y, m, d).unwrap().and_hms(h, n, s).unwrap();
+            let dt = NaiveDate::from_ymd(y, m, d).unwrap().at_hms(h, n, s).unwrap();
             assert_eq!(lookup_with_dst_transitions(transitions, dt), result);
         }
 

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -102,7 +102,7 @@ mod tz_info;
 /// use chrono::{DateTime, Local, TimeZone};
 ///
 /// let dt1: DateTime<Local> = Local::now();
-/// let dt2: DateTime<Local> = Local.timestamp(0, 0).unwrap();
+/// let dt2: DateTime<Local> = Local.at_timestamp(0, 0).unwrap();
 /// assert!(dt1 >= dt2);
 /// ```
 #[derive(Copy, Clone, Debug)]

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -151,7 +151,7 @@ impl Cache {
         if !local {
             let offset = self
                 .zone
-                .find_local_time_type(d.and_utc().timestamp())
+                .find_local_time_type(d.in_utc().timestamp())
                 .expect("unable to select local time type")
                 .offset();
 
@@ -164,7 +164,7 @@ impl Cache {
         // we pass through the year as the year of a local point in time must either be valid in that locale, or
         // the entire time was skipped in which case we will return MappedLocalTime::None anyway.
         self.zone
-            .find_local_time_type_from_local(d.and_utc().timestamp(), d.year())
+            .find_local_time_type_from_local(d.in_utc().timestamp(), d.year())
             .expect("unable to select local time type")
             .and_then(|o| FixedOffset::east(o.offset()))
     }

--- a/src/offset/local/windows.rs
+++ b/src/offset/local/windows.rs
@@ -286,7 +286,7 @@ mod tests {
             (bit_shift as i64 - HECTONANOSEC_TO_UNIX_EPOCH) / HECTONANOSECS_IN_SEC
         }
 
-        let mut date = NaiveDate::from_ymd(1975, 1, 1).unwrap().and_hms(0, 30, 0).unwrap();
+        let mut date = NaiveDate::from_ymd(1975, 1, 1).unwrap().at_hms(0, 30, 0).unwrap();
 
         while date.year() < 2078 {
             // Windows doesn't handle non-existing dates, it just treats it as valid.

--- a/src/offset/local/windows.rs
+++ b/src/offset/local/windows.rs
@@ -187,7 +187,7 @@ fn naive_date_time_from_system_time(
         // We have a concrete date.
         let date = NaiveDate::from_ymd(st.wYear as i32, st.wMonth as u32, st.wDay as u32)
             .map_err(|_| ())?;
-        return Ok(Some(date.and_time(time)));
+        return Ok(Some(date.at(time)));
     }
 
     // Resolve a rule with month, weekday, and nth weekday of the month to a date in the current
@@ -213,7 +213,7 @@ fn naive_date_time_from_system_time(
         }
         Err(_) => return Err(()), // `st.wMonth` must be invalid
     };
-    Ok(Some(date.and_time(time)))
+    Ok(Some(date.at(time)))
 }
 
 #[cfg(test)]

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -209,9 +209,9 @@ pub trait TimeZone: Sized + Clone {
     /// ```
     /// use chrono::{TimeZone, Utc};
     ///
-    /// assert_eq!(Utc.timestamp(1431648000, 0).unwrap().to_string(), "2015-05-15 00:00:00 UTC");
+    /// assert_eq!(Utc.at_timestamp(1431648000, 0).unwrap().to_string(), "2015-05-15 00:00:00 UTC");
     /// ```
-    fn timestamp(&self, secs: i64, nsecs: u32) -> MappedLocalTime<DateTime<Self>> {
+    fn at_timestamp(&self, secs: i64, nsecs: u32) -> MappedLocalTime<DateTime<Self>> {
         match DateTime::from_timestamp(secs, nsecs) {
             Ok(dt) => MappedLocalTime::Single(self.from_utc_datetime(dt.naive_utc())),
             Err(_) => MappedLocalTime::None,
@@ -230,12 +230,12 @@ pub trait TimeZone: Sized + Clone {
     ///
     /// ```
     /// use chrono::{MappedLocalTime, TimeZone, Utc};
-    /// match Utc.timestamp_millis(1431648000) {
+    /// match Utc.at_timestamp_millis(1431648000) {
     ///     MappedLocalTime::Single(dt) => assert_eq!(dt.timestamp(), 1431648),
     ///     _ => panic!("Incorrect timestamp_millis"),
     /// };
     /// ```
-    fn timestamp_millis(&self, millis: i64) -> MappedLocalTime<DateTime<Self>> {
+    fn at_timestamp_millis(&self, millis: i64) -> MappedLocalTime<DateTime<Self>> {
         match DateTime::from_timestamp_millis(millis) {
             Ok(dt) => MappedLocalTime::Single(self.from_utc_datetime(dt.naive_utc())),
             Err(_) => MappedLocalTime::None,
@@ -245,16 +245,16 @@ pub trait TimeZone: Sized + Clone {
     /// Makes a new `DateTime` from the number of non-leap nanoseconds
     /// since January 1, 1970 0:00:00 UTC (aka "UNIX timestamp").
     ///
-    /// Unlike [`timestamp_millis`](#method.timestamp_millis), this never fails.
+    /// Unlike [`at_timestamp_millis`](#method.at_timestamp_millis), this never fails.
     ///
     /// # Example
     ///
     /// ```
     /// use chrono::{TimeZone, Utc};
     ///
-    /// assert_eq!(Utc.timestamp_nanos(1431648000000000).timestamp(), 1431648);
+    /// assert_eq!(Utc.at_timestamp_nanos(1431648000000000).timestamp(), 1431648);
     /// ```
-    fn timestamp_nanos(&self, nanos: i64) -> DateTime<Self> {
+    fn at_timestamp_nanos(self, nanos: i64) -> DateTime<Self> {
         self.from_utc_datetime(DateTime::from_timestamp_nanos(nanos).naive_utc())
     }
 
@@ -266,9 +266,9 @@ pub trait TimeZone: Sized + Clone {
     /// ```
     /// use chrono::{TimeZone, Utc};
     ///
-    /// assert_eq!(Utc.timestamp_micros(1431648000000).unwrap().timestamp(), 1431648);
+    /// assert_eq!(Utc.at_timestamp_micros(1431648000000).unwrap().timestamp(), 1431648);
     /// ```
-    fn timestamp_micros(&self, micros: i64) -> MappedLocalTime<DateTime<Self>> {
+    fn at_timestamp_micros(&self, micros: i64) -> MappedLocalTime<DateTime<Self>> {
         match DateTime::from_timestamp_micros(micros) {
             Ok(dt) => MappedLocalTime::Single(self.from_utc_datetime(dt.naive_utc())),
             Err(_) => MappedLocalTime::None,
@@ -334,21 +334,21 @@ mod tests {
 
     #[test]
     fn test_negative_millis() {
-        let dt = Utc.timestamp_millis(-1000).unwrap();
+        let dt = Utc.at_timestamp_millis(-1000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59 UTC");
-        let dt = Utc.timestamp_millis(-7000).unwrap();
+        let dt = Utc.at_timestamp_millis(-7000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:53 UTC");
-        let dt = Utc.timestamp_millis(-7001).unwrap();
+        let dt = Utc.at_timestamp_millis(-7001).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:52.999 UTC");
-        let dt = Utc.timestamp_millis(-7003).unwrap();
+        let dt = Utc.at_timestamp_millis(-7003).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:52.997 UTC");
-        let dt = Utc.timestamp_millis(-999).unwrap();
+        let dt = Utc.at_timestamp_millis(-999).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59.001 UTC");
-        let dt = Utc.timestamp_millis(-1).unwrap();
+        let dt = Utc.at_timestamp_millis(-1).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59.999 UTC");
-        let dt = Utc.timestamp_millis(-60000).unwrap();
+        let dt = Utc.at_timestamp_millis(-60000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:00 UTC");
-        let dt = Utc.timestamp_millis(-3600000).unwrap();
+        let dt = Utc.at_timestamp_millis(-3600000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:00:00 UTC");
 
         for (millis, expected) in &[
@@ -356,7 +356,7 @@ mod tests {
             (-7001, "1969-12-31 23:59:52.999 UTC"),
             (-7003, "1969-12-31 23:59:52.997 UTC"),
         ] {
-            match Utc.timestamp_millis(*millis) {
+            match Utc.at_timestamp_millis(*millis) {
                 MappedLocalTime::Single(dt) => {
                     assert_eq!(dt.to_string(), *expected);
                 }
@@ -367,36 +367,36 @@ mod tests {
 
     #[test]
     fn test_negative_nanos() {
-        let dt = Utc.timestamp_nanos(-1_000_000_000);
+        let dt = Utc.at_timestamp_nanos(-1_000_000_000);
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59 UTC");
-        let dt = Utc.timestamp_nanos(-999_999_999);
+        let dt = Utc.at_timestamp_nanos(-999_999_999);
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59.000000001 UTC");
-        let dt = Utc.timestamp_nanos(-1);
+        let dt = Utc.at_timestamp_nanos(-1);
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59.999999999 UTC");
-        let dt = Utc.timestamp_nanos(-60_000_000_000);
+        let dt = Utc.at_timestamp_nanos(-60_000_000_000);
         assert_eq!(dt.to_string(), "1969-12-31 23:59:00 UTC");
-        let dt = Utc.timestamp_nanos(-3_600_000_000_000);
+        let dt = Utc.at_timestamp_nanos(-3_600_000_000_000);
         assert_eq!(dt.to_string(), "1969-12-31 23:00:00 UTC");
     }
 
     #[test]
     fn test_nanos_never_panics() {
-        Utc.timestamp_nanos(i64::max_value());
-        Utc.timestamp_nanos(i64::default());
-        Utc.timestamp_nanos(i64::min_value());
+        Utc.at_timestamp_nanos(i64::max_value());
+        Utc.at_timestamp_nanos(i64::default());
+        Utc.at_timestamp_nanos(i64::min_value());
     }
 
     #[test]
     fn test_negative_micros() {
-        let dt = Utc.timestamp_micros(-1_000_000).unwrap();
+        let dt = Utc.at_timestamp_micros(-1_000_000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59 UTC");
-        let dt = Utc.timestamp_micros(-999_999).unwrap();
+        let dt = Utc.at_timestamp_micros(-999_999).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59.000001 UTC");
-        let dt = Utc.timestamp_micros(-1).unwrap();
+        let dt = Utc.at_timestamp_micros(-1).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:59.999999 UTC");
-        let dt = Utc.timestamp_micros(-60_000_000).unwrap();
+        let dt = Utc.at_timestamp_micros(-60_000_000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:59:00 UTC");
-        let dt = Utc.timestamp_micros(-3_600_000_000).unwrap();
+        let dt = Utc.at_timestamp_micros(-3_600_000_000).unwrap();
         assert_eq!(dt.to_string(), "1969-12-31 23:00:00 UTC");
     }
 }

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -185,7 +185,7 @@ pub trait TimeZone: Sized + Clone {
         min: u32,
         sec: u32,
     ) -> MappedLocalTime<DateTime<Self>> {
-        match NaiveDate::from_ymd(year, month, day).and_then(|d| d.and_hms(hour, min, sec)) {
+        match NaiveDate::from_ymd(year, month, day).and_then(|d| d.at_hms(hour, min, sec)) {
             Ok(dt) => self.from_local_datetime(dt),
             Err(_) => MappedLocalTime::None,
         }

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -176,7 +176,7 @@ pub trait TimeZone: Sized + Clone {
     /// This assumes the proleptic Gregorian calendar, with the year 0 being 1 BCE.
     ///
     /// Returns `MappedLocalTime::None` on invalid input data.
-    fn with_ymd_and_hms(
+    fn at_ymd_and_hms(
         &self,
         year: i32,
         month: u32,

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -39,7 +39,7 @@ use crate::OutOfRange;
 /// let dt = DateTime::from_timestamp(61, 0).unwrap();
 ///
 /// assert_eq!(Utc.at_timestamp(61, 0).unwrap(), dt);
-/// assert_eq!(Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(), dt);
+/// assert_eq!(Utc.at_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(), dt);
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -38,7 +38,7 @@ use crate::OutOfRange;
 ///
 /// let dt = DateTime::from_timestamp(61, 0).unwrap();
 ///
-/// assert_eq!(Utc.timestamp(61, 0).unwrap(), dt);
+/// assert_eq!(Utc.at_timestamp(61, 0).unwrap(), dt);
 /// assert_eq!(Utc.with_ymd_and_hms(1970, 1, 1, 0, 1, 1).unwrap(), dt);
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]

--- a/src/round.rs
+++ b/src/round.rs
@@ -23,7 +23,7 @@ pub trait SubsecRound {
     /// ``` rust
     /// # use chrono::{SubsecRound, Timelike, NaiveDate};
     /// let dt =
-    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_milli(12, 0, 0, 154).unwrap().and_utc();
+    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_milli(12, 0, 0, 154).unwrap().in_utc();
     /// assert_eq!(dt.round_subsecs(2).nanosecond(), 150_000_000);
     /// assert_eq!(dt.round_subsecs(1).nanosecond(), 200_000_000);
     /// ```
@@ -36,7 +36,7 @@ pub trait SubsecRound {
     /// ``` rust
     /// # use chrono::{SubsecRound, Timelike, NaiveDate};
     /// let dt =
-    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_milli(12, 0, 0, 154).unwrap().and_utc();
+    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_milli(12, 0, 0, 154).unwrap().in_utc();
     /// assert_eq!(dt.trunc_subsecs(2).nanosecond(), 150_000_000);
     /// assert_eq!(dt.trunc_subsecs(1).nanosecond(), 100_000_000);
     /// ```
@@ -112,7 +112,7 @@ pub trait DurationRound: Sized {
     /// ``` rust
     /// # use chrono::{DurationRound, TimeDelta, NaiveDate};
     /// let dt =
-    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_milli(12, 0, 0, 154).unwrap().and_utc();
+    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_milli(12, 0, 0, 154).unwrap().in_utc();
     /// assert_eq!(
     ///     dt.duration_round(TimeDelta::milliseconds(10).unwrap()).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
@@ -130,7 +130,7 @@ pub trait DurationRound: Sized {
     /// ``` rust
     /// # use chrono::{DurationRound, TimeDelta, NaiveDate};
     /// let dt =
-    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_milli(12, 0, 0, 154).unwrap().and_utc();
+    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_milli(12, 0, 0, 154).unwrap().in_utc();
     /// assert_eq!(
     ///     dt.duration_trunc(TimeDelta::milliseconds(10).unwrap()).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
@@ -180,7 +180,7 @@ where
             return Err(RoundingError::DurationExceedsLimit);
         }
         let stamp =
-            naive.and_utc().timestamp_nanos().map_err(|_| RoundingError::TimestampExceedsLimit)?;
+            naive.in_utc().timestamp_nanos().map_err(|_| RoundingError::TimestampExceedsLimit)?;
         if span == 0 {
             return Ok(original);
         }
@@ -217,7 +217,7 @@ where
             return Err(RoundingError::DurationExceedsLimit);
         }
         let stamp =
-            naive.and_utc().timestamp_nanos().map_err(|_| RoundingError::TimestampExceedsLimit)?;
+            naive.in_utc().timestamp_nanos().map_err(|_| RoundingError::TimestampExceedsLimit)?;
         let delta_down = stamp % span;
         match delta_down.cmp(&0) {
             Ordering::Equal => Ok(original),
@@ -247,7 +247,7 @@ pub enum RoundingError {
     ///     .unwrap()
     ///     .at_hms_nano(23, 59, 59, 1_75_500_000)
     ///     .unwrap()
-    ///     .and_utc();
+    ///     .in_utc();
     ///
     /// assert_eq!(
     ///     dt.duration_round(TimeDelta::days(300 * 365)),

--- a/src/round.rs
+++ b/src/round.rs
@@ -23,7 +23,7 @@ pub trait SubsecRound {
     /// ``` rust
     /// # use chrono::{SubsecRound, Timelike, NaiveDate};
     /// let dt =
-    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli(12, 0, 0, 154).unwrap().and_utc();
+    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_milli(12, 0, 0, 154).unwrap().and_utc();
     /// assert_eq!(dt.round_subsecs(2).nanosecond(), 150_000_000);
     /// assert_eq!(dt.round_subsecs(1).nanosecond(), 200_000_000);
     /// ```
@@ -36,7 +36,7 @@ pub trait SubsecRound {
     /// ``` rust
     /// # use chrono::{SubsecRound, Timelike, NaiveDate};
     /// let dt =
-    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli(12, 0, 0, 154).unwrap().and_utc();
+    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_milli(12, 0, 0, 154).unwrap().and_utc();
     /// assert_eq!(dt.trunc_subsecs(2).nanosecond(), 150_000_000);
     /// assert_eq!(dt.trunc_subsecs(1).nanosecond(), 100_000_000);
     /// ```
@@ -112,7 +112,7 @@ pub trait DurationRound: Sized {
     /// ``` rust
     /// # use chrono::{DurationRound, TimeDelta, NaiveDate};
     /// let dt =
-    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli(12, 0, 0, 154).unwrap().and_utc();
+    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_milli(12, 0, 0, 154).unwrap().and_utc();
     /// assert_eq!(
     ///     dt.duration_round(TimeDelta::milliseconds(10).unwrap()).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
@@ -130,7 +130,7 @@ pub trait DurationRound: Sized {
     /// ``` rust
     /// # use chrono::{DurationRound, TimeDelta, NaiveDate};
     /// let dt =
-    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().and_hms_milli(12, 0, 0, 154).unwrap().and_utc();
+    ///     NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_milli(12, 0, 0, 154).unwrap().and_utc();
     /// assert_eq!(
     ///     dt.duration_trunc(TimeDelta::milliseconds(10).unwrap()).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
@@ -245,7 +245,7 @@ pub enum RoundingError {
     /// # use chrono::{DurationRound, TimeDelta, RoundingError, NaiveDate};
     /// let dt = NaiveDate::from_ymd(2260, 12, 31)
     ///     .unwrap()
-    ///     .and_hms_nano(23, 59, 59, 1_75_500_000)
+    ///     .at_hms_nano(23, 59, 59, 1_75_500_000)
     ///     .unwrap()
     ///     .and_utc();
     ///
@@ -305,7 +305,7 @@ mod tests {
             .from_local_datetime(
                 NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
-                    .and_hms_nano(10, 5, 13, 84_660_684)
+                    .at_hms_nano(10, 5, 13, 84_660_684)
                     .unwrap(),
             )
             .unwrap();
@@ -328,7 +328,7 @@ mod tests {
             .from_local_datetime(
                 NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
-                    .and_hms_nano(10, 5, 27, 750_500_000)
+                    .at_hms_nano(10, 5, 27, 750_500_000)
                     .unwrap(),
             )
             .unwrap();
@@ -348,7 +348,7 @@ mod tests {
             .from_local_datetime(
                 NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
-                    .and_hms_nano(23, 59, 59, 1_750_500_000)
+                    .at_hms_nano(23, 59, 59, 1_750_500_000)
                     .unwrap(),
             )
             .unwrap();
@@ -369,7 +369,7 @@ mod tests {
             .from_local_datetime(
                 NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
-                    .and_hms_nano(10, 5, 13, 84_660_684)
+                    .at_hms_nano(10, 5, 13, 84_660_684)
                     .unwrap(),
             )
             .unwrap();
@@ -392,7 +392,7 @@ mod tests {
             .from_local_datetime(
                 NaiveDate::from_ymd(2018, 1, 11)
                     .unwrap()
-                    .and_hms_nano(10, 5, 27, 750_500_000)
+                    .at_hms_nano(10, 5, 27, 750_500_000)
                     .unwrap(),
             )
             .unwrap();
@@ -412,7 +412,7 @@ mod tests {
             .from_local_datetime(
                 NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
-                    .and_hms_nano(23, 59, 59, 1_750_500_000)
+                    .at_hms_nano(23, 59, 59, 1_750_500_000)
                     .unwrap(),
             )
             .unwrap();
@@ -432,7 +432,7 @@ mod tests {
             .from_local_datetime(
                 NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
-                    .and_hms_nano(23, 59, 59, 175_500_000)
+                    .at_hms_nano(23, 59, 59, 175_500_000)
                     .unwrap(),
             )
             .unwrap();
@@ -450,7 +450,7 @@ mod tests {
         // round up
         let dt = Utc
             .from_local_datetime(
-                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().at_hms_milli(18, 22, 30, 0).unwrap(),
             )
             .unwrap();
         assert_eq!(
@@ -460,7 +460,7 @@ mod tests {
         // round down
         let dt = Utc
             .from_local_datetime(
-                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().at_hms_milli(18, 22, 29, 999).unwrap(),
             )
             .unwrap();
         assert_eq!(
@@ -514,7 +514,7 @@ mod tests {
             .from_local_datetime(
                 NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
-                    .and_hms_nano(23, 59, 59, 175_500_000)
+                    .at_hms_nano(23, 59, 59, 175_500_000)
                     .unwrap(),
             )
             .unwrap()
@@ -533,7 +533,7 @@ mod tests {
         // round up
         let dt = Utc
             .from_local_datetime(
-                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().at_hms_milli(18, 22, 30, 0).unwrap(),
             )
             .unwrap()
             .naive_utc();
@@ -544,7 +544,7 @@ mod tests {
         // round down
         let dt = Utc
             .from_local_datetime(
-                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().at_hms_milli(18, 22, 29, 999).unwrap(),
             )
             .unwrap()
             .naive_utc();
@@ -586,7 +586,7 @@ mod tests {
             .from_local_datetime(
                 NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
-                    .and_hms_nano(23, 59, 59, 175_500_000)
+                    .at_hms_nano(23, 59, 59, 175_500_000)
                     .unwrap(),
             )
             .unwrap();
@@ -599,7 +599,7 @@ mod tests {
         // would round up
         let dt = Utc
             .from_local_datetime(
-                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().at_hms_milli(18, 22, 30, 0).unwrap(),
             )
             .unwrap();
         assert_eq!(
@@ -609,7 +609,7 @@ mod tests {
         // would round down
         let dt = Utc
             .from_local_datetime(
-                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().at_hms_milli(18, 22, 29, 999).unwrap(),
             )
             .unwrap();
         assert_eq!(
@@ -662,7 +662,7 @@ mod tests {
             .from_local_datetime(
                 NaiveDate::from_ymd(2016, 12, 31)
                     .unwrap()
-                    .and_hms_nano(23, 59, 59, 175_500_000)
+                    .at_hms_nano(23, 59, 59, 175_500_000)
                     .unwrap(),
             )
             .unwrap()
@@ -676,7 +676,7 @@ mod tests {
         // would round up
         let dt = Utc
             .from_local_datetime(
-                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 30, 0).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().at_hms_milli(18, 22, 30, 0).unwrap(),
             )
             .unwrap()
             .naive_utc();
@@ -687,7 +687,7 @@ mod tests {
         // would round down
         let dt = Utc
             .from_local_datetime(
-                NaiveDate::from_ymd(2012, 12, 12).unwrap().and_hms_milli(18, 22, 29, 999).unwrap(),
+                NaiveDate::from_ymd(2012, 12, 12).unwrap().at_hms_milli(18, 22, 29, 999).unwrap(),
             )
             .unwrap()
             .naive_utc();
@@ -741,10 +741,10 @@ mod tests {
     fn test_duration_trunc_close_to_epoch() {
         let span = TimeDelta::minutes(15);
 
-        let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms(0, 0, 15).unwrap();
+        let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().at_hms(0, 0, 15).unwrap();
         assert_eq!(dt.duration_trunc(span).unwrap().to_string(), "1970-01-01 00:00:00");
 
-        let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().and_hms(23, 59, 45).unwrap();
+        let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().at_hms(23, 59, 45).unwrap();
         assert_eq!(dt.duration_trunc(span).unwrap().to_string(), "1969-12-31 23:45:00");
     }
 
@@ -752,10 +752,10 @@ mod tests {
     fn test_duration_round_close_to_epoch() {
         let span = TimeDelta::minutes(15);
 
-        let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms(0, 0, 15).unwrap();
+        let dt = NaiveDate::from_ymd(1970, 1, 1).unwrap().at_hms(0, 0, 15).unwrap();
         assert_eq!(dt.duration_round(span).unwrap().to_string(), "1970-01-01 00:00:00");
 
-        let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().and_hms(23, 59, 45).unwrap();
+        let dt = NaiveDate::from_ymd(1969, 12, 31).unwrap().at_hms(23, 59, 45).unwrap();
         assert_eq!(dt.duration_round(span).unwrap().to_string(), "1970-01-01 00:00:00");
     }
 

--- a/src/round.rs
+++ b/src/round.rs
@@ -260,7 +260,7 @@ pub enum RoundingError {
     ///
     /// ``` rust
     /// # use chrono::{DurationRound, TimeDelta, RoundingError, TimeZone, Utc};
-    /// let dt = Utc.with_ymd_and_hms(2300, 12, 12, 0, 0, 0).unwrap();
+    /// let dt = Utc.at_ymd_and_hms(2300, 12, 12, 0, 0, 0).unwrap();
     ///
     /// assert_eq!(dt.duration_round(TimeDelta::days(1)), Err(RoundingError::TimestampExceedsLimit));
     /// ```
@@ -486,7 +486,7 @@ mod tests {
         );
 
         // timezone east
-        let dt = FixedOffset::east(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
+        let dt = FixedOffset::east(3600).unwrap().at_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
         assert_eq!(
             dt.duration_round(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-28 00:00:00 +01:00"
@@ -497,7 +497,7 @@ mod tests {
         );
 
         // timezone west
-        let dt = FixedOffset::west(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
+        let dt = FixedOffset::west(3600).unwrap().at_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
         assert_eq!(
             dt.duration_round(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-28 00:00:00 -01:00"
@@ -573,7 +573,7 @@ mod tests {
 
     #[test]
     fn test_duration_round_pre_epoch() {
-        let dt = Utc.with_ymd_and_hms(1969, 12, 12, 12, 12, 12).unwrap();
+        let dt = Utc.at_ymd_and_hms(1969, 12, 12, 12, 12, 12).unwrap();
         assert_eq!(
             dt.duration_round(TimeDelta::minutes(10)).unwrap().to_string(),
             "1969-12-12 12:10:00 UTC"
@@ -634,7 +634,7 @@ mod tests {
         );
 
         // timezone east
-        let dt = FixedOffset::east(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
+        let dt = FixedOffset::east(3600).unwrap().at_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
         assert_eq!(
             dt.duration_trunc(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-27 00:00:00 +01:00"
@@ -645,7 +645,7 @@ mod tests {
         );
 
         // timezone west
-        let dt = FixedOffset::west(3600).unwrap().with_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
+        let dt = FixedOffset::west(3600).unwrap().at_ymd_and_hms(2020, 10, 27, 15, 0, 0).unwrap();
         assert_eq!(
             dt.duration_trunc(TimeDelta::days(1)).unwrap().to_string(),
             "2020-10-27 00:00:00 -01:00"
@@ -715,7 +715,7 @@ mod tests {
 
     #[test]
     fn test_duration_trunc_pre_epoch() {
-        let dt = Utc.with_ymd_and_hms(1969, 12, 12, 12, 12, 12).unwrap();
+        let dt = Utc.at_ymd_and_hms(1969, 12, 12, 12, 12, 12).unwrap();
         assert_eq!(
             dt.duration_trunc(TimeDelta::minutes(10)).unwrap().to_string(),
             "1969-12-12 12:10:00 UTC"

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -90,8 +90,8 @@ fn try_verify_against_date_command() {
     let mut children = vec![];
     for year in [1975, 1976, 1977, 2020, 2021, 2022, 2073, 2074, 2075, 2076, 2077].iter() {
         children.push(thread::spawn(|| {
-            let mut date = NaiveDate::from_ymd(*year, 1, 1).unwrap().and_time(NaiveTime::MIN);
-            let end = NaiveDate::from_ymd(*year + 1, 1, 1).unwrap().and_time(NaiveTime::MIN);
+            let mut date = NaiveDate::from_ymd(*year, 1, 1).unwrap().at(NaiveTime::MIN);
+            let end = NaiveDate::from_ymd(*year + 1, 1, 1).unwrap().at(NaiveTime::MIN);
             while date <= end {
                 verify_against_date_command_local(DATE_PATH, date);
                 date += chrono::TimeDelta::hours(1);

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -17,7 +17,7 @@ fn verify_against_date_command_local(path: &'static str, dt: NaiveDateTime) {
     // seems to be consistent with the output of the `date` command, so we simply
     // compare both.
     // let local = Local
-    //     .with_ymd_and_hms(year, month, day, hour, 5, 1)
+    //     .at_ymd_and_hms(year, month, day, hour, 5, 1)
     //     // looks like the "date" command always returns a given time when it is ambiguous
     //     .earliest();
 

--- a/tests/dateutils.rs
+++ b/tests/dateutils.rs
@@ -33,7 +33,7 @@ fn verify_against_date_command_local(path: &'static str, dt: NaiveDateTime) {
     // differently
 
     let date = NaiveDate::from_ymd(dt.year(), dt.month(), dt.day()).unwrap();
-    match Local.from_local_datetime(date.and_hms(dt.hour(), 5, 1).unwrap()) {
+    match Local.from_local_datetime(date.at_hms(dt.hour(), 5, 1).unwrap()) {
         chrono::MappedLocalTime::Ambiguous(a, b) => assert!(
             format!("{}\n", a) == date_command_str || format!("{}\n", b) == date_command_str
         ),
@@ -139,7 +139,7 @@ fn verify_against_date_command_format_local(path: &'static str, dt: NaiveDateTim
     let date_command_str = String::from_utf8(output.stdout).unwrap();
     let date = NaiveDate::from_ymd(dt.year(), dt.month(), dt.day()).unwrap();
     let ldt = Local
-        .from_local_datetime(date.and_hms(dt.hour(), dt.minute(), dt.second()).unwrap())
+        .from_local_datetime(date.at_hms(dt.hour(), dt.minute(), dt.second()).unwrap())
         .unwrap();
     let formated_date = format!("{}\n", ldt.format(required_format));
     assert_eq!(date_command_str, formated_date);
@@ -154,7 +154,7 @@ fn try_verify_against_date_command_format() {
     }
     assert_run_date_version();
 
-    let mut date = NaiveDate::from_ymd(1970, 1, 1).unwrap().and_hms(12, 11, 13).unwrap();
+    let mut date = NaiveDate::from_ymd(1970, 1, 1).unwrap().at_hms(12, 11, 13).unwrap();
     while date.year() < 2008 {
         verify_against_date_command_format_local(DATE_PATH, date);
         date = date + Days::new(55);

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -22,7 +22,7 @@ fn now() {
 
     // Ensure time set by the test script is correct
     let now = env!("NOW");
-    let actual = NaiveDateTime::parse_from_str(&now, "%s").unwrap().and_utc();
+    let actual = NaiveDateTime::parse_from_str(&now, "%s").unwrap().in_utc();
     let diff = utc - actual;
     assert!(
         diff < chrono::TimeDelta::minutes(5),


### PR DESCRIPTION
We have the pattern to use the name `and_` for methods that add information to convert to a more complete type.
`NaiveDate` had `and_time` and `and_hms*`, `NaiveDateTime` has `and_local_timezone`.

This makes the methods on `TimeZone` consistent. `TimeZone::timestamp*` is renamed to `TimeZone::and_timestamp*` and `TimeZone::with_ymd_and_hms` to `TimeZone::and_ymd_and_hms*`.