### PR TITLE
Small simplifications

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -173,8 +173,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     #[inline]
     #[must_use]
     pub fn date_naive(&self) -> NaiveDate {
-        let local = self.naive_local();
-        NaiveDate::from_ymd_opt(local.year(), local.month(), local.day()).unwrap()
+        self.naive_local().date()
     }
 
     /// Retrieves the time component.

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -652,13 +652,12 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// # Examples
     ///
     /// ```rust
-    /// # use chrono::{FixedOffset, SecondsFormat, TimeZone, Utc, NaiveDate};
+    /// # use chrono::{FixedOffset, SecondsFormat, TimeZone, NaiveDate};
     /// let dt = NaiveDate::from_ymd_opt(2018, 1, 26)
     ///     .unwrap()
     ///     .and_hms_micro_opt(18, 30, 9, 453_829)
     ///     .unwrap()
-    ///     .and_local_timezone(Utc)
-    ///     .unwrap();
+    ///     .and_utc();
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Millis, false), "2018-01-26T18:30:09.453+00:00");
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Millis, true), "2018-01-26T18:30:09.453Z");
     /// assert_eq!(dt.to_rfc3339_opts(SecondsFormat::Secs, true), "2018-01-26T18:30:09Z");

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -133,8 +133,7 @@ impl<'de> de::Deserialize<'de> for DateTime<Local> {
 ///     .unwrap()
 ///     .and_hms_nano_opt(02, 04, 59, 918355733)
 ///     .unwrap()
-///     .and_local_timezone(Utc)
-///     .unwrap();
+///     .and_utc();
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -181,8 +180,7 @@ pub mod ts_nanoseconds {
     ///         .unwrap()
     ///         .and_hms_nano_opt(02, 04, 59, 918355733)
     ///         .unwrap()
-    ///         .and_local_timezone(Utc)
-    ///         .unwrap(),
+    ///         .and_utc(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355733}"#);
@@ -278,8 +276,7 @@ pub mod ts_nanoseconds {
 ///         .unwrap()
 ///         .and_hms_nano_opt(02, 04, 59, 918355733)
 ///         .unwrap()
-///         .and_local_timezone(Utc)
-///         .unwrap(),
+///         .and_utc(),
 /// );
 /// let my_s = S { time: time.clone() };
 ///
@@ -327,8 +324,7 @@ pub mod ts_nanoseconds_option {
     ///             .unwrap()
     ///             .and_hms_nano_opt(02, 04, 59, 918355733)
     ///             .unwrap()
-    ///             .and_local_timezone(Utc)
-    ///             .unwrap(),
+    ///             .and_utc(),
     ///     ),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
@@ -429,8 +425,7 @@ pub mod ts_nanoseconds_option {
 ///     .unwrap()
 ///     .and_hms_micro_opt(02, 04, 59, 918355)
 ///     .unwrap()
-///     .and_local_timezone(Utc)
-///     .unwrap();
+///     .and_utc();
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -469,8 +464,7 @@ pub mod ts_microseconds {
     ///         .unwrap()
     ///         .and_hms_micro_opt(02, 04, 59, 918355)
     ///         .unwrap()
-    ///         .and_local_timezone(Utc)
-    ///         .unwrap(),
+    ///         .and_utc(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918355}"#);
@@ -567,8 +561,7 @@ pub mod ts_microseconds {
 ///         .unwrap()
 ///         .and_hms_micro_opt(02, 04, 59, 918355)
 ///         .unwrap()
-///         .and_local_timezone(Utc)
-///         .unwrap(),
+///         .and_utc(),
 /// );
 /// let my_s = S { time: time.clone() };
 ///
@@ -607,8 +600,7 @@ pub mod ts_microseconds_option {
     ///             .unwrap()
     ///             .and_hms_micro_opt(02, 04, 59, 918355)
     ///             .unwrap()
-    ///             .and_local_timezone(Utc)
-    ///             .unwrap(),
+    ///             .and_utc(),
     ///     ),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
@@ -707,8 +699,7 @@ pub mod ts_microseconds_option {
 ///     .unwrap()
 ///     .and_hms_milli_opt(02, 04, 59, 918)
 ///     .unwrap()
-///     .and_local_timezone(Utc)
-///     .unwrap();
+///     .and_utc();
 /// let my_s = S { time: time.clone() };
 ///
 /// let as_string = serde_json::to_string(&my_s)?;
@@ -747,8 +738,7 @@ pub mod ts_milliseconds {
     ///         .unwrap()
     ///         .and_hms_milli_opt(02, 04, 59, 918)
     ///         .unwrap()
-    ///         .and_local_timezone(Utc)
-    ///         .unwrap(),
+    ///         .and_utc(),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699918}"#);
@@ -838,8 +828,7 @@ pub mod ts_milliseconds {
 ///         .unwrap()
 ///         .and_hms_milli_opt(02, 04, 59, 918)
 ///         .unwrap()
-///         .and_local_timezone(Utc)
-///         .unwrap(),
+///         .and_utc(),
 /// );
 /// let my_s = S { time: time.clone() };
 ///
@@ -878,8 +867,7 @@ pub mod ts_milliseconds_option {
     ///             .unwrap()
     ///             .and_hms_milli_opt(02, 04, 59, 918)
     ///             .unwrap()
-    ///             .and_local_timezone(Utc)
-    ///             .unwrap(),
+    ///             .and_utc(),
     ///     ),
     /// };
     /// let as_string = serde_json::to_string(&my_s)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,8 +140,7 @@
 //!     dt,
 //!     NaiveDate::from_ymd_opt(2014, 7, 8)?
 //!         .and_hms_opt(9, 10, 11)?
-//!         .and_local_timezone(Utc)
-//!         .unwrap()
+//!         .and_utc()
 //! );
 //!
 //! // July 8 is 188th day of the year 2014 (`o` for "ordinal")
@@ -154,21 +153,18 @@
 //!
 //! let dt = NaiveDate::from_ymd_opt(2014, 7, 8)?
 //!     .and_hms_milli_opt(9, 10, 11, 12)?
-//!     .and_local_timezone(Utc)
-//!     .unwrap(); // `2014-07-08T09:10:11.012Z`
+//!     .and_utc(); // `2014-07-08T09:10:11.012Z`
 //! assert_eq!(
 //!     dt,
 //!     NaiveDate::from_ymd_opt(2014, 7, 8)?
 //!         .and_hms_micro_opt(9, 10, 11, 12_000)?
-//!         .and_local_timezone(Utc)
-//!         .unwrap()
+//!         .and_utc()
 //! );
 //! assert_eq!(
 //!     dt,
 //!     NaiveDate::from_ymd_opt(2014, 7, 8)?
 //!         .and_hms_nano_opt(9, 10, 11, 12_000_000)?
-//!         .and_local_timezone(Utc)
-//!         .unwrap()
+//!         .and_utc()
 //! );
 //!
 //! // dynamic verification
@@ -245,8 +241,7 @@
 //!         .unwrap()
 //!         .and_hms_nano_opt(12, 45, 59, 324310806)
 //!         .unwrap()
-//!         .and_local_timezone(Utc)
-//!         .unwrap()
+//!         .and_utc()
 //! );
 //!
 //! // a sample of property manipulations (validates dynamically)
@@ -313,8 +308,7 @@
 //!     .unwrap()
 //!     .and_hms_nano_opt(12, 0, 9, 1)
 //!     .unwrap()
-//!     .and_local_timezone(Utc)
-//!     .unwrap();
+//!     .and_utc();
 //! assert_eq!(format!("{:?}", dt_nano), "2014-11-28T12:00:09.000000001Z");
 //! # }
 //! # #[cfg(not(all(feature = "unstable-locales", feature = "alloc")))]

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -903,16 +903,8 @@ impl NaiveDateTime {
         self.format_with_items(StrftimeItems::new(fmt))
     }
 
-    /// Converts the `NaiveDateTime` into the timezone-aware `DateTime<Tz>`
-    /// with the provided timezone, if possible.
-    ///
-    /// This can fail in cases where the local time represented by the `NaiveDateTime`
-    /// is not a valid local timestamp in the target timezone due to an offset transition
-    /// for example if the target timezone had a change from +00:00 to +01:00
-    /// occurring at 2015-09-05 22:59:59, then a local time of 2015-09-05 23:56:04
-    /// could never occur. Similarly, if the offset transitioned in the opposite direction
-    /// then there would be two local times of 2015-09-05 23:56:04, one at +00:00 and one
-    /// at +01:00.
+    /// Converts the `NaiveDateTime` into a timezone-aware `DateTime<Tz>` with the provided
+    /// time zone.
     ///
     /// # Example
     ///

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -274,7 +274,7 @@ fn test_datetime_add_sub_invariant() {
 #[test]
 fn test_and_local_timezone() {
     let ndt = NaiveDate::from_ymd_opt(2022, 6, 15).unwrap().and_hms_opt(18, 59, 36).unwrap();
-    let dt_utc = ndt.and_local_timezone(Utc).unwrap();
+    let dt_utc = ndt.and_utc();
     assert_eq!(dt_utc.naive_local(), ndt);
     assert_eq!(dt_utc.timezone(), Utc);
 

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -76,7 +76,7 @@ mod tests;
 /// All methods accepting fractional seconds will accept such values.
 ///
 /// ```
-/// use chrono::{NaiveDate, NaiveTime, Utc};
+/// use chrono::{NaiveDate, NaiveTime};
 ///
 /// let t = NaiveTime::from_hms_milli_opt(8, 59, 59, 1_000).unwrap();
 ///
@@ -89,8 +89,7 @@ mod tests;
 ///     .unwrap()
 ///     .and_hms_nano_opt(23, 59, 59, 1_000_000_000)
 ///     .unwrap()
-///     .and_local_timezone(Utc)
-///     .unwrap();
+///     .and_utc();
 /// # let _ = (t, dt1, dt2);
 /// ```
 ///
@@ -172,14 +171,13 @@ mod tests;
 /// will be represented as the second part being 60, as required by ISO 8601.
 ///
 /// ```
-/// use chrono::{NaiveDate, Utc};
+/// use chrono::NaiveDate;
 ///
 /// let dt = NaiveDate::from_ymd_opt(2015, 6, 30)
 ///     .unwrap()
 ///     .and_hms_milli_opt(23, 59, 59, 1_000)
 ///     .unwrap()
-///     .and_local_timezone(Utc)
-///     .unwrap();
+///     .and_utc();
 /// assert_eq!(format!("{:?}", dt), "2015-06-30T23:59:60Z");
 /// ```
 ///

--- a/src/round.rs
+++ b/src/round.rs
@@ -21,13 +21,12 @@ pub trait SubsecRound {
     ///
     /// # Example
     /// ``` rust
-    /// # use chrono::{SubsecRound, Timelike, Utc, NaiveDate};
+    /// # use chrono::{SubsecRound, Timelike, NaiveDate};
     /// let dt = NaiveDate::from_ymd_opt(2018, 1, 11)
     ///     .unwrap()
     ///     .and_hms_milli_opt(12, 0, 0, 154)
     ///     .unwrap()
-    ///     .and_local_timezone(Utc)
-    ///     .unwrap();
+    ///     .and_utc();
     /// assert_eq!(dt.round_subsecs(2).nanosecond(), 150_000_000);
     /// assert_eq!(dt.round_subsecs(1).nanosecond(), 200_000_000);
     /// ```
@@ -38,13 +37,12 @@ pub trait SubsecRound {
     ///
     /// # Example
     /// ``` rust
-    /// # use chrono::{SubsecRound, Timelike, Utc, NaiveDate};
+    /// # use chrono::{SubsecRound, Timelike, NaiveDate};
     /// let dt = NaiveDate::from_ymd_opt(2018, 1, 11)
     ///     .unwrap()
     ///     .and_hms_milli_opt(12, 0, 0, 154)
     ///     .unwrap()
-    ///     .and_local_timezone(Utc)
-    ///     .unwrap();
+    ///     .and_utc();
     /// assert_eq!(dt.trunc_subsecs(2).nanosecond(), 150_000_000);
     /// assert_eq!(dt.trunc_subsecs(1).nanosecond(), 100_000_000);
     /// ```
@@ -118,13 +116,12 @@ pub trait DurationRound: Sized {
     ///
     /// # Example
     /// ``` rust
-    /// # use chrono::{DurationRound, TimeDelta, Utc, NaiveDate};
+    /// # use chrono::{DurationRound, TimeDelta, NaiveDate};
     /// let dt = NaiveDate::from_ymd_opt(2018, 1, 11)
     ///     .unwrap()
     ///     .and_hms_milli_opt(12, 0, 0, 154)
     ///     .unwrap()
-    ///     .and_local_timezone(Utc)
-    ///     .unwrap();
+    ///     .and_utc();
     /// assert_eq!(
     ///     dt.duration_round(TimeDelta::try_milliseconds(10).unwrap()).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
@@ -140,13 +137,12 @@ pub trait DurationRound: Sized {
     ///
     /// # Example
     /// ``` rust
-    /// # use chrono::{DurationRound, TimeDelta, Utc, NaiveDate};
+    /// # use chrono::{DurationRound, TimeDelta, NaiveDate};
     /// let dt = NaiveDate::from_ymd_opt(2018, 1, 11)
     ///     .unwrap()
     ///     .and_hms_milli_opt(12, 0, 0, 154)
     ///     .unwrap()
-    ///     .and_local_timezone(Utc)
-    ///     .unwrap();
+    ///     .and_utc();
     /// assert_eq!(
     ///     dt.duration_trunc(TimeDelta::try_milliseconds(10).unwrap()).unwrap().to_string(),
     ///     "2018-01-11 12:00:00.150 UTC"
@@ -258,13 +254,12 @@ pub enum RoundingError {
     /// Error when `TimeDelta.num_nanoseconds` exceeds the limit.
     ///
     /// ``` rust
-    /// # use chrono::{DurationRound, TimeDelta, RoundingError, Utc, NaiveDate};
+    /// # use chrono::{DurationRound, TimeDelta, RoundingError, NaiveDate};
     /// let dt = NaiveDate::from_ymd_opt(2260, 12, 31)
     ///     .unwrap()
     ///     .and_hms_nano_opt(23, 59, 59, 1_75_500_000)
     ///     .unwrap()
-    ///     .and_local_timezone(Utc)
-    ///     .unwrap();
+    ///     .and_utc();
     ///
     /// assert_eq!(
     ///     dt.duration_round(TimeDelta::try_days(300 * 365).unwrap()),


### PR DESCRIPTION
Some small simplifications to `DateTime::date_naive` and `NaiveDate::diff_months`, a commit from #1523 to replace `.and_local_timezone(Utc).unwrap()` with `and_utc()`, and a commit to remove some strange documentation from `NaiveDateTime::and_local_timezone`.