### PR TITLE
Add infallible method DateTime::from_timestamp_nanos support

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -867,7 +867,7 @@ impl DateTime<Utc> {
 
     /// Creates a new [`DateTime<Utc>`] from the number of non-leap nanoseconds
     ///  since January 1, 1970 0:00:00.000 UTC (aka "UNIX timestamp").
-    ///  This is an infallible version of `from_timestamp_nanos`. please see more detail in there.
+    ///  This is an infallible version of [`from_timestamp_nanos`](Self::from_timestamp_nanos). Please see more detail in there.
     #[inline]
     #[must_use]
     pub const fn from_timestamp_nanos_opt(nanos: i64) -> Option<Self> {

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -848,13 +848,24 @@ impl DateTime<Utc> {
     /// let timestamp_nanos: i64 = -2208936075_000_000_000; // Mon, 1 Jan 1900 14:38:45 UTC
     /// let dt = DateTime::from_timestamp_nanos(timestamp_nanos);
     /// assert_eq!(timestamp_nanos, dt.timestamp_nanos_opt().unwrap());
+    ///
+    /// // the maximum and minimum values of i64 can be represented as a timestamp with nanosecond precision
+    /// let timestamp_nanos: i64 = i64::MIN;
+    /// let dt = DateTime::from_timestamp_nanos(timestamp_nanos);
+    /// assert_eq!(timestamp_nanos, dt.timestamp_nanos_opt().unwrap());
+    ///
+    /// let timestamp_nanos: i64 = i64::MAX;
+    /// let dt = DateTime::from_timestamp_nanos(timestamp_nanos);
+    /// assert_eq!(timestamp_nanos, dt.timestamp_nanos_opt().unwrap());
     /// ```
     #[inline]
     #[must_use]
     pub const fn from_timestamp_nanos(nanos: i64) -> Self {
         let secs = nanos.div_euclid(1_000_000_000);
         let nsecs = nanos.rem_euclid(1_000_000_000) as u32;
-        expect(Self::from_timestamp(secs, nsecs), "timestamp in nanos is always in range")
+
+        // this would never fail as the input is always valid
+        Self::from_timestamp(secs, nsecs).unwrap()
     }
 
     /// The Unix Epoch, 1970-01-01 00:00:00 UTC.

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -861,11 +861,21 @@ impl DateTime<Utc> {
     #[inline]
     #[must_use]
     pub const fn from_timestamp_nanos(nanos: i64) -> Self {
+        // add expect here to make compiler happy, as we can call `unwrap` in const functions
+        expect(Self::from_timestamp_nanos_opt(nanos), "timestamp in nanos is always in range")
+    }
+
+    /// Creates a new [`DateTime<Utc>`] from the number of non-leap nanoseconds
+    ///  since January 1, 1970 0:00:00.000 UTC (aka "UNIX timestamp").
+    ///  This is an infallible version of `from_timestamp_nanos`. please see more detail in there.
+    #[inline]
+    #[must_use]
+    pub const fn from_timestamp_nanos_opt(nanos: i64) -> Option<Self> {
         let secs = nanos.div_euclid(1_000_000_000);
         let nsecs = nanos.rem_euclid(1_000_000_000) as u32;
 
         // this would never fail as the input is always valid
-        Self::from_timestamp(secs, nsecs).unwrap()
+        Self::from_timestamp(secs, nsecs)
     }
 
     /// The Unix Epoch, 1970-01-01 00:00:00 UTC.


### PR DESCRIPTION
The `DateTime::from_timestamp_nanos` would never fail, so we don't need this PR as it always returns a `Some(value)

# Summary
This PR wants to resolve #1722, adds an infallible method `DateTime::from_timestamp_nanos`

# Change
Add an infallible method `DateTime::from_timestamp_nanos`, keep the original fallible method `DateTime::from_timestamp_nanos`

In the first, I want to remove the `expect` in `DateTime::from_timestamp_nanos` as the method would never fail (we have described this in the doc), but it seems the compiler does not support this because `(std::option::Option::<t>::unwrap is not yet stable as a const fn)`.

I also tried 

1. to use `try_opt!` macro, but it complains that `expected DateTime<Utc>, but found Option<_>`
2. Add a rule such as below in `try_opt!`, but the compiler can't pass as mismatched types(detail error message attached below)
```
    ($e:expr, $t:ty) => {
        match $e {
            Some(v) => v,
            None => return None::<$t>,
        }
    };
```


Error message 
```rust
error[E0308]: mismatched types
   --> src/lib.rs:706:28
    |
706 |             None => return None::<$t>,
    |                            ^^^^^^^^^^ expected `DateTime<Utc>`, found `Option<DateTime<Utc>>`
    |
   ::: src/datetime/mod.rs:863:54
    |
863 |     pub const fn from_timestamp_nanos(nanos: i64) -> Self {
    |                                                      ---- expected `datetime::DateTime<Utc>` because of return type
...
866 |         try_opt!(Self::from_timestamp_nanos_opt(nanos), DateTime<Utc>)
    |         -------------------------------------------------------------- in this macro invocation
    |
    = note: expected struct `datetime::DateTime<_>`
                 found enum `Option<datetime::DateTime<_>>`
    = note: this error originates in the macro `try_opt` (in Nightly builds, run with -Z macro-backtrace for more info)
```