### PR TITLE
Implements rkyv 0.8 feature flags, fixes #1778

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,11 @@ oldtime = []
 wasmbind = ["wasm-bindgen", "js-sys"]
 unstable-locales = ["pure-rust-locales"]
 # Note that rkyv-16, rkyv-32, and rkyv-64 are mutually exclusive.
-rkyv = ["dep:rkyv", "rkyv/size_32"]
-rkyv-16 = ["dep:rkyv", "rkyv?/size_16"]
-rkyv-32 = ["dep:rkyv", "rkyv?/size_32"]
-rkyv-64 = ["dep:rkyv", "rkyv?/size_64"]
-rkyv-validation = ["rkyv?/validation"]
+rkyv = ["dep:rkyv", "rkyv/pointer_width_32"]
+rkyv-16 = ["dep:rkyv", "rkyv?/pointer_width_16"]
+rkyv-32 = ["dep:rkyv", "rkyv?/pointer_width_32"]
+rkyv-64 = ["dep:rkyv", "rkyv?/pointer_width_64"]
+rkyv-validation = ["dep:rkyv", "rkyv?/bytecheck", "rkyv?/alloc"]
 # Features for internal use only:
 __internal_bench = []
 
@@ -43,7 +43,7 @@ __internal_bench = []
 num-traits = { version = "0.2", default-features = false }
 serde = { version = "1.0.99", default-features = false, optional = true }
 pure-rust-locales = { version = "0.8.2", optional = true }
-rkyv = { version = "0.7.43", optional = true, default-features = false }
+rkyv = { version = "0.8.15", optional = true, default-features = false }
 arbitrary = { version = "1.0.0", features = ["derive"], optional = true }
 defmt = { version = "1.0.1", optional = true }
 
@@ -61,7 +61,7 @@ iana-time-zone = { version = "0.1.45", optional = true, features = ["fallback"] 
 serde_json = { version = "1" }
 serde_derive = { version = "1", default-features = false }
 similar-asserts = { version = "1.6.1" }
-bincode = { version = "1.3.0" }
+bincode = { version = "1" }
 windows-bindgen = { version = "0.66" }                     # MSRV is 1.74
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -50,9 +50,8 @@ mod tests;
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
-    archive(compare(PartialEq, PartialOrd))
+    rkyv(compare(PartialEq, PartialOrd))
 )]
-#[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub struct DateTime<Tz: TimeZone> {
     datetime: NaiveDateTime,
     offset: Tz::Offset,
@@ -1846,7 +1845,7 @@ where
 // * https://github.com/rust-lang/rust/issues/26925
 // * https://github.com/rkyv/rkyv/issues/333
 // * https://github.com/dtolnay/syn/issues/370
-#[cfg(feature = "rkyv-validation")]
+#[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]
 impl<Tz: TimeZone> fmt::Debug for ArchivedDateTime<Tz>
 where
     Tz: Archive,

--- a/src/month.rs
+++ b/src/month.rs
@@ -33,10 +33,11 @@ use crate::naive::NaiveDate;
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
-    archive(compare(PartialEq, PartialOrd)),
-    archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+    rkyv(
+        compare(PartialEq, PartialOrd),
+        attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+    )
 )]
-#[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 #[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Month {
@@ -471,8 +472,8 @@ mod tests {
     #[cfg(feature = "rkyv-validation")]
     fn test_rkyv_validation() {
         let month = Month::January;
-        let bytes = rkyv::to_bytes::<_, 1>(&month).unwrap();
-        assert_eq!(rkyv::from_bytes::<Month>(&bytes).unwrap(), month);
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&month).unwrap();
+        assert_eq!(rkyv::from_bytes::<Month, rkyv::rancor::Error>(&bytes).unwrap(), month);
     }
 
     #[test]

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -95,10 +95,11 @@ mod tests;
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
-    archive(compare(PartialEq, PartialOrd)),
-    archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+    rkyv(
+        compare(PartialEq, PartialOrd),
+        attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+    )
 )]
