### PR TITLE
Use different method to ignore feature-dependent doctests

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -79,8 +79,8 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// # Example
     ///
-    #[cfg_attr(not(feature = "clock"), doc = "```ignore")]
-    #[cfg_attr(feature = "clock", doc = "```rust")]
+    /// ```
+    /// # #[cfg(feature = "clock")] {
     /// use chrono::{DateTime, Local};
     ///
     /// let dt = Local::now();
@@ -90,6 +90,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// // Serialize, pass through FFI... and recreate the `DateTime`:
     /// let dt_new = DateTime::<Local>::from_naive_utc_and_offset(naive_utc, offset);
     /// assert_eq!(dt, dt_new);
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -691,8 +692,8 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// # Example
     ///
-    #[cfg_attr(not(feature = "clock"), doc = "```ignore")]
-    #[cfg_attr(feature = "clock", doc = "```rust")]
+    /// ```
+    /// # #[cfg(feature = "clock")] {
     /// use chrono::{Local, NaiveTime};
     ///
     /// let noon = NaiveTime::from_hms_opt(12, 0, 0).unwrap();
@@ -701,6 +702,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// assert_eq!(today_noon.single().unwrap().time(), noon);
     /// assert_eq!(today_midnight.single().unwrap().time(), NaiveTime::MIN);
