### PR TITLE
manually implement `Copy` on `DateTime<Tz>`

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -46,7 +46,7 @@ mod tests;
 /// There are some constructors implemented here (the `from_*` methods), but
 /// the general-purpose constructors are all via the methods on the
 /// [`TimeZone`](./offset/trait.TimeZone.html) implementations.
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
@@ -57,6 +57,10 @@ pub struct DateTime<Tz: TimeZone> {
     datetime: NaiveDateTime,
     offset: Tz::Offset,
 }
+
+// The Copy impl is not derived, because it would add an un-necessary
+// `Tz: Copy` bound
+impl<Tz: TimeZone> Copy for DateTime<Tz> where <Tz as TimeZone>::Offset: Copy {}
 
 /// The minimum possible `DateTime<Utc>`.
 #[deprecated(since = "0.4.20", note = "Use DateTime::MIN_UTC instead")]


### PR DESCRIPTION
`derive` generates the following impls:

```rust
impl<Tz: ::core::marker::Copy + TimeZone> ::core::marker::Copy for DateTime<Tz>
where
    Tz::Offset: ::core::marker::Copy,
{}

impl<Tz: ::core::clone::Clone + TimeZone> ::core::clone::Clone for DateTime<Tz>
where
    Tz::Offset: ::core::clone::Clone,
{
    #[inline]
    fn clone(&self) -> DateTime<Tz> {
        DateTime {
            datetime: ::core::clone::Clone::clone(&self.datetime),
            offset: ::core::clone::Clone::clone(&self.offset),
        }
    }
}
```

In the `Copy` impl, the `Tz: Copy` bound is un-necessary. Note that in the `Clone` impl, he `Tz: Clone` is also un-necessary, but it's implied by the `TimeZone` bound anyway, so there's not point having a manual implementation of `Clone`.

Fixes https://github.com/chronotope/chrono/issues/1571