### PR TITLE
Replace `target_arch = "wasm32"` with `target_family = "wasm"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ rkyv = { version = "0.7.43", optional = true, default-features = false }
 arbitrary = { version = "1.0.0", features = ["derive"], optional = true }
 defmt = { version = "1.0.1", optional = true }
 
-[target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
+[target.'cfg(all(target_family = "wasm", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 wasm-bindgen = { version = "0.2", optional = true }
 js-sys = { version = "0.3", optional = true }       # contains FFI bindings for the JS Date API
 
@@ -64,7 +64,7 @@ similar-asserts = { version = "2.0.0" }
 bincode = { version = "1.3.0" }
 windows-bindgen = { version = "0.66" }                     # MSRV is 1.74
 
-[target.'cfg(all(target_arch = "wasm32", not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]
+[target.'cfg(all(target_family = "wasm", not(any(target_os = "emscripten", target_os = "wasi"))))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 [package.metadata.docs.rs]

--- a/src/datetime/mod.rs
+++ b/src/datetime/mod.rs
@@ -1954,7 +1954,7 @@ impl<Tz: TimeZone> From<DateTime<Tz>> for SystemTime {
 }
 
 #[cfg(all(
-    target_arch = "wasm32",
+    target_family = "wasm",
     feature = "wasmbind",
     not(any(target_os = "emscripten", target_os = "wasi", target_os = "linux"))
 ))]
@@ -1965,7 +1965,7 @@ impl From<js_sys::Date> for DateTime<Utc> {
 }
 
 #[cfg(all(
-    target_arch = "wasm32",
+    target_family = "wasm",
     feature = "wasmbind",
     not(any(target_os = "emscripten", target_os = "wasi", target_os = "linux"))
 ))]
@@ -1976,7 +1976,7 @@ impl From<&js_sys::Date> for DateTime<Utc> {
 }
 
 #[cfg(all(
-    target_arch = "wasm32",
+    target_family = "wasm",
     feature = "wasmbind",
     not(any(target_os = "emscripten", target_os = "wasi", target_os = "linux"))
 ))]

--- a/src/datetime/tests.rs
+++ b/src/datetime/tests.rs
@@ -1387,7 +1387,7 @@ fn test_subsecond_part() {
 // `i32` (year 2035 problem), or an `u64` (no values before `UNIX-EPOCH`).
 // See https://github.com/rust-lang/rust/issues/44394.
 #[test]
-#[cfg(all(feature = "std", not(all(target_arch = "wasm32", target_os = "wasi"))))]
+#[cfg(all(feature = "std", not(all(target_family = "wasm", target_os = "wasi"))))]
 fn test_from_system_time() {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 

--- a/src/offset/local/mod.rs
+++ b/src/offset/local/mod.rs
@@ -35,7 +35,7 @@ mod tz_data;
     not(unix),
     not(windows),
     not(all(
-        target_arch = "wasm32",
+        target_family = "wasm",
         feature = "wasmbind",
         not(any(target_os = "emscripten", target_os = "wasi"))
     ))
@@ -57,7 +57,7 @@ mod inner {
 }
 
 #[cfg(all(
-    target_arch = "wasm32",
+    target_family = "wasm",
     feature = "wasmbind",
     not(any(target_os = "emscripten", target_os = "wasi", target_os = "linux"))
 ))]

--- a/src/offset/utc.rs
+++ b/src/offset/utc.rs
@@ -7,7 +7,7 @@ use core::fmt;
 #[cfg(all(
     feature = "now",
     not(all(
-        target_arch = "wasm32",
+        target_family = "wasm",
         feature = "wasmbind",
         not(any(target_os = "emscripten", target_os = "wasi", target_os = "linux"))
     ))
@@ -87,7 +87,7 @@ impl Utc {
     /// let now_with_offset = Utc::now().with_timezone(&offset);
     /// ```
     #[cfg(not(all(
-        target_arch = "wasm32",
+        target_family = "wasm",
         feature = "wasmbind",
         not(any(target_os = "emscripten", target_os = "wasi", target_os = "linux"))
     )))]
@@ -100,7 +100,7 @@ impl Utc {
 
     /// Returns a `DateTime` which corresponds to the current date and time.
     #[cfg(all(
-        target_arch = "wasm32",
+        target_family = "wasm",
         feature = "wasmbind",
         not(any(target_os = "emscripten", target_os = "wasi", target_os = "linux"))
     ))]

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -6,7 +6,7 @@
 //! The check will fail if the local timezone does not match one of the timezones defined below.
 
 #![cfg(all(
-    target_arch = "wasm32",
+    target_family = "wasm",
     feature = "wasmbind",
     feature = "clock",
     not(any(target_os = "emscripten", target_os = "wasi"))


### PR DESCRIPTION
Web-target cfg gates (the wasm-bindgen / js-sys code paths and the `wasm-pack test --node` harness) currently key on
`target_arch = "wasm32"`. As a result they silently disappear when building for `wasm64-unknown-unknown`: the `wasm-bindgen` and `js-sys` optional dependencies are not pulled in, `Utc::now()`, `Local`'s offset lookup, and the `js_sys::Date` conversions fall back to the non-web default (which calls `SystemTime::now()` and panics on wasm), and the `tests/wasm.rs` harness is compiled out.

Switching the gates to `target_family = "wasm"` makes the same web backend apply to any WebAssembly target, including `wasm64`. The existing `not(any(target_os = "emscripten", target_os = "wasi"[, "linux"]))` exclusions are preserved, so behavior on `wasm32-unknown-emscripten`, `wasm32-wasip*` and emscripten/WASI variants is unchanged.

`target_family = "wasm"` has been stable since Rust 1.54, well below chrono's MSRV (1.62).

`wasm64-unknown-unknown` is a Tier 3 target, so it cannot be added to CI, but the same code paths are still exercised by the existing `wasm-pack test --node --features wasmbind` job on `wasm32`.