### PR TITLE
Add track_caller to non-deprecated functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 description = "Date and time library for Rust"
 homepage = "https://github.com/chronotope/chrono"
 documentation = "https://docs.rs/chrono/"

--- a/src/date.rs
+++ b/src/date.rs
@@ -497,6 +497,7 @@ impl<Tz: TimeZone> Add<TimeDelta> for Date<Tz> {
     type Output = Date<Tz>;
 
     #[inline]
+    #[track_caller]
     fn add(self, rhs: TimeDelta) -> Date<Tz> {
         self.checked_add_signed(rhs).expect("`Date + TimeDelta` overflowed")
     }
@@ -504,6 +505,7 @@ impl<Tz: TimeZone> Add<TimeDelta> for Date<Tz> {
 
 impl<Tz: TimeZone> AddAssign<TimeDelta> for Date<Tz> {
     #[inline]
+    #[track_caller]
     fn add_assign(&mut self, rhs: TimeDelta) {
         self.date = self.date.checked_add_signed(rhs).expect("`Date + TimeDelta` overflowed");
     }
@@ -513,6 +515,7 @@ impl<Tz: TimeZone> Sub<TimeDelta> for Date<Tz> {
     type Output = Date<Tz>;
 
     #[inline]
+    #[track_caller]
     fn sub(self, rhs: TimeDelta) -> Date<Tz> {
         self.checked_sub_signed(rhs).expect("`Date - TimeDelta` overflowed")
     }
@@ -520,6 +523,7 @@ impl<Tz: TimeZone> Sub<TimeDelta> for Date<Tz> {
 
 impl<Tz: TimeZone> SubAssign<TimeDelta> for Date<Tz> {
     #[inline]
+    #[track_caller]
     fn sub_assign(&mut self, rhs: TimeDelta) {
         self.date = self.date.checked_sub_signed(rhs).expect("`Date - TimeDelta` overflowed");
     }

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -623,7 +623,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     pub fn to_rfc2822(&self) -> String {
         let mut result = String::with_capacity(32);
         write_rfc2822(&mut result, self.overflowing_naive_local(), self.offset.fix())
-            .expect("writing rfc2822 datetime to string should never fail");
+            .expect("date cannot be represented by RFC 2822");
         result
     }
 

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -620,6 +620,7 @@ impl<Tz: TimeZone> DateTime<Tz> {
     /// can not have more than 4 digits.
     #[cfg(feature = "alloc")]
     #[must_use]
+    #[track_caller]
     pub fn to_rfc2822(&self) -> String {
         let mut result = String::with_capacity(32);
         write_rfc2822(&mut result, self.overflowing_naive_local(), self.offset.fix())
@@ -1529,6 +1530,7 @@ impl<Tz: TimeZone> Add<TimeDelta> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
     #[inline]
+    #[track_caller]
     fn add(self, rhs: TimeDelta) -> DateTime<Tz> {
         self.checked_add_signed(rhs).expect("`DateTime + TimeDelta` overflowed")
     }
@@ -1548,6 +1550,7 @@ impl<Tz: TimeZone> Add<Duration> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
     #[inline]
+    #[track_caller]
     fn add(self, rhs: Duration) -> DateTime<Tz> {
         let rhs = TimeDelta::from_std(rhs)
             .expect("overflow converting from core::time::Duration to TimeDelta");
@@ -1567,6 +1570,7 @@ impl<Tz: TimeZone> Add<Duration> for DateTime<Tz> {
 /// Consider using [`DateTime<Tz>::checked_add_signed`] to get an `Option` instead.
 impl<Tz: TimeZone> AddAssign<TimeDelta> for DateTime<Tz> {
     #[inline]
+    #[track_caller]
     fn add_assign(&mut self, rhs: TimeDelta) {
         let datetime =
             self.datetime.checked_add_signed(rhs).expect("`DateTime + TimeDelta` overflowed");
@@ -1587,6 +1591,7 @@ impl<Tz: TimeZone> AddAssign<TimeDelta> for DateTime<Tz> {
 /// Consider using [`DateTime<Tz>::checked_add_signed`] to get an `Option` instead.
 impl<Tz: TimeZone> AddAssign<Duration> for DateTime<Tz> {
     #[inline]
+    #[track_caller]
     fn add_assign(&mut self, rhs: Duration) {
         let rhs = TimeDelta::from_std(rhs)
             .expect("overflow converting from core::time::Duration to TimeDelta");
@@ -1603,6 +1608,7 @@ impl<Tz: TimeZone> Add<FixedOffset> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
     #[inline]
+    #[track_caller]
     fn add(mut self, rhs: FixedOffset) -> DateTime<Tz> {
         self.datetime =
             self.naive_utc().checked_add_offset(rhs).expect("`DateTime + FixedOffset` overflowed");
@@ -1626,6 +1632,7 @@ impl<Tz: TimeZone> Add<FixedOffset> for DateTime<Tz> {
 impl<Tz: TimeZone> Add<Months> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
+    #[track_caller]
     fn add(self, rhs: Months) -> Self::Output {
         self.checked_add_months(rhs).expect("`DateTime + Months` out of range")
     }
@@ -1647,6 +1654,7 @@ impl<Tz: TimeZone> Sub<TimeDelta> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
     #[inline]
+    #[track_caller]
     fn sub(self, rhs: TimeDelta) -> DateTime<Tz> {
         self.checked_sub_signed(rhs).expect("`DateTime - TimeDelta` overflowed")
     }
@@ -1666,6 +1674,7 @@ impl<Tz: TimeZone> Sub<Duration> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
     #[inline]
+    #[track_caller]
     fn sub(self, rhs: Duration) -> DateTime<Tz> {
         let rhs = TimeDelta::from_std(rhs)
             .expect("overflow converting from core::time::Duration to TimeDelta");
@@ -1687,6 +1696,7 @@ impl<Tz: TimeZone> Sub<Duration> for DateTime<Tz> {
 /// Consider using [`DateTime<Tz>::checked_sub_signed`] to get an `Option` instead.
 impl<Tz: TimeZone> SubAssign<TimeDelta> for DateTime<Tz> {
     #[inline]
+    #[track_caller]
     fn sub_assign(&mut self, rhs: TimeDelta) {
         let datetime =
             self.datetime.checked_sub_signed(rhs).expect("`DateTime - TimeDelta` overflowed");
@@ -1707,6 +1717,7 @@ impl<Tz: TimeZone> SubAssign<TimeDelta> for DateTime<Tz> {
 /// Consider using [`DateTime<Tz>::checked_sub_signed`] to get an `Option` instead.
 impl<Tz: TimeZone> SubAssign<Duration> for DateTime<Tz> {
     #[inline]
+    #[track_caller]
     fn sub_assign(&mut self, rhs: Duration) {
         let rhs = TimeDelta::from_std(rhs)
             .expect("overflow converting from core::time::Duration to TimeDelta");
@@ -1723,6 +1734,7 @@ impl<Tz: TimeZone> Sub<FixedOffset> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
     #[inline]
+    #[track_caller]
     fn sub(mut self, rhs: FixedOffset) -> DateTime<Tz> {
         self.datetime =
             self.naive_utc().checked_sub_offset(rhs).expect("`DateTime - FixedOffset` overflowed");
@@ -1746,6 +1758,7 @@ impl<Tz: TimeZone> Sub<FixedOffset> for DateTime<Tz> {
 impl<Tz: TimeZone> Sub<Months> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
+    #[track_caller]
     fn sub(self, rhs: Months) -> Self::Output {
         self.checked_sub_months(rhs).expect("`DateTime - Months` out of range")
     }
@@ -1782,6 +1795,7 @@ impl<Tz: TimeZone> Sub<&DateTime<Tz>> for DateTime<Tz> {
 impl<Tz: TimeZone> Add<Days> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
+    #[track_caller]
     fn add(self, days: Days) -> Self::Output {
         self.checked_add_days(days).expect("`DateTime + Days` out of range")
     }
@@ -1800,6 +1814,7 @@ impl<Tz: TimeZone> Add<Days> for DateTime<Tz> {
 impl<Tz: TimeZone> Sub<Days> for DateTime<Tz> {
     type Output = DateTime<Tz>;
 
+    #[track_caller]
     fn sub(self, days: Days) -> Self::Output {
         self.checked_sub_days(days).expect("`DateTime - Days` out of range")
     }

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -1982,6 +1982,7 @@ impl Add<TimeDelta> for NaiveDate {
     type Output = NaiveDate;
 
     #[inline]
+    #[track_caller]
     fn add(self, rhs: TimeDelta) -> NaiveDate {
         self.checked_add_signed(rhs).expect("`NaiveDate + TimeDelta` overflowed")
     }
@@ -1998,6 +1999,7 @@ impl Add<TimeDelta> for NaiveDate {
 /// Consider using [`NaiveDate::checked_add_signed`] to get an `Option` instead.
 impl AddAssign<TimeDelta> for NaiveDate {
     #[inline]
+    #[track_caller]
     fn add_assign(&mut self, rhs: TimeDelta) {
         *self = self.add(rhs);
     }
@@ -2030,6 +2032,7 @@ impl AddAssign<TimeDelta> for NaiveDate {
 impl Add<Months> for NaiveDate {
     type Output = NaiveDate;
 
+    #[track_caller]
     fn add(self, months: Months) -> Self::Output {
         self.checked_add_months(months).expect("`NaiveDate + Months` out of range")
     }
@@ -2059,6 +2062,7 @@ impl Add<Months> for NaiveDate {
 impl Sub<Months> for NaiveDate {
     type Output = NaiveDate;
 
+    #[track_caller]
     fn sub(self, months: Months) -> Self::Output {
         self.checked_sub_months(months).expect("`NaiveDate - Months` out of range")
     }
@@ -2073,6 +2077,7 @@ impl Sub<Months> for NaiveDate {
 impl Add<Days> for NaiveDate {
     type Output = NaiveDate;
 
+    #[track_caller]
     fn add(self, days: Days) -> Self::Output {
         self.checked_add_days(days).expect("`NaiveDate + Days` out of range")
     }
@@ -2087,6 +2092,7 @@ impl Add<Days> for NaiveDate {
 impl Sub<Days> for NaiveDate {
     type Output = NaiveDate;
 
+    #[track_caller]
     fn sub(self, days: Days) -> Self::Output {
         self.checked_sub_days(days).expect("`NaiveDate - Days` out of range")
     }
@@ -2134,6 +2140,7 @@ impl Sub<TimeDelta> for NaiveDate {
     type Output = NaiveDate;
 
     #[inline]
+    #[track_caller]
     fn sub(self, rhs: TimeDelta) -> NaiveDate {
         self.checked_sub_signed(rhs).expect("`NaiveDate - TimeDelta` overflowed")
     }
@@ -2151,6 +2158,7 @@ impl Sub<TimeDelta> for NaiveDate {
 /// Consider using [`NaiveDate::checked_sub_signed`] to get an `Option` instead.
 impl SubAssign<TimeDelta> for NaiveDate {
     #[inline]
+    #[track_caller]
     fn sub_assign(&mut self, rhs: TimeDelta) {
         *self = self.sub(rhs);
     }

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -1631,6 +1631,7 @@ impl Add<TimeDelta> for NaiveDateTime {
     type Output = NaiveDateTime;
 
     #[inline]
+    #[track_caller]
     fn add(self, rhs: TimeDelta) -> NaiveDateTime {
         self.checked_add_signed(rhs).expect("`NaiveDateTime + TimeDelta` overflowed")
     }
@@ -1650,6 +1651,7 @@ impl Add<Duration> for NaiveDateTime {
     type Output = NaiveDateTime;
 
     #[inline]
+    #[track_caller]
     fn add(self, rhs: Duration) -> NaiveDateTime {
         let rhs = TimeDelta::from_std(rhs)
             .expect("overflow converting from core::time::Duration to TimeDelta");
@@ -1669,6 +1671,7 @@ impl Add<Duration> for NaiveDateTime {
 /// Consider using [`NaiveDateTime::checked_add_signed`] to get an `Option` instead.
 impl AddAssign<TimeDelta> for NaiveDateTime {
     #[inline]
+    #[track_caller]
     fn add_assign(&mut self, rhs: TimeDelta) {
         *self = self.add(rhs);
     }
@@ -1686,6 +1689,7 @@ impl AddAssign<TimeDelta> for NaiveDateTime {
 /// Consider using [`NaiveDateTime::checked_add_signed`] to get an `Option` instead.
 impl AddAssign<Duration> for NaiveDateTime {
     #[inline]
+    #[track_caller]
     fn add_assign(&mut self, rhs: Duration) {
         *self = self.add(rhs);
     }
@@ -1701,6 +1705,7 @@ impl Add<FixedOffset> for NaiveDateTime {
     type Output = NaiveDateTime;
 
     #[inline]
+    #[track_caller]
     fn add(self, rhs: FixedOffset) -> NaiveDateTime {
         self.checked_add_offset(rhs).expect("`NaiveDateTime + FixedOffset` out of range")
     }
@@ -1754,6 +1759,7 @@ impl Add<FixedOffset> for NaiveDateTime {
 impl Add<Months> for NaiveDateTime {
     type Output = NaiveDateTime;
 
+    #[track_caller]
     fn add(self, rhs: Months) -> Self::Output {
         self.checked_add_months(rhs).expect("`NaiveDateTime + Months` out of range")
     }
@@ -1819,6 +1825,7 @@ impl Sub<TimeDelta> for NaiveDateTime {
     type Output = NaiveDateTime;
 
     #[inline]
+    #[track_caller]
     fn sub(self, rhs: TimeDelta) -> NaiveDateTime {
         self.checked_sub_signed(rhs).expect("`NaiveDateTime - TimeDelta` overflowed")
     }
@@ -1838,6 +1845,7 @@ impl Sub<Duration> for NaiveDateTime {
     type Output = NaiveDateTime;
 
     #[inline]
+    #[track_caller]
     fn sub(self, rhs: Duration) -> NaiveDateTime {
         let rhs = TimeDelta::from_std(rhs)
             .expect("overflow converting from core::time::Duration to TimeDelta");
@@ -1859,6 +1867,7 @@ impl Sub<Duration> for NaiveDateTime {
 /// Consider using [`NaiveDateTime::checked_sub_signed`] to get an `Option` instead.
 impl SubAssign<TimeDelta> for NaiveDateTime {
     #[inline]
+    #[track_caller]
     fn sub_assign(&mut self, rhs: TimeDelta) {
         *self = self.sub(rhs);
     }
@@ -1876,6 +1885,7 @@ impl SubAssign<TimeDelta> for NaiveDateTime {
 /// Consider using [`NaiveDateTime::checked_sub_signed`] to get an `Option` instead.
 impl SubAssign<Duration> for NaiveDateTime {
     #[inline]
+    #[track_caller]
     fn sub_assign(&mut self, rhs: Duration) {
         *self = self.sub(rhs);
     }
@@ -1891,6 +1901,7 @@ impl Sub<FixedOffset> for NaiveDateTime {
     type Output = NaiveDateTime;
 
     #[inline]
+    #[track_caller]
     fn sub(self, rhs: FixedOffset) -> NaiveDateTime {
         self.checked_sub_offset(rhs).expect("`NaiveDateTime - FixedOffset` out of range")
     }
@@ -1930,6 +1941,7 @@ impl Sub<FixedOffset> for NaiveDateTime {
 impl Sub<Months> for NaiveDateTime {
     type Output = NaiveDateTime;
 
+    #[track_caller]
     fn sub(self, rhs: Months) -> Self::Output {
         self.checked_sub_months(rhs).expect("`NaiveDateTime - Months` out of range")
     }
@@ -2002,6 +2014,7 @@ impl Sub<NaiveDateTime> for NaiveDateTime {
 impl Add<Days> for NaiveDateTime {
     type Output = NaiveDateTime;
 
+    #[track_caller]
     fn add(self, days: Days) -> Self::Output {
         self.checked_add_days(days).expect("`NaiveDateTime + Days` out of range")
     }
@@ -2016,6 +2029,7 @@ impl Add<Days> for NaiveDateTime {
 impl Sub<Days> for NaiveDateTime {
     type Output = NaiveDateTime;
 
+    #[track_caller]
     fn sub(self, days: Days) -> Self::Output {
         self.checked_sub_days(days).expect("`NaiveDateTime - Days` out of range")
     }

--- a/src/naive/mod.rs
+++ b/src/naive/mod.rs
@@ -61,6 +61,7 @@ impl NaiveWeek {
     /// ```
     #[inline]
     #[must_use]
+    #[track_caller]
     pub const fn first_day(&self) -> NaiveDate {
         expect(self.checked_first_day(), "first weekday out of range for `NaiveDate`")
     }
@@ -113,6 +114,7 @@ impl NaiveWeek {
     /// ```
     #[inline]
     #[must_use]
+    #[track_caller]
     pub const fn last_day(&self) -> NaiveDate {
         expect(self.checked_last_day(), "last weekday out of range for `NaiveDate`")
     }
@@ -167,6 +169,7 @@ impl NaiveWeek {
     /// ```
     #[inline]
     #[must_use]
+    #[track_caller]
     pub const fn days(&self) -> RangeInclusive<NaiveDate> {
         // `expect` doesn't work because `RangeInclusive` is not `Copy`
         match self.checked_days() {

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -105,6 +105,7 @@ impl TimeDelta {
     /// Panics when the duration is out of bounds.
     #[inline]
     #[must_use]
+    #[track_caller]
     pub const fn weeks(weeks: i64) -> TimeDelta {
         expect(TimeDelta::try_weeks(weeks), "TimeDelta::weeks out of bounds")
     }
@@ -132,6 +133,7 @@ impl TimeDelta {
     /// Panics when the `TimeDelta` would be out of bounds.
     #[inline]
     #[must_use]
+    #[track_caller]
     pub const fn days(days: i64) -> TimeDelta {
         expect(TimeDelta::try_days(days), "TimeDelta::days out of bounds")
     }
@@ -158,6 +160,7 @@ impl TimeDelta {
     /// Panics when the `TimeDelta` would be out of bounds.
     #[inline]
     #[must_use]
+    #[track_caller]
     pub const fn hours(hours: i64) -> TimeDelta {
         expect(TimeDelta::try_hours(hours), "TimeDelta::hours out of bounds")
     }
@@ -183,6 +186,7 @@ impl TimeDelta {
     /// Panics when the `TimeDelta` would be out of bounds.
     #[inline]
     #[must_use]
+    #[track_caller]
     pub const fn minutes(minutes: i64) -> TimeDelta {
         expect(TimeDelta::try_minutes(minutes), "TimeDelta::minutes out of bounds")
     }
@@ -207,6 +211,7 @@ impl TimeDelta {
     /// (in this context, this is the same as `i64::MIN / 1_000` due to rounding).
     #[inline]
     #[must_use]
+    #[track_caller]
     pub const fn seconds(seconds: i64) -> TimeDelta {
         expect(TimeDelta::try_seconds(seconds), "TimeDelta::seconds out of bounds")
     }
@@ -230,6 +235,7 @@ impl TimeDelta {
     /// Panics when the `TimeDelta` would be out of bounds, i.e. when `milliseconds` is more than
     /// `i64::MAX` or less than `-i64::MAX`. Notably, this is not the same as `i64::MIN`.
     #[inline]
+    #[track_caller]
     pub const fn milliseconds(milliseconds: i64) -> TimeDelta {
         expect(TimeDelta::try_milliseconds(milliseconds), "TimeDelta::milliseconds out of bounds")
     }
@@ -514,6 +520,7 @@ impl Neg for TimeDelta {
     type Output = TimeDelta;
 
     #[inline]
+    #[track_caller]
     fn neg(self) -> TimeDelta {
         let (secs_diff, nanos) = match self.nanos {
             0 => (0, 0),
@@ -526,6 +533,7 @@ impl Neg for TimeDelta {
 impl Add for TimeDelta {
     type Output = TimeDelta;
 
+    #[track_caller]
     fn add(self, rhs: TimeDelta) -> TimeDelta {
         self.checked_add(&rhs).expect("`TimeDelta + TimeDelta` overflowed")
     }
@@ -534,12 +542,14 @@ impl Add for TimeDelta {
 impl Sub for TimeDelta {
     type Output = TimeDelta;
 
+    #[track_caller]
     fn sub(self, rhs: TimeDelta) -> TimeDelta {
         self.checked_sub(&rhs).expect("`TimeDelta - TimeDelta` overflowed")
     }
 }
 
 impl AddAssign for TimeDelta {
+    #[track_caller]
     fn add_assign(&mut self, rhs: TimeDelta) {
         let new = self.checked_add(&rhs).expect("`TimeDelta + TimeDelta` overflowed");
         *self = new;
@@ -547,6 +557,7 @@ impl AddAssign for TimeDelta {
 }
 
 impl SubAssign for TimeDelta {
+    #[track_caller]
     fn sub_assign(&mut self, rhs: TimeDelta) {
         let new = self.checked_sub(&rhs).expect("`TimeDelta - TimeDelta` overflowed");
         *self = new;
@@ -556,6 +567,7 @@ impl SubAssign for TimeDelta {
 impl Mul<i32> for TimeDelta {
     type Output = TimeDelta;
 
+    #[track_caller]
     fn mul(self, rhs: i32) -> TimeDelta {
         self.checked_mul(rhs).expect("`TimeDelta * i32` overflowed")
     }
@@ -564,6 +576,7 @@ impl Mul<i32> for TimeDelta {
 impl Div<i32> for TimeDelta {
     type Output = TimeDelta;
 
+    #[track_caller]
     fn div(self, rhs: i32) -> TimeDelta {
         self.checked_div(rhs).expect("`i32` is zero")
     }


### PR DESCRIPTION
… that can panic because of invalid user input.

Closes #1773.
