### PR TITLE
Remove Utc::now() and Local::now() on unsupported platforms

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -874,11 +874,7 @@ impl DateTime<Utc> {
         feature = "std",
         all(
             feature = "now",
-            not(all(
-                target_arch = "wasm32",
-                feature = "wasmbind",
-                not(any(target_os = "emscripten", target_os = "wasi"))
-            ))
+            any(not(target_arch = "wasm32"), target_os = "emscripten", target_os = "wasi")
         )
     ))]
     pub(crate) fn try_from_system_time(t: std::time::SystemTime) -> Result<DateTime<Utc>, Error> {

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -874,7 +874,16 @@ impl DateTime<Utc> {
         feature = "std",
         all(
             feature = "now",
-            any(not(target_arch = "wasm32"), target_os = "emscripten", target_os = "wasi")
+            any(
+                unix,
+                windows,
+                target_os = "solid_asp3",
+                target_os = "hermit",
+                target_os = "wasi",
+                target_os = "xous",
+                all(target_vendor = "fortanix", target_env = "sgx"),
+                target_os = "teeos",
+            )
         )
     ))]
     pub(crate) fn try_from_system_time(t: std::time::SystemTime) -> Result<DateTime<Utc>, Error> {

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -11,7 +11,7 @@ use rkyv::{Archive, Deserialize, Serialize};
 
 use super::fixed::FixedOffset;
 use super::{MappedLocalTime, TimeZone};
-use crate::{DateTime, NaiveDateTime, Utc};
+use crate::NaiveDateTime;
 
 #[cfg(unix)]
 #[path = "unix.rs"]
@@ -120,8 +120,8 @@ impl Local {
     /// Returns a `DateTime<Local>` which corresponds to the current date, time and offset from
     /// UTC.
     ///
-    /// See also the similar [`Utc::now()`] which returns `DateTime<Utc>`, i.e. without the local
-    /// offset.
+    /// See also the similar [`Utc::now()`](crate::Utc::now) which returns `DateTime<Utc>`, i.e.
+    /// without the local offset.
     ///
     /// # Example
     ///
@@ -144,8 +144,14 @@ impl Local {
     /// let offset = FixedOffset::east(5 * 60 * 60).unwrap();
     /// let now_with_offset = Local::now().with_timezone(&offset);
     /// ```
-    pub fn now() -> DateTime<Local> {
-        Utc::now().with_timezone(&Local)
+    #[cfg(any(
+        not(target_arch = "wasm32"),
+        feature = "wasmbind",
+        target_os = "emscripten",
+        target_os = "wasi",
+    ))]
+    pub fn now() -> crate::DateTime<Local> {
+        crate::Utc::now().with_timezone(&Local)
     }
 }
 

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -145,10 +145,15 @@ impl Local {
     /// let now_with_offset = Local::now().with_timezone(&offset);
     /// ```
     #[cfg(any(
-        not(target_arch = "wasm32"),
-        feature = "wasmbind",
-        target_os = "emscripten",
+        unix,
+        windows,
+        target_os = "solid_asp3",
+        target_os = "hermit",
         target_os = "wasi",
+        target_os = "xous",
+        all(target_vendor = "fortanix", target_env = "sgx"),
+        target_os = "teeos",
+        all(target_arch = "wasm32", feature = "wasmbind")
     ))]
     pub fn now() -> crate::DateTime<Local> {
         crate::Utc::now().with_timezone(&Local)

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -71,7 +71,21 @@ impl Utc {
     /// Panics if the system clock is set to a time in the extremely distant past or future, such
     /// that it is out of the range representable by `DateTime<Utc>`. It is assumed that this
     /// crate will no longer be in use by that time.
-    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten", target_os = "wasi"))]
+    // Covers the platforms with `SystemTime::time()` supported by the Rust Standard Library as of
+    // Rust 1.78. See:
+    //   https://github.com/rust-lang/rust/blob/22a5267c83a3e17f2b763279eb24bb632c45dc6b/library/std/src/sys/pal/uefi/mod.rs
+    // Note that some platforms listed in the PAL table do not support `SystemTime::time()` (e.g.,
+    // `zkvm` and `wasm`).
+    #[cfg(any(
+        unix,
+        windows,
+        target_os = "solid_asp3",
+        target_os = "hermit",
+        target_os = "wasi",
+        target_os = "xous",
+        all(target_vendor = "fortanix", target_env = "sgx"),
+        target_os = "teeos",
+    ))]
     #[must_use]
     pub fn now() -> crate::DateTime<Utc> {
         crate::DateTime::try_from_system_time(std::time::SystemTime::now()).expect(

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -73,9 +73,10 @@ impl Utc {
     /// crate will no longer be in use by that time.
     // Covers the platforms with `SystemTime::time()` supported by the Rust Standard Library as of
     // Rust 1.78. See:
-    //   https://github.com/rust-lang/rust/blob/22a5267c83a3e17f2b763279eb24bb632c45dc6b/library/std/src/sys/pal/uefi/mod.rs
+    //   https://github.com/rust-lang/rust/blob/5e9bed7b1e1524936001b37b6ecbf406179d8ebe/library/std/src/sys/pal/mod.rs
     // Note that some platforms listed in the PAL table do not support `SystemTime::time()` (e.g.,
-    // `zkvm` and `wasm`).
+    // `zkvm` and `wasm`). When updating this configuration, also be sure to update `Local::now()`
+    // and `DateTime::try_from_system_time()`.
     #[cfg(any(
         unix,
         windows,

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -4,23 +4,12 @@
 //! The UTC (Coordinated Universal Time) time zone.
 
 use core::fmt;
-#[cfg(all(
-    feature = "now",
-    not(all(
-        target_arch = "wasm32",
-        feature = "wasmbind",
-        not(any(target_os = "emscripten", target_os = "wasi"))
-    ))
-))]
-use std::time::SystemTime;
 
 #[cfg(any(feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
 use super::{FixedOffset, MappedLocalTime, Offset, TimeZone};
 use crate::naive::NaiveDateTime;
