### PR TITLE
Add safe RFC 2822 formatter; deprecate panick-y to_rfc2822

### DIFF
--- a/bench/benches/chrono.rs
+++ b/bench/benches/chrono.rs
@@ -46,14 +46,14 @@ fn bench_datetime_from_str(c: &mut Criterion) {
     });
 }
 
-fn bench_datetime_to_rfc2822(c: &mut Criterion) {
+fn bench_datetime_to_rfc2822_opt(c: &mut Criterion) {
     let pst = FixedOffset::east(8 * 60 * 60).unwrap();
     let dt = pst
         .from_local_datetime(
             NaiveDate::from_ymd(2018, 1, 11).unwrap().at_hms_nano(10, 5, 13, 84_660_000).unwrap(),
         )
         .unwrap();
-    c.bench_function("bench_datetime_to_rfc2822", |b| b.iter(|| black_box(dt).to_rfc2822()));
+    c.bench_function("bench_datetime_to_rfc2822_opt", |b| b.iter(|| black_box(dt).to_rfc2822_opt()));
 }
 
 fn bench_datetime_to_rfc3339(c: &mut Criterion) {
@@ -208,7 +208,7 @@ criterion_group!(
     bench_datetime_parse_from_rfc2822,
     bench_datetime_parse_from_rfc3339,
     bench_datetime_from_str,
-    bench_datetime_to_rfc2822,
+    bench_datetime_to_rfc2822_opt,
     bench_datetime_to_rfc3339,
     bench_datetime_to_rfc3339_opts,
     bench_num_days_from_ce,

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -497,13 +497,27 @@ impl<Tz: TimeZone> DateTime<Tz> {
     ///
     /// Panics if the date can not be represented in this format: the year may not be negative and
     /// can not have more than 4 digits.
+    #[deprecated(since = "0.5.0", note = "Use to_rfc2822_opt() instead")]
     #[cfg(feature = "alloc")]
     #[must_use]
     pub fn to_rfc2822(&self) -> String {
+        self.to_rfc2822_opt().expect("date cannot be represented by RFC 2822")
+    }
+
+    /// Returns an RFC 2822 date and time string such as `Tue, 1 Jul 2003 10:52:37 +0200`.
+    ///
+    /// Returns `None` if the date can not be represented in this format.
+    /// This format does not support negative years or years greater than 9999.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    #[track_caller]
+    pub fn to_rfc2822_opt(&self) -> Option<String> {
         let mut result = String::with_capacity(32);
-        write_rfc2822(&mut result, self.overflowing_naive_local(), self.offset.fix())
-            .expect("writing rfc2822 datetime to string should never fail");
-        result
+        if write_rfc2822(&mut result, self.overflowing_naive_local(), self.offset.fix()).is_ok() {
+            Some(result)
+        } else {
+            None
+        }
     }
 
     /// Returns an RFC 3339 and ISO 8601 date and time string such as `1996-12-19T16:39:57-08:00`.

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -633,12 +633,12 @@ fn test_datetime_rfc2822() {
 
     // timezone 0
     assert_eq!(
-        Utc.at_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap().to_rfc2822(),
-        "Wed, 18 Feb 2015 23:16:09 +0000"
+        Utc.at_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap().to_rfc2822_opt(),
+        Some("Wed, 18 Feb 2015 23:16:09 +0000".to_string())
     );
     assert_eq!(
-        Utc.at_ymd_and_hms(2015, 2, 1, 23, 16, 9).unwrap().to_rfc2822(),
-        "Sun, 1 Feb 2015 23:16:09 +0000"
+        Utc.at_ymd_and_hms(2015, 2, 1, 23, 16, 9).unwrap().to_rfc2822_opt(),
+        Some("Sun, 1 Feb 2015 23:16:09 +0000".to_string())
     );
     // timezone +05
     assert_eq!(
@@ -646,8 +646,8 @@ fn test_datetime_rfc2822() {
             NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms_milli(23, 16, 9, 150).unwrap()
         )
         .unwrap()
-        .to_rfc2822(),
-        "Wed, 18 Feb 2015 23:16:09 +0500"
+        .to_rfc2822_opt(),
+        Some("Wed, 18 Feb 2015 23:16:09 +0500".to_string())
     );
     assert_eq!(
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:60 +0500"),
@@ -675,8 +675,8 @@ fn test_datetime_rfc2822() {
             NaiveDate::from_ymd(2015, 2, 18).unwrap().at_hms_micro(23, 59, 59, 1_234_567).unwrap()
         )
         .unwrap()
-        .to_rfc2822(),
-        "Wed, 18 Feb 2015 23:59:60 +0500"
+        .to_rfc2822_opt(),
+        Some("Wed, 18 Feb 2015 23:59:60 +0500".to_string())
     );
 
     assert_eq!(
@@ -688,8 +688,8 @@ fn test_datetime_rfc2822() {
         Ok(FixedOffset::east(0).unwrap().at_ymd_and_hms(2015, 2, 18, 23, 16, 9).unwrap())
     );
     assert_eq!(
-        ymdhms_micro(&edt, 2015, 2, 18, 23, 59, 59, 1_234_567).to_rfc2822(),
-        "Wed, 18 Feb 2015 23:59:60 +0500"
+        ymdhms_micro(&edt, 2015, 2, 18, 23, 59, 59, 1_234_567).to_rfc2822_opt(),
+        Some("Wed, 18 Feb 2015 23:59:60 +0500".to_string())
     );
     assert_eq!(
         DateTime::parse_from_rfc2822("Wed, 18 Feb 2015 23:59:58 +0500"),
@@ -1443,8 +1443,7 @@ fn test_min_max_getters() {
     let beyond_max = offset_max.from_utc_datetime(NaiveDateTime::MAX);
 
     assert_eq!(format!("{:?}", beyond_min), "-262144-12-31T22:00:00-02:00");
-    // RFC 2822 doesn't support years with more than 4 digits.
-    // assert_eq!(beyond_min.to_rfc2822(), "");
+    assert!(beyond_min.to_rfc2822_opt().is_none(), "RFC 2822 doesn't support negative years.");
     #[cfg(feature = "alloc")]
     assert_eq!(beyond_min.to_rfc3339(), "-262144-12-31T22:00:00-02:00");
     #[cfg(feature = "alloc")]
@@ -1468,8 +1467,10 @@ fn test_min_max_getters() {
     assert_eq!(beyond_min.nanosecond(), 0);
 
     assert_eq!(format!("{:?}", beyond_max), "+262143-01-01T01:59:59.999999999+02:00");
-    // RFC 2822 doesn't support years with more than 4 digits.
-    // assert_eq!(beyond_max.to_rfc2822(), "");
+    assert!(
+        beyond_max.to_rfc2822_opt().is_none(),
+        "RFC 2822 doesn't support years with more than 4 digits."
+    );
     #[cfg(feature = "alloc")]
     assert_eq!(beyond_max.to_rfc3339(), "+262143-01-01T01:59:59.999999999+02:00");
     #[cfg(feature = "alloc")]

--- a/src/format/parsed.rs
+++ b/src/format/parsed.rs
@@ -73,7 +73,7 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 ///     .set_second(40)?
 ///     .set_offset(0)?;
 /// let dt = parsed.to_datetime()?;
-/// assert_eq!(dt.to_rfc2822(), "Wed, 31 Dec 2014 04:26:40 +0000");
+/// assert_eq!(dt.to_rfc2822_opt(), Some("Wed, 31 Dec 2014 04:26:40 +0000".to_string()));
 ///
 /// let mut parsed = Parsed::default();
 /// parsed
@@ -112,7 +112,7 @@ use crate::{DateTime, Datelike, TimeDelta, Timelike, Weekday};
 /// parse(&mut parsed, "Wed, 31 Dec 2014 04:26:40 +0000", rfc_2822.iter())?;
 /// let dt = parsed.to_datetime()?;
 ///
-/// assert_eq!(dt.to_rfc2822(), "Wed, 31 Dec 2014 04:26:40 +0000");
+/// assert_eq!(dt.to_rfc2822_opt(), Some("Wed, 31 Dec 2014 04:26:40 +0000".to_string()));
 ///
 /// let mut parsed = Parsed::default();
 /// parse(&mut parsed, "Thu, 31 Dec 2014 04:26:40 +0000", rfc_2822.iter())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@
 //! specifiers.
 //!
 //! The default `to_string` method and `{:?}` specifier also give a reasonable representation.
-//! Chrono also provides [`to_rfc2822`](DateTime::to_rfc2822) and
+//! Chrono also provides [`to_rfc2822`](DateTime::to_rfc2822_opt) and
 //! [`to_rfc3339`](DateTime::to_rfc3339) methods for well-known formats.
 //!
 //! Chrono now also provides date formatting in almost any language without the help of an
@@ -265,7 +265,7 @@
 //!
 //! assert_eq!(dt.format("%a %b %e %T %Y").to_string(), dt.format("%c").to_string());
 //! assert_eq!(dt.to_string(), "2014-11-28 12:00:09 UTC");
-//! assert_eq!(dt.to_rfc2822(), "Fri, 28 Nov 2014 12:00:09 +0000");
+//! assert_eq!(dt.to_rfc2822_opt(), Some("Fri, 28 Nov 2014 12:00:09 +0000".to_string()));
 //! assert_eq!(dt.to_rfc3339(), "2014-11-28T12:00:09+00:00");
 //! assert_eq!(format!("{:?}", dt), "2014-11-28T12:00:09Z");
 //!
@@ -347,7 +347,7 @@
 //!
 //! // Construct a datetime from epoch:
 //! let dt: DateTime<Utc> = DateTime::from_timestamp(1_500_000_000, 0).unwrap();
-//! assert_eq!(dt.to_rfc2822(), "Fri, 14 Jul 2017 02:40:00 +0000");
+//! assert_eq!(dt.to_rfc2822_opt(), Some("Fri, 14 Jul 2017 02:40:00 +0000".to_string()));
 //!
 //! // Get epoch value from a datetime:
 //! let dt = DateTime::parse_from_rfc2822("Fri, 14 Jul 2017 02:40:00 +0000").unwrap();


### PR DESCRIPTION
I noticed (via a prod crash 😬) that the RFC 2822 string conversion will crash if the date is out of range (ish).

I also noticed that there was an effort to transform these crash-y APIs in https://github.com/chronotope/chrono/issues/1469. I've attempted to follow what seem like current conventions, but let me know if I've missed something.

I'm opening this against the 0.5.x branch as deprecations are technically semver breaking changes.

Open question to raise real quick as well (doesn't necessarily need to be addressed in this PR): RFC 2822 explicitly states that the year must be "1900 or later" 😂 Source: https://www.rfc-editor.org/rfc/rfc2822#section-3.3. `chrono` does not currently enforce this. I don't really have an opinion on whether it should, but raising that since I noticed.