### PR TITLE
0.5: Revise exposed crate features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,9 +77,8 @@ jobs:
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
       - run: |
-          cargo hack check --feature-powerset --optional-deps arbitrary,serde \
-            --skip __internal_bench,iana-time-zone,oldtime,pure-rust-locales,libc,winapi,rkyv-validation,wasmbind \
-            --mutually-exclusive-features arbitrary,rkyv,rkyv-16,rkyv-32,rkyv-64,serde \
+          cargo hack check --feature-powerset --skip rkyv-validation,wasmbind \
+            --mutually-exclusive-features arbitrary,rkyv-16,rkyv-32,rkyv-64,serde \
             --all-targets
         # run using `bash` on all platforms for consistent
         # line-continuation marks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,26 +16,37 @@ rust-version = "1.61.0"
 [lib]
 name = "chrono"
 
-[features]
-# Don't forget to adjust `ALL_NON_EXCLUSIVE_FEATURES` in CI scripts when adding a feature or an optional dependency.
+[features] # Don't forget to adjust `ALL_NON_EXCLUSIVE_FEATURES` in CI scripts when adding a feature or an optional dependency.
 default = ["clock", "std"]
+# Enable features that depend on allocation (primarily string formatting).
 alloc = []
+# Implements `TryFrom<SystemTime>` and `std::error::Error` for error types, implies of `alloc`.
 std = ["alloc"]
+# Enables reading the local timezone (`Local`), implies `now`.
 clock = [
   "dep:windows-targets",
   "dep:iana-time-zone",
   "dep:android-tzdata",
   "now",
 ]
+# Enables reading the system time (`now()`), on most platforms using the standard library.
 now = []
+# Enable features that depend on allocation (primarily string formatting).
 serde = ["dep:serde"]
 # Note that rkyv-16, rkyv-32, and rkyv-64 are mutually exclusive.
+# Enable serialization/deserialization via rkyv, using 16-bit integers for integral `*size` types.
 rkyv-16 = ["dep:rkyv", "rkyv?/size_16"]
+# Enable serialization/deserialization via rkyv, using 32-bit integers for integral `*size` types.
 rkyv-32 = ["dep:rkyv", "rkyv?/size_32"]
+# Enable serialization/deserialization via rkyv, using 64-bit integers for integral `*size` types.
 rkyv-64 = ["dep:rkyv", "rkyv?/size_64"]
+# Enable rkyv validation support using `bytecheck`.
 rkyv-validation = ["dep:rkyv", "rkyv?/validation"]
+# Construct arbitrary instances of a type with the arbitrary crate.
 arbitrary = ["dep:arbitrary"]
+# Interface with the JS Date API for the `wasm32` target.
 wasmbind = ["dep:wasm-bindgen", "dep:js-sys"]
+# Enable localization. This adds various methods with a `_localized` suffix.
 unstable-locales = ["dep:pure-rust-locales"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,9 @@ name = "chrono"
 # Don't forget to adjust `ALL_NON_EXCLUSIVE_FEATURES` in CI scripts when adding a feature or an optional dependency.
 default = ["clock", "std"]
 alloc = []
-libc = []
-winapi = ["windows-targets"]
 std = ["alloc"]
-clock = ["winapi", "iana-time-zone", "android-tzdata", "now"]
+clock = ["windows-targets", "iana-time-zone", "android-tzdata", "now"]
 now = ["std"]
-oldtime = []
 wasmbind = ["wasm-bindgen", "js-sys"]
 unstable-locales = ["pure-rust-locales"]
 # Note that rkyv-16, rkyv-32, and rkyv-64 are mutually exclusive.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,15 @@ clock = [
   "now",
 ]
 now = []
-wasmbind = ["dep:wasm-bindgen", "dep:js-sys"]
-unstable-locales = ["dep:pure-rust-locales"]
+serde = ["dep:serde"]
 # Note that rkyv-16, rkyv-32, and rkyv-64 are mutually exclusive.
 rkyv-16 = ["dep:rkyv", "rkyv?/size_16"]
 rkyv-32 = ["dep:rkyv", "rkyv?/size_32"]
 rkyv-64 = ["dep:rkyv", "rkyv?/size_64"]
 rkyv-validation = ["dep:rkyv", "rkyv?/validation"]
