### PR TITLE
Allow nanoseconds unix epoch, and numeric literal after year format

### DIFF
--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -412,12 +412,6 @@ where
                     );
                     max_width = numeric_bytes_available - next_size;
                 }
-                if substr.len() < min_width {
-                    return Err(TOO_SHORT);
-                }
-                if max_width == 0 {
-                    return Err(INVALID);
-                }
                 // println!("min_width: {:?}, max_width: {:?}", min_width, max_width);
                 let mut v = try_consume!(scan::number(substr, min_width, max_width));
                 if neg {

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -1596,6 +1596,21 @@ mod tests {
             parsed!(nanosecond: 567_000_000, timestamp: 12_345_678_901_234),
         );
         check(
+            "12345678901234567",
+            &[num(Timestamp), internal_fixed(Nanosecond3NoDot)],
+            parsed!(nanosecond: 567_000_000, timestamp: 12_345_678_901_234),
+        );
+        check(
+            "12345678901234567890",
+            &[num(Timestamp), internal_fixed(Nanosecond6NoDot)],
+            parsed!(nanosecond: 567_890_000, timestamp: 12_345_678_901_234),
+        );
+        check(
+            "12345678901234567890123",
+            &[num(Timestamp), internal_fixed(Nanosecond9NoDot)],
+            parsed!(nanosecond: 567_890_123, timestamp: 12_345_678_901_234),
+        );
+        check(
             "12345678901234.56789",
             &[num(Timestamp), fixed(Fixed::Nanosecond)],
             parsed!(nanosecond: 567_890_000, timestamp: 12_345_678_901_234),

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -366,7 +366,7 @@ where
                 type Setter = fn(&mut Parsed, i64) -> ParseResult<()>;
 
                 s = s.trim_start();
-                let mut substr = &s[..];
+                let mut substr = s;
                 let negative = s.starts_with('-');
                 let positive = s.starts_with('+');
                 let starts_with_sign = negative || positive;

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -290,7 +290,7 @@ where
         Item::Fixed(Internal(InternalFixed { val: InternalInternal::Nanosecond6NoDot })) => 6,
         Item::Fixed(Internal(InternalFixed { val: InternalInternal::Nanosecond9NoDot })) => 9,
         Item::Literal(prefix) => {
-            prefix.as_bytes().iter().take_while(|&&c| b'0' <= c && c <= b'9').count()
+            prefix.as_bytes().iter().take_while(|&&c| (b'0'..=b'9').contains(&c)).count()
         }
         _ => 0,
     })
@@ -404,8 +404,11 @@ where
                 // Try to consume the number in the non-greedy way.
                 if max_width == usize::MAX {
                     let next_size = get_numeric_item_len(next_item).unwrap_or(0);
-                    let numeric_bytes_available =
-                        substr.as_bytes().iter().take_while(|&&c| b'0' <= c && c <= b'9').count();
+                    let numeric_bytes_available = substr
+                        .as_bytes()
+                        .iter()
+                        .take_while(|&&c| (b'0'..=b'9').contains(&c))
+                        .count();
                     max_width = numeric_bytes_available - next_size;
                 }
                 let mut v = try_consume!(scan::number(substr, min_width, max_width));

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -317,17 +317,10 @@ where
         }};
     }
 
-    // convert items to a pair (current, Option(next_item))
-    // so we can have information about the next item
-    let items: Vec<B> = items.collect::<Vec<_>>();
-    let last_item = items.last();
-    let mut items: Vec<(&B, Option<&B>)> =
-        items.windows(2).map(|arr| (&arr[0], Some(&arr[1]))).collect::<Vec<_>>();
-    if let Some(last_item) = last_item {
-        items.push((last_item, None));
-    }
+    let mut items_iter = items.peekable();
 
