### PR TITLE
Impl serde::Serialize and serde::Deserialize for TimeDelta

### DIFF
--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -658,7 +658,7 @@ mod serde {
 
     #[cfg(test)]
     mod tests {
-        use super::{TimeDelta, super::MAX};
+        use super::{super::MAX, TimeDelta};
 
         #[test]
         fn test_serde() {

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -62,6 +62,29 @@ pub struct TimeDelta {
     nanos: i32, // Always 0 <= nanos < NANOS_PER_SEC
 }
 
+#[cfg(feature = "serde")]
+impl serde::Serialize for TimeDelta {
+	fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+		<(i64, i32) as serde::Serialize>::serialize(&(self.secs, self.nanos), serializer)
+	}
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for TimeDelta {
+	fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+		let (secs, nanos) = <(i64, i32) as serde::Deserialize>::deserialize(deserializer)?;
+        if secs < MIN.secs
+            || secs > MAX.secs
+            || nanos >= 1_000_000_000
+            || (secs == MAX.secs && nanos > MAX.nanos)
+            || (secs == MIN.secs && nanos < MIN.nanos)
+        {
+            return Err(serde::de::Error::custom("TimeDelta out of bounds"));
+        }
+		Ok(TimeDelta { secs, nanos })
+	}
+}
+
 /// The minimum possible `TimeDelta`: `-i64::MAX` milliseconds.
 pub(crate) const MIN: TimeDelta = TimeDelta {
     secs: -i64::MAX / MILLIS_PER_SEC - 1,
@@ -1304,5 +1327,12 @@ mod tests {
         let duration = TimeDelta::try_seconds(1).unwrap();
         let bytes = rkyv::to_bytes::<_, 16>(&duration).unwrap();
         assert_eq!(rkyv::from_bytes::<TimeDelta>(&bytes).unwrap(), duration);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_serde() {
+        let duration = TimeDelta::new(123, 456).unwrap();
+        assert_eq!(serde_json::from_value::<TimeDelta>(serde_json::to_value(&duration).unwrap()).unwrap(), duration);
     }
 }

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -1337,4 +1337,11 @@ mod tests {
             duration
         );
     }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    #[should_panic(expected = "TimeDelta out of bounds")]
+    fn test_serde_oob_panic() {
+        let _ = serde_json::from_value::<TimeDelta>(serde_json::json!([MAX.secs + 1, 0])).unwrap();
+    }
 }

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -64,25 +64,24 @@ pub struct TimeDelta {
 
 #[cfg(feature = "serde")]
 impl serde::Serialize for TimeDelta {
-	fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-		<(i64, i32) as serde::Serialize>::serialize(&(self.secs, self.nanos), serializer)
-	}
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        <(i64, i32) as serde::Serialize>::serialize(&(self.secs, self.nanos), serializer)
+    }
 }
 
 #[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for TimeDelta {
-	fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-		let (secs, nanos) = <(i64, i32) as serde::Deserialize>::deserialize(deserializer)?;
-        if secs < MIN.secs
-            || secs > MAX.secs
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let (secs, nanos) = <(i64, i32) as serde::Deserialize>::deserialize(deserializer)?;
+        if !(MIN.secs..=MAX.secs).contains(&secs)
             || nanos >= 1_000_000_000
             || (secs == MAX.secs && nanos > MAX.nanos)
             || (secs == MIN.secs && nanos < MIN.nanos)
         {
             return Err(serde::de::Error::custom("TimeDelta out of bounds"));
         }
-		Ok(TimeDelta { secs, nanos })
-	}
+        Ok(TimeDelta { secs, nanos })
+    }
 }
 
 /// The minimum possible `TimeDelta`: `-i64::MAX` milliseconds.
@@ -1333,6 +1332,9 @@ mod tests {
     #[cfg(feature = "serde")]
     fn test_serde() {
         let duration = TimeDelta::new(123, 456).unwrap();
-        assert_eq!(serde_json::from_value::<TimeDelta>(serde_json::to_value(&duration).unwrap()).unwrap(), duration);
+        assert_eq!(
+            serde_json::from_value::<TimeDelta>(serde_json::to_value(duration).unwrap()).unwrap(),
+            duration
+        );
     }
 }


### PR DESCRIPTION
Could rewrite this to use ISO 8601 representation, which since 2019 allows negative durations, if preferred. However, parsing then is a little ambiguous wrt what to do about years/months.