### PR TITLE
Manually implement `Copy` for `DateTime` if offset is `Copy`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,8 +3,8 @@ cff-version: 1.2.0
 message: Please cite this crate using these information.
 
 # Version information.
-date-released: 2024-03-27
-version: 0.4.37
+date-released: 2024-04-15
+version: 0.4.38
 
 # Project information.
 abstract: Date and time library for Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono"
-version = "0.4.37"
+version = "0.4.38"
 description = "Date and time library for Rust"
 homepage = "https://github.com/chronotope/chrono"
 documentation = "https://docs.rs/chrono/"

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -46,7 +46,7 @@ mod tests;
 /// There are some constructors implemented here (the `from_*` methods), but
 /// the general-purpose constructors are all via the methods on the
 /// [`TimeZone`](./offset/trait.TimeZone.html) implementations.
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
@@ -1406,6 +1406,15 @@ impl<Tz: TimeZone> Timelike for DateTime<Tz> {
     fn with_nanosecond(&self, nano: u32) -> Option<DateTime<Tz>> {
         map_local(self, |datetime| datetime.with_nanosecond(nano))
     }
+}
+
+// We don't store a field with the `Tz` type, so it doesn't need to influence whether `DateTime` can
+// be `Copy`. Implement it manually if the two types we do have are `Copy`.
+impl<Tz: TimeZone> Copy for DateTime<Tz>
+where
+    <Tz as TimeZone>::Offset: Copy,
+    NaiveDateTime: Copy,
+{
 }
 
 impl<Tz: TimeZone, Tz2: TimeZone> PartialEq<DateTime<Tz2>> for DateTime<Tz> {


### PR DESCRIPTION
Also extended the test to have the type that implements `Offset` be `Send` and `Copy` while the type for `TimeZone` is not.

Fixes #1571.