### PR TITLE
Swap `MappedLocalTime` and `LocalResult` type alias

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ cff-version: 1.2.0
 message: Please cite this crate using these information.
 
 # Version information.
-date-released: 2024-03-26
-version: 0.4.36
+date-released: 2024-03-27
+version: 0.4.37
 
 # Project information.
 abstract: Date and time library for Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono"
-version = "0.4.36"
+version = "0.4.37"
 description = "Date and time library for Rust"
 homepage = "https://github.com/chronotope/chrono"
 documentation = "https://docs.rs/chrono/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -573,9 +573,11 @@ pub mod offset;
 #[cfg(feature = "clock")]
 #[doc(inline)]
 pub use offset::Local;
+#[doc(hidden)]
+pub use offset::LocalResult;
+pub use offset::MappedLocalTime;
 #[doc(inline)]
 pub use offset::{FixedOffset, Offset, TimeZone, Utc};
-pub use offset::{LocalResult, MappedLocalTime};
 
 pub mod round;
 pub use round::{DurationRound, RoundingError, SubsecRound};

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -54,8 +54,11 @@ pub use self::utc::Utc;
 /// the `MappedLocalTime` type to help deal with the result correctly.
 ///
 /// The type of `T` is usually a [`DateTime`] but may also be only an offset.
+pub type MappedLocalTime<T> = LocalResult<T>;
 #[derive(Clone, PartialEq, Debug, Copy, Eq, Hash)]
-pub enum MappedLocalTime<T> {
+
+/// Old name of [`MappedLocalTime`]. See that type for more documentation.
+pub enum LocalResult<T> {
     /// The local time maps to a single unique result.
     Single(T),
 
@@ -140,9 +143,6 @@ impl<T> MappedLocalTime<T> {
         }
     }
 }
-
-/// The conversion result from the local time to the timezone-aware datetime types.
-pub type LocalResult<T> = MappedLocalTime<T>;
 
 #[allow(deprecated)]
 impl<Tz: TimeZone> MappedLocalTime<Date<Tz>> {


### PR DESCRIPTION
In #1501 I thought renaming `LocalResult` to `MappedLocalTime` would be entirely without consequences as long as there is a type alias with the old name. Turns out there is one case where a type alias behaves differently :disappointed:. You can't import enum variants from a type alias with `use chrono::LocalResult::*`.

We have two choices:
- revert the rename entirely for the 0.4.x versions.
- change the enum definition to be on `LocalResult`, and use the type alias everywhere else.

The second choice has my preference. The docs look mostly sane, but break down once you come to the trait implementations section:

![afbeelding](https://github.com/chronotope/chrono/assets/6255050/6e24b3bd-d689-4cbd-8191-84ad09e06581)

...

![afbeelding](https://github.com/chronotope/chrono/assets/6255050/274cafb2-44d4-44c5-bcaf-513e4c0d5c98)

