### PR TITLE
Refactor `unix::Cache`

### DIFF
--- a/src/offset/local/tz_info/timezone.rs
+++ b/src/offset/local/tz_info/timezone.rs
@@ -33,7 +33,7 @@ impl TimeZone {
     }
 
     /// Construct a time zone from a POSIX TZ string, as described in [the POSIX documentation of the `TZ` environment variable](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html).
-    fn from_posix_tz(tz_string: &str) -> Result<Self, Error> {
+    pub(crate) fn from_posix_tz(tz_string: &str) -> Result<Self, Error> {
         if tz_string.is_empty() {
             return Err(Error::InvalidTzString("empty TZ string"));
         }

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -124,11 +124,17 @@ impl Cache {
         let env_tz = env::var("TZ").ok();
         self.source = Source::new(env_tz.as_deref());
         self.zone = Some(
-            TimeZone::local(env_tz.as_deref())
+            self.read_from_tz_env_or_localtime(env_tz.as_deref())
                 .ok()
                 .or_else(fallback_timezone)
                 .unwrap_or_else(TimeZone::utc),
         );
+    }
+
+    /// Read the `TZ` environment variable or the TZif file that it points to.
+    /// Read from `/etc/localtime` if the variable is not set.
+    fn read_from_tz_env_or_localtime(&self, env_tz: Option<&str>) -> Result<TimeZone, ()> {
+        TimeZone::local(env_tz).map_err(|_| ())
     }
 }
 

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -189,6 +189,16 @@ impl CachedTzInfo {
         const ZONE_INFO_DIRECTORIES: [&str; 4] =
             ["/usr/share/zoneinfo", "/share/zoneinfo", "/etc/zoneinfo", "/usr/share/lib/zoneinfo"];
 
+        // Use the value of the `TZDIR` environment variable if set.
+        if let Some(tz_dir) = env::var_os("TZDIR") {
+            if !tz_dir.is_empty() {
+                let path = PathBuf::from(tz_dir);
+                if path.exists() {
+                    return Ok(path);
+                }
+            }
+        }
+
         for dir in &ZONE_INFO_DIRECTORIES {
             let path = PathBuf::from(dir);
             if path.exists() {

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -47,13 +47,13 @@ pub(super) fn offset_from_local_datetime(local: &NaiveDateTime) -> MappedLocalTi
     })
 }
 
-struct Cache {
+struct CachedTzInfo {
     zone: Option<TimeZone>,
     source: Source,
     last_checked: SystemTime,
 }
 
-impl Cache {
+impl CachedTzInfo {
     fn tz_info(&mut self) -> &TimeZone {
         self.refresh_cache();
         self.zone.as_ref().unwrap()
@@ -200,8 +200,8 @@ impl Cache {
 }
 
 thread_local! {
-    static TZ_INFO: RefCell<Cache> = const { RefCell::new(
-        Cache {
+    static TZ_INFO: RefCell<CachedTzInfo> = const { RefCell::new(
+        CachedTzInfo {
             zone: None,
             source: Source::Uninitialized,
             last_checked: SystemTime::UNIX_EPOCH,

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -41,37 +41,6 @@ pub(super) fn offset_from_local_datetime(local: &NaiveDateTime) -> MappedLocalTi
     })
 }
 
-thread_local! {
-    static TZ_INFO: RefCell<Cache> = const { RefCell::new(
-        Cache {
-            zone: None,
-            source: Source::Uninitialized,
-            last_checked: SystemTime::UNIX_EPOCH,
-        }
-    ) };
-}
-
-#[derive(PartialEq)]
-enum Source {
-    Environment { hash: u64 },
-    LocalTime,
-    Uninitialized,
-}
-
-impl Source {
-    fn new(env_tz: Option<&str>) -> Source {
-        match env_tz {
-            Some(tz) => {
-                let mut hasher = hash_map::DefaultHasher::new();
-                hasher.write(tz.as_bytes());
-                let hash = hasher.finish();
-                Source::Environment { hash }
-            }
-            None => Source::LocalTime,
-        }
-    }
-}
-
 struct Cache {
     zone: Option<TimeZone>,
     source: Source,
@@ -145,6 +114,37 @@ impl Cache {
                 }
             }
             _ => true,
+        }
+    }
+}
+
+thread_local! {
+    static TZ_INFO: RefCell<Cache> = const { RefCell::new(
+        Cache {
+            zone: None,
+            source: Source::Uninitialized,
+            last_checked: SystemTime::UNIX_EPOCH,
+        }
+    ) };
+}
+
+#[derive(PartialEq)]
+enum Source {
+    Environment { hash: u64 },
+    LocalTime,
+    Uninitialized,
+}
+
+impl Source {
+    fn new(env_tz: Option<&str>) -> Source {
+        match env_tz {
+            Some(tz) => {
+                let mut hasher = hash_map::DefaultHasher::new();
+                hasher.write(tz.as_bytes());
+                let hash = hasher.finish();
+                Source::Environment { hash }
+            }
+            None => Source::LocalTime,
         }
     }
 }


### PR DESCRIPTION
I put in the effort to slice the first commit of #1457 into 17 commits that each are readable as a refactor.

The goal is to move all logic for determining and parsing the time zone with fallbacks in one layer.
This will make it possible to properly hook up errors, and to make the cache invalidation work beyond the most basic cases.
But those improvements are not included in this PR.

The last commit, adding support for the `TZ_DIR` variable, is the only noticeable change in functionality.