### PR TITLE
Fix typo in rustdoc of `from_timestamp_nanos()`

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -822,7 +822,7 @@ impl DateTime<Utc> {
         Self::from_timestamp(secs, nsecs)
     }
 
-    /// Creates a new [`DateTime<Utc>`] from the number of non-leap microseconds
+    /// Creates a new [`DateTime<Utc>`] from the number of non-leap nanoseconds
     /// since January 1, 1970 0:00:00.000 UTC (aka "UNIX timestamp").
     ///
     /// This is guaranteed to round-trip with [`timestamp_nanos`](DateTime::timestamp_nanos).


### PR DESCRIPTION
This change is pure documentation and fixes a typo in the description of [`from_timestamp_nanos()`](https://docs.rs/chrono/latest/chrono/struct.DateTime.html#method.from_timestamp_nanos).