### PR TITLE
CI: Reduce combinations in `cargo hack check`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: |
           cargo hack check --feature-powerset --optional-deps arbitrary,serde \
-            --skip __internal_bench,iana-time-zone,pure-rust-locales,libc,oldtime,winapi,rkyv-16,rkyv-64,rkyv-validation,wasmbind \
+            --skip __internal_bench,iana-time-zone,oldtime,pure-rust-locales,libc,winapi,rkyv-validation,wasmbind \
+            --mutually-exclusive-features arbitrary,rkyv,rkyv-16,rkyv-32,rkyv-64,serde \
             --all-targets
         # run using `bash` on all platforms for consistent
         # line-continuation marks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: |
           cargo hack check --feature-powerset --optional-deps arbitrary,serde \
-            --skip __internal_bench,iana-time-zone,pure-rust-locales,libc,winapi,rkyv-16,rkyv-64,rkyv-validation \
+            --skip __internal_bench,iana-time-zone,pure-rust-locales,libc,oldtime,winapi,rkyv-16,rkyv-64,rkyv-validation,wasmbind \
             --all-targets
         # run using `bash` on all platforms for consistent
         # line-continuation marks


### PR DESCRIPTION
I'm not sure why but within the last week the combinations `cargo hack check` tries on our CI has increased 4x to 672. Cargo hack has seen a couple of new releases, so there may be a change or bugfix there.

Disabling the `oldtime` (unused) and `wasmbind` (not checked on linux anyway) features reduces it back to 192 combinations.

We can also now inform cargo hack that some features are mutually exclusive, or don't effect each other. The `rkyv` features are truly mutually exclusive. The `arbitrary` feature is far removed from serialization, and serde also doesn't seem to have anything in common with rkyv. So I think we can treat them as mutually exclusive.

This allows us to run `cargo hack check` for more meaningful combinations with the `rkyv-*` features while we only check 84 combinations. Room to grow again :smile:.

This should bring our CI time back below 5 minutes instead of close to 20 minutes.