### PR TITLE
Add `subsec_micros` and `subsec_millis` methods to `TimeDelta`

### DIFF
--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -313,6 +313,24 @@ impl TimeDelta {
         if self.secs < 0 && self.nanos > 0 { self.nanos - NANOS_PER_SEC } else { self.nanos }
     }
 
+    /// Returns the number of microseconds in the fractional part of the duration.
+    ///
+    /// This is the number of microseconds such that
+    /// `subsec_micros() + num_seconds() * 1_000_000` is the truncated number of
+    /// microseconds in the duration.
+    pub const fn subsec_micros(&self) -> i32 {
+        self.subsec_nanos() / NANOS_PER_MICRO
+    }
+
+    /// Returns the number of milliseconds in the fractional part of the duration.
+    ///
+    /// This is the number of milliseconds such that
+    /// `subsec_millis() + num_seconds() * 1_000` is the truncated number of
+    /// milliseconds in the duration.
+    pub const fn subsec_millis(&self) -> i32 {
+        self.subsec_nanos() / NANOS_PER_MILLI
+    }
+
     /// Returns the total number of whole milliseconds in the `TimeDelta`.
     pub const fn num_milliseconds(&self) -> i64 {
         // A proper TimeDelta will not overflow, because MIN and MAX are defined such
@@ -777,6 +795,26 @@ mod tests {
         assert_eq!(TimeDelta::nanoseconds(-1).subsec_nanos(), -1);
         assert_eq!(TimeDelta::seconds(1).subsec_nanos(), 0);
         assert_eq!(TimeDelta::nanoseconds(1_000_000_001).subsec_nanos(), 1);
+    }
+
+    #[test]
+    fn test_duration_subsec_micros() {
+        assert_eq!(TimeDelta::zero().subsec_micros(), 0);
+        assert_eq!(TimeDelta::microseconds(1).subsec_micros(), 1);
+        assert_eq!(TimeDelta::microseconds(-1).subsec_micros(), -1);
+        assert_eq!(TimeDelta::seconds(1).subsec_micros(), 0);
+        assert_eq!(TimeDelta::microseconds(1_000_001).subsec_micros(), 1);
+        assert_eq!(TimeDelta::nanoseconds(1_000_001_999).subsec_micros(), 1);
+    }
+
+    #[test]
+    fn test_duration_subsec_millis() {
+        assert_eq!(TimeDelta::zero().subsec_millis(), 0);
+        assert_eq!(TimeDelta::milliseconds(1).subsec_millis(), 1);
+        assert_eq!(TimeDelta::milliseconds(-1).subsec_millis(), -1);
+        assert_eq!(TimeDelta::seconds(1).subsec_millis(), 0);
+        assert_eq!(TimeDelta::milliseconds(1_001).subsec_millis(), 1);
+        assert_eq!(TimeDelta::microseconds(1_001_999).subsec_millis(), 1);
     }
 
     #[test]

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -304,8 +304,10 @@ impl TimeDelta {
         if self.secs < 0 && self.nanos > 0 { self.secs + 1 } else { self.secs }
     }
 
-    /// Returns the number of nanoseconds such that
-    /// `subsec_nanos() + num_seconds() * NANOS_PER_SEC` is the total number of
+    /// Returns the number of nanoseconds in the fractional part of the duration.
+    ///
+    /// This is the number of nanoseconds such that
+    /// `subsec_nanos() + num_seconds() * 1_000_000_000` is the total number of
     /// nanoseconds in the `TimeDelta`.
     pub const fn subsec_nanos(&self) -> i32 {
         if self.secs < 0 && self.nanos > 0 { self.nanos - NANOS_PER_SEC } else { self.nanos }
@@ -766,6 +768,15 @@ mod tests {
     #[should_panic(expected = "TimeDelta::seconds out of bounds")]
     fn test_duration_seconds_min_underflow_panic() {
         let _ = TimeDelta::seconds(-i64::MAX / 1_000 - 1);
+    }
+
+    #[test]
+    fn test_duration_subsec_nanos() {
+        assert_eq!(TimeDelta::zero().subsec_nanos(), 0);
+        assert_eq!(TimeDelta::nanoseconds(1).subsec_nanos(), 1);
+        assert_eq!(TimeDelta::nanoseconds(-1).subsec_nanos(), -1);
+        assert_eq!(TimeDelta::seconds(1).subsec_nanos(), 0);
+        assert_eq!(TimeDelta::nanoseconds(1_000_000_001).subsec_nanos(), 1);
     }
 
     #[test]


### PR DESCRIPTION
This PR revives @botahamec 's PR #1351, which has been abandoned, and adds `subsec_micros` and `subsec_millis` to the public API for `chrono::TimeDelta`, for consistency with the API of `std::time::Duration`.

Summary of changes:
   - update the docstring for `TimeDelta::subsec_nanos()` and add a test for the method.
   - add `subsec_millis` and `subsec_micros`, along with unit tests.

Fixes: #1348