### PR TITLE
rkyv-08 feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,11 @@ rkyv-16 = ["dep:rkyv", "rkyv?/size_16"]
 rkyv-32 = ["dep:rkyv", "rkyv?/size_32"]
 rkyv-64 = ["dep:rkyv", "rkyv?/size_64"]
 rkyv-validation = ["rkyv?/validation"]
+rkyv-08 = ["dep:rkyv-08", "rkyv-08/pointer_width_32"]
+rkyv-08-16 = ["dep:rkyv-08", "rkyv-08/pointer_width_16"]
+rkyv-08-32 = ["dep:rkyv-08", "rkyv-08/pointer_width_32"]
+rkyv-08-64 = ["dep:rkyv-08", "rkyv-08/pointer_width_64"]
+rkyv-08-bytecheck = ["rkyv-08/bytecheck"]
 # Features for internal use only:
 __internal_bench = []
 
@@ -42,6 +47,7 @@ num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.8", optional = true }
 rkyv = { version = "0.7.43", optional = true, default-features = false }
+rkyv-08 = { package = "rkyv", version = "0.8.8", optional = true, default-features = false }
 arbitrary = { version = "1.0.0", features = ["derive"], optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -34,6 +34,9 @@ use crate::{Datelike, Months, TimeDelta, Timelike, Weekday};
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
+#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+use rkyv_08::{Archive, Deserialize, Serialize};
+
 /// documented at re-export site
 #[cfg(feature = "serde")]
 pub(super) mod serde;
@@ -51,6 +54,11 @@ mod tests;
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq, PartialOrd))
+)]
+#[cfg_attr(
+    any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"),
+    derive(Archive, Deserialize, Serialize),
+    rkyv(crate = rkyv_08, compare(PartialEq, PartialOrd))
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub struct DateTime<Tz: TimeZone> {
@@ -1770,7 +1778,7 @@ impl<Tz: TimeZone> fmt::Debug for DateTime<Tz> {
 // * https://github.com/rust-lang/rust/issues/26925
 // * https://github.com/rkyv/rkyv/issues/333
 // * https://github.com/dtolnay/syn/issues/370
-#[cfg(feature = "rkyv-validation")]
+#[cfg(any(feature = "rkyv-validation", feature = "rkyv-08-bytecheck"))]
 impl<Tz: TimeZone> fmt::Debug for ArchivedDateTime<Tz>
 where
     Tz: Archive,

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -34,7 +34,12 @@ use crate::{Datelike, Months, TimeDelta, Timelike, Weekday};
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+#[cfg(any(
+    feature = "rkyv-08",
+    feature = "rkyv-08-16",
+    feature = "rkyv-08-32",
+    feature = "rkyv-08-64"
+))]
 use rkyv_08::{Archive, Deserialize, Serialize};
 
 /// documented at re-export site

--- a/src/month.rs
+++ b/src/month.rs
@@ -3,6 +3,9 @@ use core::fmt;
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
+#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+use rkyv_08::{Archive, Deserialize, Serialize};
+
 use crate::OutOfRange;
 
 /// The month of the year.
@@ -34,6 +37,15 @@ use crate::OutOfRange;
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq, PartialOrd)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+)]
+#[cfg_attr(
+    any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"),
+    derive(Archive, Deserialize, Serialize),
+    rkyv(
+		crate = rkyv_08,
+		compare(PartialEq, PartialOrd),
+		derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash),
+	),
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 #[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(arbitrary::Arbitrary))]
@@ -438,5 +450,13 @@ mod tests {
         let month = Month::January;
         let bytes = rkyv::to_bytes::<_, 1>(&month).unwrap();
         assert_eq!(rkyv::from_bytes::<Month>(&bytes).unwrap(), month);
+    }
+
+    #[test]
+    #[cfg(feature = "rkyv-08-bytecheck")]
+    fn test_rkyv_08_bytecheck() {
+        let month = Month::January;
+        let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&month).unwrap();
+        assert_eq!(rkyv_08::from_bytes::<Month, rkyv_08::rancor::Error>(&bytes).unwrap(), month);
     }
 }

