### PR TITLE
TimeZone::from_posix_tz: Treat empty TZ variable as UTC

### DIFF
--- a/src/offset/local/tz_info/timezone.rs
+++ b/src/offset/local/tz_info/timezone.rs
@@ -37,8 +37,9 @@ impl TimeZone {
 
     /// Construct a time zone from a POSIX TZ string, as described in [the POSIX documentation of the `TZ` environment variable](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html).
     fn from_posix_tz(tz_string: &str) -> Result<Self, Error> {
+        // It is commonly agreed (but not standard) that setting an empty `TZ=` uses UTC.
         if tz_string.is_empty() {
-            return Err(Error::InvalidTzString("empty TZ string"));
+            return Ok(Self::utc());
         }
 
         if tz_string == "localtime" {
@@ -925,7 +926,7 @@ mod tests {
         }
 
         assert!(TimeZone::from_posix_tz("EST5EDT,0/0,J365/25").is_err());
-        assert!(TimeZone::from_posix_tz("").is_err());
+        assert_eq!(TimeZone::from_posix_tz("").unwrap().find_local_time_type(0)?.offset(), 0);
 
         Ok(())
     }


### PR DESCRIPTION
This is not technically POSIX, but glibc and musl behave that way: e.g. `TZ= date` returns a UTC date.

Fixes #1690.