### PR TITLE
Use NaiveDateTime for internal tz_info methods.

### DIFF
--- a/src/offset/local/tz_info/rule.rs
+++ b/src/offset/local/tz_info/rule.rs
@@ -230,13 +230,9 @@ impl AlternateTime {
         &self,
         local_time: NaiveDateTime,
     ) -> Result<crate::MappedLocalTime<LocalTimeType>, Error> {
+        // Year must be between i32::MIN + 2 and i32::MAX - 2, year in NaiveDate is always smaller.
         let current_year = local_time.year();
         let local_time = local_time.and_utc().timestamp();
-
-        // Check if the current year is valid for the following computations
-        if !(i32::MIN + 2..=i32::MAX - 2).contains(&current_year) {
-            return Err(Error::OutOfRange("out of range date time"));
-        }
 
         let dst_start_transition_start =
             self.dst_start.unix_time(current_year, 0) + i64::from(self.dst_start_time);

--- a/src/offset/local/unix.rs
+++ b/src/offset/local/unix.rs
@@ -12,7 +12,7 @@ use std::{cell::RefCell, collections::hash_map, env, fs, hash::Hasher, time::Sys
 
 use super::tz_info::TimeZone;
 use super::{FixedOffset, NaiveDateTime};
-use crate::{Datelike, MappedLocalTime};
+use crate::MappedLocalTime;
 
 pub(super) fn offset_from_utc_datetime(utc: &NaiveDateTime) -> MappedLocalTime<FixedOffset> {
     offset(utc, false)
@@ -164,7 +164,7 @@ impl Cache {
         // we pass through the year as the year of a local point in time must either be valid in that locale, or
         // the entire time was skipped in which case we will return MappedLocalTime::None anyway.
         self.zone
-            .find_local_time_type_from_local(d.and_utc().timestamp(), d.year())
+            .find_local_time_type_from_local(d)
             .expect("unable to select local time type")
             .and_then(|o| FixedOffset::east_opt(o.offset()))
     }


### PR DESCRIPTION
When looking into doing #1628 I found this comment:
`// should we pass NaiveDateTime all the way through to this fn?`
https://github.com/chronotope/chrono/blob/7cdca4b006fba93278ba3ef532495315cf6f8724/src/offset/local/tz_info/timezone.rs#L136

It seemed a sensible bit of cleanup to do regardless of other changes, so here's a separate pull request for it. 

This replaces passing a timestamp and year to several internal functions with passing a NaiveDateTime, making the function signature slightly clearer. The values originated from in the a NaiveDateTime in first place, so it basically just postpones the conversion.
Prep for #1628

