### PR TITLE
Use environment secrets for Codecov token

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,6 +13,7 @@ jobs:
   job_code_coverage:
     name: llvm-cov
     runs-on: ubuntu-latest
+    environment: Coverage
     env:
       CARGO_TERM_COLOR: always
     steps:


### PR DESCRIPTION
It seems like there are some unexpected differences between "Repository secrets" and "Environment secrets" for GitHub repositories. In another repo, this seemed to help. (I've copied the token into the new Environment.)