### PR TITLE
Convert `with_ordinal` to return `Result`

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -622,7 +622,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///   daylight saving time transition.
     #[inline]
     pub fn with_ordinal(&self, ordinal: u32) -> Option<DateTime<Tz>> {
-        map_local(self, |datetime| datetime.with_ordinal(ordinal))
+        map_local(self, |datetime| datetime.with_ordinal(ordinal).ok())
     }
 
     /// Set the time to a new fixed time on the existing date.

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -1124,7 +1124,7 @@ fn resolve_week_date(
     if ordinal <= 0 {
         return Err(IMPOSSIBLE);
     }
-    first_day_of_year.with_ordinal(ordinal as u32).ok_or(IMPOSSIBLE)
+    first_day_of_year.with_ordinal(ordinal as u32).map_err(|_| IMPOSSIBLE)
 }
 
 #[cfg(test)]

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -1288,34 +1288,34 @@ impl NaiveDate {
     ///
     /// # Errors
     ///
-    /// Returns `None` if:
-    /// - The resulting date does not exist (`with_ordinal(366)` in a non-leap year).
-    /// - The value for `ordinal` is invalid.
+    /// This method returns:
+    /// - [`Error::DoesNotExist`] if the resulting date does not exist (`with_ordinal(366)` in a
+    ///   non-leap year).
+    /// - [`Error::InvalidArgument`] if the value for `ordinal` is invalid.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::NaiveDate;
+    /// use chrono::{Error, NaiveDate};
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1).unwrap().with_ordinal(60),
-    ///            Some(NaiveDate::from_ymd(2015, 3, 1).unwrap()));
-    /// assert_eq!(NaiveDate::from_ymd(2015, 1, 1).unwrap().with_ordinal(366),
-    ///            None); // 2015 had only 365 days
+    /// let date = NaiveDate::from_ymd(2015, 9, 8)?;
+    /// assert_eq!(date.with_ordinal(60), NaiveDate::from_ymd(2015, 3, 1));
+    /// assert_eq!(date.with_ordinal(366), Err(Error::DoesNotExist)); // 2015 had only 365 days
     ///
