### PR TITLE
Remove rustc serialize from `chrono = "0.5"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Optional features:
 * `rkyv-32`: Enable serialization/deserialization via [rkyv], using 32-bit integers for integral `*size` types.
 * `rkyv-64`: Enable serialization/deserialization via [rkyv], using 64-bit integers for integral `*size` types.
 * `rkyv-validation`: Enable rkyv validation support using `bytecheck`.
-* `rustc-serialize`: Enable serialization/deserialization via rustc-serialize (deprecated).
 * `arbitrary`: Construct arbitrary instances of a type with the Arbitrary crate.
 * `unstable-locales`: Enable localization. This adds various methods with a `_localized` suffix.
   The implementation and API may change or even be removed in a patch release. Feedback welcome.

--- a/deny.toml
+++ b/deny.toml
@@ -5,7 +5,6 @@ copyleft = "deny"
 [advisories]
 ignore = [
   "RUSTSEC-2021-0145", # atty (dev-deps only, dependency of criterion)
-  "RUSTSEC-2022-0004", # rustc_serialize, cannot remove due to compatibility
 ]
 unmaintained = "deny"
 unsound = "deny"

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -13,14 +13,14 @@ use core::fmt::{self, Write};
 
 #[cfg(feature = "alloc")]
 use crate::offset::Offset;
-#[cfg(any(feature = "alloc", feature = "serde", feature = "rustc-serialize"))]
+#[cfg(any(feature = "alloc", feature = "serde"))]
 use crate::{Datelike, FixedOffset, NaiveDateTime, Timelike};
 #[cfg(feature = "alloc")]
 use crate::{NaiveDate, NaiveTime, Weekday};
 
 #[cfg(feature = "alloc")]
 use super::locales;
-#[cfg(any(feature = "alloc", feature = "serde", feature = "rustc-serialize"))]
+#[cfg(any(feature = "alloc", feature = "serde"))]
 use super::{Colons, OffsetFormat, OffsetPrecision, Pad};
 #[cfg(feature = "alloc")]
 use super::{Fixed, InternalFixed, InternalInternal, Item, Numeric};
@@ -373,7 +373,7 @@ fn format_inner(
     }
 }
 
-#[cfg(any(feature = "alloc", feature = "serde", feature = "rustc-serialize"))]
+#[cfg(any(feature = "alloc", feature = "serde"))]
 impl OffsetFormat {
     /// Writes an offset from UTC with the format defined by `self`.
     fn format(&self, w: &mut impl Write, off: FixedOffset) -> fmt::Result {
@@ -480,7 +480,7 @@ pub enum SecondsFormat {
 
 /// Writes the date, time and offset to the string. same as `%Y-%m-%dT%H:%M:%S%.f%:z`
 #[inline]
-#[cfg(any(feature = "alloc", feature = "serde", feature = "rustc-serialize"))]
+#[cfg(any(feature = "alloc", feature = "serde"))]
 pub(crate) fn write_rfc3339(
     w: &mut impl Write,
     dt: NaiveDateTime,

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -57,7 +57,7 @@ pub(crate) mod locales;
 pub(crate) use formatting::write_hundreds;
 #[cfg(feature = "alloc")]
 pub(crate) use formatting::write_rfc2822;
-#[cfg(any(feature = "alloc", feature = "serde", feature = "rustc-serialize"))]
+#[cfg(any(feature = "alloc", feature = "serde"))]
 pub(crate) use formatting::write_rfc3339;
 #[cfg(feature = "alloc")]
 pub use formatting::DelayedFormat;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,6 @@
 //! - `rkyv-64`: Enable serialization/deserialization via [rkyv],
 //!    using 64-bit integers for integral `*size` types.
 //! - `rkyv-validation`: Enable rkyv validation support using `bytecheck`.
-//! - `rustc-serialize`: Enable serialization/deserialization via rustc-serialize (deprecated).
 //! - `arbitrary`: Construct arbitrary instances of a type with the Arbitrary crate.
 //! - `unstable-locales`: Enable localization. This adds various methods with a `_localized` suffix.
 //!   The implementation and API may change or even be removed in a patch release. Feedback welcome.


### PR DESCRIPTION
This removes the remnants of rustc-serialize from `chrono = "0.5"`.

There's only one leftover offhand remark in `.github/workflows/tests.yml` on line 162 that I don't know what to make of.