--- a/src/month.rs
+++ b/src/month.rs
@@ -3,7 +3,12 @@ use core::fmt;
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+#[cfg(any(
+    feature = "rkyv-08",
+    feature = "rkyv-08-16",
+    feature = "rkyv-08-32",
+    feature = "rkyv-08-64"
+))]
 use rkyv_08::{Archive, Deserialize, Serialize};
 
 use crate::OutOfRange;

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -23,6 +23,9 @@ use core::{fmt, str};
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
+#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+use rkyv_08::{Archive, Deserialize, Serialize};
+
 /// L10n locales.
 #[cfg(all(feature = "unstable-locales", feature = "alloc"))]
 use pure_rust_locales::Locale;
@@ -97,6 +100,15 @@ mod tests;
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq, PartialOrd)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+)]
+#[cfg_attr(
+    any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"),
+    derive(Archive, Deserialize, Serialize),
+    rkyv(
+		crate = rkyv_08,
+		compare(PartialEq, PartialOrd),
+		derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash),
+	),
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub struct NaiveDate {

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -23,7 +23,12 @@ use core::{fmt, str};
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+#[cfg(any(
+    feature = "rkyv-08",
+    feature = "rkyv-08-16",
+    feature = "rkyv-08-32",
+    feature = "rkyv-08-64"
+))]
 use rkyv_08::{Archive, Deserialize, Serialize};
 
 /// L10n locales.

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -862,6 +862,18 @@ fn test_rkyv_validation() {
     assert_eq!(rkyv::from_bytes::<NaiveDate>(&bytes).unwrap(), date_max);
 }
 
+#[test]
+#[cfg(feature = "rkyv-08-bytecheck")]
+fn test_rkyv_validation() {
+    let date_min = NaiveDate::MIN;
+    let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&date_min).unwrap();
+    assert_eq!(rkyv_08::from_bytes::<NaiveDate, rkyv_08::rancor::Error>(&bytes).unwrap(), date_min);
+
+    let date_max = NaiveDate::MAX;
+    let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&date_max).unwrap();
+    assert_eq!(rkyv_08::from_bytes::<NaiveDate, rkyv_08::rancor::Error>(&bytes).unwrap(), date_max);
+}
+
 //   MAX_YEAR-12-31 minus 0000-01-01
 // = (MAX_YEAR-12-31 minus 0000-12-31) + (0000-12-31 - 0000-01-01)
 // = MAX_YEAR * 365 + (# of leap years from 0001 to MAX_YEAR) + 365

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -13,7 +13,12 @@ use core::{fmt, str};
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+#[cfg(any(
+    feature = "rkyv-08",
+    feature = "rkyv-08-16",
+    feature = "rkyv-08-32",
+    feature = "rkyv-08-64"
+))]
 use rkyv_08::{Archive, Deserialize, Serialize};
 
 #[cfg(feature = "alloc")]

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -13,6 +13,9 @@ use core::{fmt, str};
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
+#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+use rkyv_08::{Archive, Deserialize, Serialize};
+
 #[cfg(feature = "alloc")]
 use crate::format::DelayedFormat;
 use crate::format::{parse, parse_and_remainder, ParseError, ParseResult, Parsed, StrftimeItems};
@@ -70,6 +73,15 @@ pub const MAX_DATETIME: NaiveDateTime = NaiveDateTime::MAX;
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq, PartialOrd)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+)]
+#[cfg_attr(
+    any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"),
+    derive(Archive, Deserialize, Serialize),
+    rkyv(
+		crate = rkyv_08,
+		compare(PartialEq, PartialOrd),
+		derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash),
+	),
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 #[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(arbitrary::Arbitrary))]

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -412,10 +412,16 @@ fn test_rkyv_validation() {
 #[cfg(feature = "rkyv-08-bytecheck")]
 fn test_rkyv_validation() {
     let dt_min = NaiveDateTime::MIN;
-	let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&dt_min).unwrap();
-    assert_eq!(rkyv_08::from_bytes::<NaiveDateTime, rkyv_08::rancor::Error>(&bytes).unwrap(), dt_min);
+    let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&dt_min).unwrap();
+    assert_eq!(
+        rkyv_08::from_bytes::<NaiveDateTime, rkyv_08::rancor::Error>(&bytes).unwrap(),
+        dt_min
+    );
 
     let dt_max = NaiveDateTime::MAX;