-    /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1).unwrap().with_ordinal(60),
-    ///            Some(NaiveDate::from_ymd(2016, 2, 29).unwrap()));
-    /// assert_eq!(NaiveDate::from_ymd(2016, 1, 1).unwrap().with_ordinal(366),
-    ///            Some(NaiveDate::from_ymd(2016, 12, 31).unwrap()));
+    /// let date = NaiveDate::from_ymd(2016, 9, 8)?;
+    /// assert_eq!(date.with_ordinal(60), NaiveDate::from_ymd(2016, 2, 29));
+    /// assert_eq!(date.with_ordinal(366), NaiveDate::from_ymd(2016, 12, 31));
+    /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn with_ordinal(self, ordinal: u32) -> Option<NaiveDate> {
+    pub const fn with_ordinal(self, ordinal: u32) -> Result<NaiveDate, Error> {
         if ordinal == 0 || ordinal > 366 {
-            return None;
+            return Err(Error::InvalidArgument);
         }
         let yof = (self.yof() & !ORDINAL_MASK) | (ordinal << 4) as i32;
         match yof & OL_MASK <= MAX_OL {
-            true => Some(NaiveDate::from_yof(yof)),
-            false => None, // Does not exist: Ordinal 366 in a common year.
+            true => Ok(NaiveDate::from_yof(yof)),
+            false => Err(Error::DoesNotExist), // Ordinal 366 in a common year.
         }
     }
 

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -399,16 +399,16 @@ fn test_date_with_fields() {
 #[test]
 fn test_date_with_ordinal() {
     let d = NaiveDate::from_ymd(2000, 5, 5).unwrap();
-    assert_eq!(d.with_ordinal(0), None);
-    assert_eq!(d.with_ordinal(1), Some(NaiveDate::from_ymd(2000, 1, 1).unwrap()));
-    assert_eq!(d.with_ordinal(60), Some(NaiveDate::from_ymd(2000, 2, 29).unwrap()));
-    assert_eq!(d.with_ordinal(61), Some(NaiveDate::from_ymd(2000, 3, 1).unwrap()));
-    assert_eq!(d.with_ordinal(366), Some(NaiveDate::from_ymd(2000, 12, 31).unwrap()));
-    assert_eq!(d.with_ordinal(367), None);
-    assert_eq!(d.with_ordinal(1 << 28 | 60), None);
+    assert_eq!(d.with_ordinal(0), Err(Error::InvalidArgument));
+    assert_eq!(d.with_ordinal(1), Ok(NaiveDate::from_ymd(2000, 1, 1).unwrap()));
+    assert_eq!(d.with_ordinal(60), Ok(NaiveDate::from_ymd(2000, 2, 29).unwrap()));
+    assert_eq!(d.with_ordinal(61), Ok(NaiveDate::from_ymd(2000, 3, 1).unwrap()));
+    assert_eq!(d.with_ordinal(366), Ok(NaiveDate::from_ymd(2000, 12, 31).unwrap()));
+    assert_eq!(d.with_ordinal(367), Err(Error::InvalidArgument));
+    assert_eq!(d.with_ordinal(1 << 28 | 60), Err(Error::InvalidArgument));
     let d = NaiveDate::from_ymd(1999, 5, 5).unwrap();
-    assert_eq!(d.with_ordinal(366), None);
-    assert_eq!(d.with_ordinal(u32::MAX), None);
+    assert_eq!(d.with_ordinal(366), Err(Error::DoesNotExist));
+    assert_eq!(d.with_ordinal(u32::MAX), Err(Error::InvalidArgument));
 }
 
 #[test]
@@ -745,7 +745,7 @@ fn test_leap_year() {
         let date = NaiveDate::from_ymd(year, 1, 1).unwrap();
         let is_leap = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
         assert_eq!(date.leap_year(), is_leap);
-        assert_eq!(date.leap_year(), date.with_ordinal(366).is_some());
+        assert_eq!(date.leap_year(), date.with_ordinal(366).is_ok());
     }
 }
 

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -838,7 +838,7 @@ impl NaiveDateTime {
     /// ```
     #[inline]
     pub const fn with_ordinal(self, ordinal: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { date: try_opt!(self.date.with_ordinal(ordinal)), ..self })
+        Some(NaiveDateTime { date: try_opt!(ok!(self.date.with_ordinal(ordinal))), ..self })
     }
 
     /// Makes a new `NaiveDateTime` with the hour number changed.

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -810,35 +810,28 @@ impl NaiveDateTime {
     ///
     /// # Errors
     ///
-    /// Returns `None` if:
-    /// - The resulting date does not exist (`with_ordinal(366)` in a non-leap year).
-    /// - The value for `ordinal` is invalid.
+    /// This method returns:
+    /// - [`Error::DoesNotExist`] if the resulting date does not exist (`with_ordinal(366)` in a
+    ///   non-leap year).
+    /// - [`Error::InvalidArgument`] if the value for `ordinal` is invalid.
     ///
     /// # Example
     ///
     /// ```
-    /// use chrono::{NaiveDate, NaiveDateTime};
+    /// use chrono::{Error, NaiveDate, NaiveDateTime};
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8).unwrap().and_hms(12, 34, 56).unwrap();
-    /// assert_eq!(
-    ///     dt.with_ordinal(60),
-    ///     Some(NaiveDate::from_ymd(2015, 3, 1).unwrap().and_hms(12, 34, 56).unwrap())
-    /// );
-    /// assert_eq!(dt.with_ordinal(366), None); // 2015 had only 365 days
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 8)?.and_hms(12, 34, 56)?;
+    /// assert_eq!(dt.with_ordinal(60), NaiveDate::from_ymd(2015, 3, 1)?.and_hms(12, 34, 56));
+    /// assert_eq!(dt.with_ordinal(366), Err(Error::DoesNotExist)); // 2015 had only 365 days
     ///
-    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 9, 8).unwrap().and_hms(12, 34, 56).unwrap();
-    /// assert_eq!(
-    ///     dt.with_ordinal(60),
-    ///     Some(NaiveDate::from_ymd(2016, 2, 29).unwrap().and_hms(12, 34, 56).unwrap())
-    /// );
-    /// assert_eq!(
-    ///     dt.with_ordinal(366),
-    ///     Some(NaiveDate::from_ymd(2016, 12, 31).unwrap().and_hms(12, 34, 56).unwrap())
-    /// );
+    /// let dt: NaiveDateTime = NaiveDate::from_ymd(2016, 9, 8)?.and_hms(12, 34, 56)?;
+    /// assert_eq!(dt.with_ordinal(60), NaiveDate::from_ymd(2016, 2, 29)?.and_hms(12, 34, 56));
+    /// assert_eq!(dt.with_ordinal(366), NaiveDate::from_ymd(2016, 12, 31)?.and_hms(12, 34, 56));
+    /// # Ok::<(), Error>(())
     /// ```
     #[inline]
-    pub const fn with_ordinal(self, ordinal: u32) -> Option<NaiveDateTime> {
-        Some(NaiveDateTime { date: try_opt!(ok!(self.date.with_ordinal(ordinal))), ..self })
+    pub const fn with_ordinal(self, ordinal: u32) -> Result<NaiveDateTime, Error> {
+        Ok(NaiveDateTime { date: try_err!(self.date.with_ordinal(ordinal)), ..self })
     }
 
     /// Makes a new `NaiveDateTime` with the hour number changed.


### PR DESCRIPTION
Only `checked_add_months` and `checked_sub_months` left and we are ready with the methods on `NaiveDate` and `NaiveDateTime` (besides parsing).