### PR TITLE
Add support for bincode v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ __internal_bench = []
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0.99", default-features = false, optional = true }
+bincode = { version = "2.0.1", default-features = false, optional = true }
 pure-rust-locales = { version = "0.8", optional = true }
 rkyv = { version = "0.7.43", optional = true, default-features = false }
 arbitrary = { version = "1.0.0", features = ["derive"], optional = true }
@@ -64,13 +65,13 @@ android-tzdata = { version = "0.1.1", optional = true }
 serde_json = { version = "1" }
 serde_derive = { version = "1", default-features = false }
 similar-asserts = { version = "1.6.1" }
-bincode = { version = "1.3.0" }
+bincode = { version = "2.0.1" }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 [package.metadata.docs.rs]
-features = ["arbitrary", "rkyv", "serde", "unstable-locales"]
+features = ["arbitrary", "bincode", "rkyv", "serde", "unstable-locales"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ android-tzdata = { version = "0.1.1", optional = true }
 serde_json = { version = "1" }
 serde_derive = { version = "1", default-features = false }
 similar-asserts = { version = "1.6.1" }
-bincode-v1 = { package = "bincode", version = "1.0" }
+bincode-v1 = { package = "bincode", version = "1.3.0" }
 bincode = { package = "bincode", version = "2.0" }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ __internal_bench = []
 [dependencies]
 num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0.99", default-features = false, optional = true }
-bincode = { version = "2.0.1", default-features = false, optional = true }
+bincode = { version = "2.0", default-features = false, optional = true }
 pure-rust-locales = { version = "0.8", optional = true }
 rkyv = { version = "0.7.43", optional = true, default-features = false }
 arbitrary = { version = "1.0.0", features = ["derive"], optional = true }
@@ -65,7 +65,8 @@ android-tzdata = { version = "0.1.1", optional = true }
 serde_json = { version = "1" }
 serde_derive = { version = "1", default-features = false }
 similar-asserts = { version = "1.6.1" }
-bincode = { version = "2.0.1" }
+bincode-v1 = { package = "bincode", version = "1.0" }
+bincode = { package = "bincode", version = "2.0" }
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/src/datetime/bincode.rs
+++ b/src/datetime/bincode.rs
@@ -6,6 +6,8 @@ use bincode::{
     error::{DecodeError, EncodeError},
 };
 
+// TODO not very optimized for space
+
 impl<Tz: TimeZone> Encode for DateTime<Tz> {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
         let v = self.to_rfc3339_opts(SecondsFormat::AutoSi, true);

--- a/src/datetime/bincode.rs
+++ b/src/datetime/bincode.rs
@@ -1,0 +1,61 @@
+use crate::DateTime;
+use crate::TimeZone;
+use crate::Utc;
+use bincode::BorrowDecode;
+use bincode::Decode;
+use bincode::Encode;
+use bincode::de::BorrowDecoder;
+use bincode::de::Decoder;
+use bincode::enc::Encoder;
+use bincode::error::DecodeError;
+use bincode::error::EncodeError;
+
+impl<Tz: TimeZone> Encode for DateTime<Tz> {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        i64::encode(&self.timestamp(), encoder)?;
+        u32::encode(&self.timestamp_subsec_nanos(), encoder)?;
+
+        Ok(())
+    }
+}
+
+impl<Context> Decode<Context> for DateTime<Utc> {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let secs = i64::decode(decoder)?;
+        let nsecs = u32::decode(decoder)?;
+
+        Ok(DateTime::from_timestamp(secs, nsecs)
+            .ok_or_else(|| DecodeError::Other("Could not decode UTC DateTime"))?)
+    }
+}
+impl<'de, Context> BorrowDecode<'de, Context> for DateTime<Utc> {
+    fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<Self, DecodeError> {
+        let secs = i64::borrow_decode(decoder)?;
+        let nsecs = u32::borrow_decode(decoder)?;
+
+        Ok(DateTime::from_timestamp(secs, nsecs)
+            .ok_or_else(|| DecodeError::Other("Could not decode UTC DateTime"))?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::DateTime;
+    use crate::Utc;
+    use bincode::config;
+
+    #[test]
+    fn bincode_utc_date_time() {
+        let dt = Utc::now();
+
+        let bytes = bincode::encode_to_vec(&dt, config::standard())
+            .expect("Should have been able to encode UTC DateTime.");
+        let (dt_decoded, _) =
+            bincode::decode_from_slice::<DateTime<Utc>, _>(&bytes, config::standard())
+                .expect("Should have been able to encode UTC DateTime.");
+
+        assert_eq!(dt, dt_decoded);
+    }
+}

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -38,6 +38,9 @@ use rkyv::{Archive, Deserialize, Serialize};
 #[cfg(feature = "serde")]
 pub(super) mod serde;
 
+#[cfg(feature = "bincode")]
+pub(super) mod bincode;
+
 #[cfg(test)]
 mod tests;
 

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -1298,7 +1298,7 @@ mod tests {
     fn test_serde_bincode() {
         // Bincode is relevant to test separately from JSON because
         // it is not self-describing.
-        use bincode::{deserialize, serialize};
+        use bincode_v1::{deserialize, serialize};
 
         let dt = Utc.with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap();
         let encoded = serialize(&dt).unwrap();

--- a/src/naive/date/bincode.rs
+++ b/src/naive/date/bincode.rs
@@ -10,7 +10,7 @@ use bincode::{
 
 impl Encode for NaiveDate {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        let v = self.to_string();
+        let v = format!("{self:?}");
 
         <String>::encode(&v, encoder)
     }

--- a/src/naive/date/bincode.rs
+++ b/src/naive/date/bincode.rs
@@ -1,4 +1,4 @@
-use crate::{NaiveDateTime, ParseError};
+use crate::{NaiveDate, ParseError};
 use bincode::{
     BorrowDecode, Decode, Encode,
     de::{BorrowDecoder, Decoder},
@@ -8,22 +8,22 @@ use bincode::{
 
 // TODO not very optimized for space
 
-impl Encode for NaiveDateTime {
+impl Encode for NaiveDate {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        let v = self.format("%Y-%m-%dT%H:%M:%S%.9f").to_string();
+        let v = self.to_string();
 
         <String>::encode(&v, encoder)
     }
 }
 
-impl<Context> Decode<Context> for NaiveDateTime {
+impl<Context> Decode<Context> for NaiveDate {
     fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let value = <String>::decode(decoder)?;
 
         Ok(value.parse().map_err(|e: ParseError| DecodeError::OtherString(e.to_string()))?)
     }
 }
-impl<'de, Context> BorrowDecode<'de, Context> for NaiveDateTime {
+impl<'de, Context> BorrowDecode<'de, Context> for NaiveDate {
     fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
@@ -35,25 +35,24 @@ impl<'de, Context> BorrowDecode<'de, Context> for NaiveDateTime {
 
 #[cfg(test)]
 mod tests {
-    use crate::NaiveDateTime;
+    use crate::NaiveDate;
     use crate::Utc;
     use bincode::config;
 
     #[test]
     fn backward_compatibility_with_bincode_v1() {
-        let initial_value = Utc::now().naive_utc();
+        let initial_value = Utc::now().date_naive();
 
         let legacy_bytes = bincode_v1::serialize(&initial_value)
-            .expect(&format!("Bincode v1 should have been able to encode NaiveDateTime."));
+            .expect(&format!("Bincode v1 should have been able to encode NaiveDate."));
         let (decoded, _) =
-            bincode::decode_from_slice::<NaiveDateTime, _>(&legacy_bytes, config::legacy())
+            bincode::decode_from_slice::<NaiveDate, _>(&legacy_bytes, config::legacy())
                 .expect(&format!("Bincode v2 should have been able to decode legacy bytes."));
         assert_eq!(initial_value, decoded);
 
-        let new_bytes = bincode::encode_to_vec(&decoded, config::legacy()).expect(
-            "Bincode v2 should have been able to encode NaiveDateTime using legacy config.",
-        );
-        let decoded = bincode_v1::deserialize::<NaiveDateTime>(&new_bytes)
+        let new_bytes = bincode::encode_to_vec(&decoded, config::legacy())
+            .expect("Bincode v2 should have been able to encode NaiveDate using legacy config.");
+        let decoded = bincode_v1::deserialize::<NaiveDate>(&new_bytes)
             .expect("Bincode v1 should have been able to decode bytes encoded by Bincode v1.");
         assert_eq!(initial_value, decoded);
     }

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -40,6 +40,9 @@ use crate::{expect, try_opt};
 
 use super::internals::{Mdf, YearFlags};
 
+#[cfg(feature = "bincode")]
+pub(crate) mod bincode;
+
 #[cfg(test)]
 mod tests;
 

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -2523,7 +2523,7 @@ mod serde {
         fn test_serde_bincode() {
             // Bincode is relevant to test separately from JSON because
             // it is not self-describing.
-            use bincode::{deserialize, serialize};
+            use bincode_v1::{deserialize, serialize};
 
             let d = NaiveDate::from_ymd_opt(2014, 7, 24).unwrap();
             let encoded = serialize(&d).unwrap();

--- a/src/naive/datetime/bincode.rs
+++ b/src/naive/datetime/bincode.rs
@@ -10,7 +10,7 @@ use bincode::{
 
 impl Encode for NaiveDateTime {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        let v = self.format("%Y-%m-%dT%H:%M:%S%.9f").to_string();
+        let v = format!("{self:?}");
 
         <String>::encode(&v, encoder)
     }

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -29,6 +29,10 @@ use crate::{
 #[cfg(feature = "serde")]
 pub(crate) mod serde;
 
+/// Tools to help encoding/decoding `NaiveDateTime`s
+#[cfg(feature = "bincode")]
+pub(crate) mod bincode;
+
 #[cfg(test)]
 mod tests;
 

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -1131,7 +1131,7 @@ mod tests {
     use crate::serde::ts_nanoseconds_option;
     use crate::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
 
-    use bincode::{deserialize, serialize};
+    use bincode_v1::{deserialize, serialize};
     use serde_derive::{Deserialize, Serialize};
 
     #[test]

--- a/src/naive/time/bincode.rs
+++ b/src/naive/time/bincode.rs
@@ -6,6 +6,8 @@ use bincode::{
     error::{DecodeError, EncodeError},
 };
 
+// TODO not very optimized for space
+
 impl Encode for NaiveTime {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
         let v = self.to_string();

--- a/src/naive/time/bincode.rs
+++ b/src/naive/time/bincode.rs
@@ -1,4 +1,4 @@
-use crate::{DateTime, ParseError, SecondsFormat, TimeZone, Utc};
+use crate::{NaiveTime, ParseError};
 use bincode::{
     BorrowDecode, Decode, Encode,
     de::{BorrowDecoder, Decoder},
@@ -6,22 +6,22 @@ use bincode::{
     error::{DecodeError, EncodeError},
 };
 
-impl<Tz: TimeZone> Encode for DateTime<Tz> {
+impl Encode for NaiveTime {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        let v = self.to_rfc3339_opts(SecondsFormat::AutoSi, true);
+        let v = self.to_string();
 
         <String>::encode(&v, encoder)
     }
 }
 
-impl<Context> Decode<Context> for DateTime<Utc> {
+impl<Context> Decode<Context> for NaiveTime {
     fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
         let value = <String>::decode(decoder)?;
 
         Ok(value.parse().map_err(|e: ParseError| DecodeError::OtherString(e.to_string()))?)
     }
 }
-impl<'de, Context> BorrowDecode<'de, Context> for DateTime<Utc> {
+impl<'de, Context> BorrowDecode<'de, Context> for NaiveTime {
     fn borrow_decode<D: BorrowDecoder<'de, Context = Context>>(
         decoder: &mut D,
     ) -> Result<Self, DecodeError> {
@@ -33,23 +33,23 @@ impl<'de, Context> BorrowDecode<'de, Context> for DateTime<Utc> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{DateTime, Utc};
+    use crate::{NaiveTime, Utc};
     use bincode::config;
 
     #[test]
     fn backward_compatibility_with_bincode_v1() {
-        let initial_value = Utc::now();
+        let initial_value = Utc::now().time();
 
         let legacy_bytes = bincode_v1::serialize(&initial_value)
-            .expect(&format!("Bincode v1 should have been able to encode DateTime."));
+            .expect(&format!("Bincode v1 should have been able to encode NaiveTime."));
         let (decoded, _) =
-            bincode::decode_from_slice::<DateTime<Utc>, _>(&legacy_bytes, config::legacy())
+            bincode::decode_from_slice::<NaiveTime, _>(&legacy_bytes, config::legacy())
                 .expect(&format!("Bincode v2 should have been able to decode legacy bytes."));
         assert_eq!(initial_value, decoded);
 
         let new_bytes = bincode::encode_to_vec(&decoded, config::legacy())
-            .expect("Bincode v2 should have been able to encode DateTime using legacy config.");
-        let decoded = bincode_v1::deserialize::<DateTime<Utc>>(&new_bytes)
+            .expect("Bincode v2 should have been able to encode NaiveTime using legacy config.");
+        let decoded = bincode_v1::deserialize::<NaiveTime>(&new_bytes)
             .expect("Bincode v1 should have been able to decode bytes encoded by Bincode v1.");
         assert_eq!(initial_value, decoded);
     }

--- a/src/naive/time/bincode.rs
+++ b/src/naive/time/bincode.rs
@@ -10,7 +10,7 @@ use bincode::{
 
 impl Encode for NaiveTime {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
-        let v = self.to_string();
+        let v = format!("{self}");
 
         <String>::encode(&v, encoder)
     }

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -24,6 +24,9 @@ use crate::{expect, try_opt};
 #[cfg(feature = "serde")]
 mod serde;
 
+#[cfg(feature = "bincode")]
+mod bincode;
+
 #[cfg(test)]
 mod tests;
 

--- a/src/naive/time/serde.rs
+++ b/src/naive/time/serde.rs
@@ -133,7 +133,7 @@ mod tests {
     fn test_serde_bincode() {
         // Bincode is relevant to test separately from JSON because
         // it is not self-describing.
-        use bincode::{deserialize, serialize};
+        use bincode_v1::{deserialize, serialize};
 
         let t = NaiveTime::from_hms_nano_opt(3, 5, 7, 98765432).unwrap();
         let encoded = serialize(&t).unwrap();


### PR DESCRIPTION
Following the latest major release of Bincode, the crate now relies on its own traits (Encode/Decode) it switched away from serde's De/Serialize. This PR is to add a feature flag here to optionally implement these traits on the DateTime structs.

The 2.0 bincode release: https://github.com/bincode-org/bincode/releases/tag/v2.0.0