-	let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&dt_max).unwrap();
-    assert_eq!(rkyv_08::from_bytes::<NaiveDateTime, rkyv_08::rancor::Error>(&bytes).unwrap(), dt_max);
+    let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&dt_max).unwrap();
+    assert_eq!(
+        rkyv_08::from_bytes::<NaiveDateTime, rkyv_08::rancor::Error>(&bytes).unwrap(),
+        dt_max
+    );
 }

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -407,3 +407,15 @@ fn test_rkyv_validation() {
     let bytes = rkyv::to_bytes::<_, 12>(&dt_max).unwrap();
     assert_eq!(rkyv::from_bytes::<NaiveDateTime>(&bytes).unwrap(), dt_max);
 }
+
+#[test]
+#[cfg(feature = "rkyv-08-bytecheck")]
+fn test_rkyv_validation() {
+    let dt_min = NaiveDateTime::MIN;
+	let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&dt_min).unwrap();
+    assert_eq!(rkyv_08::from_bytes::<NaiveDateTime, rkyv_08::rancor::Error>(&bytes).unwrap(), dt_min);
+
+    let dt_max = NaiveDateTime::MAX;
+	let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&dt_max).unwrap();
+    assert_eq!(rkyv_08::from_bytes::<NaiveDateTime, rkyv_08::rancor::Error>(&bytes).unwrap(), dt_max);
+}

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -10,7 +10,12 @@ use super::internals::YearFlags;
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+#[cfg(any(
+    feature = "rkyv-08",
+    feature = "rkyv-08-16",
+    feature = "rkyv-08-32",
+    feature = "rkyv-08-64"
+))]
 use rkyv_08::{Archive, Deserialize, Serialize};
 
 /// ISO 8601 week.
@@ -248,10 +253,16 @@ mod tests {
     fn test_rkyv_bytecheck() {
         let minweek = NaiveDate::MIN.iso_week();
         let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&minweek).unwrap();
-        assert_eq!(rkyv_08::from_bytes::<IsoWeek, rkyv_08::rancor::Error>(&bytes).unwrap(), minweek);
+        assert_eq!(
+            rkyv_08::from_bytes::<IsoWeek, rkyv_08::rancor::Error>(&bytes).unwrap(),
+            minweek
+        );
 
         let maxweek = NaiveDate::MAX.iso_week();
         let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&maxweek).unwrap();
-        assert_eq!(rkyv_08::from_bytes::<IsoWeek, rkyv_08::rancor::Error>(&bytes).unwrap(), maxweek);
+        assert_eq!(
+            rkyv_08::from_bytes::<IsoWeek, rkyv_08::rancor::Error>(&bytes).unwrap(),
+            maxweek
+        );
     }
 }

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -10,6 +10,9 @@ use super::internals::YearFlags;
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
+#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+use rkyv_08::{Archive, Deserialize, Serialize};
+
 /// ISO 8601 week.
 ///
 /// This type, combined with [`Weekday`](../enum.Weekday.html),
@@ -22,6 +25,15 @@ use rkyv::{Archive, Deserialize, Serialize};
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq, PartialOrd)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+)]
+#[cfg_attr(
+    any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"),
+    derive(Archive, Deserialize, Serialize),
+    rkyv(
+		crate = rkyv_08,
+		compare(PartialEq, PartialOrd),
+		derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash),
+	),
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub struct IsoWeek {
@@ -162,7 +174,7 @@ impl fmt::Debug for IsoWeek {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "rkyv-validation")]
+    #[cfg(any(feature = "rkyv-validation", feature = "rkyv-08-bytecheck"))]
     use super::IsoWeek;
     use crate::naive::date::{self, NaiveDate};
     use crate::Datelike;
