### PR TITLE
Add `num_days_in_month` method to `Datelike` trait

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::{IsoWeek, Weekday};
+use crate::{IsoWeek, Month, Weekday};
 
 /// The common set of methods for date component.
 ///
@@ -265,6 +265,18 @@ pub trait Datelike: Sized {
         ndays += ((year * 1461) >> 2) - div_100 + (div_100 >> 2);
         ndays + self.ordinal() as i32
     }
+
+    /// Get the length in days of the month
+    fn num_days_in_month(&self) -> u8 {
+        use num_traits::FromPrimitive;
+        // The value returned from `self.month()` is guaranteed to be in the
+        // range [1,12], which will never result in a `None` value here.
+        let month = Month::from_u32(self.month()).unwrap();
+        // `Month::num_days` will only return `None` if the provided year is out
+        // of range. Since we are passing it directly from a verified date, we
+        // know it is in range, and the result will never be `None`.
+        month.num_days(self.year()).unwrap()
+    }
 }
 
 /// The common set of methods for time component.
@@ -389,5 +401,15 @@ mod tests {
                 mid_year
             );
         }
+    }
+
+    #[test]
+    fn test_num_days_in_month() {
+        let feb_leap_year = NaiveDate::from_ymd_opt(2004, 2, 1).unwrap();
+        assert_eq!(feb_leap_year.num_days_in_month(), 29);
+        let feb = feb_leap_year.with_year(2005).unwrap();
+        assert_eq!(feb.num_days_in_month(), 28);
+        let march = feb.with_month(3).unwrap();
+        assert_eq!(march.num_days_in_month(), 31);
     }
 }


### PR DESCRIPTION
The recent `num_days` addition to the `Month` type is great, but it could be even better if we took it just a little bit further.

This change adds a `num_days_in_month` function to the `Datelike` trait.