### PR TITLE
Update mod.rs

### DIFF
--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -89,7 +89,7 @@ impl<T> MappedLocalTime<T> {
         }
     }
 
-    /// Returns the earliest possible result of a the time zone mapping.
+    /// Returns the earliest possible result of the time zone mapping.
     ///
     /// # Errors
     ///
@@ -102,7 +102,7 @@ impl<T> MappedLocalTime<T> {
         }
     }
 
-    /// Returns the latest possible result of a the time zone mapping.
+    /// Returns the latest possible result of the time zone mapping.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Changes Made
File: src/offset/mod.rs

Line 92:
Old: /// Returns the earliest possible result of a the time zone mapping.
New: /// Returns the earliest possible result of the time zone mapping.
Reason: Corrected a grammatical error by removing the redundant word "a".

Line 105:
Old: /// Returns the latest possible result of a the time zone mapping.
New: /// Returns the latest possible result of the time zone mapping.
Reason: Corrected a grammatical error by removing the redundant word "a".

