### PR TITLE
Be consistent about taking `self` by value or by reference

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -311,7 +311,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// Returns `None` if the resulting date would be out of range.
     #[inline]
     #[must_use]
-    pub fn checked_add_signed(self, rhs: TimeDelta) -> Option<DateTime<Tz>> {
+    pub fn checked_add_signed(&self, rhs: TimeDelta) -> Option<DateTime<Tz>> {
         let datetime = self.datetime.checked_add_signed(rhs).ok()?;
         let tz = self.timezone();
         Some(tz.from_utc_datetime(datetime))
@@ -331,7 +331,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// - The resulting UTC datetime would be out of range.
     /// - The resulting local datetime would be out of range (unless `months` is zero).
     #[must_use]
-    pub fn checked_add_months(self, months: Months) -> Option<DateTime<Tz>> {
+    pub fn checked_add_months(&self, months: Months) -> Option<DateTime<Tz>> {
         // `NaiveDate::checked_add_months` has a fast path for `Months(0)` that does not validate
         // the resulting date, with which we can return `Some` even for an out of range local
         // datetime.
@@ -348,7 +348,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// Returns `None` if the resulting date would be out of range.
     #[inline]
     #[must_use]
-    pub fn checked_sub_signed(self, rhs: TimeDelta) -> Option<DateTime<Tz>> {
+    pub fn checked_sub_signed(&self, rhs: TimeDelta) -> Option<DateTime<Tz>> {
         let datetime = self.datetime.checked_sub_signed(rhs).ok()?;
         let tz = self.timezone();
         Some(tz.from_utc_datetime(datetime))
@@ -368,7 +368,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// - The resulting UTC datetime would be out of range.
     /// - The resulting local datetime would be out of range (unless `months` is zero).
     #[must_use]
-    pub fn checked_sub_months(self, months: Months) -> Option<DateTime<Tz>> {
+    pub fn checked_sub_months(&self, months: Months) -> Option<DateTime<Tz>> {
         // `NaiveDate::checked_sub_months` has a fast path for `Months(0)` that does not validate
         // the resulting date, with which we can return `Some` even for an out of range local
         // datetime.
@@ -388,9 +388,9 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// - The resulting UTC datetime would be out of range.
     /// - The resulting local datetime would be out of range (unless `days` is zero).
     #[must_use]
-    pub fn checked_add_days(self, days: Days) -> Option<Self> {
+    pub fn checked_add_days(&self, days: Days) -> Option<Self> {
         if days == Days::new(0) {
-            return Some(self);
+            return Some(self.clone());
         }
         // `NaiveDate::add_days` has a fast path if the result remains within the same year, that
         // does not validate the resulting date. This allows us to return `Some` even for an out of
@@ -412,7 +412,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// - The resulting UTC datetime would be out of range.
     /// - The resulting local datetime would be out of range (unless `days` is zero).
     #[must_use]
-    pub fn checked_sub_days(self, days: Days) -> Option<Self> {
+    pub fn checked_sub_days(&self, days: Days) -> Option<Self> {
         // `NaiveDate::add_days` has a fast path if the result remains within the same year, that
         // does not validate the resulting date. This allows us to return `Some` even for an out of
         // range local datetime when adding `Days(0)`.
@@ -428,7 +428,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     #[inline]
     #[must_use]
     pub fn signed_duration_since<Tz2: TimeZone>(
-        self,
+        &self,
         rhs: impl Borrow<DateTime<Tz2>>,
     ) -> TimeDelta {
         self.datetime.signed_duration_since(rhs.borrow().datetime)

--- a/src/month.rs
+++ b/src/month.rs
@@ -75,8 +75,8 @@ impl Month {
     /// `m.succ()`: | `February` | `March`    | `...` | `January`
     #[inline]
     #[must_use]
-    pub const fn succ(&self) -> Month {
-        match *self {
+    pub const fn succ(self) -> Month {
+        match self {
             Month::January => Month::February,
             Month::February => Month::March,
             Month::March => Month::April,
@@ -99,8 +99,8 @@ impl Month {
     /// `m.pred()`: | `December` | `January`  | `...` | `November`
     #[inline]
     #[must_use]
-    pub const fn pred(&self) -> Month {
-        match *self {
+    pub const fn pred(self) -> Month {
+        match self {
             Month::January => Month::December,
             Month::February => Month::January,
             Month::March => Month::February,
@@ -123,8 +123,8 @@ impl Month {
     /// `m.number_from_month()`: | 1         | 2          | `...` | 12
     #[inline]
     #[must_use]
-    pub const fn number_from_month(&self) -> u32 {
-        match *self {
+    pub const fn number_from_month(self) -> u32 {
+        match self {
             Month::January => 1,
             Month::February => 2,
             Month::March => 3,
@@ -148,8 +148,8 @@ impl Month {
     /// assert_eq!(Month::January.name(), "January")
     /// ```
     #[must_use]
-    pub const fn name(&self) -> &'static str {
-        match *self {
+    pub const fn name(self) -> &'static str {
+        match self {
             Month::January => "January",
             Month::February => "February",
             Month::March => "March",
@@ -201,7 +201,7 @@ impl Months {
 
     /// Returns the total number of months in the `Months` instance.
     #[inline]
-    pub const fn as_u32(&self) -> u32 {
+    pub const fn as_u32(self) -> u32 {
         self.0
     }
 }

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -114,7 +114,7 @@ impl arbitrary::Arbitrary<'_> for NaiveDate {
 }
 
 impl NaiveDate {
-    pub(crate) fn weeks_from(&self, day: Weekday) -> i32 {
+    pub(crate) fn weeks_from(self, day: Weekday) -> i32 {
         (self.ordinal() as i32 - self.weekday().num_days_from(day) as i32 + 6) / 7
     }
 
@@ -658,8 +658,8 @@ impl NaiveDate {
     /// ```
     #[inline]
     #[must_use]
-    pub const fn and_time(&self, time: NaiveTime) -> NaiveDateTime {
-        NaiveDateTime::new(*self, time)
+    pub const fn and_time(self, time: NaiveTime) -> NaiveDateTime {
+        NaiveDateTime::new(self, time)
     }
 
     /// Makes a new `NaiveDateTime` from the current date, hour, minute and second.
@@ -683,7 +683,7 @@ impl NaiveDate {
     /// assert_eq!(d.and_hms(24, 34, 56), Err(Error::InvalidArgument));
     /// ```
     #[inline]
-    pub const fn and_hms(&self, hour: u32, min: u32, sec: u32) -> Result<NaiveDateTime, Error> {
+    pub const fn and_hms(self, hour: u32, min: u32, sec: u32) -> Result<NaiveDateTime, Error> {
         let time = try_err!(NaiveTime::from_hms(hour, min, sec));
         Ok(self.and_time(time))
     }
@@ -801,7 +801,7 @@ impl NaiveDate {
 
     /// Returns the packed month-day-flags.
     #[inline]
-    const fn mdf(&self) -> Mdf {
+    const fn mdf(self) -> Mdf {
         Mdf::from_ol((self.yof() & OL_MASK) >> 3, self.year_flags())
     }
 
@@ -813,7 +813,7 @@ impl NaiveDate {
     /// - [`Error::InvalidArgument`] if the `mdf` was created with `month == 0` or `day == 0`.
     /// - [`Error::DoesNotExist`] if the given day does not exist in the given month.
     #[inline]
-    const fn with_mdf(&self, mdf: Mdf) -> Result<NaiveDate, Error> {
+    const fn with_mdf(self, mdf: Mdf) -> Result<NaiveDate, Error> {
         debug_assert!(self.year_flags().0 == mdf.year_flags().0);
         let ordinal = try_err!(mdf.ordinal());
         Ok(NaiveDate::from_yof((self.yof() & !ORDINAL_MASK) | (ordinal << 4) as i32))
@@ -834,7 +834,7 @@ impl NaiveDate {
     /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn succ(&self) -> Result<NaiveDate, Error> {
+    pub const fn succ(self) -> Result<NaiveDate, Error> {
         let new_ol = (self.yof() & OL_MASK) + (1 << 4);
         match new_ol <= MAX_OL {
             true => Ok(NaiveDate::from_yof(self.yof() & !OL_MASK | new_ol)),
@@ -857,7 +857,7 @@ impl NaiveDate {
     /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn pred(&self) -> Result<NaiveDate, Error> {
+    pub const fn pred(self) -> Result<NaiveDate, Error> {
         let new_shifted_ordinal = (self.yof() & ORDINAL_MASK) - (1 << 4);
         match new_shifted_ordinal > 0 {
             true => Ok(NaiveDate::from_yof(self.yof() & !ORDINAL_MASK | new_shifted_ordinal)),
@@ -958,7 +958,7 @@ impl NaiveDate {
     ///
     /// Returns `None` if `base < self`.
     #[must_use]
-    pub const fn years_since(&self, base: Self) -> Option<u32> {
+    pub const fn years_since(self, base: Self) -> Option<u32> {
         let mut years = self.year() - base.year();
         // Comparing tuples is not (yet) possible in const context. Instead we combine month and
         // day into one `u32` for easy comparison.
@@ -1002,12 +1002,12 @@ impl NaiveDate {
     #[cfg(feature = "alloc")]
     #[inline]
     #[must_use]
-    pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
+    pub fn format_with_items<'a, I, B>(self, items: I) -> DelayedFormat<I>
     where
         I: Iterator<Item = B> + Clone,
         B: Borrow<Item<'a>>,
     {
-        DelayedFormat::new(Some(*self), None, items)
+        DelayedFormat::new(Some(self), None, items)
     }
 
     /// Formats the date with the specified format string.
@@ -1045,7 +1045,7 @@ impl NaiveDate {
     #[cfg(feature = "alloc")]
     #[inline]
     #[must_use]
-    pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
+    pub fn format(self, fmt: &str) -> DelayedFormat<StrftimeItems> {
         self.format_with_items(StrftimeItems::new(fmt))
     }
 
@@ -1107,8 +1107,8 @@ impl NaiveDate {
     /// }
     /// ```
     #[inline]
-    pub const fn iter_days(&self) -> NaiveDateDaysIterator {
-        NaiveDateDaysIterator { value: *self }
+    pub const fn iter_days(self) -> NaiveDateDaysIterator {
+        NaiveDateDaysIterator { value: self }
     }
 
     /// Returns an iterator that steps by weeks across all representable dates.
@@ -1138,15 +1138,15 @@ impl NaiveDate {
     /// }
     /// ```
     #[inline]
-    pub const fn iter_weeks(&self) -> NaiveDateWeeksIterator {
-        NaiveDateWeeksIterator { value: *self }
+    pub const fn iter_weeks(self) -> NaiveDateWeeksIterator {
+        NaiveDateWeeksIterator { value: self }
     }
 
     /// Returns the [`NaiveWeek`] that the date belongs to, starting with the [`Weekday`]
     /// specified.
     #[inline]
-    pub const fn week(&self, start: Weekday) -> NaiveWeek {
-        NaiveWeek::new(*self, start)
+    pub const fn week(self, start: Weekday) -> NaiveWeek {
+        NaiveWeek::new(self, start)
     }
 
     /// Returns `true` if this is a leap year.
@@ -1160,7 +1160,7 @@ impl NaiveDate {
     /// assert_eq!(NaiveDate::from_ymd(2004, 1, 1).unwrap().leap_year(), true);
     /// assert_eq!(NaiveDate::from_ymd(2100, 1, 1).unwrap().leap_year(), false);
     /// ```
-    pub const fn leap_year(&self) -> bool {
+    pub const fn leap_year(self) -> bool {
         self.yof() & (0b1000) == 0
     }
 
@@ -1204,7 +1204,7 @@ impl NaiveDate {
     /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn with_year(&self, year: i32) -> Result<NaiveDate, Error> {
+    pub const fn with_year(self, year: i32) -> Result<NaiveDate, Error> {
         // we need to operate with `mdf` since we should keep the month and day number as is
         let mdf = self.mdf();
 
@@ -1256,7 +1256,7 @@ impl NaiveDate {
     /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn with_month(&self, month: u32) -> Result<NaiveDate, Error> {
+    pub const fn with_month(self, month: u32) -> Result<NaiveDate, Error> {
         self.with_mdf(try_err!(self.mdf().with_month(month)))
     }
 
@@ -1280,7 +1280,7 @@ impl NaiveDate {
     /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn with_day(&self, day: u32) -> Result<NaiveDate, Error> {
+    pub const fn with_day(self, day: u32) -> Result<NaiveDate, Error> {
         self.with_mdf(try_err!(self.mdf().with_day(day)))
     }
 
@@ -1308,7 +1308,7 @@ impl NaiveDate {
     ///            Some(NaiveDate::from_ymd(2016, 12, 31).unwrap()));
     /// ```
     #[inline]
-    pub const fn with_ordinal(&self, ordinal: u32) -> Option<NaiveDate> {
+    pub const fn with_ordinal(self, ordinal: u32) -> Option<NaiveDate> {
         if ordinal == 0 || ordinal > 366 {
             return None;
         }
@@ -1321,33 +1321,33 @@ impl NaiveDate {
 
     // This duplicates `Datelike::year()`, because trait methods can't be const yet.
     #[inline]
-    const fn year(&self) -> i32 {
+    const fn year(self) -> i32 {
         self.yof() >> 13
     }
 
     /// Returns the day of year starting from 1.
     // This duplicates `Datelike::ordinal()`, because trait methods can't be const yet.
     #[inline]
-    const fn ordinal(&self) -> u32 {
+    const fn ordinal(self) -> u32 {
         ((self.yof() & ORDINAL_MASK) >> 4) as u32
     }
 
     // This duplicates `Datelike::month()`, because trait methods can't be const yet.
     #[inline]
-    const fn month(&self) -> u32 {
+    const fn month(self) -> u32 {
         self.mdf().month()
     }
 
     // This duplicates `Datelike::day()`, because trait methods can't be const yet.
     #[inline]
-    const fn day(&self) -> u32 {
+    const fn day(self) -> u32 {
         self.mdf().day()
     }
 
     /// Returns the day of week.
     // This duplicates `Datelike::weekday()`, because trait methods can't be const yet.
     #[inline]
-    pub(super) const fn weekday(&self) -> Weekday {
+    pub(super) const fn weekday(self) -> Weekday {
         match (((self.yof() & ORDINAL_MASK) >> 4) + (self.yof() & WEEKDAY_FLAGS_MASK)) % 7 {
             0 => Weekday::Mon,
             1 => Weekday::Tue,
@@ -1360,13 +1360,13 @@ impl NaiveDate {
     }
 
     #[inline]
-    const fn year_flags(&self) -> YearFlags {
+    const fn year_flags(self) -> YearFlags {
         YearFlags((self.yof() & YEAR_FLAGS_MASK) as u8)
     }
 
     /// Counts the days in the proleptic Gregorian calendar, with January 1, Year 1 (CE) as day 1.
     // This duplicates `Datelike::num_days_from_ce()`, because trait methods can't be const yet.
-    pub(crate) const fn num_days_from_ce(&self) -> i32 {
+    pub(crate) const fn num_days_from_ce(self) -> i32 {
         // we know this wouldn't overflow since year is limited to 1/2^13 of i32's full range.
         let mut year = self.year() - 1;
         let mut ndays = 0;
@@ -1392,7 +1392,7 @@ impl NaiveDate {
 
     /// Get the raw year-ordinal-flags `i32`.
     #[inline]
-    const fn yof(&self) -> i32 {
+    const fn yof(self) -> i32 {
         self.yof.get()
     }
 
@@ -1423,7 +1423,7 @@ impl Datelike for NaiveDate {
     /// ```
     #[inline]
     fn year(&self) -> i32 {
-        self.year()
+        (*self).year()
     }
 
     /// Returns the month number starting from 1.
@@ -1440,7 +1440,7 @@ impl Datelike for NaiveDate {
     /// ```
     #[inline]
     fn month(&self) -> u32 {
-        self.month()
+        (*self).month()
     }
 
     /// Returns the month number starting from 0.
@@ -1497,7 +1497,7 @@ impl Datelike for NaiveDate {
     /// ```
     #[inline]
     fn day(&self) -> u32 {
-        self.day()
+        (*self).day()
     }
 
     /// Returns the day of month starting from 0.
@@ -1585,7 +1585,7 @@ impl Datelike for NaiveDate {
     /// ```
     #[inline]
     fn weekday(&self) -> Weekday {
-        self.weekday()
+        (*self).weekday()
     }
 
     #[inline]

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -214,7 +214,7 @@ impl NaiveDateTime {
     /// assert_eq!(dt.date(), NaiveDate::from_ymd(2016, 7, 8).unwrap());
     /// ```
     #[inline]
-    pub const fn date(&self) -> NaiveDate {
+    pub const fn date(self) -> NaiveDate {
         self.date
     }
 
@@ -229,7 +229,7 @@ impl NaiveDateTime {
     /// assert_eq!(dt.time(), NaiveTime::from_hms(9, 10, 11).unwrap());
     /// ```
     #[inline]
-    pub const fn time(&self) -> NaiveTime {
+    pub const fn time(self) -> NaiveTime {
         self.time
     }
 
@@ -633,7 +633,7 @@ impl NaiveDateTime {
     #[cfg(feature = "alloc")]
     #[inline]
     #[must_use]
-    pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
+    pub fn format_with_items<'a, I, B>(self, items: I) -> DelayedFormat<I>
     where
         I: Iterator<Item = B> + Clone,
         B: Borrow<Item<'a>>,
@@ -676,7 +676,7 @@ impl NaiveDateTime {
     #[cfg(feature = "alloc")]
     #[inline]
     #[must_use]
-    pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
+    pub fn format(self, fmt: &str) -> DelayedFormat<StrftimeItems> {
         self.format_with_items(StrftimeItems::new(fmt))
     }
 
@@ -706,8 +706,8 @@ impl NaiveDateTime {
     /// assert_eq!(dt.timezone(), tz);
     /// ```
     #[must_use]
-    pub fn and_local_timezone<Tz: TimeZone>(&self, tz: Tz) -> MappedLocalTime<DateTime<Tz>> {
-        tz.from_local_datetime(*self)
+    pub fn and_local_timezone<Tz: TimeZone>(self, tz: Tz) -> MappedLocalTime<DateTime<Tz>> {
+        tz.from_local_datetime(self)
     }
 
     /// Converts the `NaiveDateTime` into the timezone-aware `DateTime<Utc>`.
@@ -720,8 +720,8 @@ impl NaiveDateTime {
     /// assert_eq!(dt.timezone(), Utc);
     /// ```
     #[must_use]
-    pub const fn and_utc(&self) -> DateTime<Utc> {
-        DateTime::from_naive_utc_and_offset(*self, Utc)
+    pub const fn and_utc(self) -> DateTime<Utc> {
+        DateTime::from_naive_utc_and_offset(self, Utc)
     }
 
     /// Makes a new `NaiveDateTime` with the year number changed, while keeping the same month and
@@ -745,8 +745,8 @@ impl NaiveDateTime {
     /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn with_year(&self, year: i32) -> Result<NaiveDateTime, Error> {
-        Ok(NaiveDateTime { date: try_err!(self.date.with_year(year)), ..*self })
+    pub const fn with_year(self, year: i32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { date: try_err!(self.date.with_year(year)), ..self })
     }
 
     /// Makes a new `NaiveDateTime` with the month number (starting from 1) changed.
@@ -774,8 +774,8 @@ impl NaiveDateTime {
     /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn with_month(&self, month: u32) -> Result<NaiveDateTime, Error> {
-        Ok(NaiveDateTime { date: try_err!(self.date.with_month(month)), ..*self })
+    pub const fn with_month(self, month: u32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { date: try_err!(self.date.with_month(month)), ..self })
     }
 
     /// Makes a new `NaiveDateTime` with the day of month (starting from 1) changed.
@@ -800,8 +800,8 @@ impl NaiveDateTime {
     /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn with_day(&self, day: u32) -> Result<NaiveDateTime, Error> {
-        Ok(NaiveDateTime { date: try_err!(self.date.with_day(day)), ..*self })
+    pub const fn with_day(self, day: u32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { date: try_err!(self.date.with_day(day)), ..self })
     }
 
     /// Makes a new `NaiveDateTime` with the day of year (starting from 1) changed.
@@ -837,8 +837,8 @@ impl NaiveDateTime {
     /// );
     /// ```
     #[inline]
-    pub const fn with_ordinal(&self, ordinal: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { date: try_opt!(self.date.with_ordinal(ordinal)), ..*self })
+    pub const fn with_ordinal(self, ordinal: u32) -> Option<NaiveDateTime> {
+        Some(NaiveDateTime { date: try_opt!(self.date.with_ordinal(ordinal)), ..self })
     }
 
     /// Makes a new `NaiveDateTime` with the hour number changed.
@@ -860,8 +860,8 @@ impl NaiveDateTime {
     /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_hour(&self, hour: u32) -> Result<NaiveDateTime, Error> {
-        Ok(NaiveDateTime { time: try_err!(self.time.with_hour(hour)), ..*self })
+    pub const fn with_hour(self, hour: u32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { time: try_err!(self.time.with_hour(hour)), ..self })
     }
 
     /// Makes a new `NaiveDateTime` with the minute number changed.
@@ -883,8 +883,8 @@ impl NaiveDateTime {
     /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_minute(&self, min: u32) -> Result<NaiveDateTime, Error> {
-        Ok(NaiveDateTime { time: try_err!(self.time.with_minute(min)), ..*self })
+    pub const fn with_minute(self, min: u32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { time: try_err!(self.time.with_minute(min)), ..self })
     }
 
     /// Makes a new `NaiveDateTime` with the second number changed.
@@ -909,8 +909,8 @@ impl NaiveDateTime {
     /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_second(&self, sec: u32) -> Result<NaiveDateTime, Error> {
-        Ok(NaiveDateTime { time: try_err!(self.time.with_second(sec)), ..*self })
+    pub const fn with_second(self, sec: u32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { time: try_err!(self.time.with_second(sec)), ..self })
     }
 
     /// Makes a new `NaiveDateTime` with nanoseconds since the whole non-leap second changed.
@@ -942,8 +942,8 @@ impl NaiveDateTime {
     /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_nanosecond(&self, nano: u32) -> Result<NaiveDateTime, Error> {
-        Ok(NaiveDateTime { time: try_err!(self.time.with_nanosecond(nano)), ..*self })
+    pub const fn with_nanosecond(self, nano: u32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { time: try_err!(self.time.with_nanosecond(nano)), ..self })
     }
 
     /// The minimum possible `NaiveDateTime`.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -598,7 +598,7 @@ impl NaiveDateTime {
         expect!(
             self.date
                 .signed_duration_since(rhs.date)
-                .checked_add(&self.time.signed_duration_since(rhs.time)),
+                .checked_add(self.time.signed_duration_since(rhs.time)),
             "always in range"
         )
     }

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -273,8 +273,8 @@ impl Mdf {
 
     /// Returns the month of this `Mdf`.
     #[inline]
-    pub(super) const fn month(&self) -> u32 {
-        let Mdf(mdf) = *self;
+    pub(super) const fn month(self) -> u32 {
+        let Mdf(mdf) = self;
         mdf >> 9
     }
 
@@ -284,19 +284,19 @@ impl Mdf {
     ///
     /// Returns [`Error::InvalidArgument`] if `month > 12`.
     #[inline]
-    pub(super) const fn with_month(&self, month: u32) -> Result<Mdf, Error> {
+    pub(super) const fn with_month(self, month: u32) -> Result<Mdf, Error> {
         if month > 12 {
             return Err(Error::InvalidArgument);
         }
 
-        let Mdf(mdf) = *self;
+        let Mdf(mdf) = self;
         Ok(Mdf((mdf & 0b1_1111_1111) | (month << 9)))
     }
 
     /// Returns the day of this `Mdf`.
     #[inline]
-    pub(super) const fn day(&self) -> u32 {
-        let Mdf(mdf) = *self;
+    pub(super) const fn day(self) -> u32 {
+        let Mdf(mdf) = self;
         (mdf >> 4) & 0b1_1111
     }
 
@@ -306,19 +306,19 @@ impl Mdf {
     ///
     /// Returns [`Error::InvalidArgument`] if `day > 31`.
     #[inline]
-    pub(super) const fn with_day(&self, day: u32) -> Result<Mdf, Error> {
+    pub(super) const fn with_day(self, day: u32) -> Result<Mdf, Error> {
         if day > 31 {
             return Err(Error::InvalidArgument);
         }
 
-        let Mdf(mdf) = *self;
+        let Mdf(mdf) = self;
         Ok(Mdf((mdf & !0b1_1111_0000) | (day << 4)))
     }
 
     /// Replaces the flags of this `Mdf`, keeping the month and day.
     #[inline]
-    pub(super) const fn with_flags(&self, YearFlags(flags): YearFlags) -> Mdf {
-        let Mdf(mdf) = *self;
+    pub(super) const fn with_flags(self, YearFlags(flags): YearFlags) -> Mdf {
+        let Mdf(mdf) = self;
         Mdf((mdf & !0b1111) | flags as u32)
     }
 
@@ -333,7 +333,7 @@ impl Mdf {
     ///
     /// Returns [`Error::DoesNotExist`] if the given day does not exist in the given month.
     #[inline]
-    pub(super) const fn ordinal(&self) -> Result<u32, Error> {
+    pub(super) const fn ordinal(self) -> Result<u32, Error> {
         let mdl = self.0 >> 3;
         let adjustment = MDL_TO_OL[mdl as usize];
         match adjustment {
@@ -345,7 +345,7 @@ impl Mdf {
 
     /// Returns the year flags of this `Mdf`.
     #[inline]
-    pub(super) const fn year_flags(&self) -> YearFlags {
+    pub(super) const fn year_flags(self) -> YearFlags {
         YearFlags((self.0 & 0b1111) as u8)
     }
 
@@ -360,7 +360,7 @@ impl Mdf {
     ///
     /// Returns [`Error::DoesNotExist`] if the given day does not exist in the given month.
     #[inline]
-    pub(super) const fn ordinal_and_flags(&self) -> Result<i32, Error> {
+    pub(super) const fn ordinal_and_flags(self) -> Result<i32, Error> {
         let mdl = self.0 >> 3;
         let adjustment = MDL_TO_OL[mdl as usize];
         match adjustment {
@@ -371,7 +371,7 @@ impl Mdf {
     }
 
     #[cfg(test)]
-    fn valid(&self) -> bool {
+    fn valid(self) -> bool {
         let mdl = self.0 >> 3;
         MDL_TO_OL[mdl as usize] > 0
     }

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -83,14 +83,14 @@ impl YearFlags {
     }
 
     #[inline]
-    pub(super) const fn ndays(&self) -> u32 {
-        let YearFlags(flags) = *self;
+    pub(super) const fn ndays(self) -> u32 {
+        let YearFlags(flags) = self;
         366 - (flags >> 3) as u32
     }
 
     #[inline]
-    pub(super) const fn isoweek_delta(&self) -> u32 {
-        let YearFlags(flags) = *self;
+    pub(super) const fn isoweek_delta(self) -> u32 {
+        let YearFlags(flags) = self;
         let mut delta = (flags & 0b0111) as u32;
         if delta < 3 {
             delta += 7;
@@ -99,8 +99,8 @@ impl YearFlags {
     }
 
     #[inline]
-    pub(super) const fn nisoweeks(&self) -> u32 {
-        let YearFlags(flags) = *self;
+    pub(super) const fn nisoweeks(self) -> u32 {
+        let YearFlags(flags) = self;
         52 + ((0b0000_0100_0000_0110 >> flags as usize) & 1)
     }
 }

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -78,7 +78,7 @@ impl IsoWeek {
     /// assert_eq!(d, NaiveDate::from_ymd(2014, 12, 29).unwrap());
     /// ```
     #[inline]
-    pub const fn year(&self) -> i32 {
+    pub const fn year(self) -> i32 {
         self.ywf >> 10
     }
 
@@ -95,7 +95,7 @@ impl IsoWeek {
     /// assert_eq!(d.iso_week().week(), 15);
     /// ```
     #[inline]
-    pub const fn week(&self) -> u32 {
+    pub const fn week(self) -> u32 {
         ((self.ywf >> 4) & 0x3f) as u32
     }
 
@@ -112,7 +112,7 @@ impl IsoWeek {
     /// assert_eq!(d.iso_week().week0(), 14);
     /// ```
     #[inline]
-    pub const fn week0(&self) -> u32 {
+    pub const fn week0(self) -> u32 {
         ((self.ywf >> 4) & 0x3f) as u32 - 1
     }
 }

--- a/src/naive/mod.rs
+++ b/src/naive/mod.rs
@@ -26,7 +26,7 @@ pub use self::internals::YearFlags as __BenchYearFlags;
 
 /// A week represented by a [`NaiveDate`] and a [`Weekday`] which is the first
 /// day of the week.
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct NaiveWeek {
     date: NaiveDate,
     start: Weekday,

--- a/src/naive/mod.rs
+++ b/src/naive/mod.rs
@@ -56,7 +56,7 @@ impl NaiveWeek {
     /// ```
     #[inline]
     #[must_use]
-    pub const fn first_day(&self) -> NaiveDate {
+    pub const fn first_day(self) -> NaiveDate {
         let start = self.start.num_days_from_monday() as i32;
         let ref_day = self.date.weekday().num_days_from_monday() as i32;
         // Calculate the number of days to subtract from `self.date`.
@@ -84,7 +84,7 @@ impl NaiveWeek {
     /// ```
     #[inline]
     #[must_use]
-    pub const fn last_day(&self) -> NaiveDate {
+    pub const fn last_day(self) -> NaiveDate {
         let end = self.start.pred().num_days_from_monday() as i32;
         let ref_day = self.date.weekday().num_days_from_monday() as i32;
         // Calculate the number of days to add to `self.date`.
@@ -114,7 +114,7 @@ impl NaiveWeek {
     /// ```
     #[inline]
     #[must_use]
-    pub const fn days(&self) -> RangeInclusive<NaiveDate> {
+    pub const fn days(self) -> RangeInclusive<NaiveDate> {
         self.first_day()..=self.last_day()
     }
 }

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -540,7 +540,7 @@ impl NaiveTime {
     /// );
     /// ```
     #[must_use]
-    pub const fn overflowing_add_signed(&self, rhs: TimeDelta) -> (NaiveTime, i64) {
+    pub const fn overflowing_add_signed(self, rhs: TimeDelta) -> (NaiveTime, i64) {
         let mut secs = self.secs as i64;
         let mut frac = self.frac as i32;
         let secs_to_add = rhs.num_seconds();
@@ -603,7 +603,7 @@ impl NaiveTime {
     /// ```
     #[inline]
     #[must_use]
-    pub const fn overflowing_sub_signed(&self, rhs: TimeDelta) -> (NaiveTime, i64) {
+    pub const fn overflowing_sub_signed(self, rhs: TimeDelta) -> (NaiveTime, i64) {
         let (time, rhs) = self.overflowing_add_signed(rhs.neg());
         (time, -rhs) // safe to negate, rhs is within +/- (2^63 / 1000)
     }
@@ -700,7 +700,7 @@ impl NaiveTime {
     ///
     /// This method is similar to [`overflowing_add_signed`](#method.overflowing_add_signed), but
     /// preserves leap seconds.
-    pub(super) const fn overflowing_add_offset(&self, offset: FixedOffset) -> (NaiveTime, i32) {
+    pub(super) const fn overflowing_add_offset(self, offset: FixedOffset) -> (NaiveTime, i32) {
         let secs = self.secs as i32 + offset.local_minus_utc();
         let days = secs.div_euclid(86_400);
         let secs = secs.rem_euclid(86_400);
@@ -713,7 +713,7 @@ impl NaiveTime {
     ///
     /// This method is similar to [`overflowing_sub_signed`](#method.overflowing_sub_signed), but
     /// preserves leap seconds.
-    pub(super) const fn overflowing_sub_offset(&self, offset: FixedOffset) -> (NaiveTime, i32) {
+    pub(super) const fn overflowing_sub_offset(self, offset: FixedOffset) -> (NaiveTime, i32) {
         let secs = self.secs as i32 - offset.local_minus_utc();
         let days = secs.div_euclid(86_400);
         let secs = secs.rem_euclid(86_400);
@@ -750,12 +750,12 @@ impl NaiveTime {
     #[cfg(feature = "alloc")]
     #[inline]
     #[must_use]
-    pub fn format_with_items<'a, I, B>(&self, items: I) -> DelayedFormat<I>
+    pub fn format_with_items<'a, I, B>(self, items: I) -> DelayedFormat<I>
     where
         I: Iterator<Item = B> + Clone,
         B: Borrow<Item<'a>>,
     {
-        DelayedFormat::new(None, Some(*self), items)
+        DelayedFormat::new(None, Some(self), items)
     }
 
     /// Formats the time with the specified format string.
@@ -795,7 +795,7 @@ impl NaiveTime {
     #[cfg(feature = "alloc")]
     #[inline]
     #[must_use]
-    pub fn format<'a>(&self, fmt: &'a str) -> DelayedFormat<StrftimeItems<'a>> {
+    pub fn format(self, fmt: &str) -> DelayedFormat<StrftimeItems> {
         self.format_with_items(StrftimeItems::new(fmt))
     }
 
@@ -816,12 +816,12 @@ impl NaiveTime {
     /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_hour(&self, hour: u32) -> Result<NaiveTime, Error> {
+    pub const fn with_hour(self, hour: u32) -> Result<NaiveTime, Error> {
         if hour >= 24 {
             return Err(Error::InvalidArgument);
         }
         let secs = hour * 3600 + self.secs % 3600;
-        Ok(NaiveTime { secs, ..*self })
+        Ok(NaiveTime { secs, ..self })
     }
 
     /// Makes a new `NaiveTime` with the minute number changed.
@@ -841,12 +841,12 @@ impl NaiveTime {
     /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_minute(&self, min: u32) -> Result<NaiveTime, Error> {
+    pub const fn with_minute(self, min: u32) -> Result<NaiveTime, Error> {
         if min >= 60 {
             return Err(Error::InvalidArgument);
         }
         let secs = self.secs / 3600 * 3600 + min * 60 + self.secs % 60;
-        Ok(NaiveTime { secs, ..*self })
+        Ok(NaiveTime { secs, ..self })
     }
 
     /// Makes a new `NaiveTime` with the second number changed.
@@ -869,12 +869,12 @@ impl NaiveTime {
     /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_second(&self, sec: u32) -> Result<NaiveTime, Error> {
+    pub const fn with_second(self, sec: u32) -> Result<NaiveTime, Error> {
         if sec >= 60 {
             return Err(Error::InvalidArgument);
         }
         let secs = self.secs / 60 * 60 + sec;
-        Ok(NaiveTime { secs, ..*self })
+        Ok(NaiveTime { secs, ..self })
     }
 
     /// Makes a new `NaiveTime` with nanoseconds since the whole non-leap second changed.
@@ -910,15 +910,15 @@ impl NaiveTime {
     /// # Ok::<(), chrono::Error>(())
     /// ```
     #[inline]
-    pub const fn with_nanosecond(&self, nano: u32) -> Result<NaiveTime, Error> {
+    pub const fn with_nanosecond(self, nano: u32) -> Result<NaiveTime, Error> {
         if nano >= 2_000_000_000 {
             return Err(Error::InvalidArgument);
         }
-        Ok(NaiveTime { frac: nano, ..*self })
+        Ok(NaiveTime { frac: nano, ..self })
     }
 
     /// Returns a triple of the hour, minute and second numbers.
-    pub(crate) fn hms(&self) -> (u32, u32, u32) {
+    pub(crate) fn hms(self) -> (u32, u32, u32) {
         let sec = self.secs % 60;
         let mins = self.secs / 60;
         let min = mins % 60;
@@ -930,14 +930,14 @@ impl NaiveTime {
     // This duplicates `Timelike::num_seconds_from_midnight()`, because trait methods can't be const
     // yet.
     #[inline]
-    pub(crate) const fn num_seconds_from_midnight(&self) -> u32 {
+    pub(crate) const fn num_seconds_from_midnight(self) -> u32 {
         self.secs
     }
 
     /// Returns the number of nanoseconds since the whole non-leap second.
     // This duplicates `Timelike::nanosecond()`, because trait methods can't be const yet.
     #[inline]
-    pub(crate) const fn nanosecond(&self) -> u32 {
+    pub(crate) const fn nanosecond(self) -> u32 {
         self.frac
     }
 

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -86,13 +86,13 @@ impl FixedOffset {
 
     /// Returns the number of seconds to add to convert from UTC to the local time.
     #[inline]
-    pub const fn local_minus_utc(&self) -> i32 {
+    pub const fn local_minus_utc(self) -> i32 {
         self.local_minus_utc
     }
 
     /// Returns the number of seconds to add to convert from the local time to UTC.
     #[inline]
-    pub const fn utc_minus_local(&self) -> i32 {
+    pub const fn utc_minus_local(self) -> i32 {
         -self.local_minus_utc
     }
 }

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -178,29 +178,29 @@ impl TimeDelta {
 
     /// Returns the total number of whole weeks in the `TimeDelta`.
     #[inline]
-    pub const fn num_weeks(&self) -> i64 {
+    pub const fn num_weeks(self) -> i64 {
         self.num_days() / 7
     }
 
     /// Returns the total number of whole days in the `TimeDelta`.
-    pub const fn num_days(&self) -> i64 {
+    pub const fn num_days(self) -> i64 {
         self.num_seconds() / SECS_PER_DAY
     }
 
     /// Returns the total number of whole hours in the `TimeDelta`.
     #[inline]
-    pub const fn num_hours(&self) -> i64 {
+    pub const fn num_hours(self) -> i64 {
         self.num_seconds() / SECS_PER_HOUR
     }
 
     /// Returns the total number of whole minutes in the `TimeDelta`.
     #[inline]
-    pub const fn num_minutes(&self) -> i64 {
+    pub const fn num_minutes(self) -> i64 {
         self.num_seconds() / SECS_PER_MINUTE
     }
 
     /// Returns the total number of whole seconds in the `TimeDelta`.
-    pub const fn num_seconds(&self) -> i64 {
+    pub const fn num_seconds(self) -> i64 {
         // If secs is negative, nanos should be subtracted from the duration.
         if self.secs < 0 && self.nanos > 0 {
             self.secs + 1
@@ -212,7 +212,7 @@ impl TimeDelta {
     /// Returns the number of nanoseconds such that
     /// `subsec_nanos() + num_seconds() * NANOS_PER_SEC` is the total number of
     /// nanoseconds in the `TimeDelta`.
-    pub const fn subsec_nanos(&self) -> i32 {
+    pub const fn subsec_nanos(self) -> i32 {
         if self.secs < 0 && self.nanos > 0 {
             self.nanos - NANOS_PER_SEC
         } else {
@@ -221,7 +221,7 @@ impl TimeDelta {
     }
 
     /// Returns the total number of whole milliseconds in the `TimeDelta`.
-    pub const fn num_milliseconds(&self) -> i64 {
+    pub const fn num_milliseconds(self) -> i64 {
         // A proper TimeDelta will not overflow, because MIN and MAX are defined such
         // that the range is within the bounds of an i64, from -i64::MAX through to
         // +i64::MAX inclusive. Notably, i64::MIN is excluded from this range.
@@ -232,7 +232,7 @@ impl TimeDelta {
 
     /// Returns the total number of whole microseconds in the `TimeDelta`,
     /// or `None` on overflow (exceeding 2^63 microseconds in either direction).
-    pub const fn num_microseconds(&self) -> Option<i64> {
+    pub const fn num_microseconds(self) -> Option<i64> {
         let secs_part = try_opt!(self.num_seconds().checked_mul(MICROS_PER_SEC));
         let nanos_part = self.subsec_nanos() / NANOS_PER_MICRO;
         secs_part.checked_add(nanos_part as i64)
@@ -240,7 +240,7 @@ impl TimeDelta {
 
     /// Returns the total number of whole nanoseconds in the `TimeDelta`,
     /// or `None` on overflow (exceeding 2^63 nanoseconds in either direction).
-    pub const fn num_nanoseconds(&self) -> Option<i64> {
+    pub const fn num_nanoseconds(self) -> Option<i64> {
         let secs_part = try_opt!(self.num_seconds().checked_mul(NANOS_PER_SEC as i64));
         let nanos_part = self.subsec_nanos();
         secs_part.checked_add(nanos_part as i64)
@@ -248,7 +248,7 @@ impl TimeDelta {
 
     /// Add two `TimeDelta`s, returning `None` if overflow occurred.
     #[must_use]
-    pub const fn checked_add(&self, rhs: &TimeDelta) -> Option<TimeDelta> {
+    pub const fn checked_add(self, rhs: &TimeDelta) -> Option<TimeDelta> {
         // No overflow checks here because we stay comfortably within the range of an `i64`.
         // Range checks happen in `TimeDelta::new`.
         let mut secs = self.secs + rhs.secs;
@@ -262,7 +262,7 @@ impl TimeDelta {
 
     /// Subtract two `TimeDelta`s, returning `None` if overflow occurred.
     #[must_use]
-    pub const fn checked_sub(&self, rhs: &TimeDelta) -> Option<TimeDelta> {
+    pub const fn checked_sub(self, rhs: &TimeDelta) -> Option<TimeDelta> {
         // No overflow checks here because we stay comfortably within the range of an `i64`.
         // Range checks happen in `TimeDelta::new`.
         let mut secs = self.secs - rhs.secs;
@@ -276,7 +276,7 @@ impl TimeDelta {
 
     /// Returns the `TimeDelta` as an absolute (non-negative) value.
     #[inline]
-    pub const fn abs(&self) -> TimeDelta {
+    pub const fn abs(self) -> TimeDelta {
         if self.secs < 0 && self.nanos != 0 {
             TimeDelta { secs: (self.secs + 1).abs(), nanos: NANOS_PER_SEC - self.nanos }
         } else {
@@ -304,7 +304,7 @@ impl TimeDelta {
 
     /// Returns `true` if the `TimeDelta` equals `TimeDelta::zero()`.
     #[inline]
-    pub const fn is_zero(&self) -> bool {
+    pub const fn is_zero(self) -> bool {
         self.secs == 0 && self.nanos == 0
     }
 
@@ -327,7 +327,7 @@ impl TimeDelta {
     ///
     /// This function errors when duration is less than zero. As standard
     /// library implementation is limited to non-negative values.
-    pub const fn to_std(&self) -> Result<Duration, OutOfRangeError> {
+    pub const fn to_std(self) -> Result<Duration, OutOfRangeError> {
         if self.secs < 0 {
             return Err(OutOfRangeError(()));
         }

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -248,7 +248,7 @@ impl TimeDelta {
 
     /// Add two `TimeDelta`s, returning `None` if overflow occurred.
     #[must_use]
-    pub const fn checked_add(self, rhs: &TimeDelta) -> Option<TimeDelta> {
+    pub const fn checked_add(self, rhs: TimeDelta) -> Option<TimeDelta> {
         // No overflow checks here because we stay comfortably within the range of an `i64`.
         // Range checks happen in `TimeDelta::new`.
         let mut secs = self.secs + rhs.secs;
@@ -262,7 +262,7 @@ impl TimeDelta {
 
     /// Subtract two `TimeDelta`s, returning `None` if overflow occurred.
     #[must_use]
-    pub const fn checked_sub(self, rhs: &TimeDelta) -> Option<TimeDelta> {
+    pub const fn checked_sub(self, rhs: TimeDelta) -> Option<TimeDelta> {
         // No overflow checks here because we stay comfortably within the range of an `i64`.
         // Range checks happen in `TimeDelta::new`.
         let mut secs = self.secs - rhs.secs;
@@ -361,7 +361,7 @@ impl Add for TimeDelta {
     type Output = TimeDelta;
 
     fn add(self, rhs: TimeDelta) -> TimeDelta {
-        self.checked_add(&rhs).expect("`TimeDelta + TimeDelta` overflowed")
+        self.checked_add(rhs).expect("`TimeDelta + TimeDelta` overflowed")
     }
 }
 
@@ -369,20 +369,20 @@ impl Sub for TimeDelta {
     type Output = TimeDelta;
 
     fn sub(self, rhs: TimeDelta) -> TimeDelta {
-        self.checked_sub(&rhs).expect("`TimeDelta - TimeDelta` overflowed")
+        self.checked_sub(rhs).expect("`TimeDelta - TimeDelta` overflowed")
     }
 }
 
 impl AddAssign for TimeDelta {
     fn add_assign(&mut self, rhs: TimeDelta) {
-        let new = self.checked_add(&rhs).expect("`TimeDelta + TimeDelta` overflowed");
+        let new = self.checked_add(rhs).expect("`TimeDelta + TimeDelta` overflowed");
         *self = new;
     }
 }
 
 impl SubAssign for TimeDelta {
     fn sub_assign(&mut self, rhs: TimeDelta) {
-        let new = self.checked_sub(&rhs).expect("`TimeDelta - TimeDelta` overflowed");
+        let new = self.checked_sub(rhs).expect("`TimeDelta - TimeDelta` overflowed");
         *self = new;
     }
 }
@@ -608,7 +608,7 @@ mod tests {
         // value will fail.
         assert!(TimeDelta::milliseconds(i64::MAX)
             .unwrap()
-            .checked_add(&TimeDelta::milliseconds(1).unwrap())
+            .checked_add(TimeDelta::milliseconds(1).unwrap())
             .is_none());
     }
 
@@ -631,7 +631,7 @@ mod tests {
         // storable value will fail.
         assert!(TimeDelta::milliseconds(-i64::MAX)
             .unwrap()
-            .checked_sub(&TimeDelta::milliseconds(1).unwrap())
+            .checked_sub(TimeDelta::milliseconds(1).unwrap())
             .is_none());
     }
 
@@ -685,7 +685,7 @@ mod tests {
         // value will fail.
         assert!(TimeDelta::milliseconds(i64::MAX)
             .unwrap()
-            .checked_add(&TimeDelta::microseconds(1))
+            .checked_add(TimeDelta::microseconds(1))
             .is_none());
     }
     #[test]
@@ -724,7 +724,7 @@ mod tests {
         // storable value will fail.
         assert!(TimeDelta::milliseconds(-i64::MAX)
             .unwrap()
-            .checked_sub(&TimeDelta::microseconds(1))
+            .checked_sub(TimeDelta::microseconds(1))
             .is_none());
     }
 
@@ -774,7 +774,7 @@ mod tests {
         // value will fail.
         assert!(TimeDelta::milliseconds(i64::MAX)
             .unwrap()
-            .checked_add(&TimeDelta::nanoseconds(1))
+            .checked_add(TimeDelta::nanoseconds(1))
             .is_none());
     }
 
@@ -814,7 +814,7 @@ mod tests {
         // storable value will fail.
         assert!(TimeDelta::milliseconds(-i64::MAX)
             .unwrap()
-            .checked_sub(&TimeDelta::nanoseconds(1))
+            .checked_sub(TimeDelta::nanoseconds(1))
             .is_none());
     }
 
@@ -867,26 +867,26 @@ mod tests {
         let milliseconds = |ms| TimeDelta::milliseconds(ms).unwrap();
 
         assert_eq!(
-            milliseconds(i64::MAX).checked_add(&milliseconds(0)),
+            milliseconds(i64::MAX).checked_add(milliseconds(0)),
             Some(milliseconds(i64::MAX))
         );
         assert_eq!(
-            milliseconds(i64::MAX - 1).checked_add(&TimeDelta::microseconds(999)),
+            milliseconds(i64::MAX - 1).checked_add(TimeDelta::microseconds(999)),
             Some(milliseconds(i64::MAX - 2) + TimeDelta::microseconds(1999))
         );
-        assert!(milliseconds(i64::MAX).checked_add(&TimeDelta::microseconds(1000)).is_none());
-        assert!(milliseconds(i64::MAX).checked_add(&TimeDelta::nanoseconds(1)).is_none());
+        assert!(milliseconds(i64::MAX).checked_add(TimeDelta::microseconds(1000)).is_none());
+        assert!(milliseconds(i64::MAX).checked_add(TimeDelta::nanoseconds(1)).is_none());
 
         assert_eq!(
-            milliseconds(-i64::MAX).checked_sub(&milliseconds(0)),
+            milliseconds(-i64::MAX).checked_sub(milliseconds(0)),
             Some(milliseconds(-i64::MAX))
         );
         assert_eq!(
-            milliseconds(-i64::MAX + 1).checked_sub(&TimeDelta::microseconds(999)),
+            milliseconds(-i64::MAX + 1).checked_sub(TimeDelta::microseconds(999)),
             Some(milliseconds(-i64::MAX + 2) - TimeDelta::microseconds(1999))
         );
-        assert!(milliseconds(-i64::MAX).checked_sub(&milliseconds(1)).is_none());
-        assert!(milliseconds(-i64::MAX).checked_sub(&TimeDelta::nanoseconds(1)).is_none());
+        assert!(milliseconds(-i64::MAX).checked_sub(milliseconds(1)).is_none());
+        assert!(milliseconds(-i64::MAX).checked_sub(TimeDelta::nanoseconds(1)).is_none());
     }
 
     #[test]

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -63,8 +63,8 @@ impl Weekday {
     /// `w.succ()`: | `Tue` | `Wed` | `Thu` | `Fri` | `Sat` | `Sun` | `Mon`
     #[inline]
     #[must_use]
-    pub const fn succ(&self) -> Weekday {
-        match *self {
+    pub const fn succ(self) -> Weekday {
+        match self {
             Weekday::Mon => Weekday::Tue,
             Weekday::Tue => Weekday::Wed,
             Weekday::Wed => Weekday::Thu,
@@ -82,8 +82,8 @@ impl Weekday {
     /// `w.pred()`: | `Sun` | `Mon` | `Tue` | `Wed` | `Thu` | `Fri` | `Sat`
     #[inline]
     #[must_use]
-    pub const fn pred(&self) -> Weekday {
-        match *self {
+    pub const fn pred(self) -> Weekday {
+        match self {
             Weekday::Mon => Weekday::Sun,
             Weekday::Tue => Weekday::Mon,
             Weekday::Wed => Weekday::Tue,
@@ -100,7 +100,7 @@ impl Weekday {
     /// ------------------------- | ----- | ----- | ----- | ----- | ----- | ----- | -----
     /// `w.number_from_monday()`: | 1     | 2     | 3     | 4     | 5     | 6     | 7
     #[inline]
-    pub const fn number_from_monday(&self) -> u32 {
+    pub const fn number_from_monday(self) -> u32 {
         self.num_days_from(Weekday::Mon) + 1
     }
 
@@ -110,7 +110,7 @@ impl Weekday {
     /// ------------------------- | ----- | ----- | ----- | ----- | ----- | ----- | -----
     /// `w.number_from_sunday()`: | 2     | 3     | 4     | 5     | 6     | 7     | 1
     #[inline]
-    pub const fn number_from_sunday(&self) -> u32 {
+    pub const fn number_from_sunday(self) -> u32 {
         self.num_days_from(Weekday::Sun) + 1
     }
 
@@ -133,7 +133,7 @@ impl Weekday {
     /// println!("{}", MTWRFSU[today.num_days_from_monday() as usize]);
     /// ```
     #[inline]
-    pub const fn num_days_from_monday(&self) -> u32 {
+    pub const fn num_days_from_monday(self) -> u32 {
         self.num_days_from(Weekday::Mon)
     }
 
@@ -143,7 +143,7 @@ impl Weekday {
     /// --------------------------- | ----- | ----- | ----- | ----- | ----- | ----- | -----
     /// `w.num_days_from_sunday()`: | 1     | 2     | 3     | 4     | 5     | 6     | 0
     #[inline]
-    pub const fn num_days_from_sunday(&self) -> u32 {
+    pub const fn num_days_from_sunday(self) -> u32 {
         self.num_days_from(Weekday::Sun)
     }
 
@@ -153,8 +153,8 @@ impl Weekday {
     /// --------------------------- | ----- | ----- | ----- | ----- | ----- | ----- | -----
     /// `w.num_days_from(wd)`:      | 0     | 1     | 2     | 3     | 4     | 5     | 6
     #[inline]
-    pub(crate) const fn num_days_from(&self, day: Weekday) -> u32 {
-        (*self as u32 + 7 - day as u32) % 7
+    pub(crate) const fn num_days_from(self, day: Weekday) -> u32 {
+        (self as u32 + 7 - day as u32) % 7
     }
 }
 


### PR DESCRIPTION
We are currently inconsistent in when we take `self` by value and when by reference.

### DateTime

For `DateTime` I propose to let all methods take `self` by reference because the type is generic and not guaranteed to be `Copy`. Otherwise users of a `TimeZone` provider such as `tzfile` would have to clone the `DateTime` if they want to use they value after calling the method.

For this reason the methods that are part of the `Datelike` and `Timelike` trait should also keep taking `self` by reference.

### Copy types

For a `Copy` type it is recommended to pass `self` by value if its size is at most the size of one or two pointers. This is a bit more optimal than by reference for non-inlined functions. There is a Clippy lint `trivially_copy_pass_by_ref` that suggest passing such values by copy, it is recommended by the [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f16-for-in-parameters-pass-cheaply-copied-types-by-value-and-others-by-reference-to-const), and similar advise can be found on the Rust Reddit, StackOverflow and [URLO](https://users.rust-lang.org/t/guidelines-for-self-ownership-on-copy-types/61262) (which even mentions chrono).

So what to do for `NaiveDate` and `IsoWeek` as 4-byte `Copy` types is clear: passing them by reference is less optimal than by value.

What to do for types of 8 and 12 bytes such as `NaiveTime` and `NaiveDateTime`, keeping in mind that there are 32-bit and 64-bit targets? When it is less clear I think the real question to pick what is optimal is: can all method arguments be passed in registers or do they have to spill to the stack? On x86 there are only four or five general-purpose registers. So we can pass up to four arguments by reference, or the total size of `self` and the arguments should at most be 16 bytes.

There are a handful of cases where passing `self` by reference would create room for passing another argument by value: `NaiveTime::{checked_add_signed, checked_sub_signed}` and `NaiveDateTime::checked_add_signed, checked_sub_signed, signed_duration_since}`. The latter would have two 12-byte values. Does it make any difference?

I made a benchmark for `NaiveDateTime::checked_add_signed` and the `i686-unknown-linux-gnu` target, and marked `checked_add_signed` as `#[inline(never)]`. Any changes between pass by reference and pass by value were in the noise. Based on the benchmark I think it is fine to simply always pass our `Copy` types by value, including the 12-byte types `NaiveDateTime` and `TimeDelta`.

This all of course only makes a difference when the methods are not inlined, despite the `[inline]` hint. And in the rare case when someone calls a method as a function it is a bit more ergonomic to use `self` by value.

The impact on user code is minimal and nice, as the diff of each commit shows.