+arbitrary = ["dep:arbitrary"]
+wasmbind = ["dep:wasm-bindgen", "dep:js-sys"]
+unstable-locales = ["dep:pure-rust-locales"]
 
 [dependencies]
 serde = { version = "1.0.99", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ now = ["std"]
 wasmbind = ["dep:wasm-bindgen", "dep:js-sys"]
 unstable-locales = ["dep:pure-rust-locales"]
 # Note that rkyv-16, rkyv-32, and rkyv-64 are mutually exclusive.
-rkyv = ["dep:rkyv", "rkyv/size_32"]
 rkyv-16 = ["dep:rkyv", "rkyv?/size_16"]
 rkyv-32 = ["dep:rkyv", "rkyv?/size_32"]
 rkyv-64 = ["dep:rkyv", "rkyv?/size_64"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,6 @@ rkyv-16 = ["dep:rkyv", "rkyv?/size_16"]
 rkyv-32 = ["dep:rkyv", "rkyv?/size_32"]
 rkyv-64 = ["dep:rkyv", "rkyv?/size_64"]
 rkyv-validation = ["dep:rkyv", "rkyv?/validation"]
-# Features for internal use only:
-__internal_bench = []
 
 [dependencies]
 serde = { version = "1.0.99", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ clock = [
   "dep:android-tzdata",
   "now",
 ]
-now = ["std"]
+now = []
 wasmbind = ["dep:wasm-bindgen", "dep:js-sys"]
 unstable-locales = ["dep:pure-rust-locales"]
 # Note that rkyv-16, rkyv-32, and rkyv-64 are mutually exclusive.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,16 +21,21 @@ name = "chrono"
 default = ["clock", "std"]
 alloc = []
 std = ["alloc"]
-clock = ["windows-targets", "iana-time-zone", "android-tzdata", "now"]
+clock = [
+  "dep:windows-targets",
+  "dep:iana-time-zone",
+  "dep:android-tzdata",
+  "now",
+]
 now = ["std"]
-wasmbind = ["wasm-bindgen", "js-sys"]
-unstable-locales = ["pure-rust-locales"]
+wasmbind = ["dep:wasm-bindgen", "dep:js-sys"]
+unstable-locales = ["dep:pure-rust-locales"]
 # Note that rkyv-16, rkyv-32, and rkyv-64 are mutually exclusive.
 rkyv = ["dep:rkyv", "rkyv/size_32"]
 rkyv-16 = ["dep:rkyv", "rkyv?/size_16"]
 rkyv-32 = ["dep:rkyv", "rkyv?/size_32"]
 rkyv-64 = ["dep:rkyv", "rkyv?/size_64"]
-rkyv-validation = ["rkyv?/validation"]
+rkyv-validation = ["dep:rkyv", "rkyv?/validation"]
 # Features for internal use only:
 __internal_bench = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ unstable-locales = ["dep:pure-rust-locales"]
 [dependencies]
 serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.8", optional = true }
-rkyv = { version = "0.7.43", optional = true, default-features = false }
+rkyv = { version = "0.7.43", default-features = false, optional = true }
 arbitrary = { version = "1.0.0", features = ["derive"], optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
@@ -55,7 +55,7 @@ windows-targets = { version = "0.52", optional = true }
 windows-bindgen = { version = "0.55" } # The MSRV of its windows-metatada dependency is 1.70
 
 [target.'cfg(unix)'.dependencies]
-iana-time-zone = { version = "0.1.45", optional = true, features = ["fallback"] }
+iana-time-zone = { version = "0.1.45", features = ["fallback"], optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android-tzdata = { version = "0.1.1", optional = true }

--- a/README.md
+++ b/README.md
@@ -50,12 +50,10 @@ See [docs.rs](https://docs.rs/chrono/latest/chrono/) for the API reference.
 
 Default features:
 
+* `std`: Implements `TryFrom<SystemTime>` and `std::error::Error` for error types, implies `alloc`.
 * `alloc`: Enable features that depend on allocation (primarily string formatting).
-* `std`: Enables functionality that depends on the standard library. This is a superset of `alloc`
-  and adds interoperation with standard library types and traits.
-* `clock`: Enables reading the local timezone (`Local`). This is a superset of `now`.
-* `now`: Enables reading the system time (`now`).
-* `wasmbind`: Interface with the JS Date API for the `wasm32` target.
+* `clock`: Enables reading the local timezone (`Local`), implies `now`.
+* `now`: Enables reading the system time (`now()`), on most platforms using the standard library.
 
 Optional features:
 
@@ -64,15 +62,16 @@ Optional features:
 * `rkyv-32`: Enable serialization/deserialization via [rkyv], using 32-bit integers for integral `*size` types.
 * `rkyv-64`: Enable serialization/deserialization via [rkyv], using 64-bit integers for integral `*size` types.
 * `rkyv-validation`: Enable rkyv validation support using `bytecheck`.
-* `arbitrary`: Construct arbitrary instances of a type with the Arbitrary crate.
+* `arbitrary`: Construct arbitrary instances of a type with the [arbitrary] crate.
+* `wasmbind`: Interface with the JS Date API for the `wasm32` target.
 * `unstable-locales`: Enable localization. This adds various methods with a `_localized` suffix.
   The implementation and API may change or even be removed in a patch release. Feedback welcome.
-* `oldtime`: This feature no longer has any effect; it used to offer compatibility with the `time` 0.1 crate.
 
 Note: The `rkyv-{16,32,64}` features are mutually exclusive.
 
 [serde]: https://github.com/serde-rs/serde
 [rkyv]: https://github.com/rkyv/rkyv
+[arbitrary]: https://github.com/rust-fuzz/arbitrary/
 
 ## Rust version requirements
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ Default features:
 Optional features:
 
 * `serde`: Enable serialization/deserialization via [serde].
-* `rkyv`: Deprecated, use the `rkyv-*` features.
 * `rkyv-16`: Enable serialization/deserialization via [rkyv], using 16-bit integers for integral `*size` types.
 * `rkyv-32`: Enable serialization/deserialization via [rkyv], using 32-bit integers for integral `*size` types.
 * `rkyv-64`: Enable serialization/deserialization via [rkyv], using 64-bit integers for integral `*size` types.
@@ -70,7 +69,7 @@ Optional features:
   The implementation and API may change or even be removed in a patch release. Feedback welcome.
 * `oldtime`: This feature no longer has any effect; it used to offer compatibility with the `time` 0.1 crate.
 
-Note: The `rkyv{,-16,-32,-64}` features are mutually exclusive.
+Note: The `rkyv-{16,32,64}` features are mutually exclusive.
 
 [serde]: https://github.com/serde-rs/serde
 [rkyv]: https://github.com/rkyv/rkyv

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 name = "benches"
 
 [dependencies]
-chrono = { path = "..", features = ["__internal_bench", "serde"] }
+chrono = { path = "..", features = ["serde"] }
 
 [[bench]]
 name = "chrono"

--- a/bench/benches/chrono.rs
+++ b/bench/benches/chrono.rs
@@ -6,7 +6,7 @@ use chrono::format::StrftimeItems;
 use chrono::prelude::*;
 #[cfg(feature = "unstable-locales")]
 use chrono::Locale;
-use chrono::{DateTime, FixedOffset, Local, SecondsFormat, TimeDelta, Utc, __BenchYearFlags};
+use chrono::{DateTime, FixedOffset, Local, SecondsFormat, TimeDelta, Utc};
 
 fn bench_date_from_ymd(c: &mut Criterion) {
     c.bench_function("bench_date_from_ymd", |b| {
@@ -75,16 +75,6 @@ fn bench_datetime_to_rfc3339_opts(c: &mut Criterion) {
         .unwrap();
     c.bench_function("bench_datetime_to_rfc3339_opts", |b| {
         b.iter(|| black_box(dt).to_rfc3339_opts(SecondsFormat::Nanos, true))
-    });
-}
-
-fn bench_year_flags_from_year(c: &mut Criterion) {
-    c.bench_function("bench_year_flags_from_year", |b| {
-        b.iter(|| {
-            for year in -999i32..1000 {
-                let _ = __BenchYearFlags::from_year(black_box(year));
-            }
-        })
     });
 }
 
@@ -221,7 +211,6 @@ criterion_group!(
     bench_datetime_to_rfc2822,
     bench_datetime_to_rfc3339,
     bench_datetime_to_rfc3339_opts,
-    bench_year_flags_from_year,
     bench_num_days_from_ce,
     bench_get_local_time,
     bench_parse_strftime,

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -30,7 +30,7 @@ use crate::offset::{FixedOffset, MappedLocalTime, Offset, TimeZone, Utc};
 use crate::OutOfRange;
 use crate::{try_err, try_ok_or, Datelike, Error, Months, TimeDelta, Timelike, Weekday};
 
-#[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
+#[cfg(any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
 /// documented at re-export site
@@ -47,7 +47,7 @@ mod tests;
 /// [`TimeZone`](./offset/trait.TimeZone.html) implementations.
 #[derive(Copy, Clone)]
 #[cfg_attr(
-    any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
+    any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq, PartialOrd))
 )]

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1244,7 +1244,7 @@ fn test_to_string_round_trip_with_local() {
 }
 
 #[test]
-#[cfg(feature = "clock")]
+#[cfg(all(feature = "alloc", feature = "clock"))]
 fn test_datetime_format_with_local() {
     // if we are not around the year boundary, local and UTC date should have the same year
     let dt = Local::now().with_month(5).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,7 +470,21 @@
 #![deny(missing_debug_implementations)]
 #![warn(unreachable_pub)]
 #![deny(clippy::tests_outside_test_module)]
-#![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![cfg_attr(
+    not(any(
+        feature = "std",
+        all(
+            feature = "now",
+            not(all(
+                target_arch = "wasm32",
+                feature = "wasmbind",
+                not(any(target_os = "emscripten", target_os = "wasi"))
+            ))
+        ),
+        test
+    )),
+    no_std
+)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "alloc")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,6 @@
 //! Optional features:
 //!
 //! - `serde`: Enable serialization/deserialization via [serde].
-//! - `rkyv`: Deprecated, use the `rkyv-*` features.
 //! - `rkyv-16`: Enable serialization/deserialization via [rkyv],
 //!    using 16-bit integers for integral `*size` types.
 //! - `rkyv-32`: Enable serialization/deserialization via [rkyv],
@@ -47,7 +46,7 @@
 //! - `unstable-locales`: Enable localization. This adds various methods with a `_localized` suffix.
 //!   The implementation and API may change or even be removed in a patch release. Feedback welcome.
 //!
-//! Note: The `rkyv{,-16,-32,-64}` features are mutually exclusive.
+//! Note: The `rkyv-{16,32,64}` features are mutually exclusive.
 //!
 //! See the [cargo docs] for examples of specifying features.
 //!
@@ -591,7 +590,7 @@ pub mod serde {
 /// Zero-copy serialization/deserialization with rkyv.
 ///
 /// This module re-exports the `Archived*` versions of chrono's types.
-#[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
+#[cfg(any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 pub mod rkyv {
     pub use crate::datetime::ArchivedDateTime;
     pub use crate::month::ArchivedMonth;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -537,10 +537,6 @@ pub use month::{Month, Months};
 mod traits;
 pub use traits::{Datelike, Timelike};
 
-#[cfg(feature = "__internal_bench")]
-#[doc(hidden)]
-pub use naive::__BenchYearFlags;
-
 /// Serialization/Deserialization with serde
 ///
 /// The [`DateTime`] type has default implementations for (de)serializing to/from the [RFC 3339]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,12 +25,12 @@
 //!
 //! Default features:
 //!
+//! - `std`: Implements `TryFrom<SystemTime>` and `std::error::Error` for error types,
+//!    implies `alloc`.
 //! - `alloc`: Enable features that depend on allocation (primarily string formatting).
-//! - `std`: Enables functionality that depends on the standard library. This is a superset of
-//!   `alloc` and adds interoperation with standard library types and traits.
-//! - `clock`: Enables reading the local timezone (`Local`). This is a superset of `now`.
-//! - `now`: Enables reading the system time (`now`).
-//! - `wasmbind`: Interface with the JS Date API for the `wasm32` target.
+//! - `clock`: Enables reading the local timezone (`Local`), implies `now`.
+//! - `now`: Enables reading the system time (`now()`), on most platforms using the standard
+//!   library.
 //!
 //! Optional features:
 //!
@@ -42,7 +42,8 @@
 //! - `rkyv-64`: Enable serialization/deserialization via [rkyv],
 //!    using 64-bit integers for integral `*size` types.
 //! - `rkyv-validation`: Enable rkyv validation support using `bytecheck`.
-//! - `arbitrary`: Construct arbitrary instances of a type with the Arbitrary crate.
+//! - `arbitrary`: Construct arbitrary instances of a type with the [arbitrary] crate.
+//! - `wasmbind`: Interface with the JS Date API for the `wasm32` target.
 //! - `unstable-locales`: Enable localization. This adds various methods with a `_localized` suffix.
 //!   The implementation and API may change or even be removed in a patch release. Feedback welcome.
 //!
@@ -52,6 +53,7 @@
 //!
 //! [serde]: https://github.com/serde-rs/serde
 //! [rkyv]: https://github.com/rkyv/rkyv
+//! [arbitrary]: https://github.com/rust-fuzz/arbitrary/
 //! [cargo docs]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choosing-features
 //!
 //! ## Overview

--- a/src/month.rs
+++ b/src/month.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-#[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
+#[cfg(any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
 use crate::OutOfRange;
@@ -32,7 +32,7 @@ use crate::OutOfRange;
 /// Can be Serialized/Deserialized with serde.
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash, PartialOrd, Ord)]
 #[cfg_attr(
-    any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
+    any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq, PartialOrd)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -20,7 +20,7 @@ use core::num::NonZeroI32;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::{fmt, str};
 
-#[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
+#[cfg(any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
 /// L10n locales.
@@ -93,7 +93,7 @@ mod tests;
 /// [proleptic Gregorian date]: crate::NaiveDate#calendar-date
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone)]
 #[cfg_attr(
-    any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
+    any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq, PartialOrd)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -10,7 +10,7 @@ use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::time::Duration;
 use core::{fmt, str};
 