-#[cfg(feature = "now")]
-use crate::DateTime;
 #[cfg(all(feature = "now", doc))]
 use crate::OutOfRange;
 
@@ -82,14 +71,10 @@ impl Utc {
     /// Panics if the system clock is set to a time in the extremely distant past or future, such
     /// that it is out of the range representable by `DateTime<Utc>`. It is assumed that this
     /// crate will no longer be in use by that time.
-    #[cfg(not(all(
-        target_arch = "wasm32",
-        feature = "wasmbind",
-        not(any(target_os = "emscripten", target_os = "wasi"))
-    )))]
+    #[cfg(any(not(target_arch = "wasm32"), target_os = "emscripten", target_os = "wasi"))]
     #[must_use]
-    pub fn now() -> DateTime<Utc> {
-        DateTime::try_from_system_time(SystemTime::now()).expect(
+    pub fn now() -> crate::DateTime<Utc> {
+        crate::DateTime::try_from_system_time(std::time::SystemTime::now()).expect(
             "system clock is set to a time extremely far into the past or future; cannot convert",
         )
     }
@@ -101,9 +86,9 @@ impl Utc {
         not(any(target_os = "emscripten", target_os = "wasi"))
     ))]
     #[must_use]
-    pub fn now() -> DateTime<Utc> {
+    pub fn now() -> crate::DateTime<Utc> {
         let now = js_sys::Date::new_0();
-        DateTime::<Utc>::from(now)
+        crate::DateTime::<Utc>::from(now)
     }
 }
 


### PR DESCRIPTION
`std::time::SystemTime::now()` panics in WASM environments other than Emscripten (i.e., wasm32-unknown-emscripten) or WASI (e.g., wasm32-wasi). Since compilation errors are preferable to unexpected runtime panics, this PR removes the `Utc::now()` and `Local::now()` functions from this crate's public interface altogether in unsupported WASM environments unless the `wasmbind` feature is enabled.

This catches the case in which a user of the crate forgets to enable the `wasmbind` feature (see ramosbugs/openidconnect-rs#127 and ramosbugs/oauth2-rs#230) in build targets that require it.

This is a breaking change: WASM targets (other than Emscripten/WASI) that referenced `Utc::now()` or `Local::now()` would previously compile (then panic at runtime). Now they will fail to compile, which is the intended purpose of this PR.

Fixes #1301.
