### PR TITLE
Optimize formatting a bit

### DIFF
--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -103,7 +103,7 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
                 Item::Literal(s) | Item::Space(s) => w.write_str(s),
                 #[cfg(feature = "alloc")]
                 Item::OwnedLiteral(ref s) | Item::OwnedSpace(ref s) => w.write_str(s),
-                Item::Numeric(ref spec, ref pad) => self.format_numeric(w, spec, pad),
+                Item::Numeric(ref spec, pad) => self.format_numeric(w, spec, pad),
                 Item::Fixed(ref spec) => self.format_fixed(w, spec),
                 Item::Error => Err(fmt::Error),
             }?;
@@ -112,7 +112,7 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
     }
 
     #[cfg(feature = "alloc")]
-    fn format_numeric(&self, w: &mut impl Write, spec: &Numeric, pad: &Pad) -> fmt::Result {
+    fn format_numeric(&self, w: &mut impl Write, spec: &Numeric, pad: Pad) -> fmt::Result {
         use self::Numeric::*;
 
         let (width, v) = match (spec, self.date, self.time) {

--- a/src/format/formatting.rs
+++ b/src/format/formatting.rs
@@ -115,9 +115,6 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
     fn format_numeric(&self, w: &mut impl Write, spec: &Numeric, pad: &Pad) -> fmt::Result {
         use self::Numeric::*;
 
-        let week_from_sun = |d: NaiveDate| d.weeks_from(Weekday::Sun);
-        let week_from_mon = |d: NaiveDate| d.weeks_from(Weekday::Mon);
-
         let (width, v) = match *spec {
             Year => (4, self.date.map(|d| i64::from(d.year()))),
             YearDiv100 => (2, self.date.map(|d| i64::from(d.year()).div_euclid(100))),
@@ -127,8 +124,8 @@ impl<'a, I: Iterator<Item = B> + Clone, B: Borrow<Item<'a>>> DelayedFormat<I> {
             IsoYearMod100 => (2, self.date.map(|d| i64::from(d.iso_week().year()).rem_euclid(100))),
             Month => (2, self.date.map(|d| i64::from(d.month()))),
             Day => (2, self.date.map(|d| i64::from(d.day()))),
-            WeekFromSun => (2, self.date.map(|d| i64::from(week_from_sun(d)))),
-            WeekFromMon => (2, self.date.map(|d| i64::from(week_from_mon(d)))),
+            WeekFromSun => (2, self.date.map(|d| i64::from(d.weeks_from(Weekday::Sun)))),
+            WeekFromMon => (2, self.date.map(|d| i64::from(d.weeks_from(Weekday::Mon)))),
             IsoWeek => (2, self.date.map(|d| i64::from(d.iso_week().week()))),
             NumDaysFromSun => (1, self.date.map(|d| i64::from(d.weekday().num_days_from_sunday()))),
             WeekdayFromMon => (1, self.date.map(|d| i64::from(d.weekday().number_from_monday()))),


### PR DESCRIPTION
This takes the commits from #1163 that simplify and optimize our formatting code a bit. #1335 took the initial refactor from that PR, so now we can take the more interesting part.

Two commits make better use of `match` to only accept a formatting item if we also have the date/time/offset fields it needs, instead of using `map` inside a match arm.

The last commit introduces a couple of optimized number formatting functions. They are the trick that makes our formatting implementations for RFC 2822 and 3339 faster, so lets use them for regular formatting too :smile:.

### Benchmarks
```
     Running benches/chrono.rs (target/release/deps/chrono-413c84d256ba35f5)
bench_format            time:   [533.37 ns 535.14 ns 537.22 ns]
                        change: [-22.588% -21.943% -21.284%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

bench_format_with_items time:   [388.35 ns 389.61 ns 391.09 ns]
                        change: [-29.520% -28.855% -28.271%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```