-#[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub struct NaiveDate {
     yof: NonZeroI32, // (year << 13) | of
 }

--- a/src/naive/date/tests.rs
+++ b/src/naive/date/tests.rs
@@ -897,12 +897,12 @@ const YEAR_FLAGS: [(i32, YearFlags, Weekday); 14] = [
 #[cfg(feature = "rkyv-validation")]
 fn test_rkyv_validation() {
     let date_min = NaiveDate::MIN;
-    let bytes = rkyv::to_bytes::<_, 4>(&date_min).unwrap();
-    assert_eq!(rkyv::from_bytes::<NaiveDate>(&bytes).unwrap(), date_min);
+    let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&date_min).unwrap();
+    assert_eq!(rkyv::from_bytes::<NaiveDate, rkyv::rancor::Error>(&bytes).unwrap(), date_min);
 
     let date_max = NaiveDate::MAX;
-    let bytes = rkyv::to_bytes::<_, 4>(&date_max).unwrap();
-    assert_eq!(rkyv::from_bytes::<NaiveDate>(&bytes).unwrap(), date_max);
+    let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&date_max).unwrap();
+    assert_eq!(rkyv::from_bytes::<NaiveDate, rkyv::rancor::Error>(&bytes).unwrap(), date_max);
 }
 
 //   MAX_YEAR-12-31 minus 0000-01-01

--- a/src/naive/datetime/mod.rs
+++ b/src/naive/datetime/mod.rs
@@ -68,10 +68,11 @@ pub const MAX_DATETIME: NaiveDateTime = NaiveDateTime::MAX;
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
-    archive(compare(PartialEq, PartialOrd)),
-    archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+    rkyv(
+        compare(PartialEq, PartialOrd),
+        attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+    )
 )]
-#[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 #[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(arbitrary::Arbitrary))]
 pub struct NaiveDateTime {
     date: NaiveDate,

--- a/src/naive/datetime/tests.rs
+++ b/src/naive/datetime/tests.rs
@@ -396,10 +396,10 @@ fn test_and_timezone_min_max_dates() {
 #[cfg(feature = "rkyv-validation")]
 fn test_rkyv_validation() {
     let dt_min = NaiveDateTime::MIN;
-    let bytes = rkyv::to_bytes::<_, 12>(&dt_min).unwrap();
-    assert_eq!(rkyv::from_bytes::<NaiveDateTime>(&bytes).unwrap(), dt_min);
+    let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&dt_min).unwrap();
+    assert_eq!(rkyv::from_bytes::<NaiveDateTime, rkyv::rancor::Error>(&bytes).unwrap(), dt_min);
 
     let dt_max = NaiveDateTime::MAX;
-    let bytes = rkyv::to_bytes::<_, 12>(&dt_max).unwrap();
-    assert_eq!(rkyv::from_bytes::<NaiveDateTime>(&bytes).unwrap(), dt_max);
+    let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&dt_max).unwrap();
+    assert_eq!(rkyv::from_bytes::<NaiveDateTime, rkyv::rancor::Error>(&bytes).unwrap(), dt_max);
 }

--- a/src/naive/isoweek.rs
+++ b/src/naive/isoweek.rs
@@ -20,10 +20,11 @@ use rkyv::{Archive, Deserialize, Serialize};
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
-    archive(compare(PartialEq, PartialOrd)),
-    archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+    rkyv(
+        compare(PartialEq, PartialOrd),
+        attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+    )
 )]
-#[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub struct IsoWeek {
     // Note that this allows for larger year range than `NaiveDate`.
     // This is crucial because we have an edge case for the first and last week supported,