+    /// # }
     /// ```
     #[must_use]
     pub fn with_time(&self, time: NaiveTime) -> LocalResult<Self> {

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -16,8 +16,8 @@
 //! C's `strftime` format. The available options can be found [here](./strftime/index.html).
 //!
 //! # Example
-#![cfg_attr(not(feature = "std"), doc = "```ignore")]
-#![cfg_attr(feature = "std", doc = "```rust")]
+//! ```
+//! # #[cfg(feature = "std")] {
 //! use chrono::{NaiveDateTime, TimeZone, Utc};
 //!
 //! let date_time = Utc.with_ymd_and_hms(2020, 11, 10, 0, 1, 32).unwrap();
@@ -27,6 +27,7 @@
 //!
 //! let parsed = NaiveDateTime::parse_from_str(&formatted, "%Y-%m-%d %H:%M:%S")?.and_utc();
 //! assert_eq!(parsed, date_time);
+//! # }
 //! # Ok::<(), chrono::ParseError>(())
 //! ```
 

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -17,7 +17,7 @@
 //!
 //! # Example
 //! ```
-//! # #[cfg(feature = "std")] {
+//! # #[cfg(feature = "alloc")] {
 //! use chrono::{NaiveDateTime, TimeZone, Utc};
 //!
 //! let date_time = Utc.with_ymd_and_hms(2020, 11, 10, 0, 1, 32).unwrap();

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -57,8 +57,8 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 ///
 /// Let's see how `Parsed` correctly detects the second RFC 2822 string from before is inconsistent.
 ///
-#[cfg_attr(not(feature = "alloc"), doc = "```ignore")]
-#[cfg_attr(feature = "alloc", doc = "```rust")]
+/// ```
+/// # #[cfg(feature = "alloc")] {
 /// use chrono::format::{ParseErrorKind, Parsed};
 /// use chrono::Weekday;
 ///
@@ -89,6 +89,7 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 /// if let Err(error) = result {
 ///     assert_eq!(error.kind(), ParseErrorKind::Impossible);
 /// }
+/// # }
 /// # Ok::<(), chrono::ParseError>(())
 /// ```
 ///
@@ -98,8 +99,8 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 /// [RFC2822 formatting item]: crate::format::Fixed::RFC2822
 /// [`format::parse()`]: crate::format::parse()
 ///
-#[cfg_attr(not(feature = "alloc"), doc = "```ignore")]
-#[cfg_attr(feature = "alloc", doc = "```rust")]
+/// ```
+/// # #[cfg(feature = "alloc")] {
 /// use chrono::format::{parse, Fixed, Item, Parsed};
 /// use chrono::Weekday;
 ///
@@ -120,6 +121,7 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 ///     // What is the weekday?
 ///     assert_eq!(parsed.weekday(), Some(Weekday::Thu));
 /// }
+/// # }
 /// # Ok::<(), chrono::ParseError>(())
 /// ```
 #[allow(clippy::manual_non_exhaustive)]

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -258,8 +258,8 @@ impl<'a> StrftimeItems<'a> {
     ///
     /// # Example
     ///
-    #[cfg_attr(not(any(feature = "alloc", feature = "std")), doc = "```ignore")]
-    #[cfg_attr(any(feature = "alloc", feature = "std"), doc = "```rust")]
+    /// ```
+    /// # #[cfg(feature = "alloc")] {
     /// use chrono::format::{Locale, StrftimeItems};
     /// use chrono::{FixedOffset, TimeZone};
     ///

--- a/src/format/strftime.rs
+++ b/src/format/strftime.rs
@@ -208,8 +208,7 @@ impl<'a> StrftimeItems<'a> {
     ///
     /// # Example
     ///
-    #[cfg_attr(not(any(feature = "alloc", feature = "std")), doc = "```ignore")]
-    #[cfg_attr(any(feature = "alloc", feature = "std"), doc = "```rust")]
+    /// ```
     /// use chrono::format::*;
     ///
     /// let strftime_parser = StrftimeItems::new("%F"); // %F: year-month-day (ISO 8601)
@@ -279,6 +278,7 @@ impl<'a> StrftimeItems<'a> {
     /// assert_eq!(fmtr.to_string(), "2023년 07월 11일");
     /// let fmtr = dt.format_with_items(StrftimeItems::new_with_locale("%x", Locale::ja_JP));
     /// assert_eq!(fmtr.to_string(), "2023年07月11日");
+    /// # }
     /// ```
     #[cfg(feature = "unstable-locales")]
     #[must_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,7 @@
 //! This is a bit verbose due to Rust's lack of function and method overloading,
 //! but in turn we get a rich combination of initialization methods.
 //!
-#![cfg_attr(not(feature = "now"), doc = "```ignore")]
-#![cfg_attr(feature = "now", doc = "```rust")]
+//! ```
 //! use chrono::offset::MappedLocalTime;
 //! use chrono::prelude::*;
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,7 +385,7 @@
 //! to get the number of additional number of nanoseconds.
 //!
 //! ```
-//! # #[cfg(feature = "std")] {
+//! # #[cfg(feature = "alloc")] {
 //! // We need the trait in scope to use Utc::timestamp().
 //! use chrono::{DateTime, Utc};
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 //! # Chrono: Date and Time for Rust
 //!
-
 //! Chrono aims to provide all functionality needed to do correct operations on dates and times in the
 //! [proleptic Gregorian calendar](https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar):
 //!
@@ -255,10 +254,16 @@
 //! let dt2 = Utc.with_ymd_and_hms(2014, 11, 14, 10, 9, 8).unwrap();
 //! assert_eq!(dt1.signed_duration_since(dt2), TimeDelta::try_seconds(-2 * 3600 + 2).unwrap());
 //! assert_eq!(dt2.signed_duration_since(dt1), TimeDelta::try_seconds(2 * 3600 - 2).unwrap());
-//! assert_eq!(Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap() + TimeDelta::try_seconds(1_000_000_000).unwrap(),
-//!            Utc.with_ymd_and_hms(2001, 9, 9, 1, 46, 40).unwrap());
-//! assert_eq!(Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap() - TimeDelta::try_seconds(1_000_000_000).unwrap(),
-//!            Utc.with_ymd_and_hms(1938, 4, 24, 22, 13, 20).unwrap());
+//! assert_eq!(
+//!     Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap()
+//!         + TimeDelta::try_seconds(1_000_000_000).unwrap(),
+//!     Utc.with_ymd_and_hms(2001, 9, 9, 1, 46, 40).unwrap()
+//! );
+//! assert_eq!(
+//!     Utc.with_ymd_and_hms(1970, 1, 1, 0, 0, 0).unwrap()
+//!         - TimeDelta::try_seconds(1_000_000_000).unwrap(),
+//!     Utc.with_ymd_and_hms(1938, 4, 24, 22, 13, 20).unwrap()
+//! );
 //! ```
 //!
 //! ### Formatting and Parsing

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,20 +108,22 @@
 //! or in the local time zone
 //! ([`Local::now()`](./offset/struct.Local.html#method.now)).
 //!
-#![cfg_attr(not(feature = "now"), doc = "```ignore")]
-#![cfg_attr(feature = "now", doc = "```rust")]
+//! ```
+//! # #[cfg(feature = "now")] {
 //! use chrono::prelude::*;
 //!
 //! let utc: DateTime<Utc> = Utc::now(); // e.g. `2014-11-28T12:45:59.324310806Z`
 //! # let _ = utc;
+//! # }
 //! ```
 //!
-#![cfg_attr(not(feature = "clock"), doc = "```ignore")]
-#![cfg_attr(feature = "clock", doc = "```rust")]
+//! ```
+//! # #[cfg(feature = "clock")] {
 //! use chrono::prelude::*;
 //!
 //! let local: DateTime<Local> = Local::now(); // e.g. `2014-11-28T21:45:59.324310806+09:00`
 //! # let _ = local;
+//! # }
 //! ```
 //!
 //! Alternatively, you can create your own date and time.
@@ -382,8 +384,8 @@
 //! [`DateTime.timestamp_subsec_nanos`](DateTime::timestamp_subsec_nanos)
 //! to get the number of additional number of nanoseconds.
 //!
-#![cfg_attr(not(feature = "std"), doc = "```ignore")]
-#![cfg_attr(feature = "std", doc = "```rust")]
+//! ```
+//! # #[cfg(feature = "std")] {
 //! // We need the trait in scope to use Utc::timestamp().
 //! use chrono::{DateTime, Utc};
 //!
@@ -394,6 +396,7 @@
 //! // Get epoch value from a datetime:
 //! let dt = DateTime::parse_from_rfc2822("Fri, 14 Jul 2017 02:40:00 +0000").unwrap();
 //! assert_eq!(dt.timestamp(), 1_500_000_000);
+//! # }
 //! ```
 //!
 //! ### Naive date and time

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -1047,8 +1047,7 @@ pub mod ts_seconds_option {
     ///     time: Option<NaiveDateTime>,
     /// }
     ///
-    /// let expected =
-    ///     NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_opt(02, 04, 59).unwrap();
+    /// let expected = NaiveDate::from_ymd_opt(2018, 5, 17).unwrap().and_hms_opt(02, 04, 59).unwrap();
     /// let my_s = S { time: Some(expected) };
     /// let as_string = serde_json::to_string(&my_s)?;
     /// assert_eq!(as_string, r#"{"time":1526522699}"#);

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -949,7 +949,7 @@ impl Timelike for NaiveTime {
     /// Use the proper [formatting method](#method.format) to get a human-readable representation.
     ///
     /// ```
-    /// # #[cfg(feature = "std")] {
+    /// # #[cfg(feature = "alloc")] {
     /// # use chrono::{NaiveTime, Timelike};
     /// let leap = NaiveTime::from_hms_milli_opt(23, 59, 59, 1_000).unwrap();
     /// assert_eq!(leap.second(), 59);
@@ -982,7 +982,7 @@ impl Timelike for NaiveTime {
     /// use the proper [formatting method](#method.format) to get a human-readable representation.
     ///
     /// ```
-    /// # #[cfg(feature = "std")] {
+    /// # #[cfg(feature = "alloc")] {
     /// # use chrono::{NaiveTime, Timelike};
     /// let leap = NaiveTime::from_hms_milli_opt(23, 59, 59, 1_000).unwrap();
     /// assert_eq!(leap.nanosecond(), 1_000_000_000);

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -948,12 +948,13 @@ impl Timelike for NaiveTime {
     /// ([Why?](#leap-second-handling))
     /// Use the proper [formatting method](#method.format) to get a human-readable representation.
     ///
-    #[cfg_attr(not(feature = "std"), doc = "```ignore")]
-    #[cfg_attr(feature = "std", doc = "```")]
+    /// ```
+    /// # #[cfg(feature = "std")] {
     /// # use chrono::{NaiveTime, Timelike};
     /// let leap = NaiveTime::from_hms_milli_opt(23, 59, 59, 1_000).unwrap();
     /// assert_eq!(leap.second(), 59);
     /// assert_eq!(leap.format("%H:%M:%S").to_string(), "23:59:60");
+    /// # }
     /// ```
     #[inline]
     fn second(&self) -> u32 {
@@ -980,12 +981,13 @@ impl Timelike for NaiveTime {
     /// You can reduce the range with `time.nanosecond() % 1_000_000_000`, or
     /// use the proper [formatting method](#method.format) to get a human-readable representation.
     ///
-    #[cfg_attr(not(feature = "std"), doc = "```ignore")]
-    #[cfg_attr(feature = "std", doc = "```")]
+    /// ```
+    /// # #[cfg(feature = "std")] {
     /// # use chrono::{NaiveTime, Timelike};
     /// let leap = NaiveTime::from_hms_milli_opt(23, 59, 59, 1_000).unwrap();
     /// assert_eq!(leap.nanosecond(), 1_000_000_000);
     /// assert_eq!(leap.format("%H:%M:%S%.9f").to_string(), "23:59:60.000000000");
+    /// # }
     /// ```
     #[inline]
     fn nanosecond(&self) -> u32 {

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -50,7 +50,7 @@ impl FixedOffset {
     /// # Example
     ///
     /// ```
-    /// # #[cfg(feature = "std")] {
+    /// # #[cfg(feature = "alloc")] {
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
     /// let datetime =
@@ -85,7 +85,7 @@ impl FixedOffset {
     /// # Example
     ///
     /// ```
-    /// # #[cfg(feature = "std")] {
+    /// # #[cfg(feature = "alloc")] {
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
     /// let datetime =

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -49,13 +49,14 @@ impl FixedOffset {
     ///
     /// # Example
     ///
-    #[cfg_attr(not(feature = "std"), doc = "```ignore")]
-    #[cfg_attr(feature = "std", doc = "```")]
+    /// ```
+    /// # #[cfg(feature = "std")] {
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
     /// let datetime =
     ///     FixedOffset::east_opt(5 * hour).unwrap().with_ymd_and_hms(2016, 11, 08, 0, 0, 0).unwrap();
     /// assert_eq!(&datetime.to_rfc3339(), "2016-11-08T00:00:00+05:00")
+    /// # }
     /// ```
     #[must_use]
     pub const fn east_opt(secs: i32) -> Option<FixedOffset> {
@@ -83,13 +84,14 @@ impl FixedOffset {
     ///
     /// # Example
     ///
-    #[cfg_attr(not(feature = "std"), doc = "```ignore")]
-    #[cfg_attr(feature = "std", doc = "```")]
+    /// ```
+    /// # #[cfg(feature = "std")] {
     /// use chrono::{FixedOffset, TimeZone};
     /// let hour = 3600;
     /// let datetime =
     ///     FixedOffset::west_opt(5 * hour).unwrap().with_ymd_and_hms(2016, 11, 08, 0, 0, 0).unwrap();
     /// assert_eq!(&datetime.to_rfc3339(), "2016-11-08T00:00:00-05:00")
+    /// # }
     /// ```
     #[must_use]
     pub const fn west_opt(secs: i32) -> Option<FixedOffset> {

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -123,8 +123,8 @@ impl Weekday {
     ///
     /// # Example
     ///
-    #[cfg_attr(not(feature = "clock"), doc = "```ignore")]
-    #[cfg_attr(feature = "clock", doc = "```rust")]
+    /// ```
+    /// # #[cfg(feature = "clock")] {
     /// # use chrono::{Local, Datelike};
     /// // MTWRFSU is occasionally used as a single-letter abbreviation of the weekdays.
     /// // Use `num_days_from_monday` to index into the array.
@@ -132,6 +132,7 @@ impl Weekday {
     ///
     /// let today = Local::now().weekday();
     /// println!("{}", MTWRFSU[today.num_days_from_monday() as usize]);
+    /// # }
     /// ```
     #[inline]
     pub const fn num_days_from_monday(&self) -> u32 {


### PR DESCRIPTION
This will enable an almost clean run with `cargo +nightly fmt -- --config format_code_in_doc_comments=true`.
It did not handle a combination of doc comments and `#[cfg_attr(feature = ..., doc = "...")]` well.