### PR TITLE
#1577: Changed years_since documentation to match its implementation

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -594,7 +594,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// # Errors
     ///
-    /// Returns `None` if `base < self`.
+    /// Returns `None` if `base > self`.
     #[must_use]
     pub fn years_since(&self, base: Self) -> Option<u32> {
         let mut years = self.year() - base.year();

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -1136,7 +1136,7 @@ impl NaiveDate {
     ///
     /// # Errors
     ///
-    /// Returns `None` if `base < self`.
+    /// Returns `None` if `base > self`.
     #[must_use]
     pub const fn years_since(&self, base: Self) -> Option<u32> {
         let mut years = self.year() - base.year();


### PR DESCRIPTION
Fixes documentation on #1577 by changing the comments on both NaiveDate and DateTime.

No tests are needed since its only comments.