@@ -229,5 +241,17 @@ mod tests {
         let maxweek = NaiveDate::MAX.iso_week();
         let bytes = rkyv::to_bytes::<_, 4>(&maxweek).unwrap();
         assert_eq!(rkyv::from_bytes::<IsoWeek>(&bytes).unwrap(), maxweek);
+    }
+
+    #[test]
+    #[cfg(feature = "rkyv-08-bytecheck")]
+    fn test_rkyv_bytecheck() {
+        let minweek = NaiveDate::MIN.iso_week();
+        let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&minweek).unwrap();
+        assert_eq!(rkyv_08::from_bytes::<IsoWeek, rkyv_08::rancor::Error>(&bytes).unwrap(), minweek);
+
+        let maxweek = NaiveDate::MAX.iso_week();
+        let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&maxweek).unwrap();
+        assert_eq!(rkyv_08::from_bytes::<IsoWeek, rkyv_08::rancor::Error>(&bytes).unwrap(), maxweek);
     }
 }

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -12,6 +12,9 @@ use core::{fmt, str};
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
+#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+use rkyv_08::{Archive, Deserialize, Serialize};
+
 #[cfg(feature = "alloc")]
 use crate::format::DelayedFormat;
 use crate::format::{
@@ -215,6 +218,15 @@ mod tests;
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq, PartialOrd)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+)]
+#[cfg_attr(
+    any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"),
+    derive(Archive, Deserialize, Serialize),
+    rkyv(
+		crate = rkyv_08,
+		compare(PartialEq, PartialOrd),
+		derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash),
+	),
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub struct NaiveTime {

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -12,7 +12,12 @@ use core::{fmt, str};
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+#[cfg(any(
+    feature = "rkyv-08",
+    feature = "rkyv-08-16",
+    feature = "rkyv-08-32",
+    feature = "rkyv-08-64"
+))]
 use rkyv_08::{Archive, Deserialize, Serialize};
 
 #[cfg(feature = "alloc")]

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -391,3 +391,15 @@ fn test_rkyv_validation() {
     let bytes = rkyv::to_bytes::<_, 8>(&t_max).unwrap();
     assert_eq!(rkyv::from_bytes::<NaiveTime>(&bytes).unwrap(), t_max);
 }
+
+#[test]
+#[cfg(feature = "rkyv-08-bytecheck")]
+fn test_rkyv_bytecheck() {
+    let t_min = NaiveTime::MIN;
+    let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&t_min).unwrap();
+    assert_eq!(rkyv_08::from_bytes::<NaiveTime, rkyv_08::rancor::Error>(&bytes).unwrap(), t_min);
+
+    let t_max = NaiveTime::MAX;
+    let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&t_max).unwrap();
+    assert_eq!(rkyv_08::from_bytes::<NaiveTime, rkyv_08::rancor::Error>(&bytes).unwrap(), t_max);
+}

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -9,6 +9,9 @@ use core::str::FromStr;
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
+#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+use rkyv_08::{Archive, Deserialize, Serialize};
+
 use super::{MappedLocalTime, Offset, TimeZone};
 use crate::format::{scan, ParseError, OUT_OF_RANGE};
 use crate::naive::{NaiveDate, NaiveDateTime};
@@ -25,6 +28,15 @@ use crate::naive::{NaiveDate, NaiveDateTime};
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, Hash, Debug))
+)]
+#[cfg_attr(
+    any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"),
+    derive(Archive, Deserialize, Serialize),
+    rkyv(
+		crate = rkyv_08,
+		compare(PartialEq),
+		derive(Clone, Copy, PartialEq, Eq, Hash, Debug),
+	),
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub struct FixedOffset {
@@ -232,5 +244,13 @@ mod tests {
         let offset = FixedOffset::from_str("-0500").unwrap();
         let bytes = rkyv::to_bytes::<_, 4>(&offset).unwrap();
         assert_eq!(rkyv::from_bytes::<FixedOffset>(&bytes).unwrap(), offset);
+    }
+
+    #[test]
+    #[cfg(feature = "rkyv-08-bytecheck")]
+    fn test_rkyv_bytecheck() {
+        let offset = FixedOffset::from_str("-0500").unwrap();
+		let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&offset).unwrap();
+        assert_eq!(rkyv_08::from_bytes::<FixedOffset, rkyv_08::rancor::Error>(&bytes).unwrap(), offset);
     }
 }

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -9,7 +9,12 @@ use core::str::FromStr;
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+#[cfg(any(
+    feature = "rkyv-08",
+    feature = "rkyv-08-16",
+    feature = "rkyv-08-32",
+    feature = "rkyv-08-64"
+))]
 use rkyv_08::{Archive, Deserialize, Serialize};
 
 use super::{MappedLocalTime, Offset, TimeZone};
@@ -250,7 +255,10 @@ mod tests {
     #[cfg(feature = "rkyv-08-bytecheck")]
     fn test_rkyv_bytecheck() {
         let offset = FixedOffset::from_str("-0500").unwrap();
-		let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&offset).unwrap();
-        assert_eq!(rkyv_08::from_bytes::<FixedOffset, rkyv_08::rancor::Error>(&bytes).unwrap(), offset);
+        let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&offset).unwrap();
+        assert_eq!(
+            rkyv_08::from_bytes::<FixedOffset, rkyv_08::rancor::Error>(&bytes).unwrap(),
+            offset
+        );
     }
 }

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -9,7 +9,12 @@ use std::cmp::Ordering;
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+#[cfg(any(
+    feature = "rkyv-08",
+    feature = "rkyv-08-16",
+    feature = "rkyv-08-32",
+    feature = "rkyv-08-64"
+))]
 use rkyv_08::{Archive, Deserialize, Serialize};
 
 use super::fixed::FixedOffset;