-#[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
+#[cfg(any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
 #[cfg(feature = "alloc")]
@@ -57,7 +57,7 @@ mod tests;
 /// ```
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone)]
 #[cfg_attr(
-    any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
+    any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq, PartialOrd)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))

--- a/src/naive/internals.rs
+++ b/src/naive/internals.rs
@@ -1,7 +1,5 @@
 //! Internal helper types for working with dates.
 
-#![cfg_attr(feature = "__internal_bench", allow(missing_docs))]
-
 use core::fmt;
 
 use crate::Error;
@@ -68,11 +66,9 @@ const YEAR_TO_FLAGS: &[YearFlags; 400] = &[
 ];
 
 impl YearFlags {
-    #[allow(unreachable_pub)] // public as an alias for benchmarks only
-    #[doc(hidden)] // for benchmarks only
     #[inline]
     #[must_use]
-    pub const fn from_year(year: i32) -> YearFlags {
+    pub(super) const fn from_year(year: i32) -> YearFlags {
         let year = year.rem_euclid(400);
         YearFlags::from_year_mod_400(year)
     }

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -7,7 +7,7 @@ use core::fmt;
 
 use super::internals::YearFlags;
 
-#[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
+#[cfg(any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
 /// ISO 8601 week.
@@ -18,7 +18,7 @@ use rkyv::{Archive, Deserialize, Serialize};
 /// via the [`Datelike::iso_week`](../trait.Datelike.html#tymethod.iso_week) method.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Hash)]
 #[cfg_attr(
-    any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
+    any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq, PartialOrd)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))

