### PR TITLE
tz_data: fix tzdata locations on Android

### DIFF
--- a/src/offset/local/tz_data.rs
+++ b/src/offset/local/tz_data.rs
@@ -25,9 +25,14 @@ pub(crate) fn for_zone(tz_string: &str) -> Result<Option<Vec<u8>>> {
 /// Open the `tzdata` file of Android from the environment variables.
 #[cfg(target_os = "android")]
 fn open_android_tz_data_file() -> Result<File> {
-    for (env_var, path) in
-        [("ANDROID_DATA", "/misc/zoneinfo"), ("ANDROID_ROOT", "/usr/share/zoneinfo")]
-    {
+    for (env_var, path) in [
+        // Default root path: /apex/com.android.tzdata
+        ("ANDROID_TZDATA_ROOT", "/etc/tz"),
+        // Default root path: /data
+        ("ANDROID_DATA", "/misc/zoneinfo/current"),
+        // Default root path: /system
+        ("ANDROID_ROOT", "/usr/share/zoneinfo"),
+    ] {
         if let Ok(env_value) = std::env::var(env_var) {
             if let Ok(file) = File::open(format!("{}{}/tzdata", env_value, path)) {
                 return Ok(file);


### PR DESCRIPTION
Hi, this PR is about a fix to find right tzdata paths for Android. Thank you for your time to review this.
- added `/apex/com.android.tzdata/etc/tz/tzdata`
- corrected the right path for `/data/misc/zoneinfo/current`
- corrected lookup priority: `apex` -> `current` -> `system`

Feel free to see more detailed issue description and verification after fix here https://github.com/chronotope/chrono/issues/1788.