@@ -556,11 +561,14 @@ mod tests {
     fn test_rkyv_bytecheck() {
         let local = Local;
         // Local is a ZST and serializes to 0 bytes
-		let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&local).unwrap();
+        let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&local).unwrap();
         assert_eq!(bytes.len(), 0);
 
         // but is deserialized to an archived variant without a
         // wrapping object
-		assert_eq!(rkyv_08::from_bytes::<Local, rkyv_08::rancor::Error>(&bytes).unwrap(), super::ArchivedLocal);
+        assert_eq!(
+            rkyv_08::from_bytes::<Local, rkyv_08::rancor::Error>(&bytes).unwrap(),
+            super::ArchivedLocal
+        );
     }
 }

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -9,6 +9,9 @@ use std::cmp::Ordering;
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
+#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+use rkyv_08::{Archive, Deserialize, Serialize};
+
 use super::fixed::FixedOffset;
 use super::{MappedLocalTime, TimeZone};
 use crate::naive::{NaiveDate, NaiveDateTime, NaiveTime};
@@ -116,6 +119,15 @@ mod tz_info;
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq)),
     archive_attr(derive(Clone, Copy, Debug))
+)]
+#[cfg_attr(
+    any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"),
+    derive(Archive, Deserialize, Serialize),
+    rkyv(
+		crate = rkyv_08,
+		compare(PartialEq),
+		derive(Clone, Copy, Debug),
+	),
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
@@ -537,5 +549,18 @@ mod tests {
         // but is deserialized to an archived variant without a
         // wrapping object
         assert_eq!(rkyv::from_bytes::<Local>(&bytes).unwrap(), super::ArchivedLocal);
+    }
+
+    #[test]
+    #[cfg(feature = "rkyv-08-bytecheck")]
+    fn test_rkyv_bytecheck() {
+        let local = Local;
+        // Local is a ZST and serializes to 0 bytes
+		let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&local).unwrap();
+        assert_eq!(bytes.len(), 0);
+
+        // but is deserialized to an archived variant without a
+        // wrapping object
+		assert_eq!(rkyv_08::from_bytes::<Local, rkyv_08::rancor::Error>(&bytes).unwrap(), super::ArchivedLocal);
     }
 }

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -17,6 +17,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
+#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+use rkyv_08::{Archive, Deserialize, Serialize};
+
 use super::{FixedOffset, MappedLocalTime, Offset, TimeZone};
 use crate::naive::{NaiveDate, NaiveDateTime};
 #[cfg(feature = "now")]
@@ -46,6 +49,15 @@ use crate::{Date, DateTime};
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, Debug, Hash))
+)]
+#[cfg_attr(
+    any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"),
+    derive(Archive, Deserialize, Serialize),
+    rkyv(
+		crate = rkyv_08,
+		compare(PartialEq),
+		derive(Clone, Copy, PartialEq, Eq, Debug, Hash),
+	),
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 #[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(arbitrary::Arbitrary))]

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -17,7 +17,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+#[cfg(any(
+    feature = "rkyv-08",
+    feature = "rkyv-08-16",
+    feature = "rkyv-08-32",
+    feature = "rkyv-08-64"
+))]
 use rkyv_08::{Archive, Deserialize, Serialize};
 
 use super::{FixedOffset, MappedLocalTime, Offset, TimeZone};

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -21,7 +21,12 @@ use crate::{expect, try_opt};
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+#[cfg(any(
+    feature = "rkyv-08",
+    feature = "rkyv-08-16",
+    feature = "rkyv-08-32",
+    feature = "rkyv-08-64"
+))]
 use rkyv_08::{Archive, Deserialize, Serialize};
 
 /// The number of nanoseconds in a microsecond.
