### PR TITLE
chore: add `#[inline]` to `num_days`

### DIFF
--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -281,6 +281,7 @@ impl TimeDelta {
     }
 
     /// Returns the total number of whole days in the `TimeDelta`.
+    #[inline]
     pub const fn num_days(&self) -> i64 {
         self.num_seconds() / SECS_PER_DAY
     }


### PR DESCRIPTION
While looking at the code, I noticed something.
All `num_*` funktions (which do the same thing, but for other divisors) are marked `#[inline]`, except for `num_days`.

=> it looks not marking this method as `#[inline]` is a mistake.