@@ -238,11 +239,11 @@ mod tests {
     #[cfg(feature = "rkyv-validation")]
     fn test_rkyv_validation() {
         let minweek = NaiveDate::MIN.iso_week();
-        let bytes = rkyv::to_bytes::<_, 4>(&minweek).unwrap();
-        assert_eq!(rkyv::from_bytes::<IsoWeek>(&bytes).unwrap(), minweek);
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&minweek).unwrap();
+        assert_eq!(rkyv::from_bytes::<IsoWeek, rkyv::rancor::Error>(&bytes).unwrap(), minweek);
 
         let maxweek = NaiveDate::MAX.iso_week();
-        let bytes = rkyv::to_bytes::<_, 4>(&maxweek).unwrap();
-        assert_eq!(rkyv::from_bytes::<IsoWeek>(&bytes).unwrap(), maxweek);
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&maxweek).unwrap();
+        assert_eq!(rkyv::from_bytes::<IsoWeek, rkyv::rancor::Error>(&bytes).unwrap(), maxweek);
     }
 }

--- a/src/naive/time/mod.rs
+++ b/src/naive/time/mod.rs
@@ -213,10 +213,11 @@ mod tests;
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
-    archive(compare(PartialEq, PartialOrd)),
-    archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+    rkyv(
+        compare(PartialEq, PartialOrd),
+        attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+    )
 )]
-#[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub struct NaiveTime {
     secs: u32,
     frac: u32,

--- a/src/naive/time/tests.rs
+++ b/src/naive/time/tests.rs
@@ -381,10 +381,10 @@ fn test_overflowing_offset() {
 #[cfg(feature = "rkyv-validation")]
 fn test_rkyv_validation() {
     let t_min = NaiveTime::MIN;
-    let bytes = rkyv::to_bytes::<_, 8>(&t_min).unwrap();
-    assert_eq!(rkyv::from_bytes::<NaiveTime>(&bytes).unwrap(), t_min);
+    let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&t_min).unwrap();
+    assert_eq!(rkyv::from_bytes::<NaiveTime, rkyv::rancor::Error>(&bytes).unwrap(), t_min);
 
     let t_max = NaiveTime::MAX;
-    let bytes = rkyv::to_bytes::<_, 8>(&t_max).unwrap();
-    assert_eq!(rkyv::from_bytes::<NaiveTime>(&bytes).unwrap(), t_max);
+    let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&t_max).unwrap();
+    assert_eq!(rkyv::from_bytes::<NaiveTime, rkyv::rancor::Error>(&bytes).unwrap(), t_max);
 }

--- a/src/offset/fixed.rs
+++ b/src/offset/fixed.rs
@@ -23,10 +23,8 @@ use crate::naive::{NaiveDate, NaiveDateTime};
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
-    archive(compare(PartialEq)),
-    archive_attr(derive(Clone, Copy, PartialEq, Eq, Hash, Debug))
+    rkyv(compare(PartialEq), attr(derive(Clone, Copy, PartialEq, Eq, Hash, Debug)))
 )]
-#[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub struct FixedOffset {
     local_minus_utc: i32,
 }
@@ -247,7 +245,7 @@ mod tests {
     #[cfg(feature = "rkyv-validation")]
     fn test_rkyv_validation() {
         let offset = FixedOffset::from_str("-0500").unwrap();
-        let bytes = rkyv::to_bytes::<_, 4>(&offset).unwrap();
-        assert_eq!(rkyv::from_bytes::<FixedOffset>(&bytes).unwrap(), offset);
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&offset).unwrap();
+        assert_eq!(rkyv::from_bytes::<FixedOffset, rkyv::rancor::Error>(&bytes).unwrap(), offset);
     }
 }

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -117,10 +117,8 @@ mod tz_info;
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
-    archive(compare(PartialEq)),
-    archive_attr(derive(Clone, Copy, Debug))
+    rkyv(compare(PartialEq), attr(derive(Clone, Copy, Debug)))
 )]
-#[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Local;
@@ -533,11 +531,14 @@ mod tests {
     fn test_rkyv_validation() {
         let local = Local;
         // Local is a ZST and serializes to 0 bytes
-        let bytes = rkyv::to_bytes::<_, 0>(&local).unwrap();
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&local).unwrap();
         assert_eq!(bytes.len(), 0);
 
         // but is deserialized to an archived variant without a
         // wrapping object
-        assert_eq!(rkyv::from_bytes::<Local>(&bytes).unwrap(), super::ArchivedLocal);
+        assert_eq!(
+            rkyv::from_bytes::<Local, rkyv::rancor::Error>(&bytes).unwrap(),
+            super::ArchivedLocal
+        );
     }
 }

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -44,10 +44,8 @@ use crate::{Date, DateTime};
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
-    archive(compare(PartialEq)),
-    archive_attr(derive(Clone, Copy, PartialEq, Eq, Debug, Hash))
+    rkyv(compare(PartialEq), attr(derive(Clone, Copy, PartialEq, Eq, Debug, Hash)))
 )]
