### PR TITLE
Fix wrong amount of micro/milliseconds

### DIFF
--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -755,7 +755,7 @@ impl NaiveDate {
 
     /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and millisecond.
     ///
-    /// The millisecond part is allowed to exceed 1,000,000,000 in order to represent a [leap second](
+    /// The millisecond part is allowed to exceed 1,000 in order to represent a [leap second](
     /// ./struct.NaiveTime.html#leap-second-handling), but only when `sec == 59`.
     ///
     /// # Panics
@@ -770,7 +770,7 @@ impl NaiveDate {
 
     /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and millisecond.
     ///
-    /// The millisecond part is allowed to exceed 1,000,000,000 in order to represent a [leap second](
+    /// The millisecond part is allowed to exceed 1,000 in order to represent a [leap second](
     /// ./struct.NaiveTime.html#leap-second-handling), but only when `sec == 59`.
     ///
     /// # Errors
@@ -805,7 +805,7 @@ impl NaiveDate {
 
     /// Makes a new `NaiveDateTime` from the current date, hour, minute, second and microsecond.
     ///
-    /// The microsecond part is allowed to exceed 1,000,000,000 in order to represent a [leap second](
+    /// The microsecond part is allowed to exceed 1,000,000 in order to represent a [leap second](
     /// ./struct.NaiveTime.html#leap-second-handling), but only when `sec == 59`.
     ///
     /// # Panics


### PR DESCRIPTION
This is just a documentation change, so should be semver compatible.
