### PR TITLE
feat: faster rfc3339 parsing

### DIFF
--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -21,8 +21,8 @@ use crate::format::Locale;
 #[cfg(feature = "alloc")]
 use crate::format::{DelayedFormat, SecondsFormat, write_rfc2822, write_rfc3339};
 use crate::format::{
-    Fixed, Item, ParseError, ParseResult, Parsed, StrftimeItems, TOO_LONG, parse,
-    parse_and_remainder, parse_rfc3339,
+    Fixed, Item, ParseError, ParseResult, Parsed, StrftimeItems, parse, parse_and_remainder,
+    parse_rfc3339,
 };
 use crate::naive::{Days, IsoWeek, NaiveDate, NaiveDateTime, NaiveTime};
 #[cfg(feature = "clock")]
@@ -1068,12 +1068,7 @@ impl DateTime<FixedOffset> {
     /// also simultaneously valid RFC 3339 values, but not all RFC 3339 values are valid ISO 8601
     /// values (or the other way around).
     pub fn parse_from_rfc3339(s: &str) -> ParseResult<DateTime<FixedOffset>> {
-        let mut parsed = Parsed::new();
-        let (s, _) = parse_rfc3339(&mut parsed, s)?;
-        if !s.is_empty() {
-            return Err(TOO_LONG);
-        }
-        parsed.to_datetime()
+        parse_rfc3339(s)
     }
 
     /// Parses a string from a user-specified format into a `DateTime<FixedOffset>` value.

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -1830,13 +1830,21 @@ mod tests {
                 "2015-01-20T17:35:20.000000000452−08:00",
                 Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -8)),
             ), // too small with MINUS SIGN (U+2212)
+            (
+                "2023-11-05T01:30:00-04:00",
+                Ok(ymd_hmsn(2023, 11, 5, 1, 30, 0, 0, -4)),
+            ), // ambiguous timestamp
             ("2015-01-20 17:35:20-08:00", Ok(ymd_hmsn(2015, 1, 20, 17, 35, 20, 0, -8))), // without 'T'
-            ("2015/01/20T17:35:20.001-08:00", Err(INVALID)), // wrong separator char YMD
-            ("2015-01-20T17-35-20.001-08:00", Err(INVALID)), // wrong separator char HMS
+            ("2015-01-20_17:35:20-08:00", Err(INVALID)), // wrong date time separator
+            ("2015/01/20T17:35:20.001-08:00", Err(INVALID)), // wrong separator char YM
+            ("2015-01/20T17:35:20.001-08:00", Err(INVALID)), // wrong separator char MD
+            ("2015-01-20T17-35-20.001-08:00", Err(INVALID)), // wrong separator char HM
+            ("2015-01-20T17-35:20.001-08:00", Err(INVALID)), // wrong separator char MS
             ("-01-20T17:35:20-08:00", Err(INVALID)),         // missing year
             ("99-01-20T17:35:20-08:00", Err(INVALID)),       // bad year format
             ("99999-01-20T17:35:20-08:00", Err(INVALID)),    // bad year value
             ("-2000-01-20T17:35:20-08:00", Err(INVALID)),    // bad year value
+            ("2015-00-30T17:35:20-08:00", Err(OUT_OF_RANGE)), // bad month value
             ("2015-02-30T17:35:20-08:00", Err(OUT_OF_RANGE)), // bad day of month value
             ("2015-01-20T25:35:20-08:00", Err(OUT_OF_RANGE)), // bad hour value
             ("2015-01-20T17:65:20-08:00", Err(OUT_OF_RANGE)), // bad minute value

--- a/src/format/parse.rs
+++ b/src/format/parse.rs
@@ -419,7 +419,7 @@ where
 
                     &Nanosecond => {
                         if s.starts_with('.') {
-                            let nano = try_consume!(scan::nanosecond(&s[1..]));
+                            let nano = i64::from(try_consume!(scan::nanosecond(&s[1..])));
                             parsed.set_nanosecond(nano)?;
                         }
                     }

--- a/src/format/scan.rs
+++ b/src/format/scan.rs
@@ -47,14 +47,15 @@ pub(super) fn number(s: &str, min: usize, max: usize) -> ParseResult<(&str, i64)
 
 /// Tries to consume at least one digits as a fractional second.
 /// Returns the number of whole nanoseconds (0--999,999,999).
-pub(super) fn nanosecond(s: &str) -> ParseResult<(&str, i64)> {
+pub(super) fn nanosecond(s: &str) -> ParseResult<(&str, u32)> {
     // record the number of digits consumed for later scaling.
     let origlen = s.len();
     let (s, v) = number(s, 1, 9)?;
+    let v = u32::try_from(v).expect("999,999,999 should fit u32");
     let consumed = origlen - s.len();
 
     // scale the number accordingly.
-    static SCALE: [i64; 10] =
+    const SCALE: [u32; 10] =
         [0, 100_000_000, 10_000_000, 1_000_000, 100_000, 10_000, 1_000, 100, 10, 1];
     let v = v.checked_mul(SCALE[consumed]).ok_or(OUT_OF_RANGE)?;
 


### PR DESCRIPTION
PR for #1735 

Improving performance of `DateTime::parse_from_rfc3339` by avoiding usage of `Parsed` and unrolling some loops. 

My simple benchmark shows 2 times improvement (~100 ns to ~50 ns). 
Though this still doesn't reach `speedate`'s ~30 ns, this is an easy `win` in optimization. 

Parsing function now performs some edge case checks that were done by `Parsed` to pass existing tests in the crate. 

Draft PR to collect feedback and also I would like to touch on `parse_rfc3339_relaxed` which is used for `serde` deserialization the same way