--- a/src/naive/mod.rs
+++ b/src/naive/mod.rs
@@ -20,10 +20,6 @@ pub use self::datetime::NaiveDateTime;
 pub use self::isoweek::IsoWeek;
 pub use self::time::NaiveTime;
 
-#[cfg(feature = "__internal_bench")]
-#[doc(hidden)]
-pub use self::internals::YearFlags as __BenchYearFlags;
-
 /// A week represented by a [`NaiveDate`] and a [`Weekday`] which is the first
 /// day of the week.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -9,7 +9,7 @@ use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::time::Duration;
 use core::{fmt, str};
 
-#[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
+#[cfg(any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
 #[cfg(feature = "alloc")]
@@ -205,7 +205,7 @@ mod tests;
 /// **there is absolutely no guarantee that the leap second read has actually happened**.
 #[derive(PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone)]
 #[cfg_attr(
-    any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
+    any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq, PartialOrd)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -6,7 +6,7 @@
 use core::fmt;
 use core::str::FromStr;
 
-#[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
+#[cfg(any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
 use super::{MappedLocalTime, Offset, TimeZone};
@@ -21,7 +21,7 @@ use crate::{Error, NaiveDateTime, ParseError};
 /// [`west`](#method.west) methods for examples.
 #[derive(PartialEq, Eq, Hash, Copy, Clone)]
 #[cfg_attr(
