### PR TITLE
feat: Change to use `core::error::Error`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test ${{ env.ALL_NON_EXCLUSIVE_FEATURES }} --color=always -- --color=always
 
-  # later this may be able to be included with the below
-  # kept separate for now as the following don't compile on 1.60
-  # * arbitrary (requires 1.63 as of v1.3.0)
   rust_msrv:
     strategy:
       matrix:
@@ -34,19 +31,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.61.0"
+          toolchain: "1.81.0"
       - uses: Swatinem/rust-cache@v2
       # run --lib and --doc to avoid the long running integration tests
       # which are run elsewhere
       - run: |
           cargo test --lib \
             --features \
-            unstable-locales,wasmbind,oldtime,clock,winapi,serde \
+            unstable-locales,wasmbind,oldtime,clock,winapi,serde,arbitrary \
             --color=always -- --color=always
       - run: |
           cargo test --doc \
             --features \
-            unstable-locales,wasmbind,oldtime,clock,winapi,serde \
+            unstable-locales,wasmbind,oldtime,clock,winapi,serde,arbitrary \
             --color=always -- --color=always
 
   rust_versions:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 include = ["src/*", "tests/*.rs", "LICENSE.txt", "CITATION.cff"]
 edition = "2021"
-rust-version = "1.61.0"
+rust-version = "1.81.0"
 
 [lib]
 name = "chrono"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Note: The `rkyv{,-16,-32,-64}` features are mutually exclusive.
 
 ## Rust version requirements
 
-The Minimum Supported Rust Version (MSRV) is currently **Rust 1.61.0**.
+The Minimum Supported Rust Version (MSRV) is currently **Rust 1.81.0**.
 
 The MSRV is explicitly tested in CI. It may be bumped in minor releases, but this is not done
 lightly.

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -33,10 +33,9 @@
 
 #[cfg(all(feature = "alloc", not(feature = "std"), not(test)))]
 use alloc::boxed::Box;
+use core::error::Error;
 use core::fmt;
 use core::str::FromStr;
-#[cfg(feature = "std")]
-use std::error::Error;
 
 use crate::{Month, ParseMonthError, ParseWeekdayError, Weekday};
 
@@ -448,7 +447,6 @@ impl fmt::Display for ParseError {
     }
 }
 
-#[cfg(feature = "std")]
 impl Error for ParseError {
     #[allow(deprecated)]
     fn description(&self) -> &str {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,7 +412,7 @@
 //!
 //! ## Rust version requirements
 //!
-//! The Minimum Supported Rust Version (MSRV) is currently **Rust 1.61.0**.
+//! The Minimum Supported Rust Version (MSRV) is currently **Rust 1.81.0**.
 //!
 //! The MSRV is explicitly tested in CI. It may be bumped in minor releases, but this is not done
 //! lightly.
@@ -684,8 +684,7 @@ impl fmt::Debug for OutOfRange {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for OutOfRange {}
+impl core::error::Error for OutOfRange {}
 
 /// Workaround because `?` is not (yet) available in const context.
 #[macro_export]

--- a/src/month.rs
+++ b/src/month.rs
@@ -246,8 +246,7 @@ pub struct ParseMonthError {
     pub(crate) _dummy: (),
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseMonthError {}
+impl core::error::Error for ParseMonthError {}
 
 impl fmt::Display for ParseMonthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/round.rs
+++ b/src/round.rs
@@ -105,12 +105,7 @@ const fn span_for_digits(digits: u16) -> u32 {
 /// will also fail if the `TimeDelta` is bigger than the timestamp, negative or zero.
 pub trait DurationRound: Sized {
     /// Error that can occur in rounding or truncating
-    #[cfg(feature = "std")]
-    type Err: std::error::Error;
-
-    /// Error that can occur in rounding or truncating
-    #[cfg(not(feature = "std"))]
-    type Err: fmt::Debug + fmt::Display;
+    type Err: core::error::Error;
 
     /// Return a copy rounded by TimeDelta.
     ///
@@ -295,8 +290,7 @@ impl fmt::Display for RoundingError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for RoundingError {
+impl core::error::Error for RoundingError {
     #[allow(deprecated)]
     fn description(&self) -> &str {
         "error from rounding or truncating with DurationRound"

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -10,11 +10,10 @@
 
 //! Temporal quantification
 
+use core::error::Error;
 use core::fmt;
 use core::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 use core::time::Duration;
-#[cfg(feature = "std")]
-use std::error::Error;
 
 use crate::{expect, try_opt};
 
@@ -607,7 +606,6 @@ impl fmt::Display for OutOfRangeError {
     }
 }
 
-#[cfg(feature = "std")]
 impl Error for OutOfRangeError {
     #[allow(deprecated)]
     fn description(&self) -> &str {

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -242,8 +242,7 @@ pub struct ParseWeekdayError {
     pub(crate) _dummy: (),
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseWeekdayError {}
+impl core::error::Error for ParseWeekdayError {}
 
 impl fmt::Display for ParseWeekdayError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
Change to use [`core::error::Error`](https://doc.rust-lang.org/core/error/trait.Error.html) instead of [`std::error::Error`](https://doc.rust-lang.org/std/error/trait.Error.html). The MSRV is bumped up to 1.81.0 by this change.