### PR TITLE
Use Formatter::pad (instead of write_str) for Weekdays

### DIFF
--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -171,7 +171,7 @@ impl Weekday {
 
 impl fmt::Display for Weekday {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(match *self {
+        f.pad(match *self {
             Weekday::Mon => "Mon",
             Weekday::Tue => "Tue",
             Weekday::Wed => "Wed",
@@ -329,6 +329,16 @@ mod tests {
             assert_eq!(base_day.days_since(base_day.succ().succ().succ().succ().succ()), 2);
             assert_eq!(base_day.days_since(base_day.succ().succ().succ().succ().succ().succ()), 1);
         }
+    }
+
+    #[test]
+    fn test_formatting_alignment() {
+        // No exhaustive testing here as we just delegate the
+        // implementation to Formatter::pad. Just some basic smoke
+        // testing to ensure that it's in fact being done.
+        assert_eq!(format!("{:x>7}", Weekday::Mon), "xxxxMon");
+        assert_eq!(format!("{:^7}", Weekday::Mon), "  Mon  ");
+        assert_eq!(format!("{:Z<7}", Weekday::Mon), "MonZZZZ");
     }
 
     #[test]


### PR DESCRIPTION
That way, width, alignment and fill from the format string are respected.

Fixes #1620.

> If your feature is semver-compatible, please target the main branch;
> for semver-incompatible changes, please target the `0.5.x` branch.

Excellent question whether this is semver-compatible. I'm not 100% sure: On the one hand, this changes behaviour others may be relying on. On the other hand, it is fixing something which may be perceived as a bug. I'll let the reviewer judge and will retarget accordingly.