### PR TITLE
fix: bincode2 bump, fixes #1780

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ iana-time-zone = { version = "0.1.45", optional = true, features = ["fallback"] 
 serde_json = { version = "1" }
 serde_derive = { version = "1", default-features = false }
 similar-asserts = { version = "1.6.1" }
-bincode = { version = "1.3.0" }
+bincode2 = { version = "2" }
 windows-bindgen = { version = "0.66" }                     # MSRV is 1.74
 
 [target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -4,5 +4,3 @@ private = { ignore = true }
 
 [advisories]
 yanked = "deny"
-# bincode is deprecated -- just a dev-dependency in this crate
-ignore = ["RUSTSEC-2025-0141"]

--- a/src/datetime/serde.rs
+++ b/src/datetime/serde.rs
@@ -1290,7 +1290,7 @@ mod tests {
     fn test_serde_bincode() {
         // Bincode is relevant to test separately from JSON because
         // it is not self-describing.
-        use bincode::{deserialize, serialize};
+        use bincode2::{deserialize, serialize};
 
         let dt = Utc.with_ymd_and_hms(2014, 7, 24, 12, 34, 6).unwrap();
         let encoded = serialize(&dt).unwrap();

--- a/src/naive/date/mod.rs
+++ b/src/naive/date/mod.rs
@@ -2623,7 +2623,7 @@ mod serde {
         fn test_serde_bincode() {
             // Bincode is relevant to test separately from JSON because
             // it is not self-describing.
-            use bincode::{deserialize, serialize};
+            use bincode2::{deserialize, serialize};
 
             let d = NaiveDate::from_ymd_opt(2014, 7, 24).unwrap();
             let encoded = serialize(&d).unwrap();

--- a/src/naive/datetime/serde.rs
+++ b/src/naive/datetime/serde.rs
@@ -1131,7 +1131,7 @@ mod tests {
     use crate::serde::ts_nanoseconds_option;
     use crate::{DateTime, NaiveDate, NaiveDateTime, TimeZone, Utc};
 
-    use bincode::{deserialize, serialize};
+    use bincode2::{deserialize, serialize};
     use serde_derive::{Deserialize, Serialize};
 
     #[test]

--- a/src/naive/time/serde.rs
+++ b/src/naive/time/serde.rs
@@ -133,7 +133,7 @@ mod tests {
     fn test_serde_bincode() {
         // Bincode is relevant to test separately from JSON because
         // it is not self-describing.
-        use bincode::{deserialize, serialize};
+        use bincode2::{deserialize, serialize};
 
         let t = NaiveTime::from_hms_nano_opt(3, 5, 7, 98765432).unwrap();
         let encoded = serialize(&t).unwrap();


### PR DESCRIPTION
Fixes #1780 

Replaced `bincode::` with `use bincode2::`
Removed the RUSTSEC-2025-0141 advisory.