@@ -1363,7 +1368,10 @@ mod tests {
     #[cfg(feature = "rkyv-08-bytecheck")]
     fn test_rkyv_bytecheck() {
         let duration = TimeDelta::try_seconds(1).unwrap();
-		let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&duration).unwrap();
-		assert_eq!(rkyv_08::from_bytes::<TimeDelta, rkyv_08::rancor::Error>(&bytes).unwrap(), duration);
+        let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&duration).unwrap();
+        assert_eq!(
+            rkyv_08::from_bytes::<TimeDelta, rkyv_08::rancor::Error>(&bytes).unwrap(),
+            duration
+        );
     }
 }

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -21,6 +21,9 @@ use crate::{expect, try_opt};
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
+#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+use rkyv_08::{Archive, Deserialize, Serialize};
+
 /// The number of nanoseconds in a microsecond.
 const NANOS_PER_MICRO: i32 = 1000;
 /// The number of nanoseconds in a millisecond.
@@ -55,6 +58,15 @@ const SECS_PER_WEEK: i64 = 604_800;
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq, PartialOrd)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+)]
+#[cfg_attr(
+    any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"),
+    derive(Archive, Deserialize, Serialize),
+    rkyv(
+		crate = rkyv_08,
+		compare(PartialEq, PartialOrd),
+		derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash),
+	),
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub struct TimeDelta {
@@ -1345,5 +1357,13 @@ mod tests {
         let duration = TimeDelta::try_seconds(1).unwrap();
         let bytes = rkyv::to_bytes::<_, 16>(&duration).unwrap();
         assert_eq!(rkyv::from_bytes::<TimeDelta>(&bytes).unwrap(), duration);
+    }
+
+    #[test]
+    #[cfg(feature = "rkyv-08-bytecheck")]
+    fn test_rkyv_bytecheck() {
+        let duration = TimeDelta::try_seconds(1).unwrap();
+		let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&duration).unwrap();
+		assert_eq!(rkyv_08::from_bytes::<TimeDelta, rkyv_08::rancor::Error>(&bytes).unwrap(), duration);
     }
 }

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -3,6 +3,9 @@ use core::fmt;
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
+#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+use rkyv_08::{Archive, Deserialize, Serialize};
+
 use crate::OutOfRange;
 
 /// The day of week.
@@ -35,6 +38,15 @@ use crate::OutOfRange;
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq)),
     archive_attr(derive(Clone, Copy, PartialEq, Eq, Debug, Hash))
+)]
+#[cfg_attr(
+    any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"),
+    derive(Archive, Deserialize, Serialize),
+    rkyv(
+		crate = rkyv_08,
+		compare(PartialEq),
+		derive(Clone, Copy, PartialEq, Eq, Debug, Hash),
+	),
 )]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 #[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(arbitrary::Arbitrary))]
@@ -398,5 +410,14 @@ mod tests {
         let bytes = rkyv::to_bytes::<_, 1>(&mon).unwrap();
 
         assert_eq!(rkyv::from_bytes::<Weekday>(&bytes).unwrap(), mon);
+    }
+
+    #[test]
+    #[cfg(feature = "rkyv-08-bytecheck")]
+    fn test_rkyv_bytecheck() {
+        let mon = Weekday::Mon;
+        let bytes = rkyv_08::to_bytes::<rkyv_08::rancor::Error>(&mon).unwrap();
+
+        assert_eq!(rkyv_08::from_bytes::<Weekday, rkyv_08::rancor::Error>(&bytes).unwrap(), mon);
     }
 }

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -3,7 +3,12 @@ use core::fmt;
 #[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 use rkyv::{Archive, Deserialize, Serialize};
 
-#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
+#[cfg(any(
+    feature = "rkyv-08",
+    feature = "rkyv-08-16",
+    feature = "rkyv-08-32",
+    feature = "rkyv-08-64"
+))]
 use rkyv_08::{Archive, Deserialize, Serialize};
 
 use crate::OutOfRange;


### PR DESCRIPTION
Supersedes #1614

Not sure what to do about CI as currently the features are incompatible with rkyv 0.7, but I could use fully qualified paths for `rkyv_08::Archive` etc and then it should be ok?

Alternatively, could do smth like
```rust
// lib.rs
#[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
pub(crate) use rkyv_07 as rkyv;

#[cfg(any(feature = "rkyv-08", feature = "rkyv-08-16", feature = "rkyv-08-32", feature = "rkyv-08-64"))]
pub(crate) use rkyv_08 as rkyv;

// elsewhere
use crate::rkyv::{Archive, Serialize, Deserialize};
```