### PR TITLE
Implement `as_seconds_f32` and `as_seconds_f64` for `TimeDelta`

### DIFF
--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -304,6 +304,16 @@ impl TimeDelta {
         if self.secs < 0 && self.nanos > 0 { self.secs + 1 } else { self.secs }
     }
 
+    /// Returns the fractional number of seconds in the `TimeDelta`.
+    pub fn as_seconds_f64(self) -> f64 {
+        self.secs as f64 + self.nanos as f64 / NANOS_PER_SEC as f64
+    }
+
+    /// Returns the fractional number of seconds in the `TimeDelta`.
+    pub fn as_seconds_f32(self) -> f32 {
+        self.secs as f32 + self.nanos as f32 / NANOS_PER_SEC as f32
+    }
+
     /// Returns the total number of whole milliseconds in the `TimeDelta`.
     pub const fn num_milliseconds(&self) -> i64 {
         // A proper TimeDelta will not overflow, because MIN and MAX are defined such
@@ -786,6 +796,32 @@ mod tests {
     #[should_panic(expected = "TimeDelta::seconds out of bounds")]
     fn test_duration_seconds_min_underflow_panic() {
         let _ = TimeDelta::seconds(-i64::MAX / 1_000 - 1);
+    }
+
+    #[test]
+    fn test_duration_as_seconds_f64() {
+        assert_eq!(TimeDelta::seconds(1).as_seconds_f64(), 1.0);
+        assert_eq!(TimeDelta::seconds(-1).as_seconds_f64(), -1.0);
+        assert_eq!(TimeDelta::seconds(100).as_seconds_f64(), 100.0);
+        assert_eq!(TimeDelta::seconds(-100).as_seconds_f64(), -100.0);
+
+        assert_eq!(TimeDelta::milliseconds(500).as_seconds_f64(), 0.5);
+        assert_eq!(TimeDelta::milliseconds(-500).as_seconds_f64(), -0.5);
+        assert_eq!(TimeDelta::milliseconds(1_500).as_seconds_f64(), 1.5);
+        assert_eq!(TimeDelta::milliseconds(-1_500).as_seconds_f64(), -1.5);
+    }
+
+    #[test]
+    fn test_duration_as_seconds_f32() {
+        assert_eq!(TimeDelta::seconds(1).as_seconds_f32(), 1.0);
+        assert_eq!(TimeDelta::seconds(-1).as_seconds_f32(), -1.0);
+        assert_eq!(TimeDelta::seconds(100).as_seconds_f32(), 100.0);
+        assert_eq!(TimeDelta::seconds(-100).as_seconds_f32(), -100.0);
+
+        assert_eq!(TimeDelta::milliseconds(500).as_seconds_f32(), 0.5);
+        assert_eq!(TimeDelta::milliseconds(-500).as_seconds_f32(), -0.5);
+        assert_eq!(TimeDelta::milliseconds(1_500).as_seconds_f32(), 1.5);
+        assert_eq!(TimeDelta::milliseconds(-1_500).as_seconds_f32(), -1.5);
     }
 
     #[test]


### PR DESCRIPTION
Implement methods for converting a  `TimeDelta` object into a fractional number of seconds, with single or double precision.

There are two possible choices for naming these methods: `as_secs_f**` or `as_seconds_f**`. The former is consistent with `core::time::Duration`, whereas the latter is consistent with existing `TimeDelta` methods (`num_seconds`, which is called `as_secs` in `core::time::Duration`). Consistency with the existing interface is chosen in this PR.

The reverse conversion (from fp seconds to a `TimeDelta`) is [tricky to get right](https://github.com/rust-lang/rust/blob/master/library/core/src/time.rs#L1466-L1544) without unexpected loss of precision, or corner cases causing incorrect rounding or overflow of the number of nanoseconds, so it's not included in this PR.

Summary of changes:
   - move `subsec_millis`, `subsec_micros`, `subsec_nanos` next to their corresponding `num_milliseconds`, `num_microseconds`, `num_nanoseconds` counterparts, which frees up a good location to add `as_secs_f32` and `add_secs_f64`;
   - implement `as_seconds_f32` and `as_seconds_f64` and associated unit tests.

Issue: #1601 