### PR TITLE
Index `Month` enum from 1

### DIFF
--- a/src/month.rs
+++ b/src/month.rs
@@ -8,19 +8,19 @@ use crate::OutOfRange;
 /// The month of the year.
 ///
 /// This enum is just a convenience implementation.
-/// The month in dates created by DateLike objects does not return this enum.
+/// The month in dates created by `Datelike` objects does not return this enum.
 ///
-/// It is possible to convert from a date to a month independently
+/// It is possible to convert from a date to a month using `try_from`:
 /// ```
 /// use chrono::prelude::*;
 /// use chrono::Month;
 ///
 /// let date = Utc.at_ymd_and_hms(2019, 10, 28, 9, 10, 11).unwrap();
 /// // `2019-10-28T09:10:11Z`
-/// let month = Month::try_from(u8::try_from(date.month()).unwrap()).ok();
-/// assert_eq!(month, Some(Month::October))
+/// let month = Month::try_from(date.month() as u8).unwrap();
+/// assert_eq!(month, Month::October)
 /// ```
-/// Or from a Month to an integer usable by dates
+/// Or from a `Month` to an integer with simple casting:
 /// ```
 /// # use chrono::prelude::*;
 /// # use chrono::Month;
@@ -28,9 +28,8 @@ use crate::OutOfRange;
 /// let dt = Utc.at_ymd_and_hms(2019, month.number_from_month(), 28, 9, 10, 11).unwrap();
 /// assert_eq!((dt.year(), dt.month(), dt.day()), (2019, 1, 28));
 /// ```
-/// Allows mapping from and to month, from 1-January to 12-December.
-/// Can be Serialized/Deserialized with serde
-// Actual implementation is zero-indexed, API intended as 1-indexed for more intuitive behavior.
+///
+/// Can be Serialized/Deserialized with serde.
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash, PartialOrd, Ord)]
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
@@ -42,29 +41,29 @@ use crate::OutOfRange;
 #[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(arbitrary::Arbitrary))]
 pub enum Month {
     /// January
-    January = 0,
+    January = 1,
     /// February
-    February = 1,
+    February = 2,
     /// March
-    March = 2,
+    March = 3,
     /// April
-    April = 3,
+    April = 4,
     /// May
-    May = 4,
+    May = 5,
     /// June
-    June = 5,
+    June = 6,
     /// July
-    July = 6,
+    July = 7,
     /// August
-    August = 7,
+    August = 8,
     /// September
-    September = 8,
+    September = 9,
     /// October
-    October = 9,
+    October = 10,
     /// November
-    November = 10,
+    November = 11,
     /// December
-    December = 11,
+    December = 12,
 }
 
 impl Month {

--- a/src/month.rs
+++ b/src/month.rs
@@ -25,7 +25,7 @@ use crate::OutOfRange;
 /// # use chrono::prelude::*;
 /// # use chrono::Month;
 /// let month = Month::January;
-/// let dt = Utc.at_ymd_and_hms(2019, month.number_from_month(), 28, 9, 10, 11).unwrap();
+/// let dt = Utc.at_ymd_and_hms(2019, month as u32, 28, 9, 10, 11).unwrap();
 /// assert_eq!((dt.year(), dt.month(), dt.day()), (2019, 1, 28));
 /// ```
 ///
@@ -112,30 +112,6 @@ impl Month {
             Month::October => Month::September,
             Month::November => Month::October,
             Month::December => Month::November,
-        }
-    }
-
-    /// Returns a month-of-year number starting from January = 1.
-    ///
-    /// `m`:                     | `January` | `February` | `...` | `December`
-    /// -------------------------| --------- | ---------- | --- | -----
-    /// `m.number_from_month()`: | 1         | 2          | `...` | 12
-    #[inline]
-    #[must_use]
-    pub const fn number_from_month(self) -> u32 {
-        match self {
-            Month::January => 1,
-            Month::February => 2,
-            Month::March => 3,
-            Month::April => 4,
-            Month::May => 5,
-            Month::June => 6,
-            Month::July => 7,
-            Month::August => 8,
-            Month::September => 9,
-            Month::October => 10,
-            Month::November => 11,
-            Month::December => 12,
         }
     }
 
@@ -285,7 +261,7 @@ mod tests {
         assert_eq!(Month::try_from(date.month() as u8), Ok(Month::October));
 
         let month = Month::January;
-        let dt = Utc.at_ymd_and_hms(2019, month.number_from_month(), 28, 9, 10, 11).unwrap();
+        let dt = Utc.at_ymd_and_hms(2019, month as u32, 28, 9, 10, 11).unwrap();
         assert_eq!((dt.year(), dt.month(), dt.day()), (2019, 1, 28));
     }
 

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -163,16 +163,15 @@ impl NaiveDate {
     /// # Example
     ///
     /// ```
-    /// use chrono::{Error, NaiveDate};
+    /// use chrono::{Error, Month, NaiveDate};
     ///
-    /// let from_ymd = NaiveDate::from_ymd;
-    ///
-    /// assert!(from_ymd(2015, 3, 14).is_ok());
-    /// assert_eq!(from_ymd(2015, 0, 14), Err(Error::InvalidArgument));
-    /// assert_eq!(from_ymd(2015, 2, 29), Err(Error::DoesNotExist));
-    /// assert!(from_ymd(-4, 2, 29).is_ok()); // 5 BCE is a leap year
-    /// assert_eq!(from_ymd(400000, 1, 1), Err(Error::OutOfRange));
-    /// assert_eq!(from_ymd(-400000, 1, 1), Err(Error::OutOfRange));
+    /// assert!(NaiveDate::from_ymd(2015, 3, 14).is_ok());
+    /// assert!(NaiveDate::from_ymd(2015, Month::March as u32, 14).is_ok());
+    /// assert_eq!(NaiveDate::from_ymd(2015, 0, 14), Err(Error::InvalidArgument));
+    /// assert_eq!(NaiveDate::from_ymd(2015, 2, 29), Err(Error::DoesNotExist));
+    /// assert!(NaiveDate::from_ymd(-4, 2, 29).is_ok()); // 5 BCE is a leap year
+    /// assert_eq!(NaiveDate::from_ymd(400000, 1, 1), Err(Error::OutOfRange));
+    /// assert_eq!(NaiveDate::from_ymd(-400000, 1, 1), Err(Error::OutOfRange));
     /// ```
     pub const fn from_ymd(year: i32, month: u32, day: u32) -> Result<NaiveDate, Error> {
         let flags = YearFlags::from_year(year);
@@ -1198,10 +1197,11 @@ impl NaiveDate {
     /// # Examples
     ///
     /// ```
-    /// use chrono::{Error, NaiveDate};
+    /// use chrono::{Error, Month, NaiveDate};
     ///
     /// let date = NaiveDate::from_ymd(2015, 9, 30)?;
     /// assert_eq!(date.with_month(7), NaiveDate::from_ymd(2015, 7, 30));
+    /// assert_eq!(date.with_month(Month::July as u32), NaiveDate::from_ymd(2015, 7, 30));
     /// assert_eq!(date.with_month(13), Err(Error::InvalidArgument)); // No month 13
     /// assert_eq!(date.with_month(2), Err(Error::DoesNotExist)); // No February 30
     /// # Ok::<(), Error>(())

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -756,10 +756,14 @@ impl NaiveDateTime {
     /// # Example
     ///
     /// ```
-    /// use chrono::{Error, NaiveDate, NaiveDateTime};
+    /// use chrono::{Error, Month, NaiveDate, NaiveDateTime};
     ///
     /// let dt: NaiveDateTime = NaiveDate::from_ymd(2015, 9, 30)?.at_hms(12, 34, 56)?;
     /// assert_eq!(dt.with_month(10), NaiveDate::from_ymd(2015, 10, 30)?.at_hms(12, 34, 56));
+    /// assert_eq!(
+    ///     dt.with_month(Month::October as u32),
+    ///     NaiveDate::from_ymd(2015, 10, 30)?.at_hms(12, 34, 56)
+    /// );
     /// assert_eq!(dt.with_month(13), Err(Error::InvalidArgument));
     /// assert_eq!(dt.with_month(2), Err(Error::DoesNotExist)); // No February 30
     /// # Ok::<(), Error>(())


### PR DESCRIPTION
For 0.5 I'd like to make the `Month` enum less useless.

By defining `Month::January` as 1 users can do simple casting, and use it for example in:
```rust
let date = NaiveDate::from_ymd(2015, Month::March as u32, 14);
```

We can also choose to make `Datelike::month` return `Month` (#727). I didn't do so here for two reasons:
- For my personal projects using integers for months was perfectly fine and matches that `year()` and `day()` also return integers. I find working with integers more convenient than wordy month names.
- Returning en enum will introduce extra checks in the `month` method on `NaiveDate` that can't be optimized out without unsafe code. We know `Mdf::from_ol(/* ... */).month()` will reaturn a value in `1..=12`, but the compiler doesn't.