-    for (item, next_item) in items {
+    while let Some(item) = items_iter.next() {
+        let next_item = items_iter.peek();
         match *item.borrow() {
             Item::Literal(prefix) => {
                 if s.len() < prefix.len() {

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -377,9 +377,11 @@ where
                     Second => (2, false, Parsed::set_second),
                     Nanosecond => (9, false, Parsed::set_nanosecond),
                     Timestamp => (usize::MAX, false, Parsed::set_timestamp),
+
                     // for the future expansion
                     Internal(ref int) => match int._dummy {},
                 };
+
                 s = s.trim_start();
 
                 let (neg, start_idx, min_width, mut max_width) = {

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -406,6 +406,8 @@ where
 
                 if starts_with_sign && signed {
                     width = recalculate_numeric_item_width(substr, next_item);
+                } else if starts_with_sign {
+                    return Err(INVALID);
                 }
 
                 let v = try_consume!(scan::number(substr, 1, width));

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -400,6 +400,8 @@ where
                 };
                 let substr = &s[start_idx..];
 
+                // If the width is not fixed, we need to determine the width from the next item.
+                // Try to consume the number in the non-greedy way.
                 if max_width == usize::MAX {
                     let next_size = get_numeric_item_len(next_item).unwrap_or(0);
                     let numeric_bytes_available =

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -290,7 +290,7 @@ where
         Item::Fixed(Internal(InternalFixed { val: InternalInternal::Nanosecond6NoDot })) => 6,
         Item::Fixed(Internal(InternalFixed { val: InternalInternal::Nanosecond9NoDot })) => 9,
         Item::Literal(prefix) => {
-            prefix.as_bytes().iter().take_while(|&&c| (b'0'..=b'9').contains(&c)).count()
+            prefix.as_bytes().iter().take_while(|&&c| c.is_ascii_digit()).count()
         }
         _ => 0,
     })
@@ -404,11 +404,8 @@ where
                 // Try to consume the number in the non-greedy way.
                 if max_width == usize::MAX {
                     let next_size = get_numeric_item_len(next_item).unwrap_or(0);
-                    let numeric_bytes_available = substr
-                        .as_bytes()
-                        .iter()
-                        .take_while(|&&c| (b'0'..=b'9').contains(&c))
-                        .count();
+                    let numeric_bytes_available =
+                        substr.as_bytes().iter().take_while(|&&c| c.is_ascii_digit()).count();
                     max_width = numeric_bytes_available - next_size;
                 }
                 let mut v = try_consume!(scan::number(substr, min_width, max_width));

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -794,6 +794,7 @@ mod tests {
             &[num(Year), Space(" "), Literal("x"), Space(" "), Literal("1235")],
             parsed!(year: 1234),
         );
+        check("12341235", &[num(Year), Literal("1235")], parsed!(year: 1234));
 
         // signed numeric
         check("-42", &[num(Year)], parsed!(year: -42));
@@ -806,9 +807,12 @@ mod tests {
         check("  -42195", &[num(Year)], parsed!(year: -42195));
         check(" +42195", &[num(Year)], parsed!(year: 42195));
         check("  -42195", &[num(Year)], parsed!(year: -42195));
+        check("  -42195123", &[num(Year), Literal("123")], parsed!(year: -42195));
         check("  +42195", &[num(Year)], parsed!(year: 42195));
+        check("  +42195123", &[num(Year), Literal("123")], parsed!(year: 42195));
         check("-42195 ", &[num(Year)], Err(TOO_LONG));
         check("+42195 ", &[num(Year)], Err(TOO_LONG));
+        check("+42195123 ", &[num(Year), Literal("123")], Err(TOO_LONG));
         check("  -   42", &[num(Year)], Err(INVALID));
         check("  +   42", &[num(Year)], Err(INVALID));
         check("  -42195", &[Space("  "), num(Year)], parsed!(year: -42195));

--- a/src/format/scan.rs
+++ b/src/format/scan.rs
@@ -23,7 +23,7 @@ pub(super) fn number(s: &str, min: usize, max: usize) -> ParseResult<(&str, i64)
         return Err(TOO_SHORT);
     }
 
-    if (min > max) {
+    if min > max {
         return Err(INVALID);
     }
 

--- a/src/format/scan.rs
+++ b/src/format/scan.rs
@@ -23,7 +23,7 @@ pub(super) fn number(s: &str, min: usize, max: usize) -> ParseResult<(&str, i64)
         return Err(TOO_SHORT);
     }
 
-    if !(min <= max) {
+    if (min > max) {
         return Err(INVALID);
     }
 

--- a/src/format/scan.rs
+++ b/src/format/scan.rs
@@ -15,14 +15,16 @@ use crate::Weekday;
 /// Any number that does not fit in `i64` is an error.
 #[inline]
 pub(super) fn number(s: &str, min: usize, max: usize) -> ParseResult<(&str, i64)> {
-    assert!(min <= max);
-
     // We are only interested in ascii numbers, so we can work with the `str` as bytes. We stop on
     // the first non-numeric byte, which may be another ascii character or beginning of multi-byte
     // UTF-8 character.
     let bytes = s.as_bytes();
     if bytes.len() < min {
         return Err(TOO_SHORT);
+    }
+
+    if !(min <= max) {
+        return Err(INVALID);
     }
 
     let mut n = 0i64;

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -192,6 +192,10 @@ fn test_datetime_parse_from_str() {
         Ok(ymdhms(2014, 5, 7, 12, 34, 56))
     ); // ignore offset
     assert_eq!(
+        NaiveDateTime::parse_from_str("2014123-5-7T12:34:56+09:30", "%Y123-%m-%dT%H:%M:%S%z"),
+        Ok(ymdhms(2014, 5, 7, 12, 34, 56))
+    ); // ignore offset
+    assert_eq!(
         NaiveDateTime::parse_from_str("2015-W06-1 000000", "%G-W%V-%u%H%M%S"),
         Ok(ymdhms(2015, 2, 2, 0, 0, 0))
     );
@@ -219,11 +223,23 @@ fn test_datetime_parse_from_str() {
         Ok(ymdhmsn(2015, 9, 5, 23, 56, 4, 649000000))
     );
     assert_eq!(
+        NaiveDateTime::parse_from_str("1441497364649", "%s%3f"),
+        Ok(ymdhmsn(2015, 9, 5, 23, 56, 4, 649000000))
+    );
+    assert_eq!(
         NaiveDateTime::parse_from_str("1497854303.087654", "%s%.6f"),
         Ok(ymdhmsn(2017, 6, 19, 6, 38, 23, 87654000))
     );
     assert_eq!(
+        NaiveDateTime::parse_from_str("1497854303087654", "%s%6f"),
+        Ok(ymdhmsn(2017, 6, 19, 6, 38, 23, 87654000))
+    );
+    assert_eq!(
         NaiveDateTime::parse_from_str("1437742189.918273645", "%s%.9f"),
+        Ok(ymdhmsn(2015, 7, 24, 12, 49, 49, 918273645))
+    );
+    assert_eq!(
+        NaiveDateTime::parse_from_str("1437742189918273645", "%s%9f"),
         Ok(ymdhmsn(2015, 7, 24, 12, 49, 49, 918273645))
     );
 }


### PR DESCRIPTION
This PR aims to resolve issue #560 and #1399 based on PR #561, and the multiple issues from vector such as https://github.com/vectordotdev/vrl/issues/117, https://github.com/vectordotdev/vrl/issues/790
Since there is no any respones from the author of #561, I would like to continue his/her work.

