### PR TITLE
Update Windows dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,10 +49,10 @@ wasm-bindgen = { version = "0.2", optional = true }
 js-sys = { version = "0.3", optional = true }       # contains FFI bindings for the JS Date API
 
 [target.'cfg(windows)'.dependencies]
-windows-targets = { version = "0.52", optional = true }
+windows-targets = { version = "0.53", optional = true }
 
 [target.'cfg(windows)'.dev-dependencies]
-windows-bindgen = { version = "0.58" } # MSRV is 1.70
+windows-bindgen = { version = "0.59" } # MSRV is 1.74
 
 [target.'cfg(unix)'.dependencies]
 iana-time-zone = { version = "0.1.45", optional = true, features = ["fallback"] }

--- a/src/offset/local/win_bindings.rs
+++ b/src/offset/local/win_bindings.rs
@@ -1,10 +1,10 @@
 #![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, dead_code, clippy::all)]
+
 windows_targets::link!("kernel32.dll" "system" fn GetTimeZoneInformationForYear(wyear : u16, pdtzi : *const DYNAMIC_TIME_ZONE_INFORMATION, ptzi : *mut TIME_ZONE_INFORMATION) -> BOOL);
 windows_targets::link!("kernel32.dll" "system" fn SystemTimeToFileTime(lpsystemtime : *const SYSTEMTIME, lpfiletime : *mut FILETIME) -> BOOL);
 windows_targets::link!("kernel32.dll" "system" fn SystemTimeToTzSpecificLocalTime(lptimezoneinformation : *const TIME_ZONE_INFORMATION, lpuniversaltime : *const SYSTEMTIME, lplocaltime : *mut SYSTEMTIME) -> BOOL);
 windows_targets::link!("kernel32.dll" "system" fn TzSpecificLocalTimeToSystemTime(lptimezoneinformation : *const TIME_ZONE_INFORMATION, lplocaltime : *const SYSTEMTIME, lpuniversaltime : *mut SYSTEMTIME) -> BOOL);
 pub type BOOL = i32;
-pub type BOOLEAN = u8;
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DYNAMIC_TIME_ZONE_INFORMATION {
@@ -16,7 +16,7 @@ pub struct DYNAMIC_TIME_ZONE_INFORMATION {
     pub DaylightDate: SYSTEMTIME,
     pub DaylightBias: i32,
     pub TimeZoneKeyName: [u16; 128],
-    pub DynamicDaylightTimeDisabled: BOOLEAN,
+    pub DynamicDaylightTimeDisabled: bool,
 }
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/src/offset/local/win_bindings.txt
+++ b/src/offset/local/win_bindings.txt
@@ -1,7 +1,7 @@
 --out src/offset/local/win_bindings.rs
---config flatten sys no-bindgen-comment
+--flat --sys --no-comment
 --filter
-    Windows.Win32.System.Time.GetTimeZoneInformationForYear
-    Windows.Win32.System.Time.SystemTimeToFileTime
-    Windows.Win32.System.Time.SystemTimeToTzSpecificLocalTime
-    Windows.Win32.System.Time.TzSpecificLocalTimeToSystemTime
+    GetTimeZoneInformationForYear
+    SystemTimeToFileTime
+    SystemTimeToTzSpecificLocalTime
+    TzSpecificLocalTimeToSystemTime

--- a/tests/win_bindings.rs
+++ b/tests/win_bindings.rs
@@ -9,8 +9,7 @@ fn gen_bindings() {
     let output = "src/offset/local/win_bindings.rs";
     let existing = fs::read_to_string(output).unwrap();
 
-    let log = bindgen(["--etc", input]).unwrap();
-    eprintln!("{}", log);
+    bindgen(["--etc", input]);
 
     // Check the output is the same as before.
     // Depending on the git configuration the file may have been checked out with `\r\n` newlines or


### PR DESCRIPTION
The latest release of the `windows-bindgen` and `windows-targets` crates are now available.

https://github.com/microsoft/windows-rs/releases/tag/0.61.0

As I explained in https://github.com/rust-lang/cc-rs/pull/1347 the `bindgen` arguments have been simplified and filters no longer need to include the fully qualified type/function names.