-#[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 #[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(arbitrary::Arbitrary))]
 pub struct Utc;
 

--- a/src/time_delta.rs
+++ b/src/time_delta.rs
@@ -55,10 +55,11 @@ const SECS_PER_WEEK: i64 = 604_800;
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
-    archive(compare(PartialEq, PartialOrd)),
-    archive_attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+    rkyv(
+        compare(PartialEq, PartialOrd),
+        attr(derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash))
+    )
 )]
-#[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct TimeDelta {
     secs: i64,
@@ -1450,7 +1451,7 @@ mod tests {
     #[cfg(feature = "rkyv-validation")]
     fn test_rkyv_validation() {
         let duration = TimeDelta::try_seconds(1).unwrap();
-        let bytes = rkyv::to_bytes::<_, 16>(&duration).unwrap();
-        assert_eq!(rkyv::from_bytes::<TimeDelta>(&bytes).unwrap(), duration);
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&duration).unwrap();
+        assert_eq!(rkyv::from_bytes::<TimeDelta, rkyv::rancor::Error>(&bytes).unwrap(), duration);
     }
 }

--- a/src/weekday.rs
+++ b/src/weekday.rs
@@ -33,10 +33,8 @@ use crate::OutOfRange;
 #[cfg_attr(
     any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"),
     derive(Archive, Deserialize, Serialize),
-    archive(compare(PartialEq)),
-    archive_attr(derive(Clone, Copy, PartialEq, Eq, Debug, Hash))
+    rkyv(compare(PartialEq), attr(derive(Clone, Copy, PartialEq, Eq, Debug, Hash)))
 )]
-#[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 #[cfg_attr(all(feature = "arbitrary", feature = "std"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Weekday {
@@ -412,8 +410,8 @@ mod tests {
     #[cfg(feature = "rkyv-validation")]
     fn test_rkyv_validation() {
         let mon = Weekday::Mon;
-        let bytes = rkyv::to_bytes::<_, 1>(&mon).unwrap();
+        let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&mon).unwrap();
 
-        assert_eq!(rkyv::from_bytes::<Weekday>(&bytes).unwrap(), mon);
+        assert_eq!(rkyv::from_bytes::<Weekday, rkyv::rancor::Error>(&bytes).unwrap(), mon);
     }
 }


### PR DESCRIPTION
Fixes #1778 

Removed 
 - all instances of `#[cfg_attr(feature = "rkyv-validation", archive(check_bytes))] ` -  rkyv 0.8 auto-derives CheckBytes via the `bytecheck` feature
 
Amended rkyv flags
 - rkyv-validation flags `["rkyv_dyn?/validation"]` to `["dep:rkyv", "rkyv?/bytecheck", "rkyv?/alloc"]`
 - `archive(compare(...))` to `rkyv(compare(...))`
 - `archive_attr(derive(...))` to `rkyv(attr(derive(...)))`

Changed error handling type in tests to `rkyv::rancor::Error`
 - `rkyv::to_bytes::<_, SIZE>(&val)` to `rkyv::to_bytes::<rkyv::rancor::Error>(&val)`
 - `rkyv::from_bytes::<T>(&bytes)` to `rkyv::from_bytes::<T, rkyv::rancor::Error>(&bytes)`
 
Amended debug `#cfg`
 - `#[cfg(feature = "rkyv-validation")]` to `#[cfg(any(feature = "rkyv", feature = "rkyv-16", feature = "rkyv-32", feature = "rkyv-64"))]` - archived type only exists when derives fire, not when validation alone is enabled
 