-    any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
+    any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, Hash, Debug))

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -6,7 +6,7 @@
 #[cfg(windows)]
 use std::cmp::Ordering;
 
-#[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
+#[cfg(any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
 use super::fixed::FixedOffset;
@@ -107,7 +107,7 @@ mod tz_info;
 /// ```
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(
-    any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
+    any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq)),
     archive_attr(derive(Clone, Copy, Debug))

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -89,7 +89,7 @@ impl Utc {
     )))]
     #[must_use]
     pub fn now() -> DateTime<Utc> {
-        SystemTime::now().try_into().expect(
+        DateTime::try_from_system_time(SystemTime::now()).expect(
             "system clock is set to a time extremely far into the past or future; cannot convert",
         )
     }

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -14,7 +14,7 @@ use core::fmt;
 ))]
 use std::time::SystemTime;
 
-#[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
+#[cfg(any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
 use super::{FixedOffset, MappedLocalTime, Offset, TimeZone};
@@ -43,7 +43,7 @@ use crate::OutOfRange;
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(
-    any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
+    any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, Debug, Hash))

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -16,7 +16,7 @@ use core::{fmt, i64};
 
 use crate::{expect, ok, try_ok_or, Error};
 
-#[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
+#[cfg(any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
 /// The number of nanoseconds in a microsecond.
@@ -49,7 +49,7 @@ const SECS_PER_WEEK: i64 = 604_800;
 /// instance `abs()` can be called without any checks.
 #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
 #[cfg_attr(
-    any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
+    any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq, PartialOrd)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-#[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
+#[cfg(any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
 use crate::OutOfRange;
@@ -31,7 +31,7 @@ use crate::OutOfRange;
 /// ```
 #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[cfg_attr(
-    any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
+    any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, Debug, Hash))


### PR DESCRIPTION
Remove the old crate features `libc`, `old_time`, `rkyv` and `winapi`.
Switch to the `dep:` syntax for optional dependencies that where exposed as features: `pure-rust-locales`, `android-tzdata`, `iana-time-zone`, `js-sys`, `wasm-bindgen